### PR TITLE
ci: fix generate-notes on Windows runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         run: npx electron-builder --win --publish always
 
       - name: Generate release notes
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Add `shell: bash` to the Generate release notes step — Windows runners default to PowerShell which doesn't support bash subshell syntax `$(...)`.