### PR TITLE
release: v0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -305,6 +305,7 @@ export default function App() {
                   onConfigImported={handleConfigImported}
                   onSaved={() => {
                     setSaveRequested(false)
+                    setRefreshKey((k) => k + 1)
                     if (pendingView) {
                       setView(pendingView)
                       setPendingView(null)

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -301,6 +301,21 @@ export function SettingsView({
     setCustomSlots((current) => Math.max(1, current - 1))
   }
 
+  const handleGamePathChange = (key: string, path: string) => {
+    setGamePaths((prev) => ({ ...prev, [key]: path }))
+  }
+
+  const handleAppPathChange = (key: string, path: string) => {
+    setAppPaths((prev) => ({ ...prev, [key]: path }))
+    if (!path) {
+      setAppIcons((prev) => {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    }
+  }
+
   const handleAppNameChange = (key: string, name: string) => {
     setAppNames((prev) => ({ ...prev, [key]: name }))
   }
@@ -451,6 +466,7 @@ export function SettingsView({
         gameIcons={gameIcons}
         onOpenChange={setGamesOpen}
         onBrowse={(key) => handleBrowse(key, true)}
+        onGamePathChange={handleGamePathChange}
       />
 
       <AppsSection
@@ -463,6 +479,7 @@ export function SettingsView({
         customSlots={customSlots}
         onOpenChange={setAppsOpen}
         onAppNameChange={handleAppNameChange}
+        onAppPathChange={handleAppPathChange}
         onIconLoadError={handleIconLoadError}
         onBrowse={(key) => handleBrowse(key, false)}
         onAddCustomSlot={handleAddCustomSlot}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -28,6 +28,7 @@ interface AppsSectionProps {
   customSlots: number
   onOpenChange: (open: boolean) => void
   onAppNameChange: (key: string, name: string) => void
+  onAppPathChange: (key: string, path: string) => void
   onIconLoadError: (key: string) => void
   onBrowse: (key: string) => void
   onAddCustomSlot: () => void
@@ -44,6 +45,7 @@ export function AppsSection({
   customSlots,
   onOpenChange,
   onAppNameChange,
+  onAppPathChange,
   onIconLoadError,
   onBrowse,
   onAddCustomSlot,
@@ -135,9 +137,9 @@ export function AppsSection({
                   <input
                     type="text"
                     value={appPaths[utility.key] || ''}
-                    readOnly
+                    onChange={(e) => onAppPathChange(utility.key, e.target.value)}
                     placeholder="No executable path set"
-                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
                   />
 
                   {utility.isCustom && (

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -6,6 +6,7 @@ interface GamesSectionProps {
   gameIcons: Record<string, string>
   onOpenChange: (open: boolean) => void
   onBrowse: (key: string) => void
+  onGamePathChange: (key: string, path: string) => void
 }
 
 export function GamesSection({
@@ -13,7 +14,8 @@ export function GamesSection({
   gamePaths,
   gameIcons,
   onOpenChange,
-  onBrowse
+  onBrowse,
+  onGamePathChange
 }: GamesSectionProps) {
   return (
     <section className="space-y-4">
@@ -80,9 +82,9 @@ export function GamesSection({
                   <input
                     type="text"
                     value={gamePaths[game.key] || ''}
-                    readOnly
+                    onChange={(e) => onGamePathChange(game.key, e.target.value)}
                     placeholder="No game path set"
-                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
                   />
 
                   <button


### PR DESCRIPTION
## Summary
- Settings path inputs (games & apps) are now editable — type or clear paths directly without Browse
- Launcher tab refreshes immediately after saving settings (no restart needed)

## Hotfix for
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #210
<!-- auto-closes -->