### PR TITLE
fix: scope docs: hook exemption to subject line only

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,8 +4,8 @@
 
 MSG=$(cat "$1")
 
-# docs: commits don't require an issue ref
-if echo "$MSG" | grep -qE '^docs(\(.+\))?:'; then
+# docs: commits don't require an issue ref (subject line only)
+if sed -n '1p' "$1" | grep -qE '^docs(\(.+\))?:'; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Fixes hook bypass: exemption now checks only the commit subject line via `sed -n '1p'`, not the entire message body
- Reported by Codex review on #171

refs #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)