### PR TITLE
fix: resolve VSCode warnings in GameList.tsx

### DIFF
--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -300,7 +300,7 @@ function GameRow({
       ref={rowRef}
     >
       <div
-        className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? '!isolation-auto z-20' : 'z-0'}`}
+        className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? 'isolation-auto! z-20' : 'z-0'}`}
       >
         <div className="flex items-center gap-5">
           <div className="relative flex h-12 w-12 shrink-0 items-center justify-center">
@@ -703,7 +703,7 @@ export function GameList() {
         const cache: Record<string, string> = {}
         await Promise.all(
           Object.values(settings.appPaths)
-            .filter(Boolean)
+            .filter((p): p is string => Boolean(p))
             .map(async (p) => {
               const icon = await getFileIcon(p)
               if (icon) cache[p.toLowerCase()] = icon


### PR DESCRIPTION
## Summary
- `!isolation-auto` → `isolation-auto!` (canonical Tailwind v4 important modifier syntax)
- `.filter(Boolean)` → `.filter((p): p is string => Boolean(p))` to narrow `unknown` to `string`

refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)