### PR TITLE
release: v0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -8,13 +8,17 @@ export function useRunningApps(configuredGames: Game[]) {
   const [runningApps, setRunningApps] = useState<RunningApp[]>([])
   const [runningStatus, setRunningStatus] = useState<Record<string, boolean>>({})
 
+  const clearRunningState = useCallback(() => {
+    setRunningApps((current) => (current.length === 0 ? current : []))
+    setRunningStatus((current) => (Object.keys(current).length === 0 ? current : {}))
+  }, [])
+
   const refreshRunningState = useCallback(
     async (isMounted: () => boolean = () => true) => {
       try {
         if (configuredGames.length === 0) {
           if (isMounted()) {
-            setRunningApps([])
-            setRunningStatus({})
+            clearRunningState()
           }
           return
         }
@@ -34,12 +38,19 @@ export function useRunningApps(configuredGames: Game[]) {
         console.error('Consolidated polling error:', err)
       }
     },
-    [configuredGames]
+    [clearRunningState, configuredGames]
   )
 
   useEffect(() => {
     let mounted = true
     const isMounted = () => mounted
+
+    if (configuredGames.length === 0) {
+      clearRunningState()
+      return () => {
+        mounted = false
+      }
+    }
 
     refreshRunningState(isMounted)
     const intervalId = window.setInterval(() => refreshRunningState(isMounted), 2000)
@@ -48,7 +59,7 @@ export function useRunningApps(configuredGames: Game[]) {
       mounted = false
       window.clearInterval(intervalId)
     }
-  }, [refreshRunningState])
+  }, [clearRunningState, configuredGames.length, refreshRunningState])
 
   return { runningApps, runningStatus, refreshRunningState }
 }


### PR DESCRIPTION
## Summary

- Stop idle polling and re-renders when no games are configured (Closes #202)
- Bump version to v0.8.1

## Background

Patch release addressing a CPU regression surfaced via community feedback on Reddit. On the No Games Configured screen, `useRunningApps` was running a 2s `setInterval` that called `setState` with new empty references on every tick, causing unnecessary React re-renders and elevated idle CPU usage.

## Milestone
v0.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #202
<!-- auto-closes -->