### PR TITLE
ci: add TypeScript type check to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build app
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dist:win": "npm run build && electron-builder --win",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "typecheck": "tsc",
     "preview": "electron-vite preview",
     "prepare": "git config core.hooksPath .githooks"
   },


### PR DESCRIPTION
## Summary
- Add `npm run typecheck` (`tsc`) step to CI between formatting and build
- Add `typecheck` script to `package.json`

Catches type errors that Vite/electron-vite build can silently skip.

ESLint is tracked in #164 but blocked on migrating `.eslintrc.json` → `eslint.config.js` for ESLint v10.

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)