### PR TITLE
fix: ErrorBoundary restart, path edit race, elevated app close

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -30,7 +30,7 @@ const UTILITY_COMPANION_PROCESS_NAMES: Record<string, string[]> = {
 }
 
 function isAccessDeniedMessage(message: string) {
-  return /access is denied/i.test(message)
+  return /(access is denied|permission denied|administrator|elevat)/i.test(message)
 }
 
 function isNotFoundMessage(message: string) {
@@ -150,7 +150,7 @@ function registerUnclosedProcess(attempt: KillAttemptResult) {
   const error =
     attempt.error ||
     (attempt.accessDenied
-      ? 'Windows denied permission to close this app.'
+      ? 'Windows denied SimLauncher permission to close this app. It may be running as administrator.'
       : 'The app is still running after the close request.')
 
   unclosedProcesses.set(getUnclosedProcessKey(gameKey, appPath, attempt.processName), {
@@ -195,8 +195,12 @@ function formatKillWarning(failedAttempts: KillAttemptResult[]) {
 
   if (failedAttempts.length === 1) {
     return first.accessDenied
-      ? `${appName} is still running because Windows denied permission to close it.`
+      ? `${appName} is still running because Windows denied SimLauncher permission to close it. If it is running as administrator, close it manually or run SimLauncher as administrator.`
       : `${appName} could not be closed and is still running.`
+  }
+
+  if (failedAttempts.some((attempt) => attempt.accessDenied)) {
+    return `${failedAttempts.length} apps could not be closed because Windows denied SimLauncher permission. Elevated apps may need to be closed manually or by running SimLauncher as administrator.`
   }
 
   return `${failedAttempts.length} apps could not be closed and are still running.`
@@ -219,7 +223,9 @@ async function finalizeKillAttempts(attempts: KillAttemptResult[]): Promise<Kill
   }))
 
   finalizedAttempts.forEach((attempt) => {
-    if (attempt.stillRunning) {
+    const failedToClose = attempt.stillRunning || (!attempt.success && !attempt.notFound)
+
+    if (failedToClose) {
       registerUnclosedProcess(attempt)
       return
     }
@@ -235,7 +241,9 @@ async function finalizeKillAttempts(attempts: KillAttemptResult[]): Promise<Kill
     })
   })
 
-  const failedAttempts = finalizedAttempts.filter((attempt) => attempt.stillRunning)
+  const failedAttempts = finalizedAttempts.filter(
+    (attempt) => attempt.stillRunning || (!attempt.success && !attempt.notFound)
+  )
   const closedCount = finalizedAttempts.length - failedAttempts.length
   const warning = formatKillWarning(failedAttempts)
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -189,4 +189,10 @@ export function registerWindowHandlers() {
 
     mainWindow?.close()
   })
