### PR TITLE
release: v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -290,7 +290,7 @@ textarea {
 }
 
 .game-row-surface:hover {
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+  box-shadow: none;
 }
 
 .accent-subtle-hover:active {

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -289,6 +289,10 @@ textarea {
     0 0 20px -16px var(--accent-glow);
 }
 
+.game-row-surface:hover {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
 .accent-subtle-hover:active {
   transform: scale(0.99);
 }

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -290,7 +290,7 @@ textarea {
 }
 
 .game-row-surface:hover {
-  box-shadow: none;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .accent-subtle-hover:active {

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -289,10 +289,6 @@ textarea {
     0 0 20px -16px var(--accent-glow);
 }
 
-.game-row-surface:hover {
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
-}
-
 .accent-subtle-hover:active {
   transform: scale(0.99);
 }

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -296,7 +296,7 @@ function GameRow({
 
   return (
     <div
-      className={`relative flex flex-col transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`}
+      className={`relative flex flex-col ${isActive ? '' : 'gap-2'} transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`}
       ref={rowRef}
     >
       <div

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -368,7 +368,7 @@ function GameRow({
           </div>
         </div>
 
-        <div className="grid grid-cols-[36px_260px] items-center gap-3 no-drag">
+        <div className="grid grid-cols-[36px_200px] items-center gap-3 no-drag">
           <div className="flex h-9 w-9 items-center justify-center">
             {canRelaunch && (
               <button
@@ -396,7 +396,7 @@ function GameRow({
             )}
           </div>
 
-          <div className="no-drag glass-surface flex w-[260px] shrink-0 items-center rounded-full">
+          <div className="no-drag glass-surface flex w-[200px] shrink-0 items-center rounded-full">
             <div ref={profileMenuRef} className="relative">
               <button
                 ref={triggerRef}
@@ -538,7 +538,7 @@ function GameRow({
               type="button"
               onClick={primaryAction}
               disabled={isLaunchBlocked && !canKill}
-              className={`cursor-pointer flex h-9 w-[92px] items-center justify-center ${primaryButtonClass}`}
+              className={`flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center ${primaryButtonClass}`}
               title={primaryTitle}
               aria-label={primaryTitle}
             >
@@ -587,7 +587,7 @@ function GameRow({
             <button
               type="button"
               onClick={handleToggle}
-              className={`group flex h-9 w-10 cursor-pointer items-center justify-center rounded-r-full ${
+              className={`group flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-r-full ${
                 isActive ? 'icon-action-active' : 'icon-action'
               }`}
               title={isActive ? 'Close Profile Settings' : 'Profile Settings'}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -590,22 +590,40 @@ function GameRow({
               className={`group flex h-9 w-10 cursor-pointer items-center justify-center rounded-r-full ${
                 isActive ? 'icon-action-active' : 'icon-action'
               }`}
-              title="Profile Settings"
+              title={isActive ? 'Close Profile Settings' : 'Profile Settings'}
+              aria-label={isActive ? 'Close Profile Settings' : 'Profile Settings'}
             >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className={`transition-transform ${isActive ? 'rotate-90 scale-110' : 'group-hover:rotate-45'}`}
-              >
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-              </svg>
+              {isActive ? (
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="transition-transform group-hover:scale-110"
+                >
+                  <path d="M7 7l10 10" />
+                  <path d="M17 7L7 17" />
+                </svg>
+              ) : (
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="transition-transform group-hover:rotate-45"
+                >
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+              )}
             </button>
           </div>
         </div>
@@ -619,7 +637,6 @@ function GameRow({
             <div className="animate-fade-slide pb-4">
               <ProfileEditor
                 gameKey={game.key}
-                gameName={game.name}
                 activeProfileId={profileSet.activeProfileId}
                 onProfilesChanged={loadProfileSet}
                 onClose={onToggleEditor}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -296,7 +296,7 @@ function GameRow({
 
   return (
     <div
-      className={`relative flex flex-col gap-2 transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`}
+      className={`relative flex flex-col transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`}
       ref={rowRef}
     >
       <div
@@ -612,11 +612,11 @@ function GameRow({
       </div>
 
       <div
-        className={`profile-editor-wrapper relative z-0 mx-2 ${isActive ? 'profile-editor-open' : 'profile-editor-closed'}`}
+        className={`profile-editor-wrapper relative z-0 ${isActive ? 'profile-editor-open' : 'profile-editor-closed'}`}
       >
         <div className="overflow-hidden">
           {isActive && (
-            <div className="animate-fade-slide px-2 pb-4 pt-3">
+            <div className="animate-fade-slide pb-4">
               <ProfileEditor
                 gameKey={game.key}
                 gameName={game.name}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -300,7 +300,7 @@ function GameRow({
       ref={rowRef}
     >
       <div
-        className={`accent-subtle-hover game-row-surface glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? '!isolation-auto z-20' : 'z-0'}`}
+        className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? '!isolation-auto z-20' : 'z-0'}`}
       >
         <div className="flex items-center gap-5">
           <div className="relative flex h-12 w-12 shrink-0 items-center justify-center">

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -300,7 +300,7 @@ function GameRow({
       ref={rowRef}
     >
       <div
-        className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? '!isolation-auto z-20' : 'z-0'}`}
+        className={`accent-subtle-hover game-row-surface glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? '!isolation-auto z-20' : 'z-0'}`}
       >
         <div className="flex items-center gap-5">
           <div className="relative flex h-12 w-12 shrink-0 items-center justify-center">

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -420,7 +420,7 @@ export function ProfileEditor({
   }
 
   return (
-    <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5 shadow-2xl">
+    <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5">
       <div className="mb-5">
         <h2 className="text-lg font-semibold text-(--text-primary)">Edit Profile</h2>
       </div>

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -46,7 +46,6 @@ function ProfileToggleRow({ label, checked, onToggle, onChange }: ProfileToggleR
 
 interface ProfileEditorProps {
   gameKey: string
-  gameName: string
   activeProfileId: string
   onProfilesChanged: () => Promise<unknown>
   onClose: () => void
@@ -54,7 +53,6 @@ interface ProfileEditorProps {
 
 export function ProfileEditor({
   gameKey,
-  gameName,
   activeProfileId,
   onProfilesChanged,
   onClose
@@ -423,18 +421,8 @@ export function ProfileEditor({
 
   return (
     <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5 shadow-2xl">
-      <div className="mb-5 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-(--text-primary)">
-          Edit Profile: <span className="text-(--accent)">{gameName}</span>
-        </h2>
-        <button
-          type="button"
-          onClick={onClose}
-          className="icon-action flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-2xl leading-none"
-          title="Close"
-        >
-          ×
-        </button>
+      <div className="mb-5">
+        <h2 className="text-lg font-semibold text-(--text-primary)">Edit Profile</h2>
       </div>
 
       <div className="space-y-5">


### PR DESCRIPTION
## Summary

- Play button resized to square (w-9) — no longer inherits old Launch text width
- Gear button resized to square (w-9) — consistent with play button
- Gear icon switches to X when profile editor is open
- Profile dropdown narrowed to 200px
- Profile editor is now full-width (removed mx-2 margin)
- Gap shown only between inactive rows — no layout shift when opening editor
- Removed redundant close button and gameName prop from ProfileEditor
- Removed profile editor drop shadow

## Milestone

Partial work toward 0.8.0 - UI Polish (refs #143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)