### PR TITLE
ci: auto-sync Closes references from commits to PR description

### DIFF
--- a/.github/workflows/sync-pr-closes.yml
+++ b/.github/workflows/sync-pr-closes.yml
@@ -1,0 +1,78 @@
+name: sync-pr-closes
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update PR closes from commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open'
+            });
+
+            if (prs.length === 0) {
+              console.log('No open PR for branch:', branch);
+              return;
+            }
+
+            const pr = prs[0];
+
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            const pattern = /(?:closes|fixes)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+
+            for (const commit of commits) {
+              let match;
+              while ((match = pattern.exec(commit.commit.message)) !== null) {
+                issueNumbers.add(match[1]);
+              }
+            }
+
+            if (issueNumbers.size === 0) {
+              console.log('No closes references found in commits');
+              return;
+            }
+
+            const closesLines = [...issueNumbers]
+              .sort((a, b) => Number(a) - Number(b))
+              .map(n => `Closes #${n}`)
+              .join('\n');
+
+            const marker = '<!-- auto-closes -->';
+            const section = `${marker}\n${closesLines}\n${marker}`;
+
+            let body = pr.body || '';
+            if (body.includes(marker)) {
+              body = body.replace(/<!-- auto-closes -->[\s\S]*?<!-- auto-closes -->/, section);
+            } else {
+              body = body ? `${body}\n\n${section}` : section;
+            }
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              body
+            });
+
+            console.log(`PR #${pr.number} updated with: ${[...issueNumbers].join(', ')}`);


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically keeps PR descriptions in sync with `Closes #N` / `Fixes #N` references found in commits.

**How it works:**
- Triggers on every push to non-main branches
- Finds the open PR for that branch
- Scans all commits for `Closes #N` / `Fixes #N` patterns
- Writes them into a marked section in the PR description (other content untouched)
- Section is updated idempotently on each push

**Result:** open a Draft PR empty, Codex commits `Closes #73`, action auto-adds `Closes #73` to PR description → GitHub links the issue automatically. No manual work needed.