### PR TITLE
0.5.0 - Security hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "0.1.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "0.1.4",
+      "version": "0.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.0",
@@ -20,7 +20,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^5.0.0",
-        "electron": "^38.2.2",
+        "electron": "^39.8.8",
         "electron-builder": "^26.0.12",
         "electron-vite": "^4.0.0",
         "typescript": "^5.9.0"
@@ -4028,9 +4028,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.2.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.2.2.tgz",
-      "integrity": "sha512-OXSaVNXDlonXDjMRsFNQo1j5tzTKwKXh5/m46IjAFccBcZJZMISI+EjSI07oexIuhvKM8AZLuFuihVn4YjWWrA==",
+      "version": "39.8.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.8.tgz",
+      "integrity": "sha512-24MMLdwCg8xwlWzDxC1XZU2MqW0Xx2UPxt9EU15vMDoRSMHPqmi/BgRCEINXZaBLfFSeXEKGpg+QlBRdL5uwaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.0",
-    "electron": "^38.2.2",
+    "electron": "^39.8.8",
     "electron-builder": "^26.0.12",
     "electron-vite": "^4.0.0",
     "typescript": "^5.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -695,6 +695,12 @@ function createWindow() {
     }
   })
 
+  mainWindow.webContents.on('will-navigate', (event) => {
+    event.preventDefault()
+  })
+
+  mainWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+
   mainWindow.on('close', (event) => {
     if (!mainWindow || mainWindow.isDestroyed()) {
       return
@@ -764,7 +770,7 @@ function createWindow() {
     }
   })
 
-  if (process.env['ELECTRON_RENDERER_URL']) {
+  if (!app.isPackaged && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
     mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,6 +90,22 @@ const BUILT_IN_UTILITY_KEYS = ['simhub', 'crewchief', 'tradingpaints', 'garage61
 
 autoUpdater.autoDownload = false
 
+interface LaunchResult {
+  success: boolean
+  message?: string
+  warning?: string
+  error?: string
+  launchedCount?: number
+  skippedCount?: number
+  elevatedCount?: number
+  failedCount?: number
+}
+
+type AppLaunchResult =
+  | { status: 'launched'; appPath: string }
+  | { status: 'elevated'; appPath: string; warning: string }
+  | { status: 'failed'; appPath: string; error: string }
+
 interface StoredProfile extends Record<string, unknown> {
   utilities?: StoredProfileUtility[]
   launchAutomatically?: boolean
@@ -655,7 +671,7 @@ async function launchProfileApps(
   sender: WebContents,
   gameKey: string,
   profileApps: string[]
-): Promise<{ success: boolean; message?: string; error?: string; launchedCount?: number; skippedCount?: number }> {
+): Promise<LaunchResult> {
   if (activeLaunches.size > 0) {
     return { success: false, error: 'Another profile is already launching.' }
   }
@@ -705,23 +721,59 @@ async function launchProfileApps(
       }
     }
 
+    const launchResults: AppLaunchResult[] = []
+
     for (let index = 0; index < appsToLaunch.length; index += 1) {
       launchedAny = true
-      await spawnDetachedApp(sender, gameKey, appsToLaunch[index], gamePath)
+      launchResults.push(await spawnDetachedApp(sender, gameKey, appsToLaunch[index], gamePath))
 
       if (index < appsToLaunch.length - 1 && launchDelayMs > 0) {
         await wait(launchDelayMs)
       }
     }
 
+    const elevatedResults = launchResults.filter(
+      (result): result is Extract<AppLaunchResult, { status: 'elevated' }> => result.status === 'elevated'
+    )
+    const failedResults = launchResults.filter(
+      (result): result is Extract<AppLaunchResult, { status: 'failed' }> => result.status === 'failed'
+    )
+    const launchedCount = launchResults.length - failedResults.length
+
+    if (failedResults.length > 0) {
+      const firstFailure = failedResults[0]
+      const failedAppName = path.basename(firstFailure.appPath)
+
+      return {
+        success: false,
+        error:
+          failedResults.length === 1
+            ? `Failed to launch ${failedAppName}: ${firstFailure.error}`
+            : `Failed to launch ${failedResults.length} apps. First error: ${failedAppName}: ${firstFailure.error}`,
+        launchedCount,
+        skippedCount,
+        elevatedCount: elevatedResults.length,
+        failedCount: failedResults.length
+      }
+    }
+
+    const elevatedWarning =
+      elevatedResults.length === 1
+        ? elevatedResults[0].warning
+        : elevatedResults.length > 1
+          ? `${elevatedResults.length} apps requested administrator permission. SimLauncher cannot track or close elevated apps after launch.`
+          : undefined
+
     return {
       success: true,
       message:
         skippedCount > 0
-          ? `Started ${appsToLaunch.length} app${appsToLaunch.length === 1 ? '' : 's'}; skipped ${skippedCount} already running.`
+          ? `Started ${launchedCount} app${launchedCount === 1 ? '' : 's'}; skipped ${skippedCount} already running.`
           : 'All profile applications launched.',
-      launchedCount: appsToLaunch.length,
-      skippedCount
+      warning: elevatedWarning,
+      launchedCount,
+      skippedCount,
+      elevatedCount: elevatedResults.length
     }
   } finally {
     if (launchedAny) {
@@ -995,14 +1047,56 @@ function sendLaunchError(sender: WebContents, appPath: string, error: string) {
   }
 }
 
-function spawnDetachedApp(sender: WebContents, gameKey: string, appPath: string, gamePath?: string) {
-  return new Promise<void>((resolve) => {
-    let settled = false
+function getErrorMessage(err: unknown) {
+  return err instanceof Error ? err.message : String(err)
+}
 
-    const resolveOnce = () => {
+function getErrorCode(err: unknown) {
+  return err && typeof err === 'object' && 'code' in err ? String((err as { code?: unknown }).code) : undefined
+}
+
+function isElevatedLaunchError(err: unknown) {
+  return process.platform === 'win32' && getErrorCode(err) === 'EACCES'
+}
+
+function launchElevated(appPath: string) {
+  return new Promise<AppLaunchResult>((resolve) => {
+    const escapedAppPath = appPath.replace(/'/g, "''")
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', `Start-Process -FilePath '${escapedAppPath}' -Verb RunAs`],
+      { windowsHide: true },
+      (error) => {
+        if (error) {
+          const message = `Administrator permission was requested for ${path.basename(appPath)}, but Windows did not start it. ${getErrorMessage(error)}`
+          console.error(`Error launching ${appPath} as administrator: ${getErrorMessage(error)}`)
+          resolve({ status: 'failed', appPath, error: message })
+          return
+        }
+
+        resolve({
+          status: 'elevated',
+          appPath,
+          warning: `${path.basename(appPath)} requested administrator permission. SimLauncher cannot track or close elevated apps after launch.`
+        })
+      }
+    )
+  })
+}
+
+function spawnDetachedApp(sender: WebContents, gameKey: string, appPath: string, gamePath?: string) {
+  return new Promise<AppLaunchResult>((resolve) => {
+    let settled = false
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined
+
+    const resolveOnce = (result: AppLaunchResult) => {
       if (!settled) {
         settled = true
-        resolve()
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+        }
+        resolve(result)
       }
     }
 
@@ -1017,26 +1111,45 @@ function spawnDetachedApp(sender: WebContents, gameKey: string, appPath: string,
 
       child.once('spawn', () => {
         child.unref()
-        resolveOnce()
+        resolveOnce({ status: 'launched', appPath })
       })
 
-      child.once('error', (err) => {
+      child.once('error', async (err) => {
         runningProcesses.delete(appPath)
-        console.error(`Error launching ${appPath}: ${err.message}`)
-        sendLaunchError(sender, appPath, err.message)
-        resolveOnce()
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+        }
+        const message = getErrorMessage(err)
+        console.error(`Error launching ${appPath}: ${message}`)
+
+        if (settled) {
+          sendLaunchError(sender, appPath, message)
+          return
+        }
+
+        if (isElevatedLaunchError(err)) {
+          resolveOnce(await launchElevated(appPath))
+          return
+        }
+
+        resolveOnce({ status: 'failed', appPath, error: message })
       })
 
       child.once('exit', () => {
         runningProcesses.delete(appPath)
       })
 
-      setTimeout(resolveOnce, 500)
+      fallbackTimer = setTimeout(() => resolveOnce({ status: 'launched', appPath }), 500)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getErrorMessage(err)
       console.error(`Error launching ${appPath}: ${message}`)
-      sendLaunchError(sender, appPath, message)
-      resolveOnce()
+
+      if (isElevatedLaunchError(err)) {
+        launchElevated(appPath).then(resolveOnce)
+        return
+      }
+
+      resolveOnce({ status: 'failed', appPath, error: message })
     }
   })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -92,6 +92,7 @@ autoUpdater.autoDownload = false
 
 interface StoredProfile extends Record<string, unknown> {
   utilities?: StoredProfileUtility[]
+  launchAutomatically?: boolean
   trackingEnabled?: boolean
   trackedProcessPaths?: string[]
 }
@@ -561,6 +562,173 @@ app.whenReady().then(() => {
 
 function isValidExePath(p: unknown): p is string {
   return typeof p === 'string' && p.trim().length > 0 && /\.exe$/i.test(p.trim())
+}
+
+function resolveActiveProfile(entry: StoredProfileEntry | undefined): StoredNamedProfile {
+  if (!entry) {
+    return { id: 'default', name: 'Default' }
+  }
+  if (isStoredProfileSet(entry)) {
+    const validProfiles = entry.profiles.filter(
+      (p): p is StoredNamedProfile =>
+        !!p && typeof p === 'object' && typeof (p as Record<string, unknown>).id === 'string'
+    )
+    if (validProfiles.length === 0) return { id: 'default', name: 'Default' }
+    return validProfiles.find((p) => p.id === entry.activeProfileId) || validProfiles[0]
+  }
+  return { ...(entry as StoredProfile), id: 'default', name: 'Default' }
+}
+
+function resolveNamedProfile(entry: StoredProfileEntry | undefined, profileId: string): StoredNamedProfile {
+  if (isStoredProfileSet(entry)) {
+    const validProfiles = entry.profiles.filter(
+      (p): p is StoredNamedProfile =>
+        !!p && typeof p === 'object' && typeof (p as Record<string, unknown>).id === 'string'
+    )
+    return validProfiles.find((p) => p.id === profileId) || validProfiles[0] || { id: 'default', name: 'Default' }
+  }
+  return { ...(entry as StoredProfile | undefined || {}), id: 'default', name: 'Default' }
+}
+
+function getEnabledUtilityPaths(
+  profile: StoredProfile,
+  appPaths: Record<string, string>,
+  customSlots: unknown
+): string[] {
+  const count =
+    typeof customSlots === 'number' && Number.isFinite(customSlots) ? Math.max(1, Math.floor(customSlots)) : 1
+  const utilityKeys = [
+    ...BUILT_IN_UTILITY_KEYS,
+    ...Array.from({ length: count }, (_, i) => `customapp${i + 1}`)
+  ]
+  const paths: string[] = []
+
+  if (Array.isArray(profile.utilities)) {
+    profile.utilities
+      .filter(
+        (u): u is StoredProfileUtility =>
+          !!u &&
+          typeof u === 'object' &&
+          typeof (u as Record<string, unknown>).id === 'string' &&
+          typeof (u as Record<string, unknown>).enabled === 'boolean'
+      )
+      .filter((u) => u.enabled && utilityKeys.includes(u.id) && appPaths[u.id])
+      .forEach((u) => paths.push(appPaths[u.id]))
+  } else {
+    utilityKeys.forEach((key) => {
+      if (profile[key] === true && appPaths[key]) paths.push(appPaths[key])
+    })
+  }
+
+  return paths
+}
+
+function buildActiveProfileLaunchPaths(gameKey: string): string[] {
+  const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
+  const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
+  const profiles = (store.get('profiles') as Record<string, StoredProfileEntry> | undefined) || {}
+  const customSlots = store.get('customSlots')
+  const profile = resolveActiveProfile(profiles[gameKey])
+  const paths: string[] = []
+
+  if (profile.launchAutomatically !== false && gamePaths[gameKey]) paths.push(gamePaths[gameKey])
+  getEnabledUtilityPaths(profile, appPaths, customSlots).forEach((p) => paths.push(p))
+
+  return paths
+}
+
+function buildNamedProfileLaunchPaths(gameKey: string, profileId: string): string[] {
+  const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
+  const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
+  const profiles = (store.get('profiles') as Record<string, StoredProfileEntry> | undefined) || {}
+  const customSlots = store.get('customSlots')
+  const profile = resolveNamedProfile(profiles[gameKey], profileId)
+  const paths: string[] = []
+
+  if (profile.launchAutomatically !== false && gamePaths[gameKey]) paths.push(gamePaths[gameKey])
+  getEnabledUtilityPaths(profile, appPaths, customSlots).forEach((p) => paths.push(p))
+
+  return paths
+}
+
+async function launchProfileApps(
+  sender: WebContents,
+  gameKey: string,
+  profileApps: string[]
+): Promise<{ success: boolean; message?: string; error?: string; launchedCount?: number; skippedCount?: number }> {
+  if (activeLaunches.size > 0) {
+    return { success: false, error: 'Another profile is already launching.' }
+  }
+
+  const cooldownRemainingMs = launchBlockedUntil - Date.now()
+  if (cooldownRemainingMs > 0) {
+    return {
+      success: false,
+      error: `Launch is settling. Try again in ${Math.ceil(cooldownRemainingMs / 1000)}s.`
+    }
+  }
+
+  activeLaunches.add(gameKey)
+  const launchDelayMs = getLaunchDelayMs()
+  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
+  const gamePath = gamePaths?.[gameKey]?.toLowerCase()
+  const processNames = await readRunningProcessNames()
+  const validApps = profileApps.filter((appPath) => {
+    if (!isValidExePath(appPath)) {
+      console.error(`Skipping invalid path: ${appPath}`)
+      return false
+    }
+    if (!fs.existsSync(appPath.trim())) {
+      console.error(`Skipping missing executable: ${appPath}`)
+      return false
+    }
+    return true
+  })
+
+  if (validApps.length === 0) {
+    activeLaunches.delete(gameKey)
+    return { success: false, error: 'No valid executable paths configured.' }
+  }
+
+  let launchedAny = false
+
+  try {
+    const appsToLaunch = validApps.filter((appPath) => !isRunningExePath(processNames, appPath))
+    const skippedCount = validApps.length - appsToLaunch.length
+
+    if (appsToLaunch.length === 0) {
+      return {
+        success: true,
+        message: 'All profile applications are already running.',
+        launchedCount: 0,
+        skippedCount
+      }
+    }
+
+    for (let index = 0; index < appsToLaunch.length; index += 1) {
+      launchedAny = true
+      await spawnDetachedApp(sender, gameKey, appsToLaunch[index], gamePath)
+
+      if (index < appsToLaunch.length - 1 && launchDelayMs > 0) {
+        await wait(launchDelayMs)
+      }
+    }
+
+    return {
+      success: true,
+      message:
+        skippedCount > 0
+          ? `Started ${appsToLaunch.length} app${appsToLaunch.length === 1 ? '' : 's'}; skipped ${skippedCount} already running.`
+          : 'All profile applications launched.',
+      launchedCount: appsToLaunch.length,
+      skippedCount
+    }
+  } finally {
+    if (launchedAny) {
+      launchBlockedUntil = Date.now() + POST_LAUNCH_BLOCK_MS
+    }
+    activeLaunches.delete(gameKey)
+  }
 }
 
 function getLaunchDelayMs() {
@@ -1070,84 +1238,81 @@ async function getTrackedRunningApps(
 // MAIN LAUNCH LOGIC
 // ----------------------------------------------------------------
 
-/**
- * Executes a list of applications sequentially with a delay.
- * @param profileApps Array of executable paths to launch.
- */
-ipcMain.handle('launch-profile', async (event, gameKey: string, profileApps: string[]) => {
-  if (!Array.isArray(profileApps) || profileApps.length === 0) {
-    return { success: false, error: 'Profile is empty.' }
+ipcMain.handle('launch-profile', async (event, gameKey: string) => {
+  const profileApps = buildActiveProfileLaunchPaths(gameKey)
+
+  if (profileApps.length === 0) {
+    return { success: false, error: 'No executable paths configured for this profile.' }
   }
 
-  if (activeLaunches.size > 0) {
-    return { success: false, error: 'Another profile is already launching.' }
-  }
-
-  const cooldownRemainingMs = launchBlockedUntil - Date.now()
-  if (cooldownRemainingMs > 0) {
-    return {
-      success: false,
-      error: `Launch is settling. Try again in ${Math.ceil(cooldownRemainingMs / 1000)}s.`
-    }
-  }
-
-  activeLaunches.add(gameKey)
-  const launchDelayMs = getLaunchDelayMs()
-  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
-  const gamePath = gamePaths?.[gameKey]?.toLowerCase()
-  const processNames = await readRunningProcessNames()
-  const validApps = profileApps.filter((appPath) => {
-    const valid = isValidExePath(appPath)
-    if (!valid) {
-      console.error(`Skipping invalid path: ${appPath}`)
-    }
-    return valid
-  })
-
-  if (validApps.length === 0) {
-    activeLaunches.delete(gameKey)
-    return { success: false, error: 'No valid executable paths configured.' }
-  }
-
-  let launchedAny = false
-
-  try {
-    const appsToLaunch = validApps.filter((appPath) => !isRunningExePath(processNames, appPath))
-    const skippedCount = validApps.length - appsToLaunch.length
-
-    if (appsToLaunch.length === 0) {
-      return {
-        success: true,
-        message: 'All profile applications are already running.',
-        launchedCount: 0,
-        skippedCount
-      }
-    }
-
-    for (let index = 0; index < appsToLaunch.length; index += 1) {
-      launchedAny = true
-      await spawnDetachedApp(event.sender, gameKey, appsToLaunch[index], gamePath)
-
-      if (index < appsToLaunch.length - 1 && launchDelayMs > 0) {
-        await wait(launchDelayMs)
-      }
-    }
-
-    return {
-      success: true,
-      message: skippedCount > 0
-        ? `Started ${appsToLaunch.length} app${appsToLaunch.length === 1 ? '' : 's'}; skipped ${skippedCount} already running.`
-        : 'All profile applications launched.',
-      launchedCount: appsToLaunch.length,
-      skippedCount
-    }
-  } finally {
-    if (launchedAny) {
-      launchBlockedUntil = Date.now() + POST_LAUNCH_BLOCK_MS
-    }
-    activeLaunches.delete(gameKey)
-  }
+  return launchProfileApps(event.sender, gameKey, profileApps)
 })
+
+ipcMain.handle('relaunch-missing-profile', async (event, gameKey: string) => {
+  const allPaths = buildActiveProfileLaunchPaths(gameKey)
+
+  if (allPaths.length === 0) {
+    return { success: false, error: 'No executable paths configured for this profile.' }
+  }
+
+  const processNames = await readRunningProcessNames()
+  const missingPaths = allPaths.filter((p) => !isRunningExePath(processNames, p))
+
+  if (missingPaths.length === 0) {
+    return { success: true, message: 'All profile apps are already running.', launchedCount: 0, skippedCount: 0 }
+  }
+
+  return launchProfileApps(event.sender, gameKey, missingPaths)
+})
+
+ipcMain.handle('get-profile-switch-diff', (_event, gameKey: string, fromProfileId: string, toProfileId: string) => {
+  const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
+  const gamePath = gamePaths[gameKey]?.toLowerCase()
+
+  const utilityPaths = (profileId: string) =>
+    new Set(
+      buildNamedProfileLaunchPaths(gameKey, profileId)
+        .filter((p) => !gamePath || p.toLowerCase() !== gamePath)
+        .map((p) => p.toLowerCase())
+    )
+
+  const fromPaths = utilityPaths(fromProfileId)
+  const toPaths = utilityPaths(toProfileId)
+  const toStopCount = [...fromPaths].filter((p) => !toPaths.has(p)).length
+  const toStartCount = [...toPaths].filter((p) => !fromPaths.has(p)).length
+
+  return { toStopCount, toStartCount }
+})
+
+ipcMain.handle(
+  'switch-profile-apps',
+  async (event, gameKey: string, fromProfileId: string, toProfileId: string) => {
+    const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
+    const gamePath = gamePaths[gameKey]?.toLowerCase()
+
+    const fromPaths = buildNamedProfileLaunchPaths(gameKey, fromProfileId).filter(
+      (p) => !gamePath || p.toLowerCase() !== gamePath
+    )
+    const toPaths = buildNamedProfileLaunchPaths(gameKey, toProfileId).filter(
+      (p) => !gamePath || p.toLowerCase() !== gamePath
+    )
+    const fromPathSet = new Set(fromPaths.map((p) => p.toLowerCase()))
+    const toPathSet = new Set(toPaths.map((p) => p.toLowerCase()))
+
+    const pathsToStop = fromPaths.filter((p) => !toPathSet.has(p.toLowerCase()))
+    const pathsToStart = toPaths.filter((p) => !fromPathSet.has(p.toLowerCase()))
+
+    if (pathsToStop.length > 0) {
+      await killProfileApps(gameKey, pathsToStop)
+    }
+
+    if (pathsToStart.length === 0) {
+      return { success: true, launchedCount: 0, skippedCount: 0 }
+    }
+
+    return launchProfileApps(event.sender, gameKey, pathsToStart)
+  }
+)
 
 // ----------------------------------------------------------------
 // CONFIG EXPORT / IMPORT
@@ -1218,13 +1383,17 @@ ipcMain.handle('import-config', async () => {
  * Opens a file dialog to select an executable file and sends the path back.
  * @param inputId The ID of the input field in the Renderer to update.
  */
-ipcMain.handle('browse-path', async (event, inputId) => {
+ipcMain.handle('browse-path', async (_event, inputId) => {
   try {
-    const result = await dialog.showOpenDialog(null as unknown as BrowserWindow, {
+    const options = {
       title: 'Select Executable File (.exe)',
-      properties: ['openFile'],
+      properties: ['openFile'] as const,
       filters: [{ name: 'Executable Files', extensions: ['exe'] }]
-    })
+    }
+    const result =
+      mainWindow && !mainWindow.isDestroyed()
+        ? await dialog.showOpenDialog(mainWindow, options)
+        : await dialog.showOpenDialog(options)
     if (!result.canceled && result.filePaths.length > 0) {
       return { filePath: result.filePaths[0], inputId }
     }
@@ -1319,7 +1488,8 @@ ipcMain.handle('check-for-updates', async () => {
   return await checkForUpdates()
 })
 
-ipcMain.handle('get-asset-data', async (_event, filename: string) => {
+ipcMain.handle('get-asset-data', async (_event, filename: unknown) => {
+  if (typeof filename !== 'string' || path.basename(filename) !== filename || !filename) return null
   const assetsPath = app.isPackaged
     ? path.join(process.resourcesPath, 'assets')
     : path.join(app.getAppPath(), 'assets')
@@ -1370,11 +1540,13 @@ ipcMain.handle('set-zoom', (_event, factor: number) => {
   mainWindow?.webContents.setZoomFactor(factor)
 })
 
-ipcMain.handle('store-get', (_event, key) => {
+ipcMain.handle('store-get', (_event, key: unknown) => {
+  if (typeof key !== 'string' || !EXPECTED_CONFIG_KEYS.has(key)) return undefined
   return store.get(key)
 })
 
-ipcMain.handle('store-set', (_event, key, value) => {
+ipcMain.handle('store-set', (_event, key: unknown, value: unknown) => {
+  if (typeof key !== 'string' || !EXPECTED_CONFIG_KEYS.has(key)) return
   store.set(key, value)
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,10 @@ import fs from 'fs'
 import { autoUpdater } from 'electron-updater'
 import Store from 'electron-store'
 
+const DEFAULT_ZOOM_FACTOR = 1.0
+const MIN_ZOOM_FACTOR = 0.5
+const MAX_ZOOM_FACTOR = 3.0
+
 const store = new Store({
   schema: {
     appPaths:     { type: 'object',  default: {} },
@@ -21,7 +25,7 @@ const store = new Store({
     startMinimized:   { type: 'boolean', default: false },
     minimizeToTray:   { type: 'boolean', default: false },
     autoCheckUpdates:  { type: 'boolean', default: true },
-    zoomFactor:       { type: 'number',  default: 1.0 },
+    zoomFactor:       { type: 'number',  default: DEFAULT_ZOOM_FACTOR },
     windowBounds:      { type: 'object',  default: {} },
     profileUtilityOrderMigrated: { type: 'boolean', default: false },
     profileSetsMigrated: { type: 'boolean', default: false },
@@ -171,6 +175,33 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
 
+function requireSafeZoomFactor(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Zoom factor must be a finite number from ${MIN_ZOOM_FACTOR} to ${MAX_ZOOM_FACTOR}.`)
+  }
+
+  return clamp(value, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR)
+}
+
+function getSafeZoomFactor(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_ZOOM_FACTOR
+  }
+
+  return clamp(value, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR)
+}
+
+function getStoredZoomFactor() {
+  const storedZoomFactor = store.get('zoomFactor')
+  const safeZoomFactor = getSafeZoomFactor(storedZoomFactor)
+
+  if (storedZoomFactor !== safeZoomFactor) {
+    store.set('zoomFactor', safeZoomFactor)
+  }
+
+  return safeZoomFactor
+}
+
 function getInitialWindowBounds() {
   const defaultBounds = { width: 800, height: 600 }
   const savedBounds = store.get('windowBounds')
@@ -257,8 +288,8 @@ function validateImportedConfig(value: unknown): value is Record<string, unknown
     }
 
     if (key === 'zoomFactor') {
-      if (typeof setting !== 'number' || !Number.isFinite(setting) || setting <= 0) {
-        throw new Error('Config value "zoomFactor" must be a positive number.')
+      if (typeof setting !== 'number' || !Number.isFinite(setting)) {
+        throw new Error(`Config value "zoomFactor" must be a finite number from ${MIN_ZOOM_FACTOR} to ${MAX_ZOOM_FACTOR}.`)
       }
     }
   })
@@ -271,7 +302,7 @@ function getSupportedConfigValues(config: Record<string, unknown>) {
 
   Object.entries(config).forEach(([key, value]) => {
     if (EXPECTED_CONFIG_KEYS.has(key)) {
-      supportedConfig[key] = value
+      supportedConfig[key] = key === 'zoomFactor' ? requireSafeZoomFactor(value) : value
     }
   })
 
@@ -282,10 +313,7 @@ function applyRuntimeConfigSettings() {
   const startWithWindows = store.get('startWithWindows') as boolean
   app.setLoginItemSettings({ openAtLogin: !!startWithWindows })
 
-  const zoomFactor = store.get('zoomFactor')
-  if (typeof zoomFactor === 'number' && Number.isFinite(zoomFactor) && zoomFactor > 0) {
-    mainWindow?.webContents.setZoomFactor(zoomFactor)
-  }
+  mainWindow?.webContents.setZoomFactor(getStoredZoomFactor())
 }
 
 function getAppIconPath() {
@@ -650,8 +678,7 @@ async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
 }
 
 function createWindow() {
-  const savedZoom = store.get('zoomFactor') as number
-  const zoomFactor = typeof savedZoom === 'number' && Number.isFinite(savedZoom) ? savedZoom : 1.0
+  const zoomFactor = getStoredZoomFactor()
   const windowBounds = getInitialWindowBounds()
 
   mainWindow = new BrowserWindow({
@@ -1867,9 +1894,11 @@ ipcMain.handle('set-login-item', (_event, openAtLogin: boolean) => {
   app.setLoginItemSettings({ openAtLogin })
 })
 
-ipcMain.handle('set-zoom', (_event, factor: number) => {
-  store.set('zoomFactor', factor)
-  mainWindow?.webContents.setZoomFactor(factor)
+ipcMain.handle('set-zoom', (_event, factor: unknown) => {
+  const zoomFactor = requireSafeZoomFactor(factor)
+
+  store.set('zoomFactor', zoomFactor)
+  mainWindow?.webContents.setZoomFactor(zoomFactor)
 })
 
 ipcMain.handle('store-get', (_event, key: unknown) => {
@@ -1879,6 +1908,11 @@ ipcMain.handle('store-get', (_event, key: unknown) => {
 
 ipcMain.handle('store-set', (_event, key: unknown, value: unknown) => {
   if (typeof key !== 'string' || !EXPECTED_CONFIG_KEYS.has(key)) return
+  if (key === 'zoomFactor') {
+    store.set('zoomFactor', requireSafeZoomFactor(value))
+    return
+  }
+
   store.set(key, value)
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1505,6 +1505,12 @@ ipcMain.handle('get-asset-data', async (_event, filename: unknown) => {
 })
 
 ipcMain.handle('get-file-icon', async (_event, filePath: string) => {
+  const storedPaths = [
+    ...Object.values((store.get('gamePaths') as Record<string, string>) ?? {}),
+    ...Object.values((store.get('appPaths') as Record<string, string>) ?? {})
+  ]
+  if (!storedPaths.includes(filePath)) return null
+
   try {
     const icon = await app.getFileIcon(filePath, { size: 'normal' })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -78,6 +78,7 @@ let isQuitting = false
 let installAfterDownload = false
 let updateDownloaded = false
 const runningProcesses = new Map<string, { process: ChildProcess; name: string; gameKey: string; isGame: boolean }>()
+const unclosedProcesses = new Map<string, { path: string; name: string; gameKey: string; error: string }>()
 const activeLaunches = new Set<string>()
 const POST_LAUNCH_BLOCK_MS = 10000
 let launchBlockedUntil = 0
@@ -99,6 +100,26 @@ interface LaunchResult {
   skippedCount?: number
   elevatedCount?: number
   failedCount?: number
+}
+
+interface KillAttemptResult {
+  processName: string
+  success: boolean
+  appPath?: string
+  gameKey?: string
+  error?: string
+  accessDenied?: boolean
+  notFound?: boolean
+  stillRunning?: boolean
+}
+
+interface KillResult {
+  success: boolean
+  message?: string
+  warning?: string
+  error?: string
+  closedCount: number
+  failedCount: number
 }
 
 type AppLaunchResult =
@@ -325,47 +346,192 @@ async function checkForUpdates() {
   return await autoUpdater.checkForUpdates()
 }
 
+function isAccessDeniedMessage(message: string) {
+  return /access is denied/i.test(message)
+}
+
+function isNotFoundMessage(message: string) {
+  return /not found/i.test(message)
+}
+
 function runTaskkill(args: string[], description: string) {
-  return new Promise<void>((resolve) => {
-    execFile('taskkill', args, { windowsHide: true }, (error, _stdout, stderr) => {
-      if (error) {
-        const detail = stderr.trim() || error.message
-        if (!/not found/i.test(detail)) {
-          console.error(`Failed to ${description}: ${detail}`)
-        }
+  return new Promise<{ success: boolean; detail?: string; accessDenied?: boolean; notFound?: boolean }>((resolve) => {
+    execFile('taskkill', args, { windowsHide: true }, (error, stdout, stderr) => {
+      if (!error) {
+        resolve({ success: true })
+        return
       }
 
-      resolve()
+      const detail = stderr.trim() || stdout.trim() || error.message
+      const notFound = isNotFoundMessage(detail)
+      const accessDenied = isAccessDeniedMessage(detail)
+
+      if (!notFound) {
+        console.error(`Failed to ${description}: ${detail}`)
+      }
+
+      resolve({
+        success: notFound,
+        detail,
+        accessDenied,
+        notFound
+      })
     })
   })
 }
 
-function killProcessTree(child: ChildProcess, appPath: string) {
+async function killProcessTree(child: ChildProcess, appPath: string, gameKey?: string): Promise<KillAttemptResult> {
+  const processName = getExeName(appPath)
+
   if (process.platform === 'win32' && child.pid) {
-    return runTaskkill(['/PID', String(child.pid), '/T', '/F'], `kill process tree for ${appPath}`)
+    const result = await runTaskkill(['/PID', String(child.pid), '/T', '/F'], `kill process tree for ${appPath}`)
+    return {
+      processName,
+      appPath,
+      gameKey,
+      success: result.success,
+      error: result.detail,
+      accessDenied: result.accessDenied,
+      notFound: result.notFound
+    }
   }
 
   try {
     child.kill()
+    return { processName, appPath, gameKey, success: true }
   } catch (err) {
+    const error = getErrorMessage(err)
     console.error(`Error killing ${appPath}:`, err)
+    return {
+      processName,
+      appPath,
+      gameKey,
+      success: false,
+      error,
+      accessDenied: isAccessDeniedMessage(error)
+    }
   }
-
-  return Promise.resolve()
 }
 
-function killProcessByImageName(processName: string) {
+async function killProcessByImageName(processName: string, appPath?: string, gameKey?: string): Promise<KillAttemptResult> {
   if (process.platform !== 'win32') {
-    return Promise.resolve()
+    return { processName, appPath, gameKey, success: true }
   }
 
-  return runTaskkill(['/IM', processName, '/T', '/F'], `kill companion process ${processName}`)
+  const result = await runTaskkill(['/IM', processName, '/T', '/F'], `kill companion process ${processName}`)
+  return {
+    processName,
+    appPath,
+    gameKey,
+    success: result.success,
+    error: result.detail,
+    accessDenied: result.accessDenied,
+    notFound: result.notFound
+  }
 }
 
-function getProfileCompanionProcessNames(gameKey?: string) {
+function getUnclosedProcessKey(gameKey: string | undefined, appPath: string, processName: string) {
+  return `${gameKey || 'unknown'}:${(appPath || processName).toLowerCase()}`
+}
+
+function clearUnclosedProcess(gameKey: string | undefined, appPath: string | undefined, processName: string) {
+  unclosedProcesses.delete(getUnclosedProcessKey(gameKey, appPath || processName, processName))
+}
+
+function registerUnclosedProcess(attempt: KillAttemptResult) {
+  const appPath = attempt.appPath || attempt.processName
+  const gameKey = attempt.gameKey || ''
+  const error =
+    attempt.error ||
+    (attempt.accessDenied
+      ? 'Windows denied permission to close this app.'
+      : 'The app is still running after the close request.')
+
+  unclosedProcesses.set(getUnclosedProcessKey(gameKey, appPath, attempt.processName), {
+    path: appPath,
+    name: path.basename(appPath),
+    gameKey,
+    error
+  })
+}
+
+function pruneUnclosedProcesses(processNames: Set<string>) {
+  unclosedProcesses.forEach((entry, key) => {
+    if (!processNames.has(getExeName(entry.path))) {
+      unclosedProcesses.delete(key)
+    }
+  })
+}
+
+function formatKillWarning(failedAttempts: KillAttemptResult[]) {
+  if (failedAttempts.length === 0) {
+    return undefined
+  }
+
+  const first = failedAttempts[0]
+  const appName = path.basename(first.appPath || first.processName)
+
+  if (failedAttempts.length === 1) {
+    return first.accessDenied
+      ? `${appName} is still running because Windows denied permission to close it.`
+      : `${appName} could not be closed and is still running.`
+  }
+
+  return `${failedAttempts.length} apps could not be closed and are still running.`
+}
+
+async function finalizeKillAttempts(attempts: KillAttemptResult[]): Promise<KillResult> {
+  if (attempts.length === 0) {
+    return {
+      success: true,
+      message: 'No running companion apps to close.',
+      closedCount: 0,
+      failedCount: 0
+    }
+  }
+
+  const processNamesAfterKill = await readRunningProcessNames()
+  const finalizedAttempts = attempts.map((attempt) => ({
+    ...attempt,
+    stillRunning: processNamesAfterKill.has(attempt.processName)
+  }))
+
+  finalizedAttempts.forEach((attempt) => {
+    if (attempt.stillRunning) {
+      registerUnclosedProcess(attempt)
+      return
+    }
+
+    clearUnclosedProcess(attempt.gameKey, attempt.appPath, attempt.processName)
+    runningProcesses.forEach((_appProcess, runningPath) => {
+      if (
+        (attempt.appPath && runningPath.toLowerCase() === attempt.appPath.toLowerCase()) ||
+        getExeName(runningPath) === attempt.processName
+      ) {
+        runningProcesses.delete(runningPath)
+      }
+    })
+  })
+
+  const failedAttempts = finalizedAttempts.filter((attempt) => attempt.stillRunning)
+  const closedCount = finalizedAttempts.length - failedAttempts.length
+  const warning = formatKillWarning(failedAttempts)
+
+  return {
+    success: failedAttempts.length === 0,
+    message: closedCount > 0 ? `Closed ${closedCount} companion app${closedCount === 1 ? '' : 's'}.` : undefined,
+    warning,
+    error: warning,
+    closedCount,
+    failedCount: failedAttempts.length
+  }
+}
+
+function getProfileCompanionTargets(gameKey?: string) {
   const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
-  const companionNames = new Set<string>()
+  const appPaths = store.get('appPaths') as Record<string, string> | undefined
+  const companionTargets = new Map<string, { processName: string; appPath: string; gameKey: string }>()
 
   Object.entries(profiles || {}).forEach(([profileGameKey, profileEntry]) => {
     if (gameKey && profileGameKey !== gameKey) {
@@ -373,34 +539,42 @@ function getProfileCompanionProcessNames(gameKey?: string) {
     }
 
     const profile = getActiveStoredProfile(profileEntry)
-
-    Object.entries(UTILITY_COMPANION_PROCESS_NAMES).forEach(([utilityKey, processNames]) => {
-      if (isUtilityEnabled(profile, utilityKey)) {
-        processNames.forEach((processName) => companionNames.add(processName.toLowerCase()))
-      }
-    })
-
     const gameExeName = isValidExePath(gamePaths?.[profileGameKey])
       ? getExeName(gamePaths![profileGameKey])
       : null
 
-    if (Array.isArray(profile?.trackedProcessPaths)) {
-      profile.trackedProcessPaths.filter(isValidExePath).forEach((processPath) => {
-        const processName = getExeName(processPath)
-        if (processName !== gameExeName) {
-          companionNames.add(processName)
-        }
-      })
-    }
+    Object.entries(UTILITY_COMPANION_PROCESS_NAMES).forEach(([utilityKey, processNames]) => {
+      if (isUtilityEnabled(profile, utilityKey)) {
+        processNames.forEach((processName) => {
+          const normalizedProcessName = processName.toLowerCase()
+          companionTargets.set(normalizedProcessName, {
+            processName: normalizedProcessName,
+            appPath: processName,
+            gameKey: profileGameKey
+          })
+        })
+      }
+    })
+
+    getProfileTrackablePaths(profileGameKey, profile, appPaths, gamePaths).forEach((processPath) => {
+      const processName = getExeName(processPath)
+      if (processName !== gameExeName) {
+        companionTargets.set(processName, {
+          processName,
+          appPath: processPath,
+          gameKey: profileGameKey
+        })
+      }
+    })
   })
 
-  return companionNames
+  return companionTargets
 }
 
 async function killLaunchedApps(gameKey?: string) {
   const processNames = await readRunningProcessNames()
-  const companionProcessNames = getProfileCompanionProcessNames(gameKey)
-  const killTasks: Promise<void>[] = []
+  const companionTargets = getProfileCompanionTargets(gameKey)
+  const killTasks: Promise<KillAttemptResult>[] = []
 
   runningProcesses.forEach(({ process: child }, appPath) => {
     const appProcess = runningProcesses.get(appPath)
@@ -411,29 +585,37 @@ async function killLaunchedApps(gameKey?: string) {
       return
     }
 
-    companionProcessNames.delete(getExeName(appPath))
-    killTasks.push(killProcessTree(child, appPath))
-    runningProcesses.delete(appPath)
-  })
+    const processName = getExeName(appPath)
+    companionTargets.delete(processName)
 
-  companionProcessNames.forEach((processName) => {
     if (processNames.has(processName)) {
-      killTasks.push(killProcessByImageName(processName))
+      killTasks.push(killProcessTree(child, appPath, appProcess?.gameKey))
+    } else {
+      runningProcesses.delete(appPath)
     }
   })
 
-  await Promise.all(killTasks)
+  companionTargets.forEach((target) => {
+    if (processNames.has(target.processName)) {
+      killTasks.push(killProcessByImageName(target.processName, target.appPath, target.gameKey))
+    }
+  })
+
+  return finalizeKillAttempts(await Promise.all(killTasks))
 }
 
 async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
   const processNames = await readRunningProcessNames()
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
   const gamePath = gamePaths?.[gameKey]?.toLowerCase()
-  const killTasks: Promise<void>[] = []
+  const killTasks: Promise<KillAttemptResult>[] = []
   const killedExeNames = new Set<string>()
 
   appPathsToKill.filter(isValidExePath).forEach((appPath) => {
     if (gamePath && appPath.toLowerCase() === gamePath) {
+      return
+    }
+    if (!processNames.has(getExeName(appPath))) {
       return
     }
 
@@ -445,9 +627,9 @@ async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
 
     if (runningAppEntry) {
       const [runningPath, runningApp] = runningAppEntry
-      killTasks.push(killProcessTree(runningApp.process, appPath))
-      runningProcesses.delete(runningPath)
+      killTasks.push(killProcessTree(runningApp.process, appPath, runningApp.gameKey))
       killedExeNames.add(getExeName(appPath))
+      return
     }
   })
 
@@ -459,12 +641,12 @@ async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
     const processName = getExeName(appPath)
 
     if (!killedExeNames.has(processName) && processNames.has(processName)) {
-      killTasks.push(killProcessByImageName(processName))
+      killTasks.push(killProcessByImageName(processName, appPath, gameKey))
       killedExeNames.add(processName)
     }
   })
 
-  await Promise.all(killTasks)
+  return finalizeKillAttempts(await Promise.all(killTasks))
 }
 
 function createWindow() {
@@ -1378,9 +1560,10 @@ ipcMain.handle('relaunch-missing-profile', async (event, gameKey: string) => {
   return launchProfileApps(event.sender, gameKey, missingPaths)
 })
 
-ipcMain.handle('get-profile-switch-diff', (_event, gameKey: string, fromProfileId: string, toProfileId: string) => {
+ipcMain.handle('get-profile-switch-diff', async (_event, gameKey: string, fromProfileId: string, toProfileId: string) => {
   const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
   const gamePath = gamePaths[gameKey]?.toLowerCase()
+  const processNames = await readRunningProcessNames()
 
   const utilityPaths = (profileId: string) =>
     new Set(
@@ -1391,8 +1574,8 @@ ipcMain.handle('get-profile-switch-diff', (_event, gameKey: string, fromProfileI
 
   const fromPaths = utilityPaths(fromProfileId)
   const toPaths = utilityPaths(toProfileId)
-  const toStopCount = [...fromPaths].filter((p) => !toPaths.has(p)).length
-  const toStartCount = [...toPaths].filter((p) => !fromPaths.has(p)).length
+  const toStopCount = [...fromPaths].filter((p) => !toPaths.has(p) && processNames.has(getExeName(p))).length
+  const toStartCount = [...toPaths].filter((p) => !processNames.has(getExeName(p))).length
 
   return { toStopCount, toStartCount }
 })
@@ -1409,21 +1592,40 @@ ipcMain.handle(
     const toPaths = buildNamedProfileLaunchPaths(gameKey, toProfileId).filter(
       (p) => !gamePath || p.toLowerCase() !== gamePath
     )
-    const fromPathSet = new Set(fromPaths.map((p) => p.toLowerCase()))
     const toPathSet = new Set(toPaths.map((p) => p.toLowerCase()))
+    const processNamesBeforeSwitch = await readRunningProcessNames()
 
-    const pathsToStop = fromPaths.filter((p) => !toPathSet.has(p.toLowerCase()))
-    const pathsToStart = toPaths.filter((p) => !fromPathSet.has(p.toLowerCase()))
+    const pathsToStop = fromPaths.filter(
+      (p) => !toPathSet.has(p.toLowerCase()) && processNamesBeforeSwitch.has(getExeName(p))
+    )
+    let killResult: KillResult | undefined
 
     if (pathsToStop.length > 0) {
-      await killProfileApps(gameKey, pathsToStop)
+      killResult = await killProfileApps(gameKey, pathsToStop)
     }
+
+    const processNamesAfterStop = await readRunningProcessNames()
+    const pathsToStart = toPaths.filter((p) => !processNamesAfterStop.has(getExeName(p)))
 
     if (pathsToStart.length === 0) {
-      return { success: true, launchedCount: 0, skippedCount: 0 }
+      return {
+        success: true,
+        message: killResult?.message,
+        warning: killResult?.warning,
+        launchedCount: 0,
+        skippedCount: 0,
+        failedCount: killResult?.failedCount
+      }
     }
 
-    return launchProfileApps(event.sender, gameKey, pathsToStart)
+    const launchResult = await launchProfileApps(event.sender, gameKey, pathsToStart)
+    const warnings = [killResult?.warning, launchResult.warning].filter(Boolean)
+
+    return {
+      ...launchResult,
+      warning: warnings.length > 0 ? warnings.join(' ') : undefined,
+      failedCount: (launchResult.failedCount || 0) + (killResult?.failedCount || 0)
+    }
   }
 )
 
@@ -1537,6 +1739,7 @@ ipcMain.handle('window-close', () => {
 ipcMain.handle('get-running-apps', async () => {
   const processNames = await readRunningProcessNames()
   pruneStoppedRunningProcesses(processNames)
+  pruneUnclosedProcesses(processNames)
 
   const launchedApps = Array.from(runningProcesses.entries()).map(([appPath, appProcess]) => ({
     path: appPath,
@@ -1544,12 +1747,22 @@ ipcMain.handle('get-running-apps', async () => {
     gameKey: appProcess.gameKey,
     tracked: false
   }))
-  const launchedKeys = new Set(launchedApps.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`))
-  const launchedExeNames = new Set(launchedApps.map((appProcess) => path.basename(appProcess.path).toLowerCase()))
+  const unclosedApps = Array.from(unclosedProcesses.values())
+    .filter((appProcess) => processNames.has(getExeName(appProcess.path)))
+    .map((appProcess) => ({
+      path: appProcess.path,
+      name: appProcess.name,
+      gameKey: appProcess.gameKey,
+      tracked: true,
+      warning: appProcess.error
+    }))
+  const surfacedApps = [...launchedApps, ...unclosedApps]
+  const launchedKeys = new Set(surfacedApps.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`))
+  const launchedExeNames = new Set(surfacedApps.map((appProcess) => path.basename(appProcess.path).toLowerCase()))
   const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const appPaths = store.get('appPaths') as Record<string, string> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
-  const launchedGameKeys = new Set(launchedApps.map((appProcess) => appProcess.gameKey))
+  const launchedGameKeys = new Set(surfacedApps.map((appProcess) => appProcess.gameKey))
   const adoptedGameKeys = getExternallyAdoptableGameKeys(processNames, profiles, gamePaths, launchedGameKeys)
   const adoptedOrLaunchedGameKeys = new Set([...launchedGameKeys, ...adoptedGameKeys])
   const trackedApps = (await getTrackedRunningApps(
@@ -1564,7 +1777,7 @@ ipcMain.handle('get-running-apps', async () => {
       !launchedExeNames.has(path.basename(appProcess.path).toLowerCase())
   )
 
-  return [...launchedApps, ...trackedApps]
+  return [...surfacedApps, ...trackedApps]
 })
 
 ipcMain.handle('kill-launched-apps', (_event, gameKey?: string) => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -17,9 +17,12 @@ interface BrowsePathResult {
 interface LaunchResult {
   success: boolean
   message?: string
+  warning?: string
   error?: string
   launchedCount?: number
   skippedCount?: number
+  elevatedCount?: number
+  failedCount?: number
 }
 
 interface ConfigFileResult {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -32,7 +32,10 @@ interface ConfigFileResult {
 declare global {
   interface Window {
     electronAPI: {
-      launchProfile: (gameKey: string, apps: string[]) => Promise<LaunchResult>
+      launchProfile: (gameKey: string) => Promise<LaunchResult>
+      relaunchMissingProfile: (gameKey: string) => Promise<LaunchResult>
+      getProfileSwitchDiff: (gameKey: string, fromProfileId: string, toProfileId: string) => Promise<{ toStopCount: number; toStartCount: number }>
+      switchProfileApps: (gameKey: string, fromProfileId: string, toProfileId: string) => Promise<LaunchResult>
       browsePath: (inputId: string) => Promise<BrowsePathResult>
       onAppLaunchError: (cb: (data: unknown) => void) => Unsubscribe
       minimize: () => Promise<void>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,7 @@ interface RunningApp {
   name: string
   gameKey: string
   tracked?: boolean
+  warning?: string
 }
 
 interface BrowsePathResult {
@@ -23,6 +24,15 @@ interface LaunchResult {
   skippedCount?: number
   elevatedCount?: number
   failedCount?: number
+}
+
+interface KillResult {
+  success: boolean
+  message?: string
+  warning?: string
+  error?: string
+  closedCount: number
+  failedCount: number
 }
 
 interface ConfigFileResult {
@@ -45,8 +55,8 @@ declare global {
       maximize: () => Promise<void>
       close: () => Promise<void>
       getRunningApps: () => Promise<RunningApp[]>
-      killLaunchedApps: (gameKey?: string) => Promise<void>
-      killProfileApps: (gameKey: string, appPaths: string[]) => Promise<void>
+      killLaunchedApps: (gameKey?: string) => Promise<KillResult>
+      killProfileApps: (gameKey: string, appPaths: string[]) => Promise<KillResult>
       onUpdateAvailable: (cb: (info: any) => void) => Unsubscribe
       onUpdateDownloaded: (cb: (info: any) => void) => Unsubscribe
       onUpdateNotAvailable: (cb: (info: any) => void) => Unsubscribe

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,7 +2,12 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // launch
-  launchProfile: (gameKey: string, apps: string[]) => ipcRenderer.invoke('launch-profile', gameKey, apps),
+  launchProfile: (gameKey: string) => ipcRenderer.invoke('launch-profile', gameKey),
+  relaunchMissingProfile: (gameKey: string) => ipcRenderer.invoke('relaunch-missing-profile', gameKey),
+  getProfileSwitchDiff: (gameKey: string, fromProfileId: string, toProfileId: string) =>
+    ipcRenderer.invoke('get-profile-switch-diff', gameKey, fromProfileId, toProfileId),
+  switchProfileApps: (gameKey: string, fromProfileId: string, toProfileId: string) =>
+    ipcRenderer.invoke('switch-profile-apps', gameKey, fromProfileId, toProfileId),
   browsePath: (inputId: string) => ipcRenderer.invoke('browse-path', inputId),
   onAppLaunchError: (cb: (data: unknown) => void) => {
     const handler = (_: unknown, data: unknown) => cb(data)

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
+    />
     <title>SimLauncher</title>
   </head>
   <body>

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -14,7 +14,7 @@ import { useNotify } from './Notify'
 
 const POST_LAUNCH_BLOCK_MS = 10000
 
-type RunningApp = { path: string; name: string; gameKey: string }
+type RunningApp = { path: string; name: string; gameKey: string; warning?: string }
 
 function GameRow({
   game,
@@ -33,7 +33,7 @@ function GameRow({
   game: Game
   isActive: boolean
   isRunning: boolean
-  runningAppIcons: { icon: string | null; name: string }[]
+  runningAppIcons: { icon: string | null; name: string; warning?: string }[]
   isDimmed: boolean
   isLaunching: boolean
   isLaunchBlocked: boolean
@@ -269,9 +269,15 @@ function GameRow({
 
   const handleKill = async () => {
     try {
-      await window.electronAPI.killLaunchedApps(game.key)
+      const result = await window.electronAPI.killLaunchedApps(game.key)
       await onRunningStateRefresh()
-      notify(`Closing companion apps for ${game.name}`, 'warn')
+
+      if (!result.success) {
+        notify(result.warning || result.error || 'Some companion apps could not be closed', 'warn', 6000)
+        return
+      }
+
+      notify(result.message || `Closing companion apps for ${game.name}`, 'warn')
     } catch (err) {
       notify('Failed to close companion apps', 'error')
       console.error(err)
@@ -503,7 +509,8 @@ function GameRow({
                         key={i}
                         src={app.icon ?? undefined}
                         alt=""
-                        className="h-4 w-4 object-contain opacity-80"
+                        title={app.warning || app.name}
+                        className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
                         onError={() => setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))}
                       />
                     )
@@ -516,8 +523,8 @@ function GameRow({
                   return (
                     <div
                       key={i}
-                      className="h-4 w-4 rounded text-[6px] font-black flex items-center justify-center bg-(--accent)/20 text-(--accent) shrink-0"
-                      title={app.name}
+                      className={`h-4 w-4 rounded text-[6px] font-black flex items-center justify-center bg-(--accent)/20 text-(--accent) shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
+                      title={app.warning || app.name}
                     >
                       {app.name.replace(/\.exe$/i, '').slice(0, 2).toUpperCase()}
                     </div>
@@ -765,7 +772,8 @@ export function GameList() {
         )
         const runningAppIcons = appsForGame.map(a => ({
           icon: appIconCache[a.path.toLowerCase()] ?? null,
-          name: a.name
+          name: a.name,
+          warning: a.warning
         }))
 
         return (

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -238,6 +238,19 @@ function GameRow({
         const pathsToStop = currentPaths.filter((appPath) => !nextPathSet.has(appPath.toLowerCase()))
         const pathsToStart = nextPaths.filter((appPath) => !currentPathSet.has(appPath.toLowerCase()))
 
+        if (pathsToStop.length > 0 || pathsToStart.length > 0) {
+          const parts: string[] = []
+          if (pathsToStop.length > 0) parts.push(`stop ${pathsToStop.length} app(s)`)
+          if (pathsToStart.length > 0) parts.push(`start ${pathsToStart.length} app(s)`)
+          if (
+            !window.confirm(
+              `Switch to "${nextProfile.name}" while the game is running? This will ${parts.join(' and ')}.`
+            )
+          ) {
+            return
+          }
+        }
+
         if (pathsToStop.length > 0) {
           await window.electronAPI.killProfileApps(game.key, pathsToStop)
         }

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -3,15 +3,11 @@ import {
   GAMES,
   createProfileId,
   getActiveGameProfile,
-  getEnabledProfileUtilities,
-  getUtilities,
   normalizeGameProfileSet,
-  resolveCustomSlots,
   type Game,
   type GameProfileSet,
   type NamedGameProfile,
   type Profiles,
-  type Utility
 } from '../lib/config'
 import { ProfileEditor } from './ProfileEditor'
 import { useNotify } from './Notify'
@@ -25,7 +21,6 @@ function GameRow({
   isActive,
   isRunning,
   runningAppIcons,
-  runningApps,
   isDimmed,
   isLaunching,
   isLaunchBlocked,
@@ -39,7 +34,6 @@ function GameRow({
   isActive: boolean
   isRunning: boolean
   runningAppIcons: { icon: string | null; name: string }[]
-  runningApps: RunningApp[]
   isDimmed: boolean
   isLaunching: boolean
   isLaunchBlocked: boolean
@@ -129,46 +123,9 @@ function GameRow({
 
   const getProfileRuntimeConfig = async () => {
     const profiles = (await window.electronAPI.storeGet('profiles')) as Profiles || {}
-    const appPaths = (await window.electronAPI.storeGet('appPaths')) as Record<string, string> || {}
-    const gamePaths = (await window.electronAPI.storeGet('gamePaths')) as Record<string, string> || {}
-    const savedCustomSlots = await window.electronAPI.storeGet('customSlots')
-    const utilities = getUtilities(resolveCustomSlots(savedCustomSlots, appPaths, ...Object.values(profiles)))
     const nextProfileSet = normalizeGameProfileSet(profiles[game.key])
-
-    return { profiles, appPaths, gamePaths, utilities, profileSet: nextProfileSet }
+    return { profiles, profileSet: nextProfileSet }
   }
-
-  const getProfileLaunchPaths = async () => {
-    const { appPaths, gamePaths, utilities, profileSet: nextProfileSet } = await getProfileRuntimeConfig()
-    const profile = getActiveGameProfile(nextProfileSet)
-    const configuredGamePath = gamePaths[game.key]
-
-    const pathsToLaunch: string[] = []
-    let appCount = 0
-
-    // Queue game first, then ordered utilities.
-    if (profile.launchAutomatically !== false && configuredGamePath) {
-      pathsToLaunch.push(configuredGamePath)
-      appCount++
-    }
-
-    getEnabledProfileUtilities(profile, utilities).forEach((utility) => {
-      if (appPaths[utility.id]) {
-        pathsToLaunch.push(appPaths[utility.id])
-        appCount++
-      }
-    })
-
-    return { profile, pathsToLaunch, appCount }
-  }
-
-  const getOrderedUtilityPaths = (
-    profile: NamedGameProfile,
-    utilities: Utility[],
-    appPaths: Record<string, string>
-  ) => getEnabledProfileUtilities(profile, utilities)
-    .map((utility) => appPaths[utility.id])
-    .filter((appPath): appPath is string => typeof appPath === 'string' && appPath.trim().length > 0)
 
   const saveProfileSet = async (profiles: Profiles, nextProfileSet: GameProfileSet) => {
     await window.electronAPI.storeSet('profiles', {
@@ -216,7 +173,7 @@ function GameRow({
       return
     }
 
-    const { profiles, appPaths, utilities, profileSet: latestProfileSet } = await getProfileRuntimeConfig()
+    const { profiles, profileSet: latestProfileSet } = await getProfileRuntimeConfig()
     const currentProfile = getActiveGameProfile(latestProfileSet)
     const nextProfile = latestProfileSet.profiles.find((profile) => profile.id === nextProfileId)
 
@@ -231,17 +188,12 @@ function GameRow({
 
     try {
       if (isRunning) {
-        const currentPaths = getOrderedUtilityPaths(currentProfile, utilities, appPaths)
-        const nextPaths = getOrderedUtilityPaths(nextProfile, utilities, appPaths)
-        const currentPathSet = new Set(currentPaths.map((appPath) => appPath.toLowerCase()))
-        const nextPathSet = new Set(nextPaths.map((appPath) => appPath.toLowerCase()))
-        const pathsToStop = currentPaths.filter((appPath) => !nextPathSet.has(appPath.toLowerCase()))
-        const pathsToStart = nextPaths.filter((appPath) => !currentPathSet.has(appPath.toLowerCase()))
+        const diff = await window.electronAPI.getProfileSwitchDiff(game.key, currentProfile.id, nextProfile.id)
 
-        if (pathsToStop.length > 0 || pathsToStart.length > 0) {
+        if (diff.toStopCount > 0 || diff.toStartCount > 0) {
           const parts: string[] = []
-          if (pathsToStop.length > 0) parts.push(`stop ${pathsToStop.length} app(s)`)
-          if (pathsToStart.length > 0) parts.push(`start ${pathsToStart.length} app(s)`)
+          if (diff.toStopCount > 0) parts.push(`stop ${diff.toStopCount} app(s)`)
+          if (diff.toStartCount > 0) parts.push(`start ${diff.toStartCount} app(s)`)
           if (
             !window.confirm(
               `Switch to "${nextProfile.name}" while the game is running? This will ${parts.join(' and ')}.`
@@ -249,15 +201,9 @@ function GameRow({
           ) {
             return
           }
-        }
 
-        if (pathsToStop.length > 0) {
-          await window.electronAPI.killProfileApps(game.key, pathsToStop)
-        }
-
-        if (pathsToStart.length > 0) {
           onLaunchStart(game.key)
-          const result = await window.electronAPI.launchProfile(game.key, pathsToStart)
+          const result = await window.electronAPI.switchProfileApps(game.key, currentProfile.id, nextProfile.id)
           if (!result.success) {
             notify(result.error || 'Failed to switch profile', 'error')
             onLaunchEnd(game.key, 0)
@@ -300,22 +246,15 @@ function GameRow({
     let cooldownMs = 0
 
     try {
-      const { pathsToLaunch, appCount } = await getProfileLaunchPaths()
-
-      if (pathsToLaunch.length === 0) {
-        notify('No executable paths configured for launch', 'error')
-        return
-      }
-
       onLaunchStart(game.key)
-      const result = await window.electronAPI.launchProfile(game.key, pathsToLaunch)
+      const result = await window.electronAPI.launchProfile(game.key)
       if (!result.success) {
         notify(result.error || 'Failed to launch profile', 'error')
         return
       }
 
       cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-      notify(result.message || `Starting ${game.name} + ${appCount - 1} apps`, 'success')
+      notify(result.message || `Launching ${game.name}`, 'success')
     } catch (err) {
       notify('Failed to launch profile', 'error')
       console.error(err)
@@ -343,24 +282,15 @@ function GameRow({
     let cooldownMs = 0
 
     try {
-      const { pathsToLaunch } = await getProfileLaunchPaths()
-      const runningPathSet = new Set(runningApps.map((appProcess) => appProcess.path.toLowerCase()))
-      const missingPaths = pathsToLaunch.filter((launchPath) => !runningPathSet.has(launchPath.toLowerCase()))
-
-      if (missingPaths.length === 0) {
-        notify('All profile apps are already running', 'success')
-        return
-      }
-
       onLaunchStart(game.key)
-      const result = await window.electronAPI.launchProfile(game.key, missingPaths)
+      const result = await window.electronAPI.relaunchMissingProfile(game.key)
       if (!result.success) {
         notify(result.error || 'Failed to relaunch missing apps', 'error')
         return
       }
 
       cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-      notify(result.message || `Relaunching ${missingPaths.length} missing app${missingPaths.length === 1 ? '' : 's'}`, 'success')
+      notify(result.message || 'Relaunching missing apps', 'success')
     } catch (err) {
       notify('Failed to relaunch missing apps', 'error')
       console.error(err)
@@ -840,7 +770,6 @@ export function GameList() {
             isActive={activeEditorKey === game.key}
             isRunning={!!runningStatus[game.key]}
             runningAppIcons={runningAppIcons}
-            runningApps={runningApps.filter(a => a.gameKey === game.key)}
             isDimmed={hasActiveTitle && !runningStatus[game.key]}
             isLaunching={launchingGameKey === game.key}
             isLaunchBlocked={launchingGameKey !== null}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -187,6 +187,8 @@ function GameRow({
     }
 
     try {
+      let switchWarning: string | undefined
+
       if (isRunning) {
         const diff = await window.electronAPI.getProfileSwitchDiff(game.key, currentProfile.id, nextProfile.id)
 
@@ -206,10 +208,11 @@ function GameRow({
           const result = await window.electronAPI.switchProfileApps(game.key, currentProfile.id, nextProfile.id)
           if (!result.success) {
             notify(result.error || 'Failed to switch profile', 'error')
-            onLaunchEnd(game.key, 0)
+            onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
             return
           }
           onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
+          switchWarning = result.warning
         }
 
         await onRunningStateRefresh()
@@ -217,7 +220,7 @@ function GameRow({
 
       await saveProfileSet(profiles, updatedProfileSet)
       setProfileMenuOpen(false)
-      notify(`Switched to ${nextProfile.name}`, 'success')
+      notify(switchWarning || `Switched to ${nextProfile.name}`, switchWarning ? 'warn' : 'success', switchWarning ? 5000 : undefined)
     } catch (err) {
       onLaunchEnd(game.key, 0)
       notify('Failed to switch profile', 'error')
@@ -249,12 +252,13 @@ function GameRow({
       onLaunchStart(game.key)
       const result = await window.electronAPI.launchProfile(game.key)
       if (!result.success) {
+        cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
         notify(result.error || 'Failed to launch profile', 'error')
         return
       }
 
       cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-      notify(result.message || `Launching ${game.name}`, 'success')
+      notify(result.warning || result.message || `Launching ${game.name}`, result.warning ? 'warn' : 'success', result.warning ? 5000 : undefined)
     } catch (err) {
       notify('Failed to launch profile', 'error')
       console.error(err)
@@ -285,12 +289,13 @@ function GameRow({
       onLaunchStart(game.key)
       const result = await window.electronAPI.relaunchMissingProfile(game.key)
       if (!result.success) {
+        cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
         notify(result.error || 'Failed to relaunch missing apps', 'error')
         return
       }
 
       cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-      notify(result.message || 'Relaunching missing apps', 'success')
+      notify(result.warning || result.message || 'Relaunching missing apps', result.warning ? 'warn' : 'success', result.warning ? 5000 : undefined)
     } catch (err) {
       notify('Failed to relaunch missing apps', 'error')
       console.error(err)

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -33,6 +33,22 @@ const TOAST_PROGRESS_CLASSES: Record<ToastType, string> = {
 
 let toastId = 0
 
+function getPathName(filePath: string) {
+  return filePath.split(/[\\/]/).pop() || filePath
+}
+
+function formatLaunchErrorToast(data: unknown) {
+  if (!data || typeof data !== 'object') {
+    return 'App launch failed'
+  }
+
+  const { app, error } = data as { app?: unknown; error?: unknown }
+  const appName = typeof app === 'string' ? getPathName(app) : 'App'
+  const errorMessage = typeof error === 'string' && error.trim().length > 0 ? error : 'Unknown launch error'
+
+  return `${appName} failed to launch: ${errorMessage}`
+}
+
 function ToastCard({
   toast,
   isDismissing,
@@ -133,6 +149,12 @@ export function NotifyProvider({ children }: { children: ReactNode }) {
 
     setToasts((current) => [...current, toast])
   }, [])
+
+  useEffect(() => {
+    return window.electronAPI.onAppLaunchError((data) => {
+      notify(formatLaunchErrorToast(data), 'error', 5000)
+    })
+  }, [notify])
 
   const value = useMemo(() => ({ notify }), [notify])
 


### PR DESCRIPTION
## Summary

Merge 0.5.0 security hardening milestone into main.

### Security fixes included
- #68 — CSP meta tag added to renderer
- #69 — `get-file-icon` restricted to stored paths only
- #70 — IPC store key whitelist (`EXPECTED_CONFIG_KEYS`)
- #99 — UAC/EACCES elevated app handling + PowerShell path quoting
- #109 — Profile switch confirmation while game is running
- #119 — Elevated/unclosed app state preserved through profile switch
- #122 — `set-zoom` input validation and clamping `[0.5, 3.0]`
- #123 — `ELECTRON_RENDERER_URL` restricted to dev mode; navigation deny policies
- #126 — Electron upgraded from 38.2.2 to 39.8.8 (clears all runtime advisories)

### Audit
All 3 AI auditors (Claude, Codex, Gemini) verified — 0 open blockers for this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)