### PR TITLE
release: v0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -658,3 +658,24 @@ textarea {
   gap: 0.5rem;
   flex-shrink: 0;
 }
+
+.settings-control-pill {
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  border: 1px solid var(--glass-border);
+}
+
+.settings-control-pill-button {
+  padding: 0 1rem;
+  cursor: pointer;
+}
+
+.settings-control-pill-input {
+  padding: 0 0.5rem;
+  overflow: hidden;
+}

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -681,5 +681,5 @@ textarea {
 }
 
 .settings-control-preset {
-  width: 4.5rem;
+  width: 4.75rem;
 }

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -641,7 +641,7 @@ textarea {
 
 .settings-label {
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 400;
   color: var(--text-primary);
   white-space: nowrap;
 }
@@ -666,7 +666,7 @@ textarea {
   justify-content: center;
   border-radius: 9999px;
   font-size: 0.6875rem;
-  font-weight: 700;
+  font-weight: 600;
   border: 1px solid var(--glass-border);
 }
 

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -679,3 +679,7 @@ textarea {
   padding: 0 0.5rem;
   overflow: hidden;
 }
+
+.settings-control-preset {
+  width: 4.5rem;
+}

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -615,3 +615,46 @@ textarea {
 .toast-progress-error {
   background: var(--status-danger);
 }
+
+/* Settings Unified Layout */
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  min-height: 3.5rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--header-glass-border);
+}
+
+.settings-row:last-child {
+  border-bottom: none;
+}
+
+.settings-label-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.settings-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.settings-sublabel {
+  font-size: 0.625rem;
+  color: var(--text-muted);
+  line-height: 1.2;
+}
+
+.settings-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -323,7 +323,7 @@ function GameRow({
           </div>
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
-              <h3 className="game-title font-semibold text-(--text-primary)">{game.name}</h3>
+              <h3 className="game-title font-normal text-(--text-primary)">{game.name}</h3>
             </div>
             {runningAppIcons.length > 0 && (
               <div className="flex items-center gap-1">
@@ -410,7 +410,7 @@ function GameRow({
                   }
                 }}
                 onKeyDown={handleProfileMenuTriggerKeyDown}
-                className="dropdown-trigger-surface group/dropdown flex h-9 w-[120px] cursor-pointer items-center gap-1.5 rounded-l-full py-2 pl-3 pr-2.5 text-[10px] font-bold text-(--text-secondary) transition-all hover:text-(--text-primary)"
+                className="dropdown-trigger-surface group/dropdown flex h-9 w-[120px] cursor-pointer items-center gap-1.5 rounded-l-full py-2 pl-3 pr-2.5 text-[10px] font-semibold text-(--text-secondary) transition-all hover:text-(--text-primary)"
                 aria-haspopup="menu"
                 aria-expanded={profileMenuOpen}
                 aria-label={`${game.name} profile`}

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -396,13 +396,13 @@ export function SettingsView({
       <div className="flex gap-4 pt-4 px-1">
         <button
           onClick={handleSave}
-          className="accent-surface-action flex-1 cursor-pointer rounded-xl py-3 text-sm font-bold"
+          className="accent-surface-action flex-1 cursor-pointer rounded-xl py-3 text-sm font-semibold"
         >
           Save Changes
         </button>
         <button
           onClick={onClose}
-          className="accent-surface-action flex-1 cursor-pointer rounded-xl py-3 text-sm font-bold"
+          className="accent-surface-action flex-1 cursor-pointer rounded-xl py-3 text-sm font-semibold"
         >
           Back to Games
         </button>

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -52,7 +52,7 @@ export function AboutSection({
             <button
               onClick={onInstallUpdate}
               disabled={installingUpdate}
-              className="accent-surface-action w-full cursor-pointer rounded-xl py-2.5 text-xs font-bold"
+              className="accent-surface-action w-full cursor-pointer rounded-xl py-2.5 text-xs font-semibold"
             >
               {installingUpdate
                 ? updateProgress !== null
@@ -64,7 +64,7 @@ export function AboutSection({
             <button
               onClick={onManualCheck}
               disabled={checkingUpdate}
-              className="accent-surface-action w-full cursor-pointer rounded-xl py-2.5 text-xs font-bold"
+              className="accent-surface-action w-full cursor-pointer rounded-xl py-2.5 text-xs font-semibold"
             >
               {checkingUpdate ? 'Checking for updates...' : 'Check for Updates'}
             </button>

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -29,18 +29,16 @@ export function AboutSection({
   return (
     <section className="space-y-4">
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">About</h3>
-      <div className="glass-surface p-5 rounded-2xl space-y-4">
-        <div className="flex items-baseline justify-between">
-          <span className="text-sm text-(--text-secondary)">Installed Version</span>
+      <div className="glass-surface rounded-2xl flex flex-col pt-1">
+        <div className="settings-row">
+          <span className="settings-label text-(--text-secondary)">Installed Version</span>
           <span className="text-xs font-mono text-(--text-muted)">v{appVersion}</span>
         </div>
 
-        <div className="flex items-center justify-between border-t border-(--header-glass-border) pt-4">
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-(--text-primary)">
-              Automatically check for updates
-            </span>
-            <span className="text-[10px] text-(--text-muted)">Check on startup when enabled</span>
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Automatically check for updates</span>
+            <span className="settings-sublabel">Check on startup when enabled</span>
           </div>
           <Toggle
             checked={autoCheckUpdates}
@@ -49,7 +47,7 @@ export function AboutSection({
           />
         </div>
 
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 p-5 border-t border-(--header-glass-border)">
           {updateInfo ? (
             <button
               onClick={onInstallUpdate}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -95,45 +95,31 @@ export function AppearanceSection({
                 title={preset.name}
               />
             ))}
-            <div
-              className={`settings-control-pill settings-control-pill-input glass-surface relative shrink-0 transition-all duration-200 ${
-                isCustomColor ? 'selected-surface' : ''
+            <label
+              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] ${
+                isCustomColor ? 'border-(--text-primary) scale-110' : 'border-transparent'
               }`}
+              style={{
+                background: isCustomColor
+                  ? accentCustom || '#ad46ff'
+                  : 'conic-gradient(from 180deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000)'
+              }}
+              title="Custom Color"
             >
-              <button
-                type="button"
-                onClick={() => onAccentChange('custom')}
-                className={`cursor-pointer px-3 text-[9px] font-bold uppercase tracking-wide transition-colors ${
-                  isCustomColor
-                    ? 'text-(--text-primary)'
-                    : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
-                }`}
-              >
-                Custom
-              </button>
-              {isCustomColor && (
-                <div className="animate-fade-slide-inline flex h-full items-center">
-                  <div className="relative z-10 h-4 w-px bg-(--glass-border) opacity-35" />
-                  <label className="relative flex h-full min-w-0 items-center gap-2 pl-2 pr-2.5 cursor-pointer">
-                    <input
-                      type="color"
-                      value={accentCustom || '#ad46ff'}
-                      onChange={(e) => onCustomColorChange(e.target.value)}
-                      className="absolute inset-0 cursor-pointer opacity-0"
-                      aria-label="Custom accent color"
-                      title="Custom accent color"
-                    />
-                    <span
-                      className="h-4 w-7 shrink-0 rounded-full border border-(--glass-border) bg-(--custom-accent)"
-                      style={{ '--custom-accent': accentCustom || '#ad46ff' } as CSSProperties}
-                    />
-                    <span className="min-w-0 truncate text-[10px] font-mono uppercase text-(--text-muted)">
-                      {accentCustom}
-                    </span>
-                  </label>
-                </div>
-              )}
-            </div>
+              <input
+                type="color"
+                value={accentCustom || '#ad46ff'}
+                onChange={(e) => {
+                  onCustomColorChange(e.target.value)
+                  if (!isCustomColor) onAccentChange('custom')
+                }}
+                onClick={() => {
+                  if (!isCustomColor) onAccentChange('custom')
+                }}
+                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                aria-label="Custom accent color"
+              />
+            </label>
           </div>
         </div>
 

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -70,7 +70,7 @@ export function AppearanceSection({
                 key={option.value}
                 type="button"
                 onClick={() => onThemeModeChange(option.value)}
-                className={`settings-control-pill settings-control-pill-button glass-surface tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface tracking-wide transition-colors ${
                   themeMode === option.value
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -96,19 +96,31 @@ export function AppearanceSection({
               />
             ))}
             <label
-              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] ${
-                isCustomColor ? 'border-(--text-primary) scale-110' : 'border-transparent'
+              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
+                isCustomColor ? 'scale-110' : ''
               }`}
-              style={{
-                background: isCustomColor
-                  ? accentCustom || '#ad46ff'
-                  : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
-              }}
               title="Custom Color"
             >
+              {/* Background gradient/color */}
+              <div
+                className="absolute inset-0 rounded-full"
+                style={{
+                  background: isCustomColor
+                    ? accentCustom || '#ad46ff'
+                    : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
+                }}
+              />
+
+              {/* Glass overlay for unselected state */}
               {!isCustomColor && (
-                <div className="pointer-events-none absolute inset-0 bg-white/10 mix-blend-overlay dark:bg-black/10" />
+                <div className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none" />
               )}
+
+              {/* Border to match presets */}
+              <div
+                className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--text-primary)' : 'border-transparent'}`}
+              />
+
               <input
                 type="color"
                 value={accentCustom || '#ad46ff'}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -61,16 +61,16 @@ export function AppearanceSection({
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
         Appearance
       </h3>
-      <div className="glass-surface p-5 rounded-2xl space-y-6">
-        <div className="space-y-3">
-          <label className="text-sm text-(--text-secondary)">Theme</label>
-          <div className="flex flex-wrap items-center gap-2">
+      <div className="glass-surface rounded-2xl flex flex-col pt-1">
+        <div className="settings-row">
+          <label className="settings-label text-(--text-secondary)">Theme</label>
+          <div className="settings-control">
             {THEME_MODE_OPTIONS.map((option) => (
               <button
                 key={option.value}
                 type="button"
                 onClick={() => onThemeModeChange(option.value)}
-                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-2 text-xs font-bold tracking-wide transition-colors ${
+                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-1.5 text-[11px] font-bold tracking-wide transition-colors ${
                   themeMode === option.value
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
@@ -82,28 +82,28 @@ export function AppearanceSection({
           </div>
         </div>
 
-        <div className="space-y-3">
-          <label className="text-sm text-(--text-secondary)">Accent Color</label>
-          <div className="flex flex-wrap items-center gap-2">
+        <div className="settings-row">
+          <label className="settings-label text-(--text-secondary)">Accent Color</label>
+          <div className="settings-control">
             {ACCENT_PRESETS.map((preset) => (
               <button
                 key={preset.hex}
                 type="button"
                 onClick={() => onAccentChange(preset.hex)}
-                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--text-primary) scale-110' : 'border-transparent'}`}
+                className={`h-7 w-7 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--text-primary) scale-110' : 'border-transparent'}`}
                 style={{ '--preset-color': preset.hex } as CSSProperties}
                 title={preset.name}
               />
             ))}
             <div
-              className={`glass-surface relative flex h-8 shrink-0 items-center overflow-hidden rounded-full border border-(--glass-border) transition-all duration-200 ${
+              className={`glass-surface relative flex h-7 shrink-0 items-center overflow-hidden rounded-full border border-(--glass-border) transition-all duration-200 ${
                 isCustomColor ? 'selected-surface' : ''
               }`}
             >
               <button
                 type="button"
                 onClick={() => onAccentChange('custom')}
-                className={`cursor-pointer px-3 text-[10px] font-bold uppercase tracking-wide transition-colors ${
+                className={`cursor-pointer px-3 text-[9px] font-bold uppercase tracking-wide transition-colors ${
                   isCustomColor
                     ? 'text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
@@ -124,10 +124,10 @@ export function AppearanceSection({
                       title="Custom accent color"
                     />
                     <span
-                      className="h-5 w-9 shrink-0 rounded-full border border-(--glass-border) bg-(--custom-accent)"
+                      className="h-4 w-7 shrink-0 rounded-full border border-(--glass-border) bg-(--custom-accent)"
                       style={{ '--custom-accent': accentCustom || '#ad46ff' } as CSSProperties}
                     />
-                    <span className="min-w-0 truncate text-xs font-mono uppercase text-(--text-muted)">
+                    <span className="min-w-0 truncate text-[10px] font-mono uppercase text-(--text-muted)">
                       {accentCustom}
                     </span>
                   </label>
@@ -137,8 +137,8 @@ export function AppearanceSection({
           </div>
         </div>
 
-        <div className="flex items-center justify-between pt-2 border-t border-(--header-glass-border)">
-          <label className="text-sm text-(--text-secondary)">Accent Glow Background</label>
+        <div className="settings-row">
+          <label className="settings-label text-(--text-secondary)">Accent Glow Background</label>
           <Toggle
             checked={accentBgTint}
             onChange={onAccentBgTintChange}
@@ -146,8 +146,8 @@ export function AppearanceSection({
           />
         </div>
 
-        <div className="flex items-center justify-between pt-2 border-t border-(--header-glass-border)">
-          <label className="text-sm text-(--text-secondary)">Focus active title</label>
+        <div className="settings-row">
+          <label className="settings-label text-(--text-secondary)">Focus active title</label>
           <Toggle
             checked={focusActiveTitle}
             onChange={onFocusActiveTitleChange}
@@ -155,14 +155,14 @@ export function AppearanceSection({
           />
         </div>
 
-        <div className="space-y-3 pt-2 border-t border-(--header-glass-border)">
-          <label className="text-sm text-(--text-secondary)">UI Scale</label>
-          <div className="flex flex-wrap items-center gap-2">
+        <div className="settings-row">
+          <label className="settings-label text-(--text-secondary)">UI Scale</label>
+          <div className="settings-control">
             {ZOOM_PRESETS.map((preset) => (
               <button
                 key={preset.factor}
                 onClick={() => onZoomFactorChange(preset.factor)}
-                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-2 text-xs font-bold tracking-wide transition-colors ${
+                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-1.5 text-[11px] font-bold tracking-wide transition-colors ${
                   zoomFactor === preset.factor
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -162,7 +162,7 @@ export function AppearanceSection({
               <button
                 key={preset.factor}
                 onClick={() => onZoomFactorChange(preset.factor)}
-                className={`settings-control-pill settings-control-pill-button glass-surface tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface tracking-wide transition-colors ${
                   zoomFactor === preset.factor
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -90,7 +90,7 @@ export function AppearanceSection({
                 key={preset.hex}
                 type="button"
                 onClick={() => onAccentChange(preset.hex)}
-                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--text-primary) scale-110' : 'border-transparent'}`}
+                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
                 style={{ '--preset-color': preset.hex } as CSSProperties}
                 title={preset.name}
               />
@@ -118,7 +118,7 @@ export function AppearanceSection({
 
               {/* Border to match presets */}
               <div
-                className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--text-primary)' : 'border-transparent'}`}
+                className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
               />
 
               <input

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -96,16 +96,19 @@ export function AppearanceSection({
               />
             ))}
             <label
-              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] ${
+              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] ${
                 isCustomColor ? 'border-(--text-primary) scale-110' : 'border-transparent'
               }`}
               style={{
                 background: isCustomColor
                   ? accentCustom || '#ad46ff'
-                  : 'conic-gradient(from 180deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000)'
+                  : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
               }}
               title="Custom Color"
             >
+              {!isCustomColor && (
+                <div className="pointer-events-none absolute inset-0 bg-white/10 mix-blend-overlay dark:bg-black/10" />
+              )}
               <input
                 type="color"
                 value={accentCustom || '#ad46ff'}
@@ -116,7 +119,7 @@ export function AppearanceSection({
                 onClick={() => {
                   if (!isCustomColor) onAccentChange('custom')
                 }}
-                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                className="absolute -inset-4 h-16 w-16 cursor-pointer opacity-0"
                 aria-label="Custom accent color"
               />
             </label>

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -11,12 +11,13 @@ const ZOOM_PRESETS = [
 ]
 
 const ACCENT_PRESETS = [
-  { name: 'Electric Aqua', hex: DEFAULT_ACCENT_COLOR },
-  { name: 'Sky Blue', hex: '#4d9fff' },
-  { name: 'Racing Green', hex: '#00c853' },
-  { name: 'Sunset Orange', hex: '#ff6b35' },
-  { name: 'Cyber Purple', hex: '#c850c0' },
-  { name: 'Caution Yellow', hex: '#ffd600' }
+  { name: 'Pit Lane Teal', hex: DEFAULT_ACCENT_COLOR },
+  { name: 'Horizon Blue', hex: '#3080d8' },
+  { name: 'Racing Green', hex: '#008a38' },
+  { name: 'Paddock Orange', hex: '#d84e1c' },
+  { name: 'Pit Night', hex: '#9147ff' },
+  { name: 'Safety Car Gold', hex: '#a88000' },
+  { name: 'Milano Red', hex: '#d50000' }
 ]
 
 const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -70,7 +70,7 @@ export function AppearanceSection({
                 key={option.value}
                 type="button"
                 onClick={() => onThemeModeChange(option.value)}
-                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-1.5 text-[11px] font-bold tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button glass-surface tracking-wide transition-colors ${
                   themeMode === option.value
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
@@ -90,13 +90,13 @@ export function AppearanceSection({
                 key={preset.hex}
                 type="button"
                 onClick={() => onAccentChange(preset.hex)}
-                className={`h-7 w-7 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--text-primary) scale-110' : 'border-transparent'}`}
+                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--text-primary) scale-110' : 'border-transparent'}`}
                 style={{ '--preset-color': preset.hex } as CSSProperties}
                 title={preset.name}
               />
             ))}
             <div
-              className={`glass-surface relative flex h-7 shrink-0 items-center overflow-hidden rounded-full border border-(--glass-border) transition-all duration-200 ${
+              className={`settings-control-pill settings-control-pill-input glass-surface relative shrink-0 transition-all duration-200 ${
                 isCustomColor ? 'selected-surface' : ''
               }`}
             >
@@ -162,7 +162,7 @@ export function AppearanceSection({
               <button
                 key={preset.factor}
                 onClick={() => onZoomFactorChange(preset.factor)}
-                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-1.5 text-[11px] font-bold tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button glass-surface tracking-wide transition-colors ${
                   zoomFactor === preset.factor
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -83,7 +83,7 @@ export function AppsSection({
                 key={utility.key}
                 className="flex flex-col gap-2.5 border-b border-(--header-glass-border) px-5 py-4"
               >
-                <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
+                <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
                   {utility.isCustom ? (
                     <div className="flex items-center gap-2">
                       <svg
@@ -104,7 +104,7 @@ export function AppsSection({
                         type="text"
                         value={appNames[utility.key] || utility.name}
                         onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                        className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                        className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
                         placeholder="App Name"
                         aria-label={`${utility.name} name`}
                         title="Editable app name"
@@ -181,7 +181,7 @@ export function AppsSection({
                 type="button"
                 onClick={onAddCustomSlot}
                 disabled={customSlots >= MAX_CUSTOM_SLOTS}
-                className="accent-surface-action flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-bold"
+                className="accent-surface-action flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold"
               >
                 <svg
                   width="15"

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -140,12 +140,6 @@ export function AppsSection({
                     className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
                   />
 
-                  <button
-                    onClick={() => onBrowse(utility.key)}
-                    className="accent-surface-action cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
-                  >
-                    Browse
-                  </button>
                   {utility.isCustom && (
                     <button
                       type="button"
@@ -173,6 +167,12 @@ export function AppsSection({
                       </svg>
                     </button>
                   )}
+                  <button
+                    onClick={() => onBrowse(utility.key)}
+                    className="accent-surface-action cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
+                  >
+                    Browse
+                  </button>
                 </div>
               </div>
             ))}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -79,68 +79,67 @@ export function AppsSection({
         <div className="overflow-hidden">
           <div className="glass-surface rounded-2xl flex flex-col pt-1">
             {utilities.map((utility) => (
-              <div key={utility.key} className="settings-row">
-                <div className="settings-label-group">
-                  <div className="settings-label uppercase tracking-widest opacity-80">
-                    {utility.isCustom ? (
-                      <div className="flex items-center gap-2">
-                        <svg
-                          width="11"
-                          height="11"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          className="shrink-0 text-(--accent)"
-                        >
-                          <path d="M12 20h9" />
-                          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
-                        </svg>
-                        <input
-                          type="text"
-                          value={appNames[utility.key] || utility.name}
-                          onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                          className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
-                          placeholder="App Name"
-                          aria-label={`${utility.name} name`}
-                          title="Editable app name"
-                        />
-                      </div>
-                    ) : (
-                      utility.name
-                    )}
-                  </div>
-
-                  <div className="mt-2 flex items-center gap-3">
-                    {appIcons[utility.key] && !iconLoadErrors.has(utility.key) ? (
-                      <img
-                        src={appIcons[utility.key]}
-                        alt="Icon"
-                        className="h-6 w-6 object-contain drop-shadow-md shrink-0"
-                        onError={() => onIconLoadError(utility.key)}
-                      />
-                    ) : (
-                      <div
-                        className="fallback-initial-icon flex h-6 w-6 shrink-0 items-center justify-center rounded-lg text-[9px] font-black"
-                        title={`${appNames[utility.key] || utility.name} icon fallback`}
+              <div
+                key={utility.key}
+                className="flex flex-col gap-2.5 border-b border-(--header-glass-border) px-5 py-4"
+              >
+                <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
+                  {utility.isCustom ? (
+                    <div className="flex items-center gap-2">
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="shrink-0 text-(--accent)"
                       >
-                        {getInitials(appNames[utility.key] || utility.name)}
-                      </div>
-                    )}
-
-                    <input
-                      type="text"
-                      value={appPaths[utility.key] || ''}
-                      readOnly
-                      placeholder="No executable path set"
-                      className="glass-recessed flex-1 truncate rounded-lg px-2.5 py-1.5 font-mono text-[10px] text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
-                    />
-                  </div>
+                        <path d="M12 20h9" />
+                        <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                      </svg>
+                      <input
+                        type="text"
+                        value={appNames[utility.key] || utility.name}
+                        onChange={(e) => onAppNameChange(utility.key, e.target.value)}
+                        className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                        placeholder="App Name"
+                        aria-label={`${utility.name} name`}
+                        title="Editable app name"
+                      />
+                    </div>
+                  ) : (
+                    utility.name
+                  )}
                 </div>
 
-                <div className="settings-control">
+                <div className="flex items-center gap-4">
+                  {appIcons[utility.key] && !iconLoadErrors.has(utility.key) ? (
+                    <img
+                      src={appIcons[utility.key]}
+                      alt="Icon"
+                      className="h-8 w-8 object-contain drop-shadow-md shrink-0"
+                      onError={() => onIconLoadError(utility.key)}
+                    />
+                  ) : (
+                    <div
+                      className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
+                      title={`${appNames[utility.key] || utility.name} icon fallback`}
+                    >
+                      {getInitials(appNames[utility.key] || utility.name)}
+                    </div>
+                  )}
+
+                  <input
+                    type="text"
+                    value={appPaths[utility.key] || ''}
+                    readOnly
+                    placeholder="No executable path set"
+                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                  />
+
                   <button
                     onClick={() => onBrowse(utility.key)}
                     className="accent-surface-action cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
@@ -152,13 +151,13 @@ export function AppsSection({
                       type="button"
                       onClick={() => onRemoveCustomSlot(getCustomSlotNumber(utility.key))}
                       disabled={customSlots <= 1}
-                      className="danger-action flex h-8 w-8 cursor-pointer shrink-0 items-center justify-center rounded-xl"
+                      className="danger-action flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl"
                       title={`Remove ${appNames[utility.key] || utility.name}`}
                       aria-label={`Remove ${appNames[utility.key] || utility.name}`}
                     >
                       <svg
-                        width="14"
-                        height="14"
+                        width="15"
+                        height="15"
                         viewBox="0 0 24 24"
                         fill="none"
                         stroke="currentColor"

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -79,67 +79,68 @@ export function AppsSection({
         <div className="overflow-hidden">
           <div className="glass-surface rounded-2xl flex flex-col pt-1">
             {utilities.map((utility) => (
-              <div
-                key={utility.key}
-                className="flex flex-col gap-2 border-b border-(--header-glass-border) px-5 py-3"
-              >
-                <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
-                  {utility.isCustom ? (
-                    <div className="flex items-center gap-2">
-                      <svg
-                        width="11"
-                        height="11"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="shrink-0 text-(--accent)"
-                      >
-                        <path d="M12 20h9" />
-                        <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
-                      </svg>
-                      <input
-                        type="text"
-                        value={appNames[utility.key] || utility.name}
-                        onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                        className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
-                        placeholder="App Name"
-                        aria-label={`${utility.name} name`}
-                        title="Editable app name"
+              <div key={utility.key} className="settings-row">
+                <div className="settings-label-group">
+                  <div className="settings-label uppercase tracking-widest opacity-80">
+                    {utility.isCustom ? (
+                      <div className="flex items-center gap-2">
+                        <svg
+                          width="11"
+                          height="11"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="shrink-0 text-(--accent)"
+                        >
+                          <path d="M12 20h9" />
+                          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                        </svg>
+                        <input
+                          type="text"
+                          value={appNames[utility.key] || utility.name}
+                          onChange={(e) => onAppNameChange(utility.key, e.target.value)}
+                          className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                          placeholder="App Name"
+                          aria-label={`${utility.name} name`}
+                          title="Editable app name"
+                        />
+                      </div>
+                    ) : (
+                      utility.name
+                    )}
+                  </div>
+
+                  <div className="mt-2 flex items-center gap-3">
+                    {appIcons[utility.key] && !iconLoadErrors.has(utility.key) ? (
+                      <img
+                        src={appIcons[utility.key]}
+                        alt="Icon"
+                        className="h-6 w-6 object-contain drop-shadow-md shrink-0"
+                        onError={() => onIconLoadError(utility.key)}
                       />
-                    </div>
-                  ) : (
-                    utility.name
-                  )}
+                    ) : (
+                      <div
+                        className="fallback-initial-icon flex h-6 w-6 shrink-0 items-center justify-center rounded-lg text-[9px] font-black"
+                        title={`${appNames[utility.key] || utility.name} icon fallback`}
+                      >
+                        {getInitials(appNames[utility.key] || utility.name)}
+                      </div>
+                    )}
+
+                    <input
+                      type="text"
+                      value={appPaths[utility.key] || ''}
+                      readOnly
+                      placeholder="No executable path set"
+                      className="glass-recessed flex-1 truncate rounded-lg px-2.5 py-1.5 font-mono text-[10px] text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                    />
+                  </div>
                 </div>
 
-                <div className="flex items-center gap-4">
-                  {appIcons[utility.key] && !iconLoadErrors.has(utility.key) ? (
-                    <img
-                      src={appIcons[utility.key]}
-                      alt="Icon"
-                      className="w-8 h-8 object-contain drop-shadow-md shrink-0"
-                      onError={() => onIconLoadError(utility.key)}
-                    />
-                  ) : (
-                    <div
-                      className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
-                      title={`${appNames[utility.key] || utility.name} icon fallback`}
-                    >
-                      {getInitials(appNames[utility.key] || utility.name)}
-                    </div>
-                  )}
-
-                  <input
-                    type="text"
-                    value={appPaths[utility.key] || ''}
-                    readOnly
-                    placeholder="No executable path set"
-                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
-                  />
-
+                <div className="settings-control">
                   <button
                     onClick={() => onBrowse(utility.key)}
                     className="accent-surface-action cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
@@ -151,13 +152,13 @@ export function AppsSection({
                       type="button"
                       onClick={() => onRemoveCustomSlot(getCustomSlotNumber(utility.key))}
                       disabled={customSlots <= 1}
-                      className="danger-action flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl"
+                      className="danger-action flex h-8 w-8 cursor-pointer shrink-0 items-center justify-center rounded-xl"
                       title={`Remove ${appNames[utility.key] || utility.name}`}
                       aria-label={`Remove ${appNames[utility.key] || utility.name}`}
                     >
                       <svg
-                        width="15"
-                        height="15"
+                        width="14"
+                        height="14"
                         viewBox="0 0 24 24"
                         fill="none"
                         stroke="currentColor"

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -81,7 +81,7 @@ export function BehaviorSection({
               <button
                 key={preset.value}
                 onClick={() => onLaunchDelayMsChange(preset.value)}
-                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-1.5 text-[11px] font-bold tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button glass-surface min-w-[3.25rem] tracking-wide transition-colors ${
                   launchDelayMs === preset.value
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
@@ -91,7 +91,7 @@ export function BehaviorSection({
               </button>
             ))}
             <div
-              className={`glass-surface flex h-[28px] items-center overflow-hidden rounded-full border border-(--glass-border) transition-all duration-200 ${
+              className={`settings-control-pill settings-control-pill-input glass-surface transition-all duration-200 ${
                 !isPreset ? 'selected-surface' : ''
               }`}
             >

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -95,6 +95,19 @@ export function BehaviorSection({
                 !isPreset ? 'selected-surface' : ''
               }`}
             >
+              <svg
+                width="8"
+                height="8"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="ml-1 shrink-0 text-(--text-subtle) opacity-50"
+              >
+                <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+              </svg>
               <input
                 type="number"
                 min="0"
@@ -107,11 +120,11 @@ export function BehaviorSection({
                     onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
                   }
                 }}
-                className="w-full bg-transparent pl-1 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className="w-full bg-transparent pl-1 text-right text-[11px] font-semibold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 placeholder="0.0"
               />
               <div className="mx-1 h-4 w-px bg-(--glass-border) opacity-35" />
-              <span className="pr-1 text-[9px] font-bold text-(--text-muted) uppercase">s</span>
+              <span className="pr-1 text-[9px] font-semibold text-(--text-muted) uppercase">s</span>
             </div>
           </div>
         </div>

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -81,7 +81,7 @@ export function BehaviorSection({
               <button
                 key={preset.value}
                 onClick={() => onLaunchDelayMsChange(preset.value)}
-                className={`settings-control-pill settings-control-pill-button glass-surface min-w-[3.25rem] tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button glass-surface w-[3.5rem] tracking-wide transition-colors ${
                   launchDelayMs === preset.value
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
@@ -91,7 +91,7 @@ export function BehaviorSection({
               </button>
             ))}
             <div
-              className={`settings-control-pill settings-control-pill-input glass-surface min-w-[3.25rem] transition-all duration-200 ${
+              className={`settings-control-pill settings-control-pill-input glass-surface w-[3.5rem] transition-all duration-200 ${
                 !isPreset ? 'selected-surface' : ''
               }`}
             >
@@ -107,10 +107,13 @@ export function BehaviorSection({
                     onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
                   }
                 }}
-                className="w-10 bg-transparent pl-1.5 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className="w-full bg-transparent pl-2 pr-1 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 placeholder="0.0"
               />
-              <span className="px-1.5 text-[9px] font-bold text-(--text-muted) uppercase">s</span>
+              <div className="h-4 w-px bg-(--glass-border) opacity-35" />
+              <span className="pl-1.5 pr-1 text-[9px] font-bold text-(--text-muted) uppercase">
+                s
+              </span>
             </div>
           </div>
         </div>

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -111,7 +111,7 @@ export function BehaviorSection({
               <input
                 type="number"
                 min="0"
-                max="9.9"
+                max="30"
                 step="0.1"
                 value={Number.isFinite(launchDelayMs) ? launchDelayMs / 1000 : ''}
                 onChange={(e) => {

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -12,6 +12,12 @@ interface BehaviorSectionProps {
   onLaunchDelayMsChange: (delayMs: number) => void
 }
 
+const DELAY_PRESETS = [
+  { label: '1s', value: 1000 },
+  { label: '1.5s', value: 1500 },
+  { label: '2s', value: 2000 }
+]
+
 export function BehaviorSection({
   startWithWindows,
   startMinimized,
@@ -22,6 +28,8 @@ export function BehaviorSection({
   onMinimizeToTrayChange,
   onLaunchDelayMsChange
 }: BehaviorSectionProps) {
+  const isPreset = DELAY_PRESETS.some((p) => p.value === launchDelayMs)
+
   return (
     <section className="space-y-4">
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
@@ -66,35 +74,44 @@ export function BehaviorSection({
         <div className="settings-row">
           <div className="settings-label-group">
             <span className="settings-label">Launch delay between apps</span>
-            <div className="mt-2 pr-4">
-              <input
-                type="range"
-                min="0"
-                max="5000"
-                step="100"
-                value={Number.isFinite(launchDelayMs) ? launchDelayMs : 1000}
-                onChange={(e) =>
-                  onLaunchDelayMsChange(normalizeLaunchDelayMs(Number(e.target.value)))
-                }
-                className="w-full accent-(--accent) cursor-pointer"
-                aria-label="Launch delay slider"
-              />
-            </div>
+            <span className="settings-sublabel">Wait time before starting the next app</span>
           </div>
           <div className="settings-control">
-            <input
-              type="number"
-              min="0"
-              max="5000"
-              step="100"
-              value={launchDelayMs}
-              onChange={(e) =>
-                onLaunchDelayMsChange(normalizeLaunchDelayMs(Number(e.target.value)))
-              }
-              className="glass-recessed w-16 rounded-lg px-2 py-1.5 text-right text-xs text-(--text-primary) outline-none"
-              aria-label="Launch delay in milliseconds"
-            />
-            <span className="text-[10px] font-bold text-(--text-muted) uppercase">ms</span>
+            {DELAY_PRESETS.map((preset) => (
+              <button
+                key={preset.value}
+                onClick={() => onLaunchDelayMsChange(preset.value)}
+                className={`glass-surface cursor-pointer rounded-full border border-(--glass-border) px-4 py-1.5 text-[11px] font-bold tracking-wide transition-colors ${
+                  launchDelayMs === preset.value
+                    ? 'selected-surface text-(--text-primary)'
+                    : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
+                }`}
+              >
+                {preset.label}
+              </button>
+            ))}
+            <div
+              className={`glass-surface flex h-[28px] items-center overflow-hidden rounded-full border border-(--glass-border) transition-all duration-200 ${
+                !isPreset ? 'selected-surface' : ''
+              }`}
+            >
+              <input
+                type="number"
+                min="0"
+                max="5"
+                step="0.1"
+                value={Number.isFinite(launchDelayMs) ? launchDelayMs / 1000 : ''}
+                onChange={(e) => {
+                  const val = parseFloat(e.target.value)
+                  if (!isNaN(val)) {
+                    onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
+                  }
+                }}
+                className="w-10 bg-transparent pl-2 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                placeholder="0.0"
+              />
+              <span className="px-2 text-[9px] font-bold text-(--text-muted) uppercase">s</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -28,12 +28,10 @@ export function BehaviorSection({
         Behavior
       </h3>
       <div className="glass-surface rounded-2xl flex flex-col pt-1">
-        <div className="flex items-center justify-between px-4 py-4 border-b border-(--header-glass-border)">
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-(--text-primary)">Start with Windows</span>
-            <span className="text-[10px] text-(--text-muted)">
-              Launch SimLauncher automatically at login
-            </span>
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Start with Windows</span>
+            <span className="settings-sublabel">Launch SimLauncher automatically at login</span>
           </div>
           <Toggle
             checked={startWithWindows}
@@ -41,10 +39,10 @@ export function BehaviorSection({
             aria-label="Start with Windows"
           />
         </div>
-        <div className="flex items-center justify-between px-4 py-4 border-b border-(--header-glass-border)">
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-(--text-primary)">Start minimized</span>
-            <span className="text-[10px] text-(--text-muted)">Start hidden in the system tray</span>
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Start minimized</span>
+            <span className="settings-sublabel">Start hidden in the system tray</span>
           </div>
           <Toggle
             checked={startMinimized}
@@ -52,12 +50,10 @@ export function BehaviorSection({
             aria-label="Start minimized"
           />
         </div>
-        <div className="flex items-center justify-between px-4 py-4 border-b border-(--header-glass-border)">
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-(--text-primary)">
-              Minimize to tray on close
-            </span>
-            <span className="text-[10px] text-(--text-muted)">
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Minimize to tray on close</span>
+            <span className="settings-sublabel">
               Keep SimLauncher running when the window is closed
             </span>
           </div>
@@ -67,37 +63,39 @@ export function BehaviorSection({
             aria-label="Minimize to tray on close"
           />
         </div>
-        <div className="flex flex-col gap-3 px-4 py-4 border-b border-(--header-glass-border)">
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-sm font-medium text-(--text-primary)">
-              Launch delay between apps
-            </span>
-            <div className="flex items-center gap-2">
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Launch delay between apps</span>
+            <div className="mt-2 pr-4">
               <input
-                type="number"
+                type="range"
                 min="0"
                 max="5000"
                 step="100"
-                value={launchDelayMs}
+                value={Number.isFinite(launchDelayMs) ? launchDelayMs : 1000}
                 onChange={(e) =>
                   onLaunchDelayMsChange(normalizeLaunchDelayMs(Number(e.target.value)))
                 }
-                className="glass-recessed w-20 rounded-lg px-2 py-1 text-right text-xs text-(--text-primary) outline-none"
-                aria-label="Launch delay in milliseconds"
+                className="w-full accent-(--accent) cursor-pointer"
+                aria-label="Launch delay slider"
               />
-              <span className="text-xs text-(--text-muted)">ms</span>
             </div>
           </div>
-          <input
-            type="range"
-            min="0"
-            max="5000"
-            step="100"
-            value={Number.isFinite(launchDelayMs) ? launchDelayMs : 1000}
-            onChange={(e) => onLaunchDelayMsChange(normalizeLaunchDelayMs(Number(e.target.value)))}
-            className="w-full accent-(--accent)"
-            aria-label="Launch delay slider"
-          />
+          <div className="settings-control">
+            <input
+              type="number"
+              min="0"
+              max="5000"
+              step="100"
+              value={launchDelayMs}
+              onChange={(e) =>
+                onLaunchDelayMsChange(normalizeLaunchDelayMs(Number(e.target.value)))
+              }
+              className="glass-recessed w-16 rounded-lg px-2 py-1.5 text-right text-xs text-(--text-primary) outline-none"
+              aria-label="Launch delay in milliseconds"
+            />
+            <span className="text-[10px] font-bold text-(--text-muted) uppercase">ms</span>
+          </div>
         </div>
       </div>
     </section>

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -81,7 +81,7 @@ export function BehaviorSection({
               <button
                 key={preset.value}
                 onClick={() => onLaunchDelayMsChange(preset.value)}
-                className={`settings-control-pill settings-control-pill-button glass-surface w-[3.5rem] tracking-wide transition-colors ${
+                className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface tracking-wide transition-colors ${
                   launchDelayMs === preset.value
                     ? 'selected-surface text-(--text-primary)'
                     : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
@@ -91,7 +91,7 @@ export function BehaviorSection({
               </button>
             ))}
             <div
-              className={`settings-control-pill settings-control-pill-input glass-surface w-[3.5rem] transition-all duration-200 ${
+              className={`settings-control-pill settings-control-pill-input settings-control-preset glass-surface transition-all duration-200 ${
                 !isPreset ? 'selected-surface' : ''
               }`}
             >
@@ -107,13 +107,11 @@ export function BehaviorSection({
                     onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
                   }
                 }}
-                className="w-full bg-transparent pl-2 pr-1 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className="w-full bg-transparent pl-1 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 placeholder="0.0"
               />
-              <div className="h-4 w-px bg-(--glass-border) opacity-35" />
-              <span className="pl-1.5 pr-1 text-[9px] font-bold text-(--text-muted) uppercase">
-                s
-              </span>
+              <div className="mx-1 h-4 w-px bg-(--glass-border) opacity-35" />
+              <span className="pr-1 text-[9px] font-bold text-(--text-muted) uppercase">s</span>
             </div>
           </div>
         </div>

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -91,14 +91,14 @@ export function BehaviorSection({
               </button>
             ))}
             <div
-              className={`settings-control-pill settings-control-pill-input glass-surface transition-all duration-200 ${
+              className={`settings-control-pill settings-control-pill-input glass-surface min-w-[3.25rem] transition-all duration-200 ${
                 !isPreset ? 'selected-surface' : ''
               }`}
             >
               <input
                 type="number"
                 min="0"
-                max="5"
+                max="9.9"
                 step="0.1"
                 value={Number.isFinite(launchDelayMs) ? launchDelayMs / 1000 : ''}
                 onChange={(e) => {
@@ -107,10 +107,10 @@ export function BehaviorSection({
                     onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
                   }
                 }}
-                className="w-10 bg-transparent pl-2 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                className="w-10 bg-transparent pl-1.5 text-right text-[11px] font-bold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 placeholder="0.0"
               />
-              <span className="px-2 text-[9px] font-bold text-(--text-muted) uppercase">s</span>
+              <span className="px-1.5 text-[9px] font-bold text-(--text-muted) uppercase">s</span>
             </div>
           </div>
         </div>

--- a/src/renderer/src/components/settings/ConfigSection.tsx
+++ b/src/renderer/src/components/settings/ConfigSection.tsx
@@ -16,60 +16,62 @@ export function ConfigSection({
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
         Config
       </h3>
-      <div className="glass-surface rounded-2xl flex flex-col p-5 gap-4">
-        <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium text-(--text-primary)">Backup and migration</span>
-          <span className="text-[10px] text-(--text-muted)">
-            Export or replace the complete SimLauncher JSON config
-          </span>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <button
-            type="button"
-            onClick={onExportConfig}
-            disabled={exportingConfig || importingConfig}
-            className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-xs font-bold"
-          >
-            <svg
-              width="15"
-              height="15"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="shrink-0"
+      <div className="glass-surface rounded-2xl flex flex-col pt-1">
+        <div className="settings-row border-none">
+          <div className="settings-label-group">
+            <span className="settings-label">Backup and migration</span>
+            <span className="settings-sublabel">
+              Export or replace the complete SimLauncher JSON config
+            </span>
+          </div>
+          <div className="settings-control gap-3">
+            <button
+              type="button"
+              onClick={onExportConfig}
+              disabled={exportingConfig || importingConfig}
+              className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2 text-xs font-bold"
             >
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-              <path d="M7 10l5 5 5-5" />
-              <path d="M12 15V3" />
-            </svg>
-            {exportingConfig ? 'Exporting...' : 'Export config'}
-          </button>
-          <button
-            type="button"
-            onClick={onImportConfig}
-            disabled={exportingConfig || importingConfig}
-            className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-xs font-bold"
-          >
-            <svg
-              width="15"
-              height="15"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="shrink-0"
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <path d="M7 10l5 5 5-5" />
+                <path d="M12 15V3" />
+              </svg>
+              {exportingConfig ? 'Exporting...' : 'Export'}
+            </button>
+            <button
+              type="button"
+              onClick={onImportConfig}
+              disabled={exportingConfig || importingConfig}
+              className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2 text-xs font-bold"
             >
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-              <path d="M17 8l-5-5-5 5" />
-              <path d="M12 3v12" />
-            </svg>
-            {importingConfig ? 'Importing...' : 'Import config'}
-          </button>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <path d="M17 8l-5-5-5 5" />
+                <path d="M12 3v12" />
+              </svg>
+              {importingConfig ? 'Importing...' : 'Import'}
+            </button>
+          </div>
         </div>
       </div>
     </section>

--- a/src/renderer/src/components/settings/ConfigSection.tsx
+++ b/src/renderer/src/components/settings/ConfigSection.tsx
@@ -16,20 +16,21 @@ export function ConfigSection({
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
         Config
       </h3>
-      <div className="glass-surface rounded-2xl flex flex-col pt-1">
-        <div className="settings-row border-none">
+      <div className="glass-surface rounded-2xl p-5">
+        <div className="flex flex-col gap-5">
           <div className="settings-label-group">
             <span className="settings-label">Backup and migration</span>
             <span className="settings-sublabel">
               Export or replace the complete SimLauncher JSON config
             </span>
           </div>
-          <div className="settings-control gap-3">
+
+          <div className="grid grid-cols-2 gap-4">
             <button
               type="button"
               onClick={onExportConfig}
               disabled={exportingConfig || importingConfig}
-              className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2 text-xs font-bold"
+              className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold transition-all hover:scale-[1.02] active:scale-[0.98]"
             >
               <svg
                 width="14"
@@ -37,22 +38,21 @@ export function ConfigSection({
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2"
+                strokeWidth="2.4"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="shrink-0"
               >
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <path d="M7 10l5 5 5-5" />
-                <path d="M12 15V3" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
               </svg>
-              {exportingConfig ? 'Exporting...' : 'Export'}
+              {exportingConfig ? 'Exporting...' : 'Export config'}
             </button>
             <button
               type="button"
               onClick={onImportConfig}
               disabled={exportingConfig || importingConfig}
-              className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2 text-xs font-bold"
+              className="accent-surface-action flex cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold transition-all hover:scale-[1.02] active:scale-[0.98]"
             >
               <svg
                 width="14"
@@ -60,16 +60,15 @@ export function ConfigSection({
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2"
+                strokeWidth="2.4"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="shrink-0"
               >
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <path d="M17 8l-5-5-5 5" />
-                <path d="M12 3v12" />
+                <polyline points="17 8 12 3 7 8" />
+                <line x1="12" y1="3" x2="12" y2="15" />
               </svg>
-              {importingConfig ? 'Importing...' : 'Import'}
+              {importingConfig ? 'Importing...' : 'Import config'}
             </button>
           </div>
         </div>

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -44,47 +44,47 @@ export function GamesSection({
       >
         <div className="overflow-hidden">
           <div className="glass-surface rounded-2xl flex flex-col pt-1">
-            {GAMES.map((game) => (
-              <div key={game.key} className="settings-row">
-                <div className="settings-label-group">
-                  <span className="settings-label uppercase tracking-widest opacity-80">
-                    {game.name}
-                  </span>
-                  <div className="mt-2 flex items-center gap-3">
-                    {gameIcons[game.key] ? (
-                      <img
-                        src={gameIcons[game.key]}
-                        alt={game.name}
-                        className="h-6 w-6 object-contain drop-shadow-md shrink-0"
-                      />
-                    ) : (
-                      <div className="w-6 h-6 rounded shrink-0 bg-(--glass-bg) border border-(--glass-border) flex items-center justify-center">
-                        <svg
-                          width="12"
-                          height="12"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          className="text-(--text-subtle)"
-                        >
-                          <rect x="3" y="3" width="18" height="18" rx="2" />
-                        </svg>
-                      </div>
-                    )}
-                    <input
-                      type="text"
-                      value={gamePaths[game.key] || ''}
-                      readOnly
-                      placeholder="No game path set"
-                      className="glass-recessed flex-1 truncate rounded-lg px-2.5 py-1.5 font-mono text-[10px] text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
-                    />
-                  </div>
+            {GAMES.map((game, index) => (
+              <div
+                key={game.key}
+                className={`flex flex-col gap-2 px-5 py-3 ${index !== GAMES.length - 1 ? 'border-b border-(--header-glass-border)' : ''}`}
+              >
+                <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
+                  {game.name}
                 </div>
 
-                <div className="settings-control">
+                <div className="flex items-center gap-4">
+                  {gameIcons[game.key] ? (
+                    <img
+                      src={gameIcons[game.key]}
+                      alt={game.name}
+                      className="w-8 h-8 object-contain drop-shadow-md shrink-0"
+                    />
+                  ) : (
+                    <div className="w-8 h-8 rounded shrink-0 bg-(--glass-bg) border border-(--glass-border) flex items-center justify-center text-(--text-subtle)">
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <rect x="3" y="3" width="18" height="18" rx="2" />
+                      </svg>
+                    </div>
+                  )}
+
+                  <input
+                    type="text"
+                    value={gamePaths[game.key] || ''}
+                    readOnly
+                    placeholder="No game path set"
+                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                  />
+
                   <button
                     onClick={() => onBrowse(game.key)}
                     className="accent-surface-action cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -44,48 +44,47 @@ export function GamesSection({
       >
         <div className="overflow-hidden">
           <div className="glass-surface rounded-2xl flex flex-col pt-1">
-            {GAMES.map((game, index) => (
-              <div
-                key={game.key}
-                className={`flex flex-col gap-2 px-5 py-3 ${index !== GAMES.length - 1 ? 'border-b border-(--header-glass-border)' : ''}`}
-              >
-                <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
-                  {game.name}
+            {GAMES.map((game) => (
+              <div key={game.key} className="settings-row">
+                <div className="settings-label-group">
+                  <span className="settings-label uppercase tracking-widest opacity-80">
+                    {game.name}
+                  </span>
+                  <div className="mt-2 flex items-center gap-3">
+                    {gameIcons[game.key] ? (
+                      <img
+                        src={gameIcons[game.key]}
+                        alt={game.name}
+                        className="h-6 w-6 object-contain drop-shadow-md shrink-0"
+                      />
+                    ) : (
+                      <div className="w-6 h-6 rounded shrink-0 bg-(--glass-bg) border border-(--glass-border) flex items-center justify-center">
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="text-(--text-subtle)"
+                        >
+                          <rect x="3" y="3" width="18" height="18" rx="2" />
+                        </svg>
+                      </div>
+                    )}
+                    <input
+                      type="text"
+                      value={gamePaths[game.key] || ''}
+                      readOnly
+                      placeholder="No game path set"
+                      className="glass-recessed flex-1 truncate rounded-lg px-2.5 py-1.5 font-mono text-[10px] text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                    />
+                  </div>
                 </div>
 
-                <div className="flex items-center gap-4">
-                  {gameIcons[game.key] ? (
-                    <img
-                      src={gameIcons[game.key]}
-                      alt={game.name}
-                      className="w-8 h-8 object-contain drop-shadow-md shrink-0"
-                    />
-                  ) : (
-                    <div className="w-8 h-8 rounded shrink-0 bg-(--glass-bg) border border-(--glass-border) flex items-center justify-center">
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="text-(--text-subtle)"
-                      >
-                        <rect x="3" y="3" width="18" height="18" rx="2" />
-                      </svg>
-                    </div>
-                  )}
-
-                  <input
-                    type="text"
-                    value={gamePaths[game.key] || ''}
-                    readOnly
-                    placeholder="No game path set"
-                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
-                  />
-
+                <div className="settings-control">
                   <button
                     onClick={() => onBrowse(game.key)}
                     className="accent-surface-action cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -49,7 +49,7 @@ export function GamesSection({
                 key={game.key}
                 className={`flex flex-col gap-2 px-5 py-3 ${index !== GAMES.length - 1 ? 'border-b border-(--header-glass-border)' : ''}`}
               >
-                <div className="text-[10px] font-bold uppercase tracking-widest text-(--text-secondary) opacity-80">
+                <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
                   {game.name}
                 </div>
 

--- a/src/renderer/src/components/settings/settingsUtils.ts
+++ b/src/renderer/src/components/settings/settingsUtils.ts
@@ -3,5 +3,5 @@ export function normalizeLaunchDelayMs(value: number) {
     return 1000
   }
 
-  return Math.min(Math.max(Math.round(value), 0), 10000)
+  return Math.min(Math.max(Math.round(value), 0), 30000)
 }

--- a/src/renderer/src/components/settings/settingsUtils.ts
+++ b/src/renderer/src/components/settings/settingsUtils.ts
@@ -3,5 +3,5 @@ export function normalizeLaunchDelayMs(value: number) {
     return 1000
   }
 
-  return Math.min(Math.max(Math.round(value), 0), 5000)
+  return Math.min(Math.max(Math.round(value), 0), 10000)
 }

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -32,7 +32,7 @@ export interface GameProfileSet {
 export type StoredGameProfile = GameProfile | GameProfileSet
 export type Profiles = Record<string, StoredGameProfile>
 
-export const DEFAULT_ACCENT_COLOR = '#00eaff'
+export const DEFAULT_ACCENT_COLOR = '#008c99'
 export const DEFAULT_CUSTOM_SLOTS = 1
 export const DEFAULT_PROFILE_ID = 'default'
 export const DEFAULT_PROFILE_NAME = 'Default'


### PR DESCRIPTION
## Summary

- Unify settings layout to consistent single-line pattern (#142)
- Replace launch delay slider with presets + custom input in seconds (#142)
- Increase max launch delay to 30s (#142)
- Replace wide accent pill with compact circular color picker (#142)
- Automotive accent presets overhaul with accessibility improvements (#168)
- Reduce font weights across app for cleaner typography (#142)
- Swap browse/remove buttons in apps section for better alignment (#142)

## Milestone
v0.7.3 (patch — UI polish and settings layout unification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)