### PR TITLE
chore: open source readiness — community files, repo config, CI hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I click X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open SimLauncher
+        2. Go to ...
+        3. Click ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: SimLauncher version
+      placeholder: 'e.g. v0.7.2'
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: 'e.g. Windows 11 24H2'
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or logs
+      description: Optional — drag and drop images or paste logs here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Suggest an improvement or new feature
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Got an idea? Describe it below. The more context you give, the easier it is to evaluate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the situation where you'd need this.
+      placeholder: I always have to ... and it's annoying because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see?
+      placeholder: It would be great if SimLauncher could ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, links to similar features in other apps — anything that helps.
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Closes #
+
+## What does this PR do?
+
+<!-- Brief description of the change. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Docs / config
+
+## Checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm run format:check` passes
+- [ ] Tested manually
+
+## Screenshots
+
+<!-- If this changes the UI, add a before/after screenshot. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build app
         run: npm run build
+
+      - name: Audit dependencies
+        run: npm audit --omit=dev

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Use [GitHub Security Advisories](https://github.com/Stashpeak/SimLauncher/security/advisories/new) to report privately. Only you and the maintainer will be able to see the report.
+
+Include as much detail as you can: steps to reproduce, affected version, and potential impact.
+
+## Response Time
+
+|                   | Target         |
+| ----------------- | -------------- |
+| Acknowledgement   | Within 7 days  |
+| Fix or mitigation | Within 90 days |
+
+For critical vulnerabilities a fix will be prioritized sooner.
+
+## Scope
+
+Reports are welcome for vulnerabilities in **SimLauncher itself** — its Electron code, IPC handlers, and dependency chain.
+
+Out of scope: vulnerabilities in the sim racing games or utilities that SimLauncher launches, and issues in the underlying OS or hardware.
+
+## Supported Versions
+
+Only the latest release receives security fixes.

--- a/package.json
+++ b/package.json
@@ -14,8 +14,16 @@
     "preview": "electron-vite preview",
     "prepare": "git config core.hooksPath .githooks"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "simracing",
+    "launcher",
+    "electron",
+    "react",
+    "typescript",
+    "windows",
+    "sim-racing"
+  ],
+  "author": "Stashpeak",
   "license": "GPL-3.0-only",
   "dependencies": {
     "@tailwindcss/vite": "^4.1.0",


### PR DESCRIPTION
Closes #174

## What does this PR do?

Implements all P1 and P2 open source readiness items identified in the pre-Reddit reannouncement audit (Claude Opus 4.6, Codex GPT-5, Gemini 3 Flash).

## Changes

- **`SECURITY.md`** — private vulnerability reporting via GitHub Security Advisories, response SLA, scope
- **`package.json`** — fill `author` (`Stashpeak`) and `keywords`
- **`.github/dependabot.yml`** — weekly npm + GitHub Actions updates
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — YAML form with version, OS, steps fields
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — YAML form with problem + solution fields
- **`.github/pull_request_template.md`** — checklist, change type, screenshots
- **`.github/workflows/ci.yml`** — add `npm audit --omit=dev` step

## Type of change

- [x] Docs / config

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] Tested manually

## Screenshots

N/A — no UI changes.