+
+  ipcMain.handle('restart-app', () => {
+    setIsQuitting(true)
+    app.relaunch()
+    app.exit(0)
+  })
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -96,6 +96,7 @@ declare global {
       minimize: () => Promise<void>
       maximize: () => Promise<void>
       close: () => Promise<void>
+      restartApp: () => Promise<void>
       getRunningApps: () => Promise<RunningApp[]>
       killLaunchedApps: (gameKey?: string) => Promise<KillResult>
       killProfileApps: (gameKey: string, appPaths: string[]) => Promise<KillResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   minimize: () => ipcRenderer.invoke('window-minimize'),
   maximize: () => ipcRenderer.invoke('window-maximize'),
   close: () => ipcRenderer.invoke('window-close'),
+  restartApp: () => ipcRenderer.invoke('restart-app'),
 
   // process monitoring
   getRunningApps: () => ipcRenderer.invoke('get-running-apps'),

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ErrorInfo, ReactNode } from 'react'
+﻿import { Component, ErrorInfo, ReactNode } from 'react'
+import { restartApp } from '../lib/electron'
 import { WindowControls } from './WindowControls'
 
 interface Props {
@@ -24,8 +25,13 @@ export class ErrorBoundary extends Component<Props, State> {
     console.error('Uncaught error:', error, errorInfo)
   }
 
-  private handleReload = () => {
-    window.location.reload()
+  private handleReload = async () => {
+    try {
+      await restartApp()
+    } catch (err) {
+      console.error('Failed to restart app:', err)
+      window.location.reload()
+    }
   }
 
   private handleCopyError = () => {
@@ -149,3 +155,4 @@ export class ErrorBoundary extends Component<Props, State> {
     return this.props.children
   }
 }
+

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -155,4 +155,3 @@ export class ErrorBoundary extends Component<Props, State> {
     return this.props.children
   }
 }
-

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDirtyTracking } from '../hooks/useDirtyTracking'
 import {
   DEFAULT_ACCENT_COLOR,
@@ -82,6 +82,8 @@ export function SettingsView({
   const [appIcons, setAppIcons] = useState<Record<string, string>>({})
   const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
   const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
+  const appPathEditVersion = useRef(0)
+  const gamePathEditVersion = useRef(0)
 
   const updateStatus = useUpdateStatus({ updateInfo, notify })
 
@@ -252,8 +254,10 @@ export function SettingsView({
     }
     if (result && result.filePath) {
       if (isGame) {
+        gamePathEditVersion.current += 1
         setGamePaths((prev) => ({ ...prev, [key]: result.filePath }))
       } else {
+        appPathEditVersion.current += 1
         setAppPaths((prev) => ({ ...prev, [key]: result.filePath }))
         const icon = await getFileIcon(result.filePath)
         if (icon) {
@@ -306,10 +310,12 @@ export function SettingsView({
   }
 
   const handleGamePathChange = (key: string, path: string) => {
+    gamePathEditVersion.current += 1
     setGamePaths((prev) => ({ ...prev, [key]: path }))
   }
 
   const handleAppPathChange = (key: string, path: string) => {
+    appPathEditVersion.current += 1
     setAppPaths((prev) => ({ ...prev, [key]: path }))
     if (!path) {
       setAppIcons((prev) => {
@@ -382,6 +388,8 @@ export function SettingsView({
       const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
       const trimmedAppPaths = trimPathRecord(appPaths)
       const trimmedGamePaths = trimPathRecord(gamePaths)
+      const appPathEditVersionAtSave = appPathEditVersion.current
+      const gamePathEditVersionAtSave = gamePathEditVersion.current
 
       await Promise.all([
         saveSettings({
@@ -403,17 +411,29 @@ export function SettingsView({
         }),
         saveProfiles(profiles)
       ])
-      setAppPaths(trimmedAppPaths)
-      setGamePaths(trimmedGamePaths)
+      const appPathsChangedDuringSave = appPathEditVersion.current !== appPathEditVersionAtSave
+      const gamePathsChangedDuringSave = gamePathEditVersion.current !== gamePathEditVersionAtSave
+
+      if (!appPathsChangedDuringSave) {
+        setAppPaths(trimmedAppPaths)
+      }
+
+      if (!gamePathsChangedDuringSave) {
+        setGamePaths(trimmedGamePaths)
+      }
+
       setLaunchDelayMs(normalizedLaunchDelayMs)
 
       notify('Settings saved!', 'success', 2500)
-      resetDirty({
-        ...currentSettingsState,
-        appPaths: trimmedAppPaths,
-        gamePaths: trimmedGamePaths,
-        launchDelayMs: normalizedLaunchDelayMs
-      })
+
+      if (!appPathsChangedDuringSave && !gamePathsChangedDuringSave) {
+        resetDirty({
+          ...currentSettingsState,
+          appPaths: trimmedAppPaths,
+          gamePaths: trimmedGamePaths,
+          launchDelayMs: normalizedLaunchDelayMs
+        })
+      }
     } catch (err) {
       notify('Failed to save settings', 'error')
       console.error(err)

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -84,6 +84,8 @@ export function SettingsView({
   const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
   const appPathEditVersion = useRef(0)
   const gamePathEditVersion = useRef(0)
+  const latestAppPaths = useRef(appPaths)
+  const latestGamePaths = useRef(gamePaths)
 
   const updateStatus = useUpdateStatus({ updateInfo, notify })
 
@@ -143,6 +145,14 @@ export function SettingsView({
   useEffect(() => {
     loadSettingsFromStore()
   }, [])
+
+  useEffect(() => {
+    latestAppPaths.current = appPaths
+  }, [appPaths])
+
+  useEffect(() => {
+    latestGamePaths.current = gamePaths
+  }, [gamePaths])
 
   const currentSettingsState = useMemo(
     () => ({
@@ -426,14 +436,12 @@ export function SettingsView({
 
       notify('Settings saved!', 'success', 2500)
 
-      if (!appPathsChangedDuringSave && !gamePathsChangedDuringSave) {
-        resetDirty({
-          ...currentSettingsState,
-          appPaths: trimmedAppPaths,
-          gamePaths: trimmedGamePaths,
-          launchDelayMs: normalizedLaunchDelayMs
-        })
-      }
+      resetDirty({
+        ...currentSettingsState,
+        appPaths: appPathsChangedDuringSave ? latestAppPaths.current : trimmedAppPaths,
+        gamePaths: gamePathsChangedDuringSave ? latestGamePaths.current : trimmedGamePaths,
+        launchDelayMs: normalizedLaunchDelayMs
+      })
     } catch (err) {
       notify('Failed to save settings', 'error')
       console.error(err)

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -19,6 +19,7 @@ export const onAppLaunchError: typeof window.electronAPI.onAppLaunchError = (cb)
 export const minimize = () => window.electronAPI.minimize()
 export const maximize = () => window.electronAPI.maximize()
 export const close = () => window.electronAPI.close()
+export const restartApp = () => window.electronAPI.restartApp()
 export const getRunningApps = () => window.electronAPI.getRunningApps()
 export const killLaunchedApps: typeof window.electronAPI.killLaunchedApps = (gameKey) =>
   window.electronAPI.killLaunchedApps(gameKey)


### PR DESCRIPTION
Three logic bug fixes.

**#197 — ErrorBoundary Reload Application button does nothing**
Added a `restart-app` IPC handler (`app.relaunch()` + `app.exit(0)`) with `setIsQuitting(true)`. Exposed via preload and electron lib. ErrorBoundary now calls `restartApp()` with fallback to `window.location.reload()`.

**#213 — Path edits clobbered after async save**
Version counter refs track whether path inputs were edited during the async save. State is only overwritten post-save if no edits occurred in the meantime — preserving in-progress user input.

**#205 — Elevated companion apps silently fail to close**
Extended `isAccessDeniedMessage` regex to catch more elevation-related errors. Improved user-facing messages to explain the administrator elevation issue. Fixed `finalizeKillAttempts` to correctly register failed-but-not-found attempts.

Fixes #197
Fixes #213
Fixes #205

## Test plan
- [ ] Trigger error boundary — "Reload Application" fully restarts the app (not just renderer reload)
- [ ] Edit a path input, save simultaneously — verify edit is not overwritten
- [ ] Attempt to close an elevated companion app — verify clear error message is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #197
Closes #205
Closes #213
<!-- auto-closes -->