### PR TITLE
chore: exempt docs: commits from issue ref requirement

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,6 +4,11 @@
 
 MSG=$(cat "$1")
 
+# docs: commits don't require an issue ref
+if echo "$MSG" | grep -qE '^docs(\(.+\))?:'; then
+  exit 0
+fi
+
 if ! echo "$MSG" | grep -qE '#[0-9]+'; then
   echo ""
   echo "  Commit rejected: missing issue reference."


### PR DESCRIPTION
## Summary
- Adds `docs:` prefix exemption to the commit-msg hook so README and docs changes don't require an issue reference
- All other commits still require `#N` reference as before

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)