### PR TITLE
release: v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1001,10 +1001,13 @@ function getExternallyAdoptableGameKeys(
 
 // INVARIANT: manual companion utilities are only surfaced when the owning game is
 // already launched by SimLauncher or its configured game exe is externally running.
-async function getTrackedRunningApps(processNames: Set<string>, adoptedOrLaunchedGameKeys: Set<string>) {
-  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
-  const appPaths = store.get('appPaths') as Record<string, string> | undefined
-  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
+async function getTrackedRunningApps(
+  processNames: Set<string>,
+  adoptedOrLaunchedGameKeys: Set<string>,
+  profiles: Record<string, StoredProfileEntry> | undefined,
+  appPaths: Record<string, string> | undefined,
+  gamePaths: Record<string, string> | undefined
+) {
   const trackedApps: { path: string; name: string; gameKey: string; tracked: boolean }[] = []
   const seen = new Set<string>()
 
@@ -1238,11 +1241,18 @@ ipcMain.handle('get-running-apps', async () => {
   const launchedKeys = new Set(launchedApps.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`))
   const launchedExeNames = new Set(launchedApps.map((appProcess) => path.basename(appProcess.path).toLowerCase()))
   const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
+  const appPaths = store.get('appPaths') as Record<string, string> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
   const launchedGameKeys = new Set(launchedApps.map((appProcess) => appProcess.gameKey))
   const adoptedGameKeys = getExternallyAdoptableGameKeys(processNames, profiles, gamePaths, launchedGameKeys)
   const adoptedOrLaunchedGameKeys = new Set([...launchedGameKeys, ...adoptedGameKeys])
-  const trackedApps = (await getTrackedRunningApps(processNames, adoptedOrLaunchedGameKeys)).filter(
+  const trackedApps = (await getTrackedRunningApps(
+    processNames,
+    adoptedOrLaunchedGameKeys,
+    profiles,
+    appPaths,
+    gamePaths
+  )).filter(
     (appProcess) =>
       !launchedKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`) &&
       !launchedExeNames.has(path.basename(appProcess.path).toLowerCase())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ const store = new Store({
     zoomFactor:       { type: 'number',  default: 1.0 },
     windowBounds:      { type: 'object',  default: {} },
     profileUtilityOrderMigrated: { type: 'boolean', default: false },
+    profileSetsMigrated: { type: 'boolean', default: false },
     migrated:     { type: 'boolean', default: false },
   }
 })
@@ -51,6 +52,15 @@ interface StoredProfile extends Record<string, unknown> {
   trackingEnabled?: boolean
   trackedProcessPaths?: string[]
 }
+interface StoredNamedProfile extends StoredProfile {
+  id: string
+  name: string
+}
+interface StoredProfileSet {
+  activeProfileId: string
+  profiles: StoredNamedProfile[]
+}
+type StoredProfileEntry = StoredProfile | StoredProfileSet
 
 interface StoredProfileUtility {
   id: string
@@ -205,14 +215,16 @@ function killProcessByImageName(processName: string) {
 }
 
 function getProfileCompanionProcessNames(gameKey?: string) {
-  const profiles = store.get('profiles') as Record<string, StoredProfile> | undefined
+  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
   const companionNames = new Set<string>()
 
-  Object.entries(profiles || {}).forEach(([profileGameKey, profile]) => {
+  Object.entries(profiles || {}).forEach(([profileGameKey, profileEntry]) => {
     if (gameKey && profileGameKey !== gameKey) {
       return
     }
+
+    const profile = getActiveStoredProfile(profileEntry)
 
     Object.entries(UTILITY_COMPANION_PROCESS_NAMES).forEach(([utilityKey, processNames]) => {
       if (isUtilityEnabled(profile, utilityKey)) {
@@ -259,6 +271,48 @@ async function killLaunchedApps(gameKey?: string) {
   companionProcessNames.forEach((processName) => {
     if (processNames.has(processName)) {
       killTasks.push(killProcessByImageName(processName))
+    }
+  })
+
+  await Promise.all(killTasks)
+}
+
+async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
+  const processNames = await readRunningProcessNames()
+  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
+  const gamePath = gamePaths?.[gameKey]?.toLowerCase()
+  const killTasks: Promise<void>[] = []
+  const killedExeNames = new Set<string>()
+
+  appPathsToKill.filter(isValidExePath).forEach((appPath) => {
+    if (gamePath && appPath.toLowerCase() === gamePath) {
+      return
+    }
+
+    const runningAppEntry = Array.from(runningProcesses.entries()).find(([runningPath, runningApp]) => (
+      runningPath.toLowerCase() === appPath.toLowerCase() &&
+      runningApp.gameKey === gameKey &&
+      !runningApp.isGame
+    ))
+
+    if (runningAppEntry) {
+      const [runningPath, runningApp] = runningAppEntry
+      killTasks.push(killProcessTree(runningApp.process, appPath))
+      runningProcesses.delete(runningPath)
+      killedExeNames.add(getExeName(appPath))
+    }
+  })
+
+  appPathsToKill.filter(isValidExePath).forEach((appPath) => {
+    if (gamePath && appPath.toLowerCase() === gamePath) {
+      return
+    }
+
+    const processName = getExeName(appPath)
+
+    if (!killedExeNames.has(processName) && processNames.has(processName)) {
+      killTasks.push(killProcessByImageName(processName))
+      killedExeNames.add(processName)
     }
   })
 
@@ -365,7 +419,7 @@ app.on('before-quit', () => {
 })
 
 app.whenReady().then(() => {
-  migrateLegacyProfilesToUtilityOrder()
+  migrateProfilesToNamedSets()
   createTray()
   createWindow()
 })
@@ -401,6 +455,15 @@ function isStoredProfileUtility(value: unknown): value is StoredProfileUtility {
   return typeof utility.id === 'string' && typeof utility.enabled === 'boolean'
 }
 
+function isStoredProfileSet(value: unknown): value is StoredProfileSet {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const profileSet = value as Record<string, unknown>
+  return typeof profileSet.activeProfileId === 'string' && Array.isArray(profileSet.profiles)
+}
+
 function getCustomSlotNumber(key: string) {
   const match = key.match(/^customapp(\d+)$/)
   return match ? Number(match[1]) : null
@@ -409,8 +472,17 @@ function getCustomSlotNumber(key: string) {
 function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
   let highestSlot = 0
 
-  records.forEach((record) => {
+  const scanRecord = (record: Record<string, unknown> | undefined) => {
     Object.entries(record || {}).forEach(([key, value]) => {
+      if (key === 'profiles' && Array.isArray(value)) {
+        value.forEach((profile) => {
+          if (profile && typeof profile === 'object') {
+            scanRecord(profile as Record<string, unknown>)
+          }
+        })
+        return
+      }
+
       const slotNumber = getCustomSlotNumber(key)
 
       if (slotNumber !== null && (value === true || (typeof value === 'string' && value.trim().length > 0))) {
@@ -427,6 +499,10 @@ function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefi
         })
       }
     })
+  }
+
+  records.forEach((record) => {
+    scanRecord(record)
   })
 
   return highestSlot
@@ -473,48 +549,129 @@ function isUtilityEnabled(profile: StoredProfile | undefined, utilityKey: string
   return profile[utilityKey] === true
 }
 
-function migrateLegacyProfilesToUtilityOrder() {
-  if (store.get('profileUtilityOrderMigrated') === true) {
+function getActiveStoredProfile(profileEntry: StoredProfileEntry | undefined) {
+  if (!profileEntry) {
+    return undefined
+  }
+
+  if (isStoredProfileSet(profileEntry)) {
+    return profileEntry.profiles.find((profile) => profile.id === profileEntry.activeProfileId) || profileEntry.profiles[0]
+  }
+
+  return profileEntry
+}
+
+function normalizeStoredProfileUtilityOrder(profile: StoredProfile, utilityKeys: string[]) {
+  const normalizedProfile: StoredProfile = {
+    ...profile,
+    utilities: Array.isArray(profile.utilities)
+      ? profile.utilities.filter(isStoredProfileUtility)
+      : utilityKeys.map((utilityKey) => ({
+        id: utilityKey,
+        enabled: profile[utilityKey] === true
+      }))
+  }
+
+  utilityKeys.forEach((utilityKey) => {
+    delete normalizedProfile[utilityKey]
+  })
+
+  return normalizedProfile
+}
+
+function normalizeStoredNamedProfile(value: unknown, utilityKeys: string[], fallbackIndex: number): StoredNamedProfile | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const profile = value as StoredProfile
+  const orderedProfile = normalizeStoredProfileUtilityOrder(profile, utilityKeys)
+  const rawProfile = value as Record<string, unknown>
+
+  return {
+    ...orderedProfile,
+    id: typeof rawProfile.id === 'string' && rawProfile.id.trim().length > 0
+      ? rawProfile.id
+      : `profile-${Date.now().toString(36)}-${fallbackIndex}`,
+    name: typeof rawProfile.name === 'string' && rawProfile.name.trim().length > 0
+      ? rawProfile.name.trim()
+      : fallbackIndex === 0 ? 'Default' : `Profile ${fallbackIndex + 1}`
+  }
+}
+
+function normalizeStoredProfileSet(profileEntry: StoredProfileEntry, utilityKeys: string[]) {
+  if (isStoredProfileSet(profileEntry)) {
+    const seen = new Set<string>()
+    const profiles = profileEntry.profiles.flatMap((profile, index) => {
+      const normalizedProfile = normalizeStoredNamedProfile(profile, utilityKeys, index)
+
+      if (!normalizedProfile || seen.has(normalizedProfile.id)) {
+        return []
+      }
+
+      seen.add(normalizedProfile.id)
+      return [normalizedProfile]
+    })
+
+    if (profiles.length === 0) {
+      const defaultProfile = normalizeStoredNamedProfile({}, utilityKeys, 0)!
+      defaultProfile.id = 'default'
+      defaultProfile.name = 'Default'
+      return {
+        activeProfileId: defaultProfile.id,
+        profiles: [defaultProfile]
+      }
+    }
+
+    return {
+      activeProfileId: profiles.some((profile) => profile.id === profileEntry.activeProfileId)
+        ? profileEntry.activeProfileId
+        : profiles[0].id,
+      profiles
+    }
+  }
+
+  const defaultProfile = normalizeStoredNamedProfile(profileEntry, utilityKeys, 0)!
+  defaultProfile.id = 'default'
+  defaultProfile.name = 'Default'
+
+  return {
+    activeProfileId: defaultProfile.id,
+    profiles: [defaultProfile]
+  }
+}
+
+function migrateProfilesToNamedSets() {
+  if (store.get('profileSetsMigrated') === true) {
     return
   }
 
-  const profiles = store.get('profiles') as Record<string, StoredProfile> | undefined
+  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const appPaths = store.get('appPaths') as Record<string, string> | undefined
 
   if (!profiles || Object.keys(profiles).length === 0) {
     store.set('profileUtilityOrderMigrated', true)
+    store.set('profileSetsMigrated', true)
     return
   }
 
   const savedCustomSlots = store.get('customSlots')
   const customSlots = Math.max(
     typeof savedCustomSlots === 'number' && Number.isFinite(savedCustomSlots) ? savedCustomSlots : 1,
-    getHighestCustomSlot(appPaths, ...Object.values(profiles))
+    getHighestCustomSlot(appPaths, ...Object.values(profiles).map((profile) => profile as Record<string, unknown>))
   )
   const utilityKeys = getUtilityKeys(customSlots)
-  const migratedProfiles: Record<string, StoredProfile> = {}
-
-  Object.entries(profiles).forEach(([gameKey, profile]) => {
-    const migratedProfile: StoredProfile = {
-      ...profile,
-      utilities: Array.isArray(profile.utilities)
-        ? profile.utilities.filter(isStoredProfileUtility)
-        : utilityKeys.map((utilityKey) => ({
-          id: utilityKey,
-          enabled: profile[utilityKey] === true
-        }))
-    }
-
-    utilityKeys.forEach((utilityKey) => {
-      delete migratedProfile[utilityKey]
-    })
-
-    migratedProfiles[gameKey] = migratedProfile
-  })
+  const migratedProfiles = Object.fromEntries(
+    Object.entries(profiles).map(([gameKey, profileEntry]) => [
+      gameKey,
+      normalizeStoredProfileSet(profileEntry, utilityKeys)
+    ])
+  )
 
   store.set('customSlots', customSlots)
   store.set('profiles', migratedProfiles)
   store.set('profileUtilityOrderMigrated', true)
+  store.set('profileSetsMigrated', true)
 }
 
 function isRunningExePath(processNames: Set<string>, appPath: string) {
@@ -665,13 +822,15 @@ function getGenericIconFingerprint() {
 // INVARIANT: an exe name can only be "running" for one gameKey at a time.
 // Never match by exe name globally without deduplicating across all gameKeys.
 async function getTrackedRunningApps(processNames: Set<string>) {
-  const profiles = store.get('profiles') as Record<string, StoredProfile> | undefined
+  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const appPaths = store.get('appPaths') as Record<string, string> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
   const trackedApps: { path: string; name: string; gameKey: string; tracked: boolean }[] = []
   const seen = new Set<string>()
 
-  Object.entries(profiles || {}).forEach(([gameKey, profile]) => {
+  Object.entries(profiles || {}).forEach(([gameKey, profileEntry]) => {
+    const profile = getActiveStoredProfile(profileEntry)
+
     if (profile?.trackingEnabled === false) {
       return
     }
@@ -855,6 +1014,10 @@ ipcMain.handle('get-running-apps', async () => {
 
 ipcMain.handle('kill-launched-apps', (_event, gameKey?: string) => {
   return killLaunchedApps(gameKey)
+})
+
+ipcMain.handle('kill-profile-apps', (_event, gameKey: string, appPathsToKill: string[]) => {
+  return killProfileApps(gameKey, Array.isArray(appPathsToKill) ? appPathsToKill : [])
 })
 
 ipcMain.handle('install-update', async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ const store = new Store({
     autoCheckUpdates:  { type: 'boolean', default: true },
     zoomFactor:       { type: 'number',  default: 1.0 },
     windowBounds:      { type: 'object',  default: {} },
+    profileUtilityOrderMigrated: { type: 'boolean', default: false },
     migrated:     { type: 'boolean', default: false },
   }
 })
@@ -41,12 +42,19 @@ let genericIconFingerprintPromise: Promise<string | null> | null = null
 const UTILITY_COMPANION_PROCESS_NAMES: Record<string, string[]> = {
   garage61: ['Garage61 telemetry agent.exe']
 }
+const BUILT_IN_UTILITY_KEYS = ['simhub', 'crewchief', 'tradingpaints', 'garage61', 'secondmonitor']
 
 autoUpdater.autoDownload = false
 
 interface StoredProfile extends Record<string, unknown> {
+  utilities?: StoredProfileUtility[]
   trackingEnabled?: boolean
   trackedProcessPaths?: string[]
+}
+
+interface StoredProfileUtility {
+  id: string
+  enabled: boolean
 }
 
 interface WindowBounds {
@@ -207,7 +215,7 @@ function getProfileCompanionProcessNames(gameKey?: string) {
     }
 
     Object.entries(UTILITY_COMPANION_PROCESS_NAMES).forEach(([utilityKey, processNames]) => {
-      if (profile?.[utilityKey] === true) {
+      if (isUtilityEnabled(profile, utilityKey)) {
         processNames.forEach((processName) => companionNames.add(processName.toLowerCase()))
       }
     })
@@ -357,6 +365,7 @@ app.on('before-quit', () => {
 })
 
 app.whenReady().then(() => {
+  migrateLegacyProfilesToUtilityOrder()
   createTray()
   createWindow()
 })
@@ -381,6 +390,131 @@ function getLaunchDelayMs() {
 
 function getExeName(filePath: string) {
   return path.basename(filePath).toLowerCase()
+}
+
+function isStoredProfileUtility(value: unknown): value is StoredProfileUtility {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const utility = value as Record<string, unknown>
+  return typeof utility.id === 'string' && typeof utility.enabled === 'boolean'
+}
+
+function getCustomSlotNumber(key: string) {
+  const match = key.match(/^customapp(\d+)$/)
+  return match ? Number(match[1]) : null
+}
+
+function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
+  let highestSlot = 0
+
+  records.forEach((record) => {
+    Object.entries(record || {}).forEach(([key, value]) => {
+      const slotNumber = getCustomSlotNumber(key)
+
+      if (slotNumber !== null && (value === true || (typeof value === 'string' && value.trim().length > 0))) {
+        highestSlot = Math.max(highestSlot, slotNumber)
+      }
+
+      if (key === 'utilities' && Array.isArray(value)) {
+        value.filter(isStoredProfileUtility).forEach((utility) => {
+          const utilitySlotNumber = getCustomSlotNumber(utility.id)
+
+          if (utility.enabled && utilitySlotNumber !== null) {
+            highestSlot = Math.max(highestSlot, utilitySlotNumber)
+          }
+        })
+      }
+    })
+  })
+
+  return highestSlot
+}
+
+function getUtilityKeys(customSlots: unknown) {
+  const slotCount = typeof customSlots === 'number' && Number.isFinite(customSlots)
+    ? Math.max(1, Math.floor(customSlots))
+    : 1
+
+  return [
+    ...BUILT_IN_UTILITY_KEYS,
+    ...Array.from({ length: slotCount }, (_value, index) => `customapp${index + 1}`)
+  ]
+}
+
+function getEnabledUtilityKeys(profile: StoredProfile | undefined) {
+  if (!profile) {
+    return []
+  }
+
+  if (Array.isArray(profile.utilities)) {
+    return profile.utilities
+      .filter((utility) => isStoredProfileUtility(utility) && utility.enabled)
+      .map((utility) => utility.id)
+  }
+
+  return Object.entries(profile)
+    .filter(([_key, value]) => value === true)
+    .map(([key]) => key)
+}
+
+function isUtilityEnabled(profile: StoredProfile | undefined, utilityKey: string) {
+  if (!profile) {
+    return false
+  }
+
+  if (Array.isArray(profile.utilities)) {
+    return profile.utilities.some((utility) => (
+      isStoredProfileUtility(utility) && utility.id === utilityKey && utility.enabled
+    ))
+  }
+
+  return profile[utilityKey] === true
+}
+
+function migrateLegacyProfilesToUtilityOrder() {
+  if (store.get('profileUtilityOrderMigrated') === true) {
+    return
+  }
+
+  const profiles = store.get('profiles') as Record<string, StoredProfile> | undefined
+  const appPaths = store.get('appPaths') as Record<string, string> | undefined
+
+  if (!profiles || Object.keys(profiles).length === 0) {
+    store.set('profileUtilityOrderMigrated', true)
+    return
+  }
+
+  const savedCustomSlots = store.get('customSlots')
+  const customSlots = Math.max(
+    typeof savedCustomSlots === 'number' && Number.isFinite(savedCustomSlots) ? savedCustomSlots : 1,
+    getHighestCustomSlot(appPaths, ...Object.values(profiles))
+  )
+  const utilityKeys = getUtilityKeys(customSlots)
+  const migratedProfiles: Record<string, StoredProfile> = {}
+
+  Object.entries(profiles).forEach(([gameKey, profile]) => {
+    const migratedProfile: StoredProfile = {
+      ...profile,
+      utilities: Array.isArray(profile.utilities)
+        ? profile.utilities.filter(isStoredProfileUtility)
+        : utilityKeys.map((utilityKey) => ({
+          id: utilityKey,
+          enabled: profile[utilityKey] === true
+        }))
+    }
+
+    utilityKeys.forEach((utilityKey) => {
+      delete migratedProfile[utilityKey]
+    })
+
+    migratedProfiles[gameKey] = migratedProfile
+  })
+
+  store.set('customSlots', customSlots)
+  store.set('profiles', migratedProfiles)
+  store.set('profileUtilityOrderMigrated', true)
 }
 
 function isRunningExePath(processNames: Set<string>, appPath: string) {
@@ -544,9 +678,9 @@ async function getTrackedRunningApps(processNames: Set<string>) {
 
     const pathsToTrack = [
       gamePaths?.[gameKey],
-      ...Object.entries(profile || {})
-        .filter(([profileKey, value]) => value === true && isValidExePath(appPaths?.[profileKey]))
-        .map(([profileKey]) => appPaths![profileKey]),
+      ...getEnabledUtilityKeys(profile)
+        .filter((profileKey) => isValidExePath(appPaths?.[profileKey]))
+        .map((profileKey) => appPaths![profileKey]),
       ...(Array.isArray(profile?.trackedProcessPaths) ? profile.trackedProcessPaths : [])
     ].filter(isValidExePath)
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,42 @@ const store = new Store({
   }
 })
 
+const CONFIG_FILE_NAME = 'simlauncher-config.json'
+const EXPECTED_CONFIG_KEYS = new Set([
+  'appPaths',
+  'gamePaths',
+  'profiles',
+  'appNames',
+  'customSlots',
+  'accentPreset',
+  'accentCustom',
+  'accentBgTint',
+  'focusActiveTitle',
+  'launchDelayMs',
+  'startWithWindows',
+  'startMinimized',
+  'minimizeToTray',
+  'autoCheckUpdates',
+  'zoomFactor',
+  'windowBounds',
+  'profileUtilityOrderMigrated',
+  'profileSetsMigrated',
+  'migrated'
+])
+const OBJECT_CONFIG_KEYS = new Set(['appPaths', 'gamePaths', 'profiles', 'appNames', 'windowBounds'])
+const STRING_CONFIG_KEYS = new Set(['accentPreset', 'accentCustom'])
+const BOOLEAN_CONFIG_KEYS = new Set([
+  'accentBgTint',
+  'focusActiveTitle',
+  'startWithWindows',
+  'startMinimized',
+  'minimizeToTray',
+  'autoCheckUpdates',
+  'profileUtilityOrderMigrated',
+  'profileSetsMigrated',
+  'migrated'
+])
+
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuitting = false
@@ -117,6 +153,78 @@ function sendToRenderer(channel: string, payload: unknown) {
   }
 
   mainWindow.webContents.send(channel, payload)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function validateImportedConfig(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error('Config file must contain a JSON object.')
+  }
+
+  const keys = Object.keys(value)
+
+  if (keys.length === 0) {
+    throw new Error('Config file is empty.')
+  }
+
+  const unexpectedKeys = keys.filter((key) => !EXPECTED_CONFIG_KEYS.has(key))
+
+  if (unexpectedKeys.length > 0) {
+    throw new Error(`Config file contains unsupported keys: ${unexpectedKeys.join(', ')}`)
+  }
+
+  if (!keys.some((key) => EXPECTED_CONFIG_KEYS.has(key))) {
+    throw new Error('Config file does not contain SimLauncher settings.')
+  }
+
+  keys.forEach((key) => {
+    const setting = value[key]
+
+    if (OBJECT_CONFIG_KEYS.has(key) && !isRecord(setting)) {
+      throw new Error(`Config value "${key}" must be an object.`)
+    }
+
+    if (STRING_CONFIG_KEYS.has(key) && typeof setting !== 'string') {
+      throw new Error(`Config value "${key}" must be a string.`)
+    }
+
+    if (BOOLEAN_CONFIG_KEYS.has(key) && typeof setting !== 'boolean') {
+      throw new Error(`Config value "${key}" must be a boolean.`)
+    }
+
+    if (key === 'customSlots') {
+      if (typeof setting !== 'number' || !Number.isFinite(setting) || setting < 1) {
+        throw new Error('Config value "customSlots" must be a number greater than or equal to 1.')
+      }
+    }
+
+    if (key === 'launchDelayMs') {
+      if (typeof setting !== 'number' || !Number.isFinite(setting) || setting < 0 || setting > 5000) {
+        throw new Error('Config value "launchDelayMs" must be a number from 0 to 5000.')
+      }
+    }
+
+    if (key === 'zoomFactor') {
+      if (typeof setting !== 'number' || !Number.isFinite(setting) || setting <= 0) {
+        throw new Error('Config value "zoomFactor" must be a positive number.')
+      }
+    }
+  })
+
+  return true
+}
+
+function applyRuntimeConfigSettings() {
+  const startWithWindows = store.get('startWithWindows') as boolean
+  app.setLoginItemSettings({ openAtLogin: !!startWithWindows })
+
+  const zoomFactor = store.get('zoomFactor')
+  if (typeof zoomFactor === 'number' && Number.isFinite(zoomFactor) && zoomFactor > 0) {
+    mainWindow?.webContents.setZoomFactor(zoomFactor)
+  }
 }
 
 function getAppIconPath() {
@@ -942,6 +1050,66 @@ ipcMain.handle('launch-profile', async (event, gameKey: string, profileApps: str
       launchBlockedUntil = Date.now() + POST_LAUNCH_BLOCK_MS
     }
     activeLaunches.delete(gameKey)
+  }
+})
+
+// ----------------------------------------------------------------
+// CONFIG EXPORT / IMPORT
+// ----------------------------------------------------------------
+
+ipcMain.handle('export-config', async () => {
+  try {
+    const options = {
+      title: 'Export SimLauncher Config',
+      defaultPath: CONFIG_FILE_NAME,
+      filters: [{ name: 'JSON Files', extensions: ['json'] }]
+    }
+    const result = mainWindow && !mainWindow.isDestroyed()
+      ? await dialog.showSaveDialog(mainWindow, options)
+      : await dialog.showSaveDialog(options)
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, canceled: true }
+    }
+
+    await fs.promises.writeFile(result.filePath, JSON.stringify(store.store, null, 2), 'utf8')
+    return { success: true, filePath: result.filePath }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error('Failed to export config:', err)
+    return { success: false, error: message }
+  }
+})
+
+ipcMain.handle('import-config', async () => {
+  try {
+    const options = {
+      title: 'Import SimLauncher Config',
+      properties: ['openFile'] as const,
+      filters: [{ name: 'JSON Files', extensions: ['json'] }]
+    }
+    const result = mainWindow && !mainWindow.isDestroyed()
+      ? await dialog.showOpenDialog(mainWindow, options)
+      : await dialog.showOpenDialog(options)
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return { success: false, canceled: true }
+    }
+
+    const rawConfig = await fs.promises.readFile(result.filePaths[0], 'utf8')
+    const parsedConfig = JSON.parse(rawConfig) as unknown
+    validateImportedConfig(parsedConfig)
+
+    store.clear()
+    store.set(parsedConfig)
+    migrateProfilesToNamedSets()
+    applyRuntimeConfigSettings()
+
+    return { success: true, filePath: result.filePaths[0] }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error('Failed to import config:', err)
+    return { success: false, error: message }
   }
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ const store = new Store({
     gamePaths:    { type: 'object',  default: {} },
     profiles:     { type: 'object',  default: {} },
     appNames:     { type: 'object',  default: {} },
+    customSlots:  { type: 'number',  default: 1, minimum: 1 },
     accentPreset: { type: 'string',  default: '' },
     accentCustom: { type: 'string',  default: '' },
     accentBgTint: { type: 'boolean', default: false },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -927,9 +927,81 @@ function getGenericIconFingerprint() {
   return genericIconFingerprintPromise
 }
 
-// INVARIANT: an exe name can only be "running" for one gameKey at a time.
-// Never match by exe name globally without deduplicating across all gameKeys.
-async function getTrackedRunningApps(processNames: Set<string>) {
+function getProfileTrackablePaths(
+  gameKey: string,
+  profile: StoredProfile | undefined,
+  appPaths: Record<string, string> | undefined,
+  gamePaths: Record<string, string> | undefined
+) {
+  const trackablePaths = [
+    gamePaths?.[gameKey],
+    ...getEnabledUtilityKeys(profile)
+      .filter((profileKey) => isValidExePath(appPaths?.[profileKey]))
+      .map((profileKey) => appPaths![profileKey]),
+    ...(Array.isArray(profile?.trackedProcessPaths) ? profile.trackedProcessPaths : [])
+  ].filter(isValidExePath)
+  const seen = new Set<string>()
+
+  return trackablePaths.filter((trackablePath) => {
+    const key = trackablePath.toLowerCase()
+
+    if (seen.has(key)) {
+      return false
+    }
+
+    seen.add(key)
+    return true
+  })
+}
+
+function getExternallyAdoptableGameKeys(
+  processNames: Set<string>,
+  profiles: Record<string, StoredProfileEntry> | undefined,
+  gamePaths: Record<string, string> | undefined,
+  launchedGameKeys: Set<string>
+) {
+  const gameExeOwners = new Map<string, Set<string>>()
+
+  Object.entries(profiles || {}).forEach(([gameKey]) => {
+    const gamePath = gamePaths?.[gameKey]
+
+    if (!isValidExePath(gamePath)) {
+      return
+    }
+
+    const exeName = getExeName(gamePath)
+    const owners = gameExeOwners.get(exeName) || new Set<string>()
+    owners.add(gameKey)
+    gameExeOwners.set(exeName, owners)
+  })
+
+  const adoptableGameKeys = new Set<string>()
+
+  Object.entries(profiles || {}).forEach(([gameKey]) => {
+    if (launchedGameKeys.has(gameKey)) {
+      return
+    }
+
+    const gamePath = gamePaths?.[gameKey]
+
+    if (!isValidExePath(gamePath)) {
+      return
+    }
+
+    const exeName = getExeName(gamePath)
+    const owners = gameExeOwners.get(exeName)
+
+    if (owners?.size === 1 && processNames.has(exeName)) {
+      adoptableGameKeys.add(gameKey)
+    }
+  })
+
+  return adoptableGameKeys
+}
+
+// INVARIANT: manual companion utilities are only surfaced when the owning game is
+// already launched by SimLauncher or its configured game exe is externally running.
+async function getTrackedRunningApps(processNames: Set<string>, adoptedOrLaunchedGameKeys: Set<string>) {
   const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const appPaths = store.get('appPaths') as Record<string, string> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
@@ -937,19 +1009,17 @@ async function getTrackedRunningApps(processNames: Set<string>) {
   const seen = new Set<string>()
 
   Object.entries(profiles || {}).forEach(([gameKey, profileEntry]) => {
+    if (!adoptedOrLaunchedGameKeys.has(gameKey)) {
+      return
+    }
+
     const profile = getActiveStoredProfile(profileEntry)
 
     if (profile?.trackingEnabled === false) {
       return
     }
 
-    const pathsToTrack = [
-      gamePaths?.[gameKey],
-      ...getEnabledUtilityKeys(profile)
-        .filter((profileKey) => isValidExePath(appPaths?.[profileKey]))
-        .map((profileKey) => appPaths![profileKey]),
-      ...(Array.isArray(profile?.trackedProcessPaths) ? profile.trackedProcessPaths : [])
-    ].filter(isValidExePath)
+    const pathsToTrack = getProfileTrackablePaths(gameKey, profile, appPaths, gamePaths)
 
     pathsToTrack.forEach((trackedPath) => {
       const processName = getExeName(trackedPath)
@@ -1167,12 +1237,13 @@ ipcMain.handle('get-running-apps', async () => {
   }))
   const launchedKeys = new Set(launchedApps.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`))
   const launchedExeNames = new Set(launchedApps.map((appProcess) => path.basename(appProcess.path).toLowerCase()))
-  // INVARIANT: only surface tracked apps for gameKeys that SimLauncher actually launched.
-  // Prevents manually-launched utility apps from triggering a false "running" state. (refs #100)
+  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
+  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
   const launchedGameKeys = new Set(launchedApps.map((appProcess) => appProcess.gameKey))
-  const trackedApps = (await getTrackedRunningApps(processNames)).filter(
+  const adoptedGameKeys = getExternallyAdoptableGameKeys(processNames, profiles, gamePaths, launchedGameKeys)
+  const adoptedOrLaunchedGameKeys = new Set([...launchedGameKeys, ...adoptedGameKeys])
+  const trackedApps = (await getTrackedRunningApps(processNames, adoptedOrLaunchedGameKeys)).filter(
     (appProcess) =>
-      launchedGameKeys.has(appProcess.gameKey) &&
       !launchedKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`) &&
       !launchedExeNames.has(path.basename(appProcess.path).toLowerCase())
   )

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,10 @@ const EXPECTED_CONFIG_KEYS = new Set([
   'profileSetsMigrated',
   'migrated'
 ])
+const LEGACY_CONFIG_KEYS = new Set([
+  'killOnClose'
+])
+const IMPORTABLE_CONFIG_KEYS = new Set([...EXPECTED_CONFIG_KEYS, ...LEGACY_CONFIG_KEYS])
 const OBJECT_CONFIG_KEYS = new Set(['appPaths', 'gamePaths', 'profiles', 'appNames', 'windowBounds'])
 const STRING_CONFIG_KEYS = new Set(['accentPreset', 'accentCustom'])
 const BOOLEAN_CONFIG_KEYS = new Set([
@@ -63,6 +67,9 @@ const BOOLEAN_CONFIG_KEYS = new Set([
   'profileUtilityOrderMigrated',
   'profileSetsMigrated',
   'migrated'
+])
+const LEGACY_BOOLEAN_CONFIG_KEYS = new Set([
+  'killOnClose'
 ])
 
 let mainWindow: BrowserWindow | null = null
@@ -170,7 +177,7 @@ function validateImportedConfig(value: unknown): value is Record<string, unknown
     throw new Error('Config file is empty.')
   }
 
-  const unexpectedKeys = keys.filter((key) => !EXPECTED_CONFIG_KEYS.has(key))
+  const unexpectedKeys = keys.filter((key) => !IMPORTABLE_CONFIG_KEYS.has(key))
 
   if (unexpectedKeys.length > 0) {
     throw new Error(`Config file contains unsupported keys: ${unexpectedKeys.join(', ')}`)
@@ -195,6 +202,10 @@ function validateImportedConfig(value: unknown): value is Record<string, unknown
       throw new Error(`Config value "${key}" must be a boolean.`)
     }
 
+    if (LEGACY_BOOLEAN_CONFIG_KEYS.has(key) && typeof setting !== 'boolean') {
+      throw new Error(`Config value "${key}" must be a boolean.`)
+    }
+
     if (key === 'customSlots') {
       if (typeof setting !== 'number' || !Number.isFinite(setting) || setting < 1) {
         throw new Error('Config value "customSlots" must be a number greater than or equal to 1.')
@@ -215,6 +226,18 @@ function validateImportedConfig(value: unknown): value is Record<string, unknown
   })
 
   return true
+}
+
+function getSupportedConfigValues(config: Record<string, unknown>) {
+  const supportedConfig: Record<string, unknown> = {}
+
+  Object.entries(config).forEach(([key, value]) => {
+    if (EXPECTED_CONFIG_KEYS.has(key)) {
+      supportedConfig[key] = value
+    }
+  })
+
+  return supportedConfig
 }
 
 function applyRuntimeConfigSettings() {
@@ -1145,7 +1168,7 @@ ipcMain.handle('export-config', async () => {
       return { success: false, canceled: true }
     }
 
-    await fs.promises.writeFile(result.filePath, JSON.stringify(store.store, null, 2), 'utf8')
+    await fs.promises.writeFile(result.filePath, JSON.stringify(getSupportedConfigValues(store.store), null, 2), 'utf8')
     return { success: true, filePath: result.filePath }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
@@ -1172,9 +1195,10 @@ ipcMain.handle('import-config', async () => {
     const rawConfig = await fs.promises.readFile(result.filePaths[0], 'utf8')
     const parsedConfig = JSON.parse(rawConfig) as unknown
     validateImportedConfig(parsedConfig)
+    const supportedConfig = getSupportedConfigValues(parsedConfig)
 
     store.clear()
-    store.set(parsedConfig)
+    store.set(supportedConfig)
     migrateProfilesToNamedSets()
     applyRuntimeConfigSettings()
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -33,6 +33,7 @@ declare global {
       close: () => Promise<void>
       getRunningApps: () => Promise<RunningApp[]>
       killLaunchedApps: (gameKey?: string) => Promise<void>
+      killProfileApps: (gameKey: string, appPaths: string[]) => Promise<void>
       onUpdateAvailable: (cb: (info: any) => void) => Unsubscribe
       onUpdateDownloaded: (cb: (info: any) => void) => Unsubscribe
       onUpdateNotAvailable: (cb: (info: any) => void) => Unsubscribe

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -22,6 +22,13 @@ interface LaunchResult {
   skippedCount?: number
 }
 
+interface ConfigFileResult {
+  success: boolean
+  canceled?: boolean
+  error?: string
+  filePath?: string
+}
+
 declare global {
   interface Window {
     electronAPI: {
@@ -43,6 +50,8 @@ declare global {
       checkForUpdates: () => Promise<unknown>
       storeGet: (key: string) => Promise<unknown>
       storeSet: (key: string, value: unknown) => Promise<void>
+      exportConfig: () => Promise<ConfigFileResult>
+      importConfig: () => Promise<ConfigFileResult>
       setLoginItem: (openAtLogin: boolean) => Promise<void>
       setZoom: (factor: number) => Promise<void>
       getAssetData: (filename: string) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // process monitoring
   getRunningApps:   () => ipcRenderer.invoke('get-running-apps'),
   killLaunchedApps: (gameKey?: string) => ipcRenderer.invoke('kill-launched-apps', gameKey),
+  killProfileApps:  (gameKey: string, appPaths: string[]) => ipcRenderer.invoke('kill-profile-apps', gameKey, appPaths),
 
   // updater
   onUpdateAvailable: (cb: (info: any) => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,6 +56,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // electron-store
   storeGet: (key: string) => ipcRenderer.invoke('store-get', key),
   storeSet: (key: string, value: unknown) => ipcRenderer.invoke('store-set', key, value),
+  exportConfig: () => ipcRenderer.invoke('export-config'),
+  importConfig: () => ipcRenderer.invoke('import-config'),
   getAssetData: (filename: string) => ipcRenderer.invoke('get-asset-data', filename),
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
   getVersion: () => ipcRenderer.invoke('get-version')

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,11 +14,20 @@ import {
   type GameProfile
 } from './lib/config'
 
+const CONFIG_IMPORT_WARNING_KEY = 'simlauncher-config-import-warning'
 
 export default function App() {
   const [view, setView] = useState<'games' | 'settings'>('games')
   const [bgTinted, setBgTinted] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
+  const [showImportWarning, setShowImportWarning] = useState(false)
+
+  useEffect(() => {
+    if (window.sessionStorage.getItem(CONFIG_IMPORT_WARNING_KEY) === '1') {
+      window.sessionStorage.removeItem(CONFIG_IMPORT_WARNING_KEY)
+      setShowImportWarning(true)
+    }
+  }, [])
 
   useEffect(() => {
     // One-time migration from localStorage (vanilla app) to electron-store
@@ -126,6 +135,31 @@ export default function App() {
         <div className="absolute top-0 left-0 w-full z-20 header-glass">
           <WindowControls view={view} onNavigate={setView} updateInfo={updateInfo} />
         </div>
+
+        {showImportWarning && (
+          <div className="absolute left-4 right-4 top-16 z-30 animate-fade-slide">
+            <div className="mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--warning-border) bg-(--warning-surface) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040]">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+                <path d="M12 9v4" />
+                <path d="M12 17h.01" />
+              </svg>
+              <span className="min-w-0 flex-1">Config imported. Executable paths from your previous device may need to be updated.</span>
+              <button
+                type="button"
+                onClick={() => setShowImportWarning(false)}
+                className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-lg text-(--warning-text) transition-colors hover:bg-white/10 active:scale-[0.98]"
+                aria-label="Dismiss import warning"
+                title="Dismiss"
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        )}
 
         <main className="h-full relative overflow-hidden">
           {/* Games View */}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,7 +3,13 @@ import { NotifyProvider } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
-import { DEFAULT_ACCENT_COLOR, getHighestCustomSlot } from './lib/config'
+import {
+  DEFAULT_ACCENT_COLOR,
+  getHighestCustomSlot,
+  getUtilities,
+  migrateProfileToUtilityOrder,
+  type GameProfile
+} from './lib/config'
 
 
 export default function App() {
@@ -39,16 +45,25 @@ export default function App() {
           if (name) appNames[key] = name
         }
         if (Object.keys(appNames).length > 0) await window.electronAPI.storeSet('appNames', appNames)
-        const migratedCustomSlots = getHighestCustomSlot(appPaths, appNames)
-        if (migratedCustomSlots > 1) await window.electronAPI.storeSet('customSlots', migratedCustomSlots)
 
         const gameKeys = ['ac', 'acc', 'acevo', 'acrally', 'ams', 'ams2', 'beamng', 'dcsw', 'dirtrally', 'dirtrally2', 'eawrc', 'f124', 'f125', 'iracing', 'lmu', 'pmr', 'raceroom', 'rbr', 'rennsport', 'rf1', 'rf2']
-        const profiles: Record<string, unknown> = {}
+        const profiles: Record<string, GameProfile> = {}
         for (const key of gameKeys) {
           const raw = localStorage.getItem(`profile_${key}`)
           if (raw) profiles[key] = JSON.parse(raw)
         }
-        if (Object.keys(profiles).length > 0) await window.electronAPI.storeSet('profiles', profiles)
+        const migratedCustomSlots = getHighestCustomSlot(appPaths, appNames, ...Object.values(profiles))
+        const utilities = getUtilities(migratedCustomSlots)
+        const migratedProfiles = Object.fromEntries(
+          Object.entries(profiles).map(([gameKey, profile]) => [
+            gameKey,
+            migrateProfileToUtilityOrder(profile, utilities)
+          ])
+        )
+
+        if (migratedCustomSlots > 1) await window.electronAPI.storeSet('customSlots', migratedCustomSlots)
+        if (Object.keys(migratedProfiles).length > 0) await window.electronAPI.storeSet('profiles', migratedProfiles)
+        await window.electronAPI.storeSet('profileUtilityOrderMigrated', true)
 
         await window.electronAPI.storeSet('migrated', true)
       } catch (err) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,7 +3,7 @@ import { NotifyProvider } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
-import { DEFAULT_ACCENT_COLOR } from './lib/config'
+import { DEFAULT_ACCENT_COLOR, getHighestCustomSlot } from './lib/config'
 
 
 export default function App() {
@@ -20,7 +20,11 @@ export default function App() {
 
         const appPathsRaw = localStorage.getItem('simLauncherAppPaths')
         const gamePathsRaw = localStorage.getItem('simLauncherGamePaths')
-        if (appPathsRaw) await window.electronAPI.storeSet('appPaths', JSON.parse(appPathsRaw))
+        let appPaths: Record<string, unknown> = {}
+        if (appPathsRaw) {
+          appPaths = JSON.parse(appPathsRaw)
+          await window.electronAPI.storeSet('appPaths', appPaths)
+        }
         if (gamePathsRaw) await window.electronAPI.storeSet('gamePaths', JSON.parse(gamePathsRaw))
 
         const accentPreset = localStorage.getItem('simLauncherAccentPreset')
@@ -35,6 +39,8 @@ export default function App() {
           if (name) appNames[key] = name
         }
         if (Object.keys(appNames).length > 0) await window.electronAPI.storeSet('appNames', appNames)
+        const migratedCustomSlots = getHighestCustomSlot(appPaths, appNames)
+        if (migratedCustomSlots > 1) await window.electronAPI.storeSet('customSlots', migratedCustomSlots)
 
         const gameKeys = ['ac', 'acc', 'acevo', 'acrally', 'ams', 'ams2', 'beamng', 'dcsw', 'dirtrally', 'dirtrally2', 'eawrc', 'f124', 'f125', 'iracing', 'lmu', 'pmr', 'raceroom', 'rbr', 'rennsport', 'rf1', 'rf2']
         const profiles: Record<string, unknown> = {}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,9 +5,12 @@ import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
 import {
   DEFAULT_ACCENT_COLOR,
+  DEFAULT_PROFILE_ID,
+  createDefaultProfile,
   getHighestCustomSlot,
   getUtilities,
   migrateProfileToUtilityOrder,
+  type GameProfileSet,
   type GameProfile
 } from './lib/config'
 
@@ -54,12 +57,15 @@ export default function App() {
         }
         const migratedCustomSlots = getHighestCustomSlot(appPaths, appNames, ...Object.values(profiles))
         const utilities = getUtilities(migratedCustomSlots)
-        const migratedProfiles = Object.fromEntries(
+        const migratedProfiles: Record<string, GameProfileSet> = Object.fromEntries(
           Object.entries(profiles).map(([gameKey, profile]) => [
             gameKey,
-            migrateProfileToUtilityOrder(profile, utilities)
+            {
+              activeProfileId: DEFAULT_PROFILE_ID,
+              profiles: [createDefaultProfile(migrateProfileToUtilityOrder(profile, utilities))]
+            }
           ])
-        )
+        ) as Record<string, GameProfileSet>
 
         if (migratedCustomSlots > 1) await window.electronAPI.storeSet('customSlots', migratedCustomSlots)
         if (Object.keys(migratedProfiles).length > 0) await window.electronAPI.storeSet('profiles', migratedProfiles)

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,111 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react'
+
+interface Props {
+  children?: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+    error: null
+  }
+
+  public static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo)
+  }
+
+  private handleReload = () => {
+    window.location.reload()
+  }
+
+  private handleCopyError = () => {
+    if (this.state.error) {
+      navigator.clipboard.writeText(this.state.error.stack || this.state.error.message)
+      // We could add a toast here, but since the app is crashed, 
+      // we'll just rely on the button text changing temporarily if we wanted to be fancy.
+      // For now, simple clipboard is enough.
+    }
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-(--bg-gradient) overflow-hidden p-8">
+          {/* Decorative background glow */}
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-(--accent-glow) rounded-full blur-[120px] pointer-events-none opacity-50" />
+          
+          <div className="relative glass-surface-elevated max-w-2xl w-full rounded-2xl p-10 flex flex-col items-center gap-8 shadow-2xl animate-fade-slide">
+            {/* Warning Icon Container */}
+            <div className="relative">
+              <div className="absolute inset-0 bg-red-500/20 rounded-full blur-2xl animate-pulse" />
+              <div className="relative h-20 w-20 flex items-center justify-center bg-red-500/10 border border-red-500/30 rounded-2xl text-red-400">
+                <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                  <line x1="12" y1="9" x2="12" y2="13" />
+                  <line x1="12" y1="17" x2="12.01" y2="17" />
+                </svg>
+              </div>
+            </div>
+
+            {/* Text Content */}
+            <div className="text-center space-y-3">
+              <h1 className="text-3xl font-black italic tracking-tighter uppercase">
+                Something went <span className="text-red-400">wrong</span>
+              </h1>
+              <p className="text-(--text-secondary) max-w-md mx-auto">
+                The application encountered an unexpected error and needs to restart.
+                We've captured the technical details below.
+              </p>
+            </div>
+
+            {/* Error Details Recess */}
+            <div className="w-full glass-recessed rounded-xl p-4 font-mono text-[11px] text-red-300/80 overflow-auto max-h-32 custom-scrollbar">
+              <div className="font-bold mb-1 uppercase tracking-widest text-[9px] opacity-50">Error Name</div>
+              <div className="mb-3">{this.state.error?.name || 'Unknown Error'}</div>
+              <div className="font-bold mb-1 uppercase tracking-widest text-[9px] opacity-50">Message</div>
+              <div className="whitespace-pre-wrap">{this.state.error?.message || 'No message available'}</div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex flex-col sm:flex-row gap-3 w-full">
+              <button
+                type="button"
+                onClick={this.handleReload}
+                className="flex-1 cursor-pointer bg-(--accent) hover:bg-(--purple-solid-hover) text-white font-bold py-3 px-6 rounded-xl shadow-[0_0_20px_-5px_var(--accent-glow)] active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M23 4v6h-6" />
+                  <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                </svg>
+                Reload Application
+              </button>
+              
+              <button
+                type="button"
+                onClick={this.handleCopyError}
+                className="flex-1 cursor-pointer glass-surface hover:bg-(--glass-bg-elevated) text-(--text-secondary) hover:text-(--text-primary) font-bold py-3 px-6 rounded-xl active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+                Copy Details
+              </button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { GAMES, getUtilities, resolveCustomSlots, type Game, type Profiles } from '../lib/config'
+import { GAMES, getEnabledProfileUtilities, getUtilities, resolveCustomSlots, type Game, type Profiles } from '../lib/config'
 import { ProfileEditor } from './ProfileEditor'
 import { useNotify } from './Notify'
 
@@ -64,19 +64,18 @@ function GameRow({
     const pathsToLaunch: string[] = []
     let appCount = 0
 
-    // Queue utilities first
-    utilities.forEach((u) => {
-      if (profile[u.key] === true && appPaths[u.key]) {
-        pathsToLaunch.push(appPaths[u.key])
-        appCount++
-      }
-    })
-
-    // Queue game last
+    // Queue game first, then ordered utilities.
     if (profile.launchAutomatically !== false && configuredGamePath) {
       pathsToLaunch.push(configuredGamePath)
       appCount++
     }
+
+    getEnabledProfileUtilities(profile, utilities).forEach((utility) => {
+      if (appPaths[utility.id]) {
+        pathsToLaunch.push(appPaths[utility.id])
+        appCount++
+      }
+    })
 
     return { profile, pathsToLaunch, appCount }
   }

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -381,7 +381,7 @@ function GameRow({
   const activeProfile = getActiveGameProfile(profileSet)
 
   return (
-    <div className={`flex flex-col gap-2 transition-opacity duration-300 ${isDimmed ? 'opacity-45' : 'opacity-100'}`} ref={rowRef}>
+    <div className={`relative flex flex-col gap-2 transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`} ref={rowRef}>
       <div className="glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 transition-all duration-300 hover:bg-(--glass-bg-elevated) hover:border-[rgba(255,255,255,0.1)]">
         <div className="flex items-center gap-5">
           <div className="relative">

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -55,7 +55,10 @@ function GameRow({
   const [failedRunningIcons, setFailedRunningIcons] = useState<Record<string, true>>({})
   const [profileSet, setProfileSet] = useState<GameProfileSet>(() => normalizeGameProfileSet(undefined))
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
+  const [newProfileFormOpen, setNewProfileFormOpen] = useState(false)
+  const [newProfileName, setNewProfileName] = useState('')
   const profileMenuRef = useRef<HTMLDivElement | null>(null)
+  const newProfileInputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
     async function resolveIcon() {
@@ -69,12 +72,16 @@ function GameRow({
 
   useEffect(() => {
     if (!profileMenuOpen) {
+      setNewProfileFormOpen(false)
+      setNewProfileName('')
       return
     }
 
     const handlePointerDown = (event: PointerEvent) => {
       if (!profileMenuRef.current?.contains(event.target as Node)) {
         setProfileMenuOpen(false)
+        setNewProfileFormOpen(false)
+        setNewProfileName('')
       }
     }
 
@@ -82,6 +89,14 @@ function GameRow({
 
     return () => window.removeEventListener('pointerdown', handlePointerDown)
   }, [profileMenuOpen])
+
+  useEffect(() => {
+    if (!profileMenuOpen || !newProfileFormOpen) {
+      return
+    }
+
+    newProfileInputRef.current?.focus()
+  }, [profileMenuOpen, newProfileFormOpen])
 
   const loadProfileSet = useCallback(async () => {
     const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
@@ -163,10 +178,10 @@ function GameRow({
     setProfileSet(nextProfileSet)
   }
 
-  const handleCreateProfile = async () => {
-    const name = window.prompt('New profile name')
+  const handleCreateProfile = async (name: string) => {
+    const trimmedName = name.trim()
 
-    if (!name || name.trim().length === 0) {
+    if (trimmedName.length === 0) {
       return
     }
 
@@ -175,7 +190,7 @@ function GameRow({
     const newProfile: NamedGameProfile = {
       ...JSON.parse(JSON.stringify(activeProfile)),
       id: createProfileId(),
-      name: name.trim()
+      name: trimmedName
     }
     const updatedProfileSet = {
       activeProfileId: newProfile.id,
@@ -188,8 +203,7 @@ function GameRow({
 
   const handleProfileSelect = async (nextProfileId: string) => {
     if (nextProfileId === '__new__') {
-      setProfileMenuOpen(false)
-      await handleCreateProfile()
+      setNewProfileFormOpen(true)
       return
     }
 
@@ -250,6 +264,19 @@ function GameRow({
       notify('Failed to switch profile', 'error')
       console.error(err)
     }
+  }
+
+  const handleNewProfileSubmit = async () => {
+    const trimmedName = newProfileName.trim()
+
+    if (trimmedName.length === 0) {
+      return
+    }
+
+    await handleCreateProfile(trimmedName)
+    setNewProfileName('')
+    setNewProfileFormOpen(false)
+    setProfileMenuOpen(false)
   }
 
   const handleLaunch = async () => {
@@ -410,7 +437,12 @@ function GameRow({
                   type="button"
                   onClick={(event) => {
                     event.stopPropagation()
-                    setProfileMenuOpen((open) => !open)
+                    const nextOpen = !profileMenuOpen
+                    setProfileMenuOpen(nextOpen)
+                    if (!nextOpen) {
+                      setNewProfileFormOpen(false)
+                      setNewProfileName('')
+                    }
                   }}
                   className="flex max-w-40 cursor-pointer items-center gap-1.5 rounded-full border border-(--glass-border) bg-(--glass-bg-elevated) px-2.5 py-1 text-[10px] font-semibold text-(--text-primary) outline-none transition-all hover:border-(--accent) hover:bg-(--glass-bg) focus-visible:ring-2 focus-visible:ring-(--accent)"
                   aria-haspopup="menu"
@@ -452,21 +484,61 @@ function GameRow({
                       )
                     })}
                     <div className="my-1 h-px bg-(--glass-border)" />
-                    <button
-                      type="button"
-                      role="menuitem"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        handleProfileSelect('__new__')
-                      }}
-                      className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs font-bold text-(--accent) transition-colors hover:bg-(--accent)/15"
-                    >
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
-                        <path d="M12 5v14" />
-                        <path d="M5 12h14" />
-                      </svg>
-                      New profile
-                    </button>
+                    {newProfileFormOpen ? (
+                      <form
+                        onSubmit={(event) => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          handleNewProfileSubmit()
+                        }}
+                        className="flex items-center gap-1.5 rounded-lg px-1.5 py-1"
+                      >
+                        <input
+                          ref={newProfileInputRef}
+                          type="text"
+                          value={newProfileName}
+                          onChange={(event) => setNewProfileName(event.target.value)}
+                          onClick={(event) => event.stopPropagation()}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Escape') {
+                              event.stopPropagation()
+                              setNewProfileFormOpen(false)
+                              setNewProfileName('')
+                            }
+                          }}
+                          placeholder="Profile name"
+                          className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-1.5 text-xs font-semibold text-(--text-primary) outline-none placeholder:text-(--text-subtle) focus:border-(--accent)"
+                          aria-label="New profile name"
+                        />
+                        <button
+                          type="submit"
+                          disabled={newProfileName.trim().length === 0}
+                          className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md bg-(--accent) text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
+                          aria-label="Create profile"
+                          title="Create profile"
+                        >
+                          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M20 6 9 17l-5-5" />
+                          </svg>
+                        </button>
+                      </form>
+                    ) : (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          handleProfileSelect('__new__')
+                        }}
+                        className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs font-bold text-(--accent) transition-colors hover:bg-(--accent)/15"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                          <path d="M12 5v14" />
+                          <path d="M5 12h14" />
+                        </svg>
+                        New profile
+                      </button>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -382,7 +382,7 @@ function GameRow({
 
   return (
     <div className={`relative flex flex-col gap-2 transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`} ref={rowRef}>
-      <div className="glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 transition-all duration-300 hover:bg-(--glass-bg-elevated) hover:border-[rgba(255,255,255,0.1)]">
+      <div className={`glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 transition-all duration-300 hover:bg-(--glass-bg-elevated) hover:border-[rgba(255,255,255,0.1)] ${profileMenuOpen ? '!isolation-auto z-20' : 'z-0'}`}>
         <div className="flex items-center gap-5">
           <div className="relative">
             {iconUrl && !iconLoadFailed ? (
@@ -425,7 +425,7 @@ function GameRow({
                 {profileMenuOpen && (
                   <div
                     role="menu"
-                    className="absolute left-0 top-full z-30 mt-1.5 min-w-44 overflow-hidden rounded-xl border border-(--glass-border) bg-[rgba(22,22,24,0.98)] p-1 shadow-2xl backdrop-blur-xl animate-fade-slide"
+                    className="absolute left-0 top-full z-50 mt-1.5 min-w-44 overflow-hidden rounded-xl border border-(--glass-border) bg-[rgba(22,22,24,0.98)] p-1 shadow-2xl backdrop-blur-xl animate-fade-slide"
                   >
                     {profileSet.profiles.map((profile) => {
                       const selected = profile.id === profileSet.activeProfileId
@@ -554,7 +554,7 @@ function GameRow({
         </div>
       </div>
 
-      <div className={`profile-editor-wrapper mx-2 ${isActive ? 'profile-editor-open' : 'profile-editor-closed'}`}>
+      <div className={`profile-editor-wrapper relative z-0 mx-2 ${isActive ? 'profile-editor-open' : 'profile-editor-closed'}`}>
         <div className="overflow-hidden px-4 pb-12 pt-4 -mx-4 -mb-12 -mt-4">
           {isActive && (
             <div className="animate-fade-slide">

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -54,6 +54,8 @@ function GameRow({
   const [iconLoadFailed, setIconLoadFailed] = useState(false)
   const [failedRunningIcons, setFailedRunningIcons] = useState<Record<string, true>>({})
   const [profileSet, setProfileSet] = useState<GameProfileSet>(() => normalizeGameProfileSet(undefined))
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false)
+  const profileMenuRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     async function resolveIcon() {
@@ -64,6 +66,22 @@ function GameRow({
     }
     resolveIcon()
   }, [game.icon])
+
+  useEffect(() => {
+    if (!profileMenuOpen) {
+      return
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!profileMenuRef.current?.contains(event.target as Node)) {
+        setProfileMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown)
+
+    return () => window.removeEventListener('pointerdown', handlePointerDown)
+  }, [profileMenuOpen])
 
   const loadProfileSet = useCallback(async () => {
     const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
@@ -170,6 +188,7 @@ function GameRow({
 
   const handleProfileSelect = async (nextProfileId: string) => {
     if (nextProfileId === '__new__') {
+      setProfileMenuOpen(false)
       await handleCreateProfile()
       return
     }
@@ -224,6 +243,7 @@ function GameRow({
       }
 
       await saveProfileSet(profiles, updatedProfileSet)
+      setProfileMenuOpen(false)
       notify(`Switched to ${nextProfile.name}`, 'success')
     } catch (err) {
       onLaunchEnd(game.key, 0)
@@ -358,6 +378,7 @@ function GameRow({
   const primaryButtonClass = canKill
     ? 'bg-(--danger-surface) text-(--danger-text) shadow-[0_0_15px_-5px_var(--danger-border)] hover:bg-(--danger-border)'
     : 'bg-(--accent) text-white neon-glow hover:opacity-90'
+  const activeProfile = getActiveGameProfile(profileSet)
 
   return (
     <div className={`flex flex-col gap-2 transition-opacity duration-300 ${isDimmed ? 'opacity-45' : 'opacity-100'}`} ref={rowRef}>
@@ -384,18 +405,71 @@ function GameRow({
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
               <h3 className="font-semibold text-(--text-primary) text-shadow-sm">{game.name}</h3>
-              <select
-                value={profileSet.activeProfileId}
-                onChange={(event) => handleProfileSelect(event.target.value)}
-                onClick={(event) => event.stopPropagation()}
-                className="no-drag max-w-36 cursor-pointer rounded-full border border-(--glass-border) bg-(--glass-bg-elevated) px-2 py-0.5 text-[10px] font-semibold text-(--text-secondary) outline-none transition-colors hover:text-(--text-primary) focus:border-(--accent)"
-                aria-label={`${game.name} profile`}
-              >
-                {profileSet.profiles.map((profile) => (
-                  <option key={profile.id} value={profile.id}>{profile.name}</option>
-                ))}
-                <option value="__new__">+ New profile</option>
-              </select>
+              <div ref={profileMenuRef} className="relative no-drag">
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    setProfileMenuOpen((open) => !open)
+                  }}
+                  className="flex max-w-40 cursor-pointer items-center gap-1.5 rounded-full border border-(--glass-border) bg-(--glass-bg-elevated) px-2.5 py-1 text-[10px] font-semibold text-(--text-primary) outline-none transition-all hover:border-(--accent) hover:bg-(--glass-bg) focus-visible:ring-2 focus-visible:ring-(--accent)"
+                  aria-haspopup="menu"
+                  aria-expanded={profileMenuOpen}
+                  aria-label={`${game.name} profile`}
+                >
+                  <span className="min-w-0 truncate">{activeProfile.name}</span>
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={`shrink-0 text-(--text-muted) transition-transform ${profileMenuOpen ? 'rotate-180' : ''}`}>
+                    <path d="M3 6l5 5 5-5" />
+                  </svg>
+                </button>
+                {profileMenuOpen && (
+                  <div
+                    role="menu"
+                    className="absolute left-0 top-full z-30 mt-1.5 min-w-44 overflow-hidden rounded-xl border border-(--glass-border) bg-[rgba(22,22,24,0.98)] p-1 shadow-2xl backdrop-blur-xl animate-fade-slide"
+                  >
+                    {profileSet.profiles.map((profile) => {
+                      const selected = profile.id === profileSet.activeProfileId
+
+                      return (
+                        <button
+                          key={profile.id}
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={selected}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            handleProfileSelect(profile.id)
+                          }}
+                          className={`flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs font-semibold transition-colors ${
+                            selected
+                              ? 'bg-(--accent)/20 text-(--text-primary)'
+                              : 'text-(--text-secondary) hover:bg-(--glass-bg-elevated) hover:text-(--text-primary)'
+                          }`}
+                        >
+                          <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${selected ? 'bg-(--accent)' : 'bg-(--text-subtle)'}`} />
+                          <span className="min-w-0 flex-1 truncate">{profile.name}</span>
+                        </button>
+                      )
+                    })}
+                    <div className="my-1 h-px bg-(--glass-border)" />
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        handleProfileSelect('__new__')
+                      }}
+                      className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs font-bold text-(--accent) transition-colors hover:bg-(--accent)/15"
+                    >
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                        <path d="M12 5v14" />
+                        <path d="M5 12h14" />
+                      </svg>
+                      New profile
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
             {runningAppIcons.length > 0 && (
               <div className="flex items-center gap-1">

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { GAMES, UTILITIES, type Game, type Profiles } from '../lib/config'
+import { GAMES, getUtilities, resolveCustomSlots, type Game, type Profiles } from '../lib/config'
 import { ProfileEditor } from './ProfileEditor'
 import { useNotify } from './Notify'
 
@@ -55,6 +55,8 @@ function GameRow({
     const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
     const appPaths = (await window.electronAPI.storeGet('appPaths')) as Record<string, string> || {}
     const gamePaths = (await window.electronAPI.storeGet('gamePaths')) as Record<string, string> || {}
+    const savedCustomSlots = await window.electronAPI.storeGet('customSlots')
+    const utilities = getUtilities(resolveCustomSlots(savedCustomSlots, appPaths, ...Object.values(profiles)))
 
     const profile = profiles[game.key] || {}
     const configuredGamePath = gamePaths[game.key]
@@ -63,7 +65,7 @@ function GameRow({
     let appCount = 0
 
     // Queue utilities first
-    UTILITIES.forEach((u) => {
+    utilities.forEach((u) => {
       if (profile[u.key] === true && appPaths[u.key]) {
         pathsToLaunch.push(appPaths[u.key])
         appCount++

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,5 +1,18 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { GAMES, getEnabledProfileUtilities, getUtilities, resolveCustomSlots, type Game, type Profiles } from '../lib/config'
+import {
+  GAMES,
+  createProfileId,
+  getActiveGameProfile,
+  getEnabledProfileUtilities,
+  getUtilities,
+  normalizeGameProfileSet,
+  resolveCustomSlots,
+  type Game,
+  type GameProfileSet,
+  type NamedGameProfile,
+  type Profiles,
+  type Utility
+} from '../lib/config'
 import { ProfileEditor } from './ProfileEditor'
 import { useNotify } from './Notify'
 
@@ -40,6 +53,7 @@ function GameRow({
   const [iconUrl, setIconUrl] = useState<string | null>(null)
   const [iconLoadFailed, setIconLoadFailed] = useState(false)
   const [failedRunningIcons, setFailedRunningIcons] = useState<Record<string, true>>({})
+  const [profileSet, setProfileSet] = useState<GameProfileSet>(() => normalizeGameProfileSet(undefined))
 
   useEffect(() => {
     async function resolveIcon() {
@@ -51,14 +65,49 @@ function GameRow({
     resolveIcon()
   }, [game.icon])
 
-  const getProfileLaunchPaths = async () => {
+  const loadProfileSet = useCallback(async () => {
+    const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
+    const nextProfileSet = normalizeGameProfileSet(profiles[game.key])
+    setProfileSet(nextProfileSet)
+    return nextProfileSet
+  }, [game.key])
+
+  useEffect(() => {
+    let mounted = true
+
+    async function load() {
+      const nextProfileSet = await loadProfileSet()
+
+      if (!mounted) {
+        return
+      }
+
+      setProfileSet(nextProfileSet)
+    }
+
+    load()
+    window.addEventListener('focus', load)
+
+    return () => {
+      mounted = false
+      window.removeEventListener('focus', load)
+    }
+  }, [loadProfileSet, isActive])
+
+  const getProfileRuntimeConfig = async () => {
     const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
     const appPaths = (await window.electronAPI.storeGet('appPaths')) as Record<string, string> || {}
     const gamePaths = (await window.electronAPI.storeGet('gamePaths')) as Record<string, string> || {}
     const savedCustomSlots = await window.electronAPI.storeGet('customSlots')
     const utilities = getUtilities(resolveCustomSlots(savedCustomSlots, appPaths, ...Object.values(profiles)))
+    const nextProfileSet = normalizeGameProfileSet(profiles[game.key])
 
-    const profile = profiles[game.key] || {}
+    return { profiles, appPaths, gamePaths, utilities, profileSet: nextProfileSet }
+  }
+
+  const getProfileLaunchPaths = async () => {
+    const { appPaths, gamePaths, utilities, profileSet: nextProfileSet } = await getProfileRuntimeConfig()
+    const profile = getActiveGameProfile(nextProfileSet)
     const configuredGamePath = gamePaths[game.key]
 
     const pathsToLaunch: string[] = []
@@ -78,6 +127,109 @@ function GameRow({
     })
 
     return { profile, pathsToLaunch, appCount }
+  }
+
+  const getOrderedUtilityPaths = (
+    profile: NamedGameProfile,
+    utilities: Utility[],
+    appPaths: Record<string, string>
+  ) => getEnabledProfileUtilities(profile, utilities)
+    .map((utility) => appPaths[utility.id])
+    .filter((appPath): appPath is string => typeof appPath === 'string' && appPath.trim().length > 0)
+
+  const saveProfileSet = async (profiles: Profiles, nextProfileSet: GameProfileSet) => {
+    await window.electronAPI.storeSet('profiles', {
+      ...profiles,
+      [game.key]: nextProfileSet
+    })
+    setProfileSet(nextProfileSet)
+  }
+
+  const handleCreateProfile = async () => {
+    const name = window.prompt('New profile name')
+
+    if (!name || name.trim().length === 0) {
+      return
+    }
+
+    const { profiles, profileSet: nextProfileSet } = await getProfileRuntimeConfig()
+    const activeProfile = getActiveGameProfile(nextProfileSet)
+    const newProfile: NamedGameProfile = {
+      ...JSON.parse(JSON.stringify(activeProfile)),
+      id: createProfileId(),
+      name: name.trim()
+    }
+    const updatedProfileSet = {
+      activeProfileId: newProfile.id,
+      profiles: [...nextProfileSet.profiles, newProfile]
+    }
+
+    await saveProfileSet(profiles, updatedProfileSet)
+    notify(`Created profile ${newProfile.name}`, 'success')
+  }
+
+  const handleProfileSelect = async (nextProfileId: string) => {
+    if (nextProfileId === '__new__') {
+      await handleCreateProfile()
+      return
+    }
+
+    if (nextProfileId === profileSet.activeProfileId) {
+      return
+    }
+
+    if (isRunning && isLaunchBlocked) {
+      notify('Launch is settling. Try again shortly.', 'warn')
+      return
+    }
+
+    const { profiles, appPaths, utilities, profileSet: latestProfileSet } = await getProfileRuntimeConfig()
+    const currentProfile = getActiveGameProfile(latestProfileSet)
+    const nextProfile = latestProfileSet.profiles.find((profile) => profile.id === nextProfileId)
+
+    if (!nextProfile) {
+      return
+    }
+
+    const updatedProfileSet = {
+      ...latestProfileSet,
+      activeProfileId: nextProfile.id
+    }
+
+    try {
+      if (isRunning) {
+        const currentPaths = getOrderedUtilityPaths(currentProfile, utilities, appPaths)
+        const nextPaths = getOrderedUtilityPaths(nextProfile, utilities, appPaths)
+        const currentPathSet = new Set(currentPaths.map((appPath) => appPath.toLowerCase()))
+        const nextPathSet = new Set(nextPaths.map((appPath) => appPath.toLowerCase()))
+        const pathsToStop = currentPaths.filter((appPath) => !nextPathSet.has(appPath.toLowerCase()))
+        const pathsToStart = nextPaths.filter((appPath) => !currentPathSet.has(appPath.toLowerCase()))
+
+        if (pathsToStop.length > 0) {
+          await window.electronAPI.killProfileApps(game.key, pathsToStop)
+        }
+
+        if (pathsToStart.length > 0) {
+          onLaunchStart(game.key)
+          const result = await window.electronAPI.launchProfile(game.key, pathsToStart)
+          if (!result.success) {
+            notify(result.error || 'Failed to switch profile', 'error')
+            onLaunchEnd(game.key, 0)
+            return
+          }
+          onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
+        }
+
+        await onRunningStateRefresh()
+      }
+
+      await saveProfileSet(profiles, updatedProfileSet)
+      notify(`Switched to ${nextProfile.name}`, 'success')
+    } catch (err) {
+      onLaunchEnd(game.key, 0)
+      notify('Failed to switch profile', 'error')
+      console.error(err)
+    }
   }
 
   const handleLaunch = async () => {
@@ -178,7 +330,7 @@ function GameRow({
 
     async function loadProfileState() {
       const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
-      const profile = profiles[game.key] || {}
+      const profile = getActiveGameProfile(profiles[game.key])
 
       if (!mounted) {
         return
@@ -197,7 +349,7 @@ function GameRow({
       mounted = false
       window.removeEventListener('focus', loadProfileState)
     }
-  }, [game.key, isActive])
+  }, [game.key, isActive, profileSet.activeProfileId])
 
   const canKill = runningAppIcons.length > 0 && profileState.killControlsEnabled
   const canRelaunch = isRunning && profileState.relaunchControlsEnabled
@@ -230,7 +382,21 @@ function GameRow({
             )}
           </div>
           <div className="flex flex-col gap-0.5">
-            <h3 className="font-semibold text-(--text-primary) text-shadow-sm">{game.name}</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold text-(--text-primary) text-shadow-sm">{game.name}</h3>
+              <select
+                value={profileSet.activeProfileId}
+                onChange={(event) => handleProfileSelect(event.target.value)}
+                onClick={(event) => event.stopPropagation()}
+                className="no-drag max-w-36 cursor-pointer rounded-full border border-(--glass-border) bg-(--glass-bg-elevated) px-2 py-0.5 text-[10px] font-semibold text-(--text-secondary) outline-none transition-colors hover:text-(--text-primary) focus:border-(--accent)"
+                aria-label={`${game.name} profile`}
+              >
+                {profileSet.profiles.map((profile) => (
+                  <option key={profile.id} value={profile.id}>{profile.name}</option>
+                ))}
+                <option value="__new__">+ New profile</option>
+              </select>
+            </div>
             {runningAppIcons.length > 0 && (
               <div className="flex items-center gap-1">
                 {runningAppIcons.map((app, i) => {
@@ -321,6 +487,8 @@ function GameRow({
               <ProfileEditor
                 gameKey={game.key}
                 gameName={game.name}
+                activeProfileId={profileSet.activeProfileId}
+                onProfilesChanged={loadProfileSet}
                 onClose={onToggleEditor}
               />
             </div>

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -54,6 +54,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   const [utilities, setUtilities] = useState<Utility[]>(() => getUtilities(1))
   const [profileUtilities, setProfileUtilities] = useState<ProfileUtility[]>([])
   const [dragUtilityId, setDragUtilityId] = useState<string | null>(null)
+  const [dropTarget, setDropTarget] = useState<{ id: string; placement: 'before' | 'after' } | null>(null)
   const [launchAutomatically, setLaunchAutomatically] = useState(true)
   const [trackingEnabled, setTrackingEnabled] = useState(true)
   const [killControlsEnabled, setKillControlsEnabled] = useState(false)
@@ -135,7 +136,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
     })
   }
 
-  const moveEnabledUtility = (draggedId: string, targetId: string) => {
+  const moveEnabledUtility = (draggedId: string, targetId: string, placement: 'before' | 'after') => {
     if (draggedId === targetId) {
       return
     }
@@ -152,7 +153,17 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
 
       const nextEnabledEntries = [...enabledEntries]
       const [movedEntry] = nextEnabledEntries.splice(fromIndex, 1)
-      nextEnabledEntries.splice(toIndex, 0, movedEntry)
+      const targetIndexAfterRemoval = nextEnabledEntries.findIndex((entry) => entry.id === targetId)
+
+      if (targetIndexAfterRemoval === -1) {
+        return currentUtilities
+      }
+
+      nextEnabledEntries.splice(
+        placement === 'after' ? targetIndexAfterRemoval + 1 : targetIndexAfterRemoval,
+        0,
+        movedEntry
+      )
 
       return [...nextEnabledEntries, ...disabledEntries]
     })
@@ -207,7 +218,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   const disabledUtilityEntries = availableUtilityEntries.filter((entry) => !entry.enabled)
   const availableUtilities = availableUtilityEntries.map((entry) => utilityByKey.get(entry.id)!)
 
-  const renderUtilityRow = (entry: ProfileUtility, isEnabled: boolean) => {
+  const renderUtilityRow = (entry: ProfileUtility, isEnabled: boolean, orderIndex?: number) => {
     const utility = utilityByKey.get(entry.id)
 
     if (!utility) {
@@ -217,6 +228,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
     const label = appNames[utility.key] || utility.name
     const iconPath = appPaths[utility.key]?.toLowerCase()
     const icon = iconPath ? appIconCache[iconPath] : null
+    const dropPlacement = dropTarget?.id === utility.key ? dropTarget.placement : null
 
     return (
       <div
@@ -234,20 +246,42 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
         onDragOver={(event) => {
           if (isEnabled && dragUtilityId && dragUtilityId !== utility.key) {
             event.preventDefault()
+            event.dataTransfer.dropEffect = 'move'
+            const bounds = event.currentTarget.getBoundingClientRect()
+            const placement = event.clientY < bounds.top + bounds.height / 2 ? 'before' : 'after'
+            setDropTarget({ id: utility.key, placement })
+          }
+        }}
+        onDragLeave={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            setDropTarget((currentTarget) => currentTarget?.id === utility.key ? null : currentTarget)
           }
         }}
         onDrop={(event) => {
           event.preventDefault()
-          if (dragUtilityId) {
-            moveEnabledUtility(dragUtilityId, utility.key)
+          if (dragUtilityId && dropPlacement) {
+            moveEnabledUtility(dragUtilityId, utility.key, dropPlacement)
             setDragUtilityId(null)
+            setDropTarget(null)
           }
         }}
-        className={`group flex cursor-pointer items-center justify-between rounded-xl bg-(--glass-bg) p-3 transition-all duration-200 hover:bg-(--accent) hover:text-(--text-primary) ${
+        className={`group relative flex cursor-pointer items-center justify-between rounded-xl bg-(--glass-bg) p-3 transition-all duration-200 hover:bg-(--accent) hover:text-(--text-primary) ${
           isEnabled ? '' : 'opacity-55 hover:opacity-100'
         }`}
       >
+        {dropPlacement && (
+          <span
+            className={`pointer-events-none absolute left-3 right-3 h-0.5 rounded-full bg-(--accent) shadow-[0_0_10px_var(--accent-glow)] ${
+              dropPlacement === 'before' ? '-top-1.5' : '-bottom-1.5'
+            }`}
+          />
+        )}
         <div className="flex min-w-0 items-center gap-3">
+          {isEnabled && typeof orderIndex === 'number' && (
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-(--accent)/15 text-[11px] font-black tabular-nums text-(--accent)">
+              {orderIndex + 1}
+            </span>
+          )}
           <button
             type="button"
             draggable={isEnabled}
@@ -258,8 +292,18 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
               setDragUtilityId(utility.key)
               event.dataTransfer.effectAllowed = 'move'
               event.dataTransfer.setData('text/plain', utility.key)
+              const dragImage = document.createElement('div')
+              dragImage.style.width = '1px'
+              dragImage.style.height = '1px'
+              dragImage.style.opacity = '0'
+              document.body.appendChild(dragImage)
+              event.dataTransfer.setDragImage(dragImage, 0, 0)
+              window.setTimeout(() => dragImage.remove(), 0)
             }}
-            onDragEnd={() => setDragUtilityId(null)}
+            onDragEnd={() => {
+              setDragUtilityId(null)
+              setDropTarget(null)
+            }}
             className="flex h-6 w-5 shrink-0 cursor-grab items-center justify-center rounded text-(--text-subtle) transition-colors hover:bg-white/10 hover:text-(--text-primary) active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-20"
             title="Drag to reorder"
             aria-label={`Reorder ${label}`}
@@ -325,8 +369,8 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
           {availableUtilities.length > 0 ? (
             <div className="space-y-3">
               {enabledUtilityEntries.length > 0 && (
-                <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-                  {enabledUtilityEntries.map((entry) => renderUtilityRow(entry, true))}
+                <div className="grid grid-cols-1 gap-2.5">
+                  {enabledUtilityEntries.map((entry, index) => renderUtilityRow(entry, true, index))}
                 </div>
               )}
               {disabledUtilityEntries.length > 0 && (

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from 'react'
-import { getUtilities, resolveCustomSlots, type Profiles, type Utility } from '../lib/config'
+import {
+  getUtilities,
+  normalizeProfileUtilities,
+  resolveCustomSlots,
+  type ProfileUtility,
+  type Profiles,
+  type Utility
+} from '../lib/config'
 import { useNotify } from './Notify'
 import { Toggle } from './Toggle'
 
@@ -45,7 +52,8 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
   const [appNames, setAppNames] = useState<Record<string, string>>({})
   const [utilities, setUtilities] = useState<Utility[]>(() => getUtilities(1))
-  const [selection, setSelection] = useState<Record<string, boolean>>({})
+  const [profileUtilities, setProfileUtilities] = useState<ProfileUtility[]>([])
+  const [dragUtilityId, setDragUtilityId] = useState<string | null>(null)
   const [launchAutomatically, setLaunchAutomatically] = useState(true)
   const [trackingEnabled, setTrackingEnabled] = useState(true)
   const [killControlsEnabled, setKillControlsEnabled] = useState(false)
@@ -69,13 +77,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
       setAppNames(names)
       setUtilities(resolvedUtilities)
       
-      // Initialize selection state based on existing profile
-      const initialSelection: Record<string, boolean> = {}
-      resolvedUtilities.forEach((u) => {
-        initialSelection[u.key] = profile[u.key] === true
-      })
-      
-      setSelection(initialSelection)
+      setProfileUtilities(normalizeProfileUtilities(profile, resolvedUtilities))
       // Default auto-launch to true unless explicitly disabled
       setLaunchAutomatically(profile.launchAutomatically !== false)
       setTrackingEnabled(profile.trackingEnabled !== false)
@@ -106,7 +108,54 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   }, [gameKey])
 
   const handleToggleUtility = (key: string) => {
-    setSelection((prev) => ({ ...prev, [key]: !prev[key] }))
+    setProfileUtilities((currentUtilities) => {
+      const currentEntry = currentUtilities.find((entry) => entry.id === key)
+
+      if (!currentEntry) {
+        return currentUtilities
+      }
+
+      const toggledEntry = { ...currentEntry, enabled: !currentEntry.enabled }
+      const remainingEntries = currentUtilities.filter((entry) => entry.id !== key)
+
+      if (toggledEntry.enabled) {
+        const lastEnabledIndex = remainingEntries.reduce(
+          (latestIndex, entry, index) => entry.enabled ? index : latestIndex,
+          -1
+        )
+
+        return [
+          ...remainingEntries.slice(0, lastEnabledIndex + 1),
+          toggledEntry,
+          ...remainingEntries.slice(lastEnabledIndex + 1)
+        ]
+      }
+
+      return [...remainingEntries, toggledEntry]
+    })
+  }
+
+  const moveEnabledUtility = (draggedId: string, targetId: string) => {
+    if (draggedId === targetId) {
+      return
+    }
+
+    setProfileUtilities((currentUtilities) => {
+      const enabledEntries = currentUtilities.filter((entry) => entry.enabled)
+      const disabledEntries = currentUtilities.filter((entry) => !entry.enabled)
+      const fromIndex = enabledEntries.findIndex((entry) => entry.id === draggedId)
+      const toIndex = enabledEntries.findIndex((entry) => entry.id === targetId)
+
+      if (fromIndex === -1 || toIndex === -1) {
+        return currentUtilities
+      }
+
+      const nextEnabledEntries = [...enabledEntries]
+      const [movedEntry] = nextEnabledEntries.splice(fromIndex, 1)
+      nextEnabledEntries.splice(toIndex, 0, movedEntry)
+
+      return [...nextEnabledEntries, ...disabledEntries]
+    })
   }
 
   const handleAddTrackedProcess = () => {
@@ -132,7 +181,10 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
     const allProfiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
     
     allProfiles[gameKey] = {
-      ...selection,
+      utilities: profileUtilities.map((utility) => ({
+        id: utility.id,
+        enabled: utility.enabled
+      })),
       launchAutomatically,
       trackingEnabled,
       killControlsEnabled,
@@ -149,7 +201,104 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   if (loading) return null
 
   // Filter utilities to show only those that have a configured executable path
-  const availableUtilities = utilities.filter((u) => appPaths[u.key])
+  const utilityByKey = new Map(utilities.map((utility) => [utility.key, utility]))
+  const availableUtilityEntries = profileUtilities.filter((entry) => utilityByKey.has(entry.id) && appPaths[entry.id])
+  const enabledUtilityEntries = availableUtilityEntries.filter((entry) => entry.enabled)
+  const disabledUtilityEntries = availableUtilityEntries.filter((entry) => !entry.enabled)
+  const availableUtilities = availableUtilityEntries.map((entry) => utilityByKey.get(entry.id)!)
+
+  const renderUtilityRow = (entry: ProfileUtility, isEnabled: boolean) => {
+    const utility = utilityByKey.get(entry.id)
+
+    if (!utility) {
+      return null
+    }
+
+    const label = appNames[utility.key] || utility.name
+    const iconPath = appPaths[utility.key]?.toLowerCase()
+    const icon = iconPath ? appIconCache[iconPath] : null
+
+    return (
+      <div
+        key={utility.key}
+        role="switch"
+        aria-checked={isEnabled}
+        tabIndex={0}
+        onClick={() => handleToggleUtility(utility.key)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            handleToggleUtility(utility.key)
+          }
+        }}
+        onDragOver={(event) => {
+          if (isEnabled && dragUtilityId && dragUtilityId !== utility.key) {
+            event.preventDefault()
+          }
+        }}
+        onDrop={(event) => {
+          event.preventDefault()
+          if (dragUtilityId) {
+            moveEnabledUtility(dragUtilityId, utility.key)
+            setDragUtilityId(null)
+          }
+        }}
+        className={`group flex cursor-pointer items-center justify-between rounded-xl bg-(--glass-bg) p-3 transition-all duration-200 hover:bg-(--accent) hover:text-(--text-primary) ${
+          isEnabled ? '' : 'opacity-55 hover:opacity-100'
+        }`}
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <button
+            type="button"
+            draggable={isEnabled}
+            disabled={!isEnabled}
+            onClick={(event) => event.stopPropagation()}
+            onDragStart={(event) => {
+              event.stopPropagation()
+              setDragUtilityId(utility.key)
+              event.dataTransfer.effectAllowed = 'move'
+              event.dataTransfer.setData('text/plain', utility.key)
+            }}
+            onDragEnd={() => setDragUtilityId(null)}
+            className="flex h-6 w-5 shrink-0 cursor-grab items-center justify-center rounded text-(--text-subtle) transition-colors hover:bg-white/10 hover:text-(--text-primary) active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-20"
+            title="Drag to reorder"
+            aria-label={`Reorder ${label}`}
+          >
+            <svg width="12" height="16" viewBox="0 0 12 16" fill="currentColor" aria-hidden="true">
+              <circle cx="3" cy="3" r="1.2" />
+              <circle cx="9" cy="3" r="1.2" />
+              <circle cx="3" cy="8" r="1.2" />
+              <circle cx="9" cy="8" r="1.2" />
+              <circle cx="3" cy="13" r="1.2" />
+              <circle cx="9" cy="13" r="1.2" />
+            </svg>
+          </button>
+          <div className="relative flex h-6 w-6 shrink-0 items-center justify-center">
+            {icon && !failedIcons[utility.key] ? (
+              <img
+                src={icon}
+                alt=""
+                className="h-full w-full object-contain animate-fade-slide"
+                onError={() => setFailedIcons((prev) => ({ ...prev, [utility.key]: true }))}
+              />
+            ) : fetchingIcons && !failedIcons[utility.key] ? (
+              <div className="h-full w-full skeleton-icon animate-pulse" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center rounded bg-(--accent)/20 text-[8px] font-black uppercase text-(--accent)">
+                {label.slice(0, 2)}
+              </div>
+            )}
+          </div>
+          <span className="min-w-0 line-clamp-1 text-sm font-medium opacity-80 group-hover:opacity-100">
+            {label}
+          </span>
+        </div>
+        <span onClick={(event) => event.stopPropagation()}>
+          <Toggle checked={isEnabled} onChange={() => handleToggleUtility(utility.key)} aria-label={label} />
+        </span>
+      </div>
+    )
+  }
 
   return (
     <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5 shadow-2xl">
@@ -174,48 +323,17 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
           </p>
           
           {availableUtilities.length > 0 ? (
-            <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-              {availableUtilities.map((u) => (
-                <div
-                  key={u.key}
-                  role="switch"
-                  aria-checked={!!selection[u.key]}
-                  tabIndex={0}
-                  onClick={() => handleToggleUtility(u.key)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault()
-                      handleToggleUtility(u.key)
-                    }
-                  }}
-                  className="flex cursor-pointer items-center justify-between rounded-xl bg-(--glass-bg) p-3 transition-all duration-200 hover:bg-(--accent) hover:text-(--text-primary) group"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="relative flex h-6 w-6 shrink-0 items-center justify-center">
-                      {appIconCache[appPaths[u.key]?.toLowerCase()] && !failedIcons[u.key] ? (
-                        <img
-                          src={appIconCache[appPaths[u.key].toLowerCase()]}
-                          alt=""
-                          className="h-full w-full object-contain animate-fade-slide"
-                          onError={() => setFailedIcons((prev) => ({ ...prev, [u.key]: true }))}
-                        />
-                      ) : fetchingIcons && !failedIcons[u.key] ? (
-                        <div className="h-full w-full skeleton-icon animate-pulse" />
-                      ) : (
-                        <div className="flex h-full w-full items-center justify-center rounded bg-(--accent)/20 text-[8px] font-black uppercase text-(--accent)">
-                          {(appNames[u.key] || u.name).slice(0, 2)}
-                        </div>
-                      )}
-                    </div>
-                    <span className="text-sm font-medium opacity-80 group-hover:opacity-100 line-clamp-1">
-                      {appNames[u.key] || u.name}
-                    </span>
-                  </div>
-                  <span onClick={(event) => event.stopPropagation()}>
-                    <Toggle checked={!!selection[u.key]} onChange={() => handleToggleUtility(u.key)} aria-label={appNames[u.key] || u.name} />
-                  </span>
+            <div className="space-y-3">
+              {enabledUtilityEntries.length > 0 && (
+                <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+                  {enabledUtilityEntries.map((entry) => renderUtilityRow(entry, true))}
                 </div>
-              ))}
+              )}
+              {disabledUtilityEntries.length > 0 && (
+                <div className="grid grid-cols-1 gap-2.5 border-t border-(--glass-border) pt-3 sm:grid-cols-2">
+                  {disabledUtilityEntries.map((entry) => renderUtilityRow(entry, false))}
+                </div>
+              )}
             </div>
           ) : (
             <div className="flex h-20 items-center justify-center rounded-xl border border-dashed border-(--glass-border) bg-(--glass-bg)">
@@ -229,7 +347,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
         <div className="border-t border-(--glass-border) pt-4">
           <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
             <ProfileToggleRow
-              label="Launch game automatically after utilities"
+              label="Launch game with profile"
               checked={launchAutomatically}
               onToggle={() => setLaunchAutomatically((value) => !value)}
               onChange={setLaunchAutomatically}

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { UTILITIES, type Profiles } from '../lib/config'
+import { getUtilities, resolveCustomSlots, type Profiles, type Utility } from '../lib/config'
 import { useNotify } from './Notify'
 import { Toggle } from './Toggle'
 
@@ -44,6 +44,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   const [loading, setLoading] = useState(true)
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
   const [appNames, setAppNames] = useState<Record<string, string>>({})
+  const [utilities, setUtilities] = useState<Utility[]>(() => getUtilities(1))
   const [selection, setSelection] = useState<Record<string, boolean>>({})
   const [launchAutomatically, setLaunchAutomatically] = useState(true)
   const [trackingEnabled, setTrackingEnabled] = useState(true)
@@ -60,14 +61,17 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
       const paths = (await window.electronAPI.storeGet('appPaths')) as Record<string, string> || {}
       const names = (await window.electronAPI.storeGet('appNames')) as Record<string, string> || {}
       const allProfiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
+      const savedCustomSlots = await window.electronAPI.storeGet('customSlots')
       const profile = allProfiles[gameKey] || {}
+      const resolvedUtilities = getUtilities(resolveCustomSlots(savedCustomSlots, paths, names, profile))
 
       setAppPaths(paths)
       setAppNames(names)
+      setUtilities(resolvedUtilities)
       
       // Initialize selection state based on existing profile
       const initialSelection: Record<string, boolean> = {}
-      UTILITIES.forEach((u) => {
+      resolvedUtilities.forEach((u) => {
         initialSelection[u.key] = profile[u.key] === true
       })
       
@@ -145,7 +149,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   if (loading) return null
 
   // Filter utilities to show only those that have a configured executable path
-  const availableUtilities = UTILITIES.filter((u) => appPaths[u.key])
+  const availableUtilities = utilities.filter((u) => appPaths[u.key])
 
   return (
     <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5 shadow-2xl">

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import {
+  getActiveGameProfile,
   getUtilities,
+  normalizeGameProfileSet,
   normalizeProfileUtilities,
   resolveCustomSlots,
   type ProfileUtility,
@@ -43,15 +45,19 @@ function ProfileToggleRow({ label, checked, onToggle, onChange }: ProfileToggleR
 interface ProfileEditorProps {
   gameKey: string
   gameName: string
+  activeProfileId: string
+  onProfilesChanged: () => Promise<unknown>
   onClose: () => void
 }
 
-export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps) {
+export function ProfileEditor({ gameKey, gameName, activeProfileId, onProfilesChanged, onClose }: ProfileEditorProps) {
   const { notify } = useNotify()
   const [loading, setLoading] = useState(true)
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
   const [appNames, setAppNames] = useState<Record<string, string>>({})
   const [utilities, setUtilities] = useState<Utility[]>(() => getUtilities(1))
+  const [profileName, setProfileName] = useState('Default')
+  const [profileCount, setProfileCount] = useState(1)
   const [profileUtilities, setProfileUtilities] = useState<ProfileUtility[]>([])
   const [dragUtilityId, setDragUtilityId] = useState<string | null>(null)
   const [dropTarget, setDropTarget] = useState<{ id: string; placement: 'before' | 'after' } | null>(null)
@@ -66,17 +72,21 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
 
   useEffect(() => {
     async function loadData() {
+      setLoading(true)
       // Load configuration from electron-store via IPC
       const paths = (await window.electronAPI.storeGet('appPaths')) as Record<string, string> || {}
       const names = (await window.electronAPI.storeGet('appNames')) as Record<string, string> || {}
       const allProfiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
       const savedCustomSlots = await window.electronAPI.storeGet('customSlots')
-      const profile = allProfiles[gameKey] || {}
+      const profileSet = normalizeGameProfileSet(allProfiles[gameKey])
+      const profile = profileSet.profiles.find((entry) => entry.id === activeProfileId) || getActiveGameProfile(profileSet)
       const resolvedUtilities = getUtilities(resolveCustomSlots(savedCustomSlots, paths, names, profile))
 
       setAppPaths(paths)
       setAppNames(names)
       setUtilities(resolvedUtilities)
+      setProfileName(profile.name)
+      setProfileCount(profileSet.profiles.length)
       
       setProfileUtilities(normalizeProfileUtilities(profile, resolvedUtilities))
       // Default auto-launch to true unless explicitly disabled
@@ -106,7 +116,7 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
     }
 
     loadData()
-  }, [gameKey])
+  }, [gameKey, activeProfileId])
 
   const handleToggleUtility = (key: string) => {
     setProfileUtilities((currentUtilities) => {
@@ -190,8 +200,13 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
   const handleSave = async () => {
     // Read-modify-write pattern for the 'profiles' object store
     const allProfiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
+    const profileSet = normalizeGameProfileSet(allProfiles[gameKey])
+    const activeProfile = profileSet.profiles.find((profile) => profile.id === activeProfileId) || getActiveGameProfile(profileSet)
+    const normalizedProfileName = profileName.trim() || activeProfile.name
     
-    allProfiles[gameKey] = {
+    const updatedProfile = {
+      ...activeProfile,
+      name: normalizedProfileName,
       utilities: profileUtilities.map((utility) => ({
         id: utility.id,
         enabled: utility.enabled
@@ -203,9 +218,44 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
       trackedProcessPaths: trackedProcessPaths.filter((processPath) => processPath.trim().length > 0)
     }
 
+    allProfiles[gameKey] = {
+      activeProfileId: updatedProfile.id,
+      profiles: profileSet.profiles.map((profile) => (
+        profile.id === updatedProfile.id ? updatedProfile : profile
+      ))
+    }
+
     await window.electronAPI.storeSet('profiles', allProfiles)
+    await onProfilesChanged()
     
     notify('Profile saved!', 'success', 2500)
+    onClose()
+  }
+
+  const handleDeleteProfile = async () => {
+    const allProfiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
+    const profileSet = normalizeGameProfileSet(allProfiles[gameKey])
+    const activeProfile = profileSet.profiles.find((profile) => profile.id === activeProfileId) || getActiveGameProfile(profileSet)
+
+    if (profileSet.profiles.length <= 1) {
+      notify('At least one profile is required', 'warn')
+      return
+    }
+
+    if (!window.confirm(`Delete profile "${activeProfile.name}"?`)) {
+      return
+    }
+
+    const nextProfiles = profileSet.profiles.filter((profile) => profile.id !== activeProfile.id)
+
+    allProfiles[gameKey] = {
+      activeProfileId: nextProfiles[0].id,
+      profiles: nextProfiles
+    }
+
+    await window.electronAPI.storeSet('profiles', allProfiles)
+    await onProfilesChanged()
+    notify('Profile deleted', 'warn', 2500)
     onClose()
   }
 
@@ -363,6 +413,19 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
       <div className="space-y-5">
         <div className="space-y-2">
           <p className="text-xs font-medium uppercase tracking-wider text-(--text-muted)">
+            Profile name
+          </p>
+          <input
+            type="text"
+            value={profileName}
+            onChange={(event) => setProfileName(event.target.value)}
+            className="w-full glass-recessed rounded-lg px-3 py-2 text-sm text-(--text-primary) outline-none transition-colors focus:ring-2 focus:ring-(--accent)"
+            aria-label="Profile name"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wider text-(--text-muted)">
             Utilities to launch
           </p>
           
@@ -490,6 +553,23 @@ export function ProfileEditor({ gameKey, gameName, onClose }: ProfileEditorProps
           >
             Cancel
           </button>
+          {profileCount > 1 && (
+            <button
+              type="button"
+              onClick={handleDeleteProfile}
+              className="flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl bg-(--danger-surface) text-(--danger-text) transition-all duration-300 hover:bg-(--danger-border) active:scale-[0.98]"
+              title="Delete profile"
+              aria-label="Delete profile"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 6h18" />
+                <path d="M8 6V4h8v2" />
+                <path d="M19 6l-1 14H6L5 6" />
+                <path d="M10 11v5" />
+                <path d="M14 11v5" />
+              </svg>
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -4,8 +4,10 @@ import {
   GAMES,
   getCustomUtilityKey,
   getUtilities,
+  isGameProfileSet,
   isProfileUtility,
   resolveCustomSlots,
+  type NamedGameProfile,
   type Profiles
 } from '../lib/config'
 import { useNotify } from './Notify'
@@ -236,7 +238,7 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
     return shifted
   }
 
-  const shiftProfileCustomSlots = (profile: Profiles[string], removedSlot: number, slotCount: number) => {
+  const shiftSingleProfileCustomSlots = <T extends Profiles[string]>(profile: T, removedSlot: number, slotCount: number) => {
     const shiftedProfile = shiftCustomSlotRecord(profile, removedSlot, slotCount)
 
     if (Array.isArray(profile.utilities)) {
@@ -262,6 +264,19 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
     }
 
     return shiftedProfile
+  }
+
+  const shiftProfileCustomSlots = (profile: Profiles[string], removedSlot: number, slotCount: number) => {
+    if (isGameProfileSet(profile)) {
+      return {
+        ...profile,
+        profiles: profile.profiles.map((namedProfile) => (
+          shiftSingleProfileCustomSlots(namedProfile, removedSlot, slotCount) as NamedGameProfile
+        ))
+      }
+    }
+
+    return shiftSingleProfileCustomSlots(profile, removedSlot, slotCount)
   }
 
   const getCustomSlotNumber = (key: string) => Number(key.replace('customapp', ''))

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from 'react'
-import { DEFAULT_ACCENT_COLOR, UTILITIES, GAMES } from '../lib/config'
+import {
+  DEFAULT_ACCENT_COLOR,
+  GAMES,
+  getCustomUtilityKey,
+  getUtilities,
+  resolveCustomSlots,
+  type Profiles
+} from '../lib/config'
 import { useNotify } from './Notify'
 import { Toggle } from './Toggle'
 
@@ -52,7 +59,9 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
   // Settings State
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
   const [appNames, setAppNames] = useState<Record<string, string>>({})
+  const [profiles, setProfiles] = useState<Profiles>({})
   const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
+  const [customSlots, setCustomSlots] = useState(1)
   const [accentPreset, setAccentPreset] = useState<string>(DEFAULT_ACCENT_COLOR)
   const [accentCustom, setAccentCustom] = useState<string>('')
   const [accentBgTint, setAccentBgTint] = useState<boolean>(false)
@@ -82,7 +91,9 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
     async function loadSettings() {
       const savedAppPaths = (await window.electronAPI.storeGet('appPaths')) as Record<string, string> || {}
       const savedAppNames = (await window.electronAPI.storeGet('appNames')) as Record<string, string> || {}
+      const savedProfiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
       const savedGamePaths = (await window.electronAPI.storeGet('gamePaths')) as Record<string, string> || {}
+      const savedCustomSlots = await window.electronAPI.storeGet('customSlots')
       const savedAccentPreset = (await window.electronAPI.storeGet('accentPreset')) as string || DEFAULT_ACCENT_COLOR
       const savedAccentCustom = (await window.electronAPI.storeGet('accentCustom')) as string || ''
       const savedBgTint = (await window.electronAPI.storeGet('accentBgTint')) as boolean || false
@@ -96,7 +107,9 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
 
       setAppPaths(savedAppPaths)
       setAppNames(savedAppNames)
+      setProfiles(savedProfiles)
       setGamePaths(savedGamePaths)
+      setCustomSlots(resolveCustomSlots(savedCustomSlots, savedAppPaths, savedAppNames, ...Object.values(savedProfiles)))
       setAccentPreset(savedAccentPreset)
       setAccentCustom(savedAccentCustom)
       setAccentBgTint(savedBgTint)
@@ -180,6 +193,85 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
         }
       }
     }
+  }
+
+  const shiftCustomSlotRecord = <T,>(record: Record<string, T>, removedSlot: number, slotCount: number) => {
+    const next = { ...record }
+
+    for (let slot = removedSlot; slot <= slotCount; slot += 1) {
+      const currentKey = getCustomUtilityKey(slot)
+      const nextKey = getCustomUtilityKey(slot + 1)
+
+      if (slot < slotCount && Object.prototype.hasOwnProperty.call(next, nextKey)) {
+        next[currentKey] = next[nextKey]
+      } else {
+        delete next[currentKey]
+      }
+    }
+
+    return next
+  }
+
+  const shiftCustomSlotSet = (values: Set<string>, removedSlot: number, slotCount: number) => {
+    const shifted = new Set<string>()
+
+    values.forEach((value) => {
+      const match = value.match(/^customapp(\d+)$/)
+
+      if (!match) {
+        shifted.add(value)
+        return
+      }
+
+      const slot = Number(match[1])
+
+      if (slot < removedSlot) {
+        shifted.add(value)
+      } else if (slot > removedSlot && slot <= slotCount) {
+        shifted.add(getCustomUtilityKey(slot - 1))
+      }
+    })
+
+    return shifted
+  }
+
+  const getCustomSlotNumber = (key: string) => Number(key.replace('customapp', ''))
+
+  const handleAddCustomSlot = () => {
+    setCustomSlots((current) => current + 1)
+  }
+
+  const handleRemoveCustomSlot = (slotNumber: number) => {
+    if (customSlots <= 1) {
+      notify('At least one custom app slot is required', 'warn')
+      return
+    }
+
+    const slotKey = getCustomUtilityKey(slotNumber)
+    const slotName = appNames[slotKey] || `Custom App ${slotNumber}`
+
+    if (appPaths[slotKey]) {
+      const confirmed = window.confirm(`Remove ${slotName} and its executable path?`)
+
+      if (!confirmed) {
+        return
+      }
+    }
+
+    setAppPaths((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+    setAppNames((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+    setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+    setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
+    setProfiles((current) => {
+      const nextProfiles: Profiles = {}
+
+      Object.entries(current).forEach(([gameKey, profile]) => {
+        nextProfiles[gameKey] = shiftCustomSlotRecord(profile, slotNumber, customSlots)
+      })
+
+      return nextProfiles
+    })
+    setCustomSlots((current) => Math.max(1, current - 1))
   }
 
   const [appVersion, setAppVersion] = useState<string>('')
@@ -270,7 +362,9 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
 
       await window.electronAPI.storeSet('appPaths', appPaths)
       await window.electronAPI.storeSet('appNames', appNames)
+      await window.electronAPI.storeSet('profiles', profiles)
       await window.electronAPI.storeSet('gamePaths', gamePaths)
+      await window.electronAPI.storeSet('customSlots', customSlots)
       await window.electronAPI.storeSet('accentPreset', accentPreset)
       await window.electronAPI.storeSet('accentCustom', accentCustom)
       await window.electronAPI.storeSet('accentBgTint', accentBgTint)
@@ -287,6 +381,8 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
       console.error(err)
     }
   }
+
+  const utilities = getUtilities(customSlots)
 
   if (loading) return null
 
@@ -569,18 +665,26 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
           <div className={`grid transition-all duration-300 ${appsOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
             <div className="overflow-hidden">
               <div className="glass-surface rounded-2xl flex flex-col pt-1">
-                {UTILITIES.map((u, index) => (
-                  <div key={u.key} className={`flex flex-col gap-2 px-5 py-3 ${index !== UTILITIES.length - 1 ? 'border-b border-white/5' : ''}`}>
+                {utilities.map((u) => (
+                  <div key={u.key} className="flex flex-col gap-2 border-b border-white/5 px-5 py-3">
                     {/* Utility Title Above */}
                     <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
                       {u.isCustom ? (
-                        <input
-                          type="text"
-                          value={appNames[u.key] || u.name}
-                          onChange={(e) => setAppNames(prev => ({ ...prev, [u.key]: e.target.value }))}
-                          className="bg-transparent border-none outline-none text-inherit w-full py-0 font-bold uppercase tracking-widest"
-                          placeholder="App Name"
-                        />
+                        <div className="flex items-center gap-2">
+                          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-(--accent)">
+                            <path d="M12 20h9" />
+                            <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                          </svg>
+                          <input
+                            type="text"
+                            value={appNames[u.key] || u.name}
+                            onChange={(e) => setAppNames(prev => ({ ...prev, [u.key]: e.target.value }))}
+                            className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                            placeholder="App Name"
+                            aria-label={`${u.name} name`}
+                            title="Editable app name"
+                          />
+                        </div>
                       ) : u.name}
                     </div>
 
@@ -616,9 +720,40 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
                       >
                         Browse
                       </button>
+                      {u.isCustom && (
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveCustomSlot(getCustomSlotNumber(u.key))}
+                          disabled={customSlots <= 1}
+                          className="flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl bg-(--danger-surface) text-(--danger-text) transition-all hover:bg-(--danger-border) active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100"
+                          title={`Remove ${appNames[u.key] || u.name}`}
+                          aria-label={`Remove ${appNames[u.key] || u.name}`}
+                        >
+                          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M3 6h18" />
+                            <path d="M8 6V4h8v2" />
+                            <path d="M19 6l-1 14H6L5 6" />
+                            <path d="M10 11v5" />
+                            <path d="M14 11v5" />
+                          </svg>
+                        </button>
+                      )}
                     </div>
                   </div>
                 ))}
+                <div className="px-5 py-3">
+                  <button
+                    type="button"
+                    onClick={handleAddCustomSlot}
+                    className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-(--glass-bg-elevated) py-2.5 text-xs font-bold text-(--text-primary) transition-all hover:bg-(--glass-border) active:scale-[0.98]"
+                  >
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                      <path d="M12 5v14" />
+                      <path d="M5 12h14" />
+                    </svg>
+                    Add slot
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -30,6 +30,8 @@ const ACCENT_PRESETS = [
   { name: 'Caution Yellow', hex: '#ffd600' },
 ]
 
+const CONFIG_IMPORT_WARNING_KEY = 'simlauncher-config-import-warning'
+
 function normalizeLaunchDelayMs(value: number) {
   if (!Number.isFinite(value)) {
     return 1000
@@ -78,6 +80,8 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
 
   const [checkingUpdate, setCheckingUpdate] = useState(false)
   const [installingUpdate, setInstallingUpdate] = useState(false)
+  const [exportingConfig, setExportingConfig] = useState(false)
+  const [importingConfig, setImportingConfig] = useState(false)
   const [updateProgress, setUpdateProgress] = useState<number | null>(null)
   const [updateStatus, setUpdateStatus] = useState<string | null>(null)
 
@@ -400,6 +404,53 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
     }
   }
 
+  const handleExportConfig = async () => {
+    setExportingConfig(true)
+
+    try {
+      const result = await window.electronAPI.exportConfig()
+
+      if (result.success) {
+        notify('Config exported', 'success', 2500)
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to export config', 'error')
+      }
+    } catch (err) {
+      notify('Failed to export config', 'error')
+      console.error(err)
+    } finally {
+      setExportingConfig(false)
+    }
+  }
+
+  const handleImportConfig = async () => {
+    const confirmed = window.confirm(
+      'Importing a config file will replace your current SimLauncher settings. Continue?'
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    setImportingConfig(true)
+
+    try {
+      const result = await window.electronAPI.importConfig()
+
+      if (result.success) {
+        window.sessionStorage.setItem(CONFIG_IMPORT_WARNING_KEY, '1')
+        window.location.reload()
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to import config', 'error')
+      }
+    } catch (err) {
+      notify('Failed to import config', 'error')
+      console.error(err)
+    } finally {
+      setImportingConfig(false)
+    }
+  }
+
   const handleSave = async () => {
     try {
       const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
@@ -632,6 +683,45 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
                 className="w-full accent-(--accent)"
                 aria-label="Launch delay slider"
               />
+            </div>
+          </div>
+        </section>
+
+        {/* Config Section */}
+        <section className="space-y-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">Config</h3>
+          <div className="glass-surface rounded-2xl flex flex-col p-5 gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-(--text-primary)">Backup and migration</span>
+              <span className="text-[10px] text-(--text-muted)">Export or replace the complete SimLauncher JSON config</span>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={handleExportConfig}
+                disabled={exportingConfig || importingConfig}
+                className="flex cursor-pointer items-center justify-center gap-2 rounded-xl bg-(--glass-bg-elevated) px-4 py-2.5 text-xs font-bold text-(--text-primary) transition-all hover:bg-(--glass-border) active:scale-[0.98] disabled:cursor-wait disabled:opacity-60 disabled:active:scale-100"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <path d="M7 10l5 5 5-5" />
+                  <path d="M12 15V3" />
+                </svg>
+                {exportingConfig ? 'Exporting...' : 'Export config'}
+              </button>
+              <button
+                type="button"
+                onClick={handleImportConfig}
+                disabled={exportingConfig || importingConfig}
+                className="flex cursor-pointer items-center justify-center gap-2 rounded-xl bg-(--glass-bg-elevated) px-4 py-2.5 text-xs font-bold text-(--text-primary) transition-all hover:bg-(--glass-border) active:scale-[0.98] disabled:cursor-wait disabled:opacity-60 disabled:active:scale-100"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <path d="M17 8l-5-5-5 5" />
+                  <path d="M12 3v12" />
+                </svg>
+                {importingConfig ? 'Importing...' : 'Import config'}
+              </button>
             </div>
           </div>
         </section>

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -4,6 +4,7 @@ import {
   GAMES,
   getCustomUtilityKey,
   getUtilities,
+  isProfileUtility,
   resolveCustomSlots,
   type Profiles
 } from '../lib/config'
@@ -235,6 +236,34 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
     return shifted
   }
 
+  const shiftProfileCustomSlots = (profile: Profiles[string], removedSlot: number, slotCount: number) => {
+    const shiftedProfile = shiftCustomSlotRecord(profile, removedSlot, slotCount)
+
+    if (Array.isArray(profile.utilities)) {
+      shiftedProfile.utilities = profile.utilities.filter(isProfileUtility).flatMap((utility) => {
+        const match = utility.id.match(/^customapp(\d+)$/)
+
+        if (!match) {
+          return [utility]
+        }
+
+        const slot = Number(match[1])
+
+        if (slot < removedSlot) {
+          return [utility]
+        }
+
+        if (slot > removedSlot && slot <= slotCount) {
+          return [{ ...utility, id: getCustomUtilityKey(slot - 1) }]
+        }
+
+        return []
+      })
+    }
+
+    return shiftedProfile
+  }
+
   const getCustomSlotNumber = (key: string) => Number(key.replace('customapp', ''))
 
   const handleAddCustomSlot = () => {
@@ -266,7 +295,7 @@ export function SettingsView({ onClose, updateInfo }: { onClose: () => void, upd
       const nextProfiles: Profiles = {}
 
       Object.entries(current).forEach(([gameKey, profile]) => {
-        nextProfiles[gameKey] = shiftCustomSlotRecord(profile, slotNumber, customSlots)
+        nextProfiles[gameKey] = shiftProfileCustomSlots(profile, slotNumber, customSlots)
       })
 
       return nextProfiles

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -1,6 +1,12 @@
 export interface Game { key: string; name: string; icon: string }
 export interface Utility { key: string; name: string; isCustom?: boolean }
-export type GameProfile = Record<string, boolean | string[] | undefined> & {
+export interface ProfileUtility {
+  id: string
+  enabled: boolean
+}
+export interface GameProfile {
+  [key: string]: unknown
+  utilities?: ProfileUtility[]
   launchAutomatically?: boolean
   trackingEnabled?: boolean
   killControlsEnabled?: boolean
@@ -68,15 +74,36 @@ function hasCustomSlotValue(value: unknown) {
   return false
 }
 
+function getCustomSlotNumberFromKey(key: string) {
+  const match = key.match(/^customapp(\d+)$/)
+  return match ? Number(match[1]) : null
+}
+
 export function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
   let highestSlot = 0
 
   records.forEach((record) => {
     Object.entries(record || {}).forEach(([key, value]) => {
-      const match = key.match(/^customapp(\d+)$/)
+      if (key === 'utilities' && Array.isArray(value)) {
+        value.forEach((entry) => {
+          if (!isProfileUtility(entry) || !entry.enabled) {
+            return
+          }
 
-      if (match && hasCustomSlotValue(value)) {
-        highestSlot = Math.max(highestSlot, Number(match[1]))
+          const slotNumber = getCustomSlotNumberFromKey(entry.id)
+
+          if (slotNumber !== null) {
+            highestSlot = Math.max(highestSlot, slotNumber)
+          }
+        })
+
+        return
+      }
+
+      const slotNumber = getCustomSlotNumberFromKey(key)
+
+      if (slotNumber !== null && hasCustomSlotValue(value)) {
+        highestSlot = Math.max(highestSlot, slotNumber)
       }
     })
   })
@@ -107,6 +134,63 @@ export function getUtilities(customSlots: unknown): Utility[] {
     ...BUILT_IN_UTILITIES,
     ...getCustomUtilities(customSlots)
   ]
+}
+
+export function isProfileUtility(value: unknown): value is ProfileUtility {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const entry = value as Record<string, unknown>
+  return typeof entry.id === 'string' && typeof entry.enabled === 'boolean'
+}
+
+export function normalizeProfileUtilities(profile: GameProfile | undefined, utilities: Utility[]) {
+  const utilityIds = new Set(utilities.map((utility) => utility.key))
+  const orderedUtilities: ProfileUtility[] = []
+  const seen = new Set<string>()
+  const storedUtilities = Array.isArray(profile?.utilities)
+    ? profile.utilities.filter(isProfileUtility)
+    : []
+
+  storedUtilities.forEach((entry) => {
+    if (!utilityIds.has(entry.id) || seen.has(entry.id)) {
+      return
+    }
+
+    orderedUtilities.push({ id: entry.id, enabled: entry.enabled })
+    seen.add(entry.id)
+  })
+
+  utilities.forEach((utility) => {
+    if (seen.has(utility.key)) {
+      return
+    }
+
+    orderedUtilities.push({
+      id: utility.key,
+      enabled: profile?.[utility.key] === true
+    })
+  })
+
+  return orderedUtilities
+}
+
+export function getEnabledProfileUtilities(profile: GameProfile | undefined, utilities: Utility[]) {
+  return normalizeProfileUtilities(profile, utilities).filter((utility) => utility.enabled)
+}
+
+export function migrateProfileToUtilityOrder(profile: GameProfile, utilities: Utility[]) {
+  const migratedProfile: GameProfile = {
+    ...profile,
+    utilities: normalizeProfileUtilities(profile, utilities)
+  }
+
+  utilities.forEach((utility) => {
+    delete migratedProfile[utility.key]
+  })
+
+  return migratedProfile
 }
 
 export const UTILITIES: Utility[] = getUtilities(DEFAULT_CUSTOM_SLOTS)

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -10,6 +10,7 @@ export type GameProfile = Record<string, boolean | string[] | undefined> & {
 export type Profiles = Record<string, GameProfile>
 
 export const DEFAULT_ACCENT_COLOR = '#00eaff'
+export const DEFAULT_CUSTOM_SLOTS = 1
 
 export const GAMES: Game[] = [
   { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' },
@@ -35,15 +36,77 @@ export const GAMES: Game[] = [
   { key: 'rf2', name: 'rFactor 2', icon: 'assets/rf2.png' },
 ]
 
-export const UTILITIES: Utility[] = [
+export const BUILT_IN_UTILITIES: Utility[] = [
   { key: 'simhub', name: 'SimHub' },
   { key: 'crewchief', name: 'Crew Chief' },
   { key: 'tradingpaints', name: 'Trading Paints' },
   { key: 'garage61', name: 'Garage 61' },
   { key: 'secondmonitor', name: 'Second Monitor' },
-  { key: 'customapp1', name: 'Custom App 1', isCustom: true },
-  { key: 'customapp2', name: 'Custom App 2', isCustom: true },
-  { key: 'customapp3', name: 'Custom App 3', isCustom: true },
-  { key: 'customapp4', name: 'Custom App 4', isCustom: true },
-  { key: 'customapp5', name: 'Custom App 5', isCustom: true },
 ]
+
+export function normalizeCustomSlots(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_CUSTOM_SLOTS
+  }
+
+  return Math.max(1, Math.floor(value))
+}
+
+export function getCustomUtilityKey(index: number) {
+  return `customapp${index}`
+}
+
+function hasCustomSlotValue(value: unknown) {
+  if (value === true) {
+    return true
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0
+  }
+
+  return false
+}
+
+export function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
+  let highestSlot = 0
+
+  records.forEach((record) => {
+    Object.entries(record || {}).forEach(([key, value]) => {
+      const match = key.match(/^customapp(\d+)$/)
+
+      if (match && hasCustomSlotValue(value)) {
+        highestSlot = Math.max(highestSlot, Number(match[1]))
+      }
+    })
+  })
+
+  return highestSlot
+}
+
+export function resolveCustomSlots(value: unknown, ...records: Array<Record<string, unknown> | undefined>) {
+  return Math.max(normalizeCustomSlots(value), getHighestCustomSlot(...records))
+}
+
+export function getCustomUtilities(customSlots: unknown): Utility[] {
+  const slotCount = normalizeCustomSlots(customSlots)
+
+  return Array.from({ length: slotCount }, (_, index) => {
+    const slotNumber = index + 1
+
+    return {
+      key: getCustomUtilityKey(slotNumber),
+      name: `Custom App ${slotNumber}`,
+      isCustom: true
+    }
+  })
+}
+
+export function getUtilities(customSlots: unknown): Utility[] {
+  return [
+    ...BUILT_IN_UTILITIES,
+    ...getCustomUtilities(customSlots)
+  ]
+}
+
+export const UTILITIES: Utility[] = getUtilities(DEFAULT_CUSTOM_SLOTS)

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -13,10 +13,21 @@ export interface GameProfile {
   relaunchControlsEnabled?: boolean
   trackedProcessPaths?: string[]
 }
-export type Profiles = Record<string, GameProfile>
+export interface NamedGameProfile extends GameProfile {
+  id: string
+  name: string
+}
+export interface GameProfileSet {
+  activeProfileId: string
+  profiles: NamedGameProfile[]
+}
+export type StoredGameProfile = GameProfile | GameProfileSet
+export type Profiles = Record<string, StoredGameProfile>
 
 export const DEFAULT_ACCENT_COLOR = '#00eaff'
 export const DEFAULT_CUSTOM_SLOTS = 1
+export const DEFAULT_PROFILE_ID = 'default'
+export const DEFAULT_PROFILE_NAME = 'Default'
 
 export const GAMES: Game[] = [
   { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' },
@@ -82,8 +93,17 @@ function getCustomSlotNumberFromKey(key: string) {
 export function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
   let highestSlot = 0
 
-  records.forEach((record) => {
+  const scanRecord = (record: Record<string, unknown> | undefined) => {
     Object.entries(record || {}).forEach(([key, value]) => {
+      if (key === 'profiles' && Array.isArray(value)) {
+        value.forEach((profile) => {
+          if (profile && typeof profile === 'object') {
+            scanRecord(profile as Record<string, unknown>)
+          }
+        })
+        return
+      }
+
       if (key === 'utilities' && Array.isArray(value)) {
         value.forEach((entry) => {
           if (!isProfileUtility(entry) || !entry.enabled) {
@@ -106,6 +126,10 @@ export function getHighestCustomSlot(...records: Array<Record<string, unknown> |
         highestSlot = Math.max(highestSlot, slotNumber)
       }
     })
+  }
+
+  records.forEach((record) => {
+    scanRecord(record)
   })
 
   return highestSlot
@@ -191,6 +215,86 @@ export function migrateProfileToUtilityOrder(profile: GameProfile, utilities: Ut
   })
 
   return migratedProfile
+}
+
+export function isGameProfileSet(value: unknown): value is GameProfileSet {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const entry = value as Record<string, unknown>
+  return typeof entry.activeProfileId === 'string' && Array.isArray(entry.profiles)
+}
+
+export function createProfileId() {
+  return `profile-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function normalizeNamedProfile(value: unknown, fallbackIndex: number): NamedGameProfile | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const profile = value as Record<string, unknown>
+  const fallbackName = fallbackIndex === 0 ? DEFAULT_PROFILE_NAME : `Profile ${fallbackIndex + 1}`
+
+  return {
+    ...(profile as GameProfile),
+    id: typeof profile.id === 'string' && profile.id.trim().length > 0
+      ? profile.id
+      : createProfileId(),
+    name: typeof profile.name === 'string' && profile.name.trim().length > 0
+      ? profile.name.trim()
+      : fallbackName
+  }
+}
+
+export function createDefaultProfile(profile: GameProfile = {}): NamedGameProfile {
+  return {
+    ...profile,
+    id: DEFAULT_PROFILE_ID,
+    name: DEFAULT_PROFILE_NAME
+  }
+}
+
+export function normalizeGameProfileSet(value: StoredGameProfile | undefined): GameProfileSet {
+  if (isGameProfileSet(value)) {
+    const seenIds = new Set<string>()
+    const profiles = value.profiles.flatMap((profile, index) => {
+      const normalizedProfile = normalizeNamedProfile(profile, index)
+
+      if (!normalizedProfile || seenIds.has(normalizedProfile.id)) {
+        return []
+      }
+
+      seenIds.add(normalizedProfile.id)
+      return [normalizedProfile]
+    })
+
+    if (profiles.length === 0) {
+      const defaultProfile = createDefaultProfile()
+      return {
+        activeProfileId: defaultProfile.id,
+        profiles: [defaultProfile]
+      }
+    }
+
+    const activeProfileId = profiles.some((profile) => profile.id === value.activeProfileId)
+      ? value.activeProfileId
+      : profiles[0].id
+
+    return { activeProfileId, profiles }
+  }
+
+  return {
+    activeProfileId: DEFAULT_PROFILE_ID,
+    profiles: [createDefaultProfile(value)]
+  }
+}
+
+export function getActiveGameProfile(value: StoredGameProfile | undefined) {
+  const profileSet = normalizeGameProfileSet(value)
+  return profileSet.profiles.find((profile) => profile.id === profileSet.activeProfileId) || profileSet.profiles[0]
 }
 
 export const UTILITIES: Utility[] = getUtilities(DEFAULT_CUSTOM_SLOTS)

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,5 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './App.css'
 import App from './App'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />)
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+)


### PR DESCRIPTION
## Summary

- Dynamic custom app slots — add/remove beyond fixed 5 (#36)
- Per-sim launch profiles with create, rename, delete (#49)
- Custom start order for profile utilities via drag & drop (#52)
- Config export/import for backup and migration (#51)
- Adopt externally running game into managed profile state (#101)
- Fix legacy config import rejecting old keys like killOnClose (#110)
- Fix profile dropdown z-index issues
- Replace native profile dropdown with custom React menu

## Milestone
0.4.0 - Profile system

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #49
Closes #51
Closes #52
Closes #110
<!-- auto-closes -->