### PR TITLE
Fix release trust metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit production dependencies
+        run: npm audit --omit=dev
+
       - name: Build app
         run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `preload.js` with `contextBridge` for safe IPC — renderer no longer has direct Node.js access
 - Replaced `child_process.exec()` with `spawn()` — app paths are no longer shell-interpolated
 - Added path validation before launching executables
-- Added `sanitizePaths()` to validate data loaded from localStorage
 
 ### Added
 - User-facing error toast when an individual app fails to launch
-- Content Security Policy meta tag blocking external resource loading
 - ESLint config and `npm run lint` script
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "simlauncher",
-  "version": "0.0.8",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "0.0.8",
-      "license": "ISC",
+      "version": "0.1.4",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.0",
         "electron-store": "^10.0.0",
@@ -5350,9 +5350,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "GPL-3.0-only",
   "dependencies": {
     "@tailwindcss/vite": "^4.1.0",
     "electron-store": "^10.0.0",
@@ -30,5 +30,8 @@
     "electron-builder": "^26.0.12",
     "electron-vite": "^4.0.0",
     "typescript": "^5.9.0"
+  },
+  "overrides": {
+    "js-yaml": "4.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- align package metadata with GPLv3 licensing
- remove unimplemented security claims from the changelog
- pin js-yaml to 4.1.1 and gate releases with production npm audit

## Validation
- npm audit --omit=dev
- npm run build

Closes #65
Closes #66
Closes #67