### PR TITLE
perf: eliminate redundant IPC calls, add custom app CLI args, extract migrations

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -112,6 +112,7 @@ export function registerConfigHandlers() {
       appPaths: store.get('appPaths'),
       gamePaths: store.get('gamePaths'),
       appNames: store.get('appNames'),
+      appArgs: store.get('appArgs'),
       customSlots: store.get('customSlots'),
       accentPreset: store.get('accentPreset'),
       accentCustom: store.get('accentCustom'),
@@ -129,7 +130,7 @@ export function registerConfigHandlers() {
 
   ipcMain.handle('save-settings', (_event, patch: unknown) => {
     if (!isRecord(patch)) return
-    const OBJECT_KEYS = new Set(['appPaths', 'gamePaths', 'appNames'])
+    const OBJECT_KEYS = new Set(['appPaths', 'gamePaths', 'appNames', 'appArgs'])
     const BOOLEAN_KEYS = new Set([
       'accentBgTint',
       'focusActiveTitle',

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -146,6 +146,60 @@ export function isRunningExePath(processNames: Set<string>, appPath: string) {
   return processNames.has(getExeName(appPath))
 }
 
+function parseCommandLineArgs(input: string) {
+  const args: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]
+    const nextChar = input[index + 1]
+
+    if (char === '\\' && nextChar === '"') {
+      current += nextChar
+      index += 1
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = !inQuotes
+      continue
+    }
+
+    if (/\s/.test(char) && !inQuotes) {
+      if (current.length > 0) {
+        args.push(current)
+        current = ''
+      }
+      continue
+    }
+
+    current += char
+  }
+
+  if (current.length > 0) {
+    args.push(current)
+  }
+
+  return args
+}
+
+function getCustomAppArgs(appPath: string) {
+  const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
+  const appArgs = (store.get('appArgs') as Record<string, string> | undefined) || {}
+  const normalizedAppPath = appPath.trim().toLowerCase()
+  const customAppEntry = Object.entries(appPaths).find(
+    ([key, value]) => /^customapp\d+$/.test(key) && value.trim().toLowerCase() === normalizedAppPath
+  )
+
+  if (!customAppEntry) {
+    return []
+  }
+
+  const args = appArgs[customAppEntry[0]]
+  return typeof args === 'string' && args.trim().length > 0 ? parseCommandLineArgs(args) : []
+}
+
 function sendLaunchError(sender: WebContents, appPath: string, error: string) {
   if (!sender.isDestroyed()) {
     sender.send('app-launch-error', { app: appPath, error })
@@ -156,9 +210,11 @@ function isElevatedLaunchError(err: unknown) {
   return process.platform === 'win32' && getErrorCode(err) === 'EACCES'
 }
 
-function launchElevated(appPath: string) {
+function launchElevated(appPath: string, args: string[] = []) {
   return new Promise<AppLaunchResult>((resolve) => {
     const escapedAppPath = appPath.replace(/'/g, "''")
+    const escapedArgs = args.map((arg) => `'${arg.replace(/'/g, "''")}'`).join(', ')
+    const argumentList = escapedArgs ? ` -ArgumentList @(${escapedArgs})` : ''
 
     execFile(
       'powershell.exe',
@@ -166,7 +222,7 @@ function launchElevated(appPath: string) {
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        `Start-Process -FilePath '${escapedAppPath}' -Verb RunAs`
+        `Start-Process -FilePath '${escapedAppPath}'${argumentList} -Verb RunAs`
       ],
       { windowsHide: true },
       (error) => {
@@ -208,7 +264,8 @@ function spawnDetachedApp(
     }
 
     try {
-      const child = spawn(appPath, [], { detached: true, stdio: 'ignore' })
+      const args = getCustomAppArgs(appPath)
+      const child = spawn(appPath, args, { detached: true, stdio: 'ignore' })
       runningProcesses.set(appPath, {
         process: child,
         name: path.basename(appPath),
@@ -235,7 +292,7 @@ function spawnDetachedApp(
         }
 
         if (isElevatedLaunchError(err)) {
-          resolveOnce(await launchElevated(appPath))
+          resolveOnce(await launchElevated(appPath, args))
           return
         }
 
@@ -252,7 +309,7 @@ function spawnDetachedApp(
       console.error(`Error launching ${appPath}: ${message}`)
 
       if (isElevatedLaunchError(err)) {
-        launchElevated(appPath).then(resolveOnce)
+        launchElevated(appPath, getCustomAppArgs(appPath)).then(resolveOnce)
         return
       }
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -10,6 +10,7 @@ export const MAX_CONFIG_IMPORT_BYTES = 1_000_000
 
 const MAX_IMPORT_PATH_LENGTH = 300
 const MAX_CONFIG_STRING_LENGTH = 100
+const MAX_CONFIG_ARGS_LENGTH = 500
 const MAX_ACCENT_PRESET_LENGTH = 50
 const MAX_PROFILE_COUNT_PER_GAME = 20
 const MAX_TRACKED_PROCESS_PATHS = 50
@@ -57,6 +58,7 @@ export const store = new StoreConstructor({
     gamePaths: { type: 'object', default: {} },
     profiles: { type: 'object', default: {} },
     appNames: { type: 'object', default: {} },
+    appArgs: { type: 'object', default: {} },
     customSlots: { type: 'number', default: 1, minimum: 1, maximum: MAX_CUSTOM_SLOTS },
     accentPreset: { type: 'string', default: '' },
     accentCustom: { type: 'string', default: '' },
@@ -82,6 +84,7 @@ export const EXPECTED_CONFIG_KEYS = new Set([
   'gamePaths',
   'profiles',
   'appNames',
+  'appArgs',
   'customSlots',
   'accentPreset',
   'accentCustom',
@@ -254,6 +257,24 @@ function sanitizeNameRecord(value: unknown, allowedKeys: Set<string>) {
 
     if (allowedKeys.has(key) && safeName) {
       safeRecord[key] = safeName
+    }
+  })
+
+  return safeRecord
+}
+
+function sanitizeArgsRecord(value: unknown, allowedKeys: Set<string>) {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  const safeRecord: Record<string, string> = {}
+
+  getSafeObjectEntries(value).forEach(([key, entry]) => {
+    const safeArgs = getSafeString(entry, MAX_CONFIG_ARGS_LENGTH)
+
+    if (allowedKeys.has(key) && safeArgs) {
+      safeRecord[key] = safeArgs
     }
   })
 
@@ -527,6 +548,18 @@ export function getSupportedConfigValues(config: Record<string, unknown>) {
 
       if (appNames) {
         supportedConfig.appNames = appNames
+      }
+      return
+    }
+
+    if (key === 'appArgs') {
+      const customUtilityKeys = new Set(
+        [...utilityKeys].filter((utilityKey) => /^customapp\d+$/.test(utilityKey))
+      )
+      const appArgs = sanitizeArgsRecord(value, customUtilityKeys)
+
+      if (appArgs) {
+        supportedConfig.appArgs = appArgs
       }
       return
     }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,7 @@ declare global {
     appPaths: Record<string, string>
     gamePaths: Record<string, string>
     appNames: Record<string, string>
+    appArgs: Record<string, string>
     customSlots: number
     accentPreset: string
     accentCustom: string

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,33 +4,11 @@ import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
 import { ConfirmDialog } from './components/ConfirmDialog'
-import {
-  getMigrationFlags,
-  saveSettings,
-  saveProfiles,
-  getSettings,
-  setMigrationFlags
-} from './lib/store'
-import {
-  getUpdateInfo,
-  onUpdateAvailable,
-  browsePath,
-  getAssetData,
-  getFileIcon,
-  setLoginItem,
-  setZoom
-} from './lib/electron'
-import {
-  DEFAULT_ACCENT_COLOR,
-  DEFAULT_PROFILE_ID,
-  createDefaultProfile,
-  getHighestCustomSlot,
-  getUtilities,
-  migrateProfileToUtilityOrder,
-  type GameProfileSet,
-  type GameProfile
-} from './lib/config'
+import { getSettings } from './lib/store'
+import { getUpdateInfo, onUpdateAvailable, setZoom } from './lib/electron'
+import { DEFAULT_ACCENT_COLOR } from './lib/config'
 import { applyAccentTheme, applyThemeMode, normalizeThemeMode } from './lib/theme'
+import { runStartupMigrations } from './lib/migrations'
 
 export default function App() {
   const [view, setView] = useState<'games' | 'settings'>('games')
@@ -43,103 +21,7 @@ export default function App() {
   const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
-    // One-time migration from localStorage (vanilla app) to electron-store
-    async function migrateFromLocalStorage() {
-      try {
-        const flags = await getMigrationFlags()
-        if (flags.migrated) return
-
-        const patch: Partial<WritableSettings> = {}
-
-        const appPathsRaw = localStorage.getItem('simLauncherAppPaths')
-        const gamePathsRaw = localStorage.getItem('simLauncherGamePaths')
-        let appPaths: Record<string, unknown> = {}
-        if (appPathsRaw) {
-          appPaths = JSON.parse(appPathsRaw)
-          patch.appPaths = appPaths as Record<string, string>
-        }
-        if (gamePathsRaw) patch.gamePaths = JSON.parse(gamePathsRaw)
-
-        const accentPreset = localStorage.getItem('simLauncherAccentPreset')
-        const accentCustom = localStorage.getItem('simLauncherAccentCustom')
-        if (accentPreset) patch.accentPreset = accentPreset
-        if (accentCustom) patch.accentCustom = accentCustom
-
-        const utilityKeys = [
-          'simhub',
-          'crewchief',
-          'tradingpaints',
-          'garage61',
-          'secondmonitor',
-          'customapp1',
-          'customapp2',
-          'customapp3',
-          'customapp4',
-          'customapp5'
-        ]
-        const appNames: Record<string, string> = {}
-        for (const key of utilityKeys) {
-          const name = localStorage.getItem(`simLauncherAppName_${key}`)
-          if (name) appNames[key] = name
-        }
-        if (Object.keys(appNames).length > 0) patch.appNames = appNames
-
-        const gameKeys = [
-          'ac',
-          'acc',
-          'acevo',
-          'acrally',
-          'ams',
-          'ams2',
-          'beamng',
-          'dcsw',
-          'dirtrally',
-          'dirtrally2',
-          'eawrc',
-          'f124',
-          'f125',
-          'iracing',
-          'lmu',
-          'pmr',
-          'raceroom',
-          'rbr',
-          'rennsport',
-          'rf1',
-          'rf2'
-        ]
-        const profiles: Record<string, GameProfile> = {}
-        for (const key of gameKeys) {
-          const raw = localStorage.getItem(`profile_${key}`)
-          if (raw) profiles[key] = JSON.parse(raw)
-        }
-        const migratedCustomSlots = getHighestCustomSlot(
-          appPaths,
-          appNames,
-          ...Object.values(profiles)
-        )
-        const utilities = getUtilities(migratedCustomSlots)
-        const migratedProfiles: Record<string, GameProfileSet> = Object.fromEntries(
-          Object.entries(profiles).map(([gameKey, profile]) => [
-            gameKey,
-            {
-              activeProfileId: DEFAULT_PROFILE_ID,
-              profiles: [createDefaultProfile(migrateProfileToUtilityOrder(profile, utilities))]
-            }
-          ])
-        ) as Record<string, GameProfileSet>
-
-        if (migratedCustomSlots > 1) patch.customSlots = migratedCustomSlots
-        if (Object.keys(patch).length > 0) await saveSettings(patch)
-        if (Object.keys(migratedProfiles).length > 0) await saveProfiles(migratedProfiles)
-        await setMigrationFlags({
-          profileUtilityOrderMigrated: true,
-          migrated: true
-        })
-      } catch (err) {
-        console.error('Failed to migrate from localStorage', err)
-      }
-    }
-    migrateFromLocalStorage()
+    runStartupMigrations()
   }, [])
 
   const syncThemeFromStore = async () => {

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -662,45 +662,17 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
   const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
 
   useEffect(() => {
-    async function loadGames() {
-      try {
-        const settings = await getSettings()
-        setGamePaths(settings.gamePaths)
-        const available = GAMES.filter((game) => !!settings.gamePaths[game.key])
-        setConfiguredGames(available)
-      } catch (err) {
-        console.error('Failed to load game paths', err)
-      }
-    }
-
-    loadGames()
-  }, [])
-
-  useEffect(() => {
     let mounted = true
 
-    async function loadFocusActiveTitle() {
-      const settings = await getSettings()
-
-      if (mounted) {
-        setFocusActiveTitle(settings.focusActiveTitle !== false)
-      }
-    }
-
-    loadFocusActiveTitle()
-    window.addEventListener('focus', loadFocusActiveTitle)
-
-    return () => {
-      mounted = false
-      window.removeEventListener('focus', loadFocusActiveTitle)
-    }
-  }, [])
-
-  // Load app icons once at mount
-  useEffect(() => {
-    async function loadAppIcons() {
+    async function loadInitialSettings() {
       try {
         const settings = await getSettings()
+        if (!mounted) return
+
+        setGamePaths(settings.gamePaths)
+        setFocusActiveTitle(settings.focusActiveTitle !== false)
+        setConfiguredGames(GAMES.filter((game) => !!settings.gamePaths[game.key]))
+
         const cache: Record<string, string> = {}
         await Promise.all(
           Object.values(settings.appPaths)
@@ -710,15 +682,24 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
               if (icon) cache[p.toLowerCase()] = icon
             })
         )
+
+        if (!mounted) return
+
         setAppIconCache(cache)
         setCacheInitialized(true)
       } catch (err) {
-        console.error('Failed to load app icons', err)
-        setCacheInitialized(true)
+        console.error('Failed to load game settings', err)
+        if (mounted) {
+          setCacheInitialized(true)
+        }
       }
     }
 
-    loadAppIcons()
+    loadInitialSettings()
+
+    return () => {
+      mounted = false
+    }
   }, [])
 
   if (configuredGames.length === 0) {

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -38,6 +38,14 @@ function trimPathRecord(paths: Record<string, string>) {
   return Object.fromEntries(Object.entries(paths).map(([key, value]) => [key, value.trim()]))
 }
 
+function trimStringRecord(values: Record<string, string>) {
+  return Object.fromEntries(
+    Object.entries(values)
+      .map(([key, value]) => [key, value.trim()])
+      .filter(([_key, value]) => value.length > 0)
+  )
+}
+
 export function SettingsView({
   onClose,
   updateInfo,
@@ -58,6 +66,7 @@ export function SettingsView({
 
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
   const [appNames, setAppNames] = useState<Record<string, string>>({})
+  const [appArgs, setAppArgs] = useState<Record<string, string>>({})
   const [profiles, setProfiles] = useState<Profiles>({})
   const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
   const [customSlots, setCustomSlots] = useState(1)
@@ -95,6 +104,7 @@ export function SettingsView({
 
     setAppPaths(settings.appPaths)
     setAppNames(settings.appNames)
+    setAppArgs(settings.appArgs)
     setProfiles(typedProfiles)
     setGamePaths(settings.gamePaths)
     setCustomSlots(
@@ -158,6 +168,7 @@ export function SettingsView({
     () => ({
       appPaths,
       appNames,
+      appArgs,
       profiles,
       gamePaths,
       customSlots,
@@ -176,6 +187,7 @@ export function SettingsView({
     [
       appPaths,
       appNames,
+      appArgs,
       profiles,
       gamePaths,
       customSlots,
@@ -305,6 +317,7 @@ export function SettingsView({
 
     setAppPaths((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
     setAppNames((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+    setAppArgs((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
     setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
     setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
     setProfiles((current) => {
@@ -338,6 +351,10 @@ export function SettingsView({
 
   const handleAppNameChange = (key: string, name: string) => {
     setAppNames((prev) => ({ ...prev, [key]: name }))
+  }
+
+  const handleAppArgsChange = (key: string, args: string) => {
+    setAppArgs((prev) => ({ ...prev, [key]: args }))
   }
 
   const handleIconLoadError = (key: string) => {
@@ -398,6 +415,7 @@ export function SettingsView({
       const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
       const trimmedAppPaths = trimPathRecord(appPaths)
       const trimmedGamePaths = trimPathRecord(gamePaths)
+      const trimmedAppArgs = trimStringRecord(appArgs)
       const appPathEditVersionAtSave = appPathEditVersion.current
       const gamePathEditVersionAtSave = gamePathEditVersion.current
 
@@ -405,6 +423,7 @@ export function SettingsView({
         saveSettings({
           appPaths: trimmedAppPaths,
           appNames,
+          appArgs: trimmedAppArgs,
           gamePaths: trimmedGamePaths,
           customSlots,
           accentPreset,
@@ -432,6 +451,7 @@ export function SettingsView({
         setGamePaths(trimmedGamePaths)
       }
 
+      setAppArgs(trimmedAppArgs)
       setLaunchDelayMs(normalizedLaunchDelayMs)
 
       notify('Settings saved!', 'success', 2500)
@@ -439,6 +459,7 @@ export function SettingsView({
       resetDirty({
         ...currentSettingsState,
         appPaths: appPathsChangedDuringSave ? latestAppPaths.current : trimmedAppPaths,
+        appArgs: trimmedAppArgs,
         gamePaths: gamePathsChangedDuringSave ? latestGamePaths.current : trimmedGamePaths,
         launchDelayMs: normalizedLaunchDelayMs
       })
@@ -515,12 +536,14 @@ export function SettingsView({
         utilities={utilities}
         appPaths={appPaths}
         appNames={appNames}
+        appArgs={appArgs}
         appIcons={appIcons}
         iconLoadErrors={iconLoadErrors}
         customSlots={customSlots}
         onOpenChange={setAppsOpen}
         onAppNameChange={handleAppNameChange}
         onAppPathChange={handleAppPathChange}
+        onAppArgsChange={handleAppArgsChange}
         onIconLoadError={handleIconLoadError}
         onBrowse={(key) => handleBrowse(key, false)}
         onAddCustomSlot={handleAddCustomSlot}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -23,12 +23,14 @@ interface AppsSectionProps {
   utilities: Utility[]
   appPaths: Record<string, string>
   appNames: Record<string, string>
+  appArgs: Record<string, string>
   appIcons: Record<string, string>
   iconLoadErrors: Set<string>
   customSlots: number
   onOpenChange: (open: boolean) => void
   onAppNameChange: (key: string, name: string) => void
   onAppPathChange: (key: string, path: string) => void
+  onAppArgsChange: (key: string, args: string) => void
   onIconLoadError: (key: string) => void
   onBrowse: (key: string) => void
   onAddCustomSlot: () => void
@@ -40,12 +42,14 @@ export function AppsSection({
   utilities,
   appPaths,
   appNames,
+  appArgs,
   appIcons,
   iconLoadErrors,
   customSlots,
   onOpenChange,
   onAppNameChange,
   onAppPathChange,
+  onAppArgsChange,
   onIconLoadError,
   onBrowse,
   onAddCustomSlot,
@@ -176,6 +180,17 @@ export function AppsSection({
                     Browse
                   </button>
                 </div>
+
+                {utility.isCustom && (
+                  <input
+                    type="text"
+                    value={appArgs[utility.key] || ''}
+                    onChange={(e) => onAppArgsChange(utility.key, e.target.value)}
+                    placeholder="Optional command line arguments"
+                    className="glass-recessed rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+                    aria-label={`${appNames[utility.key] || utility.name} command line arguments`}
+                  />
+                )}
               </div>
             ))}
             <div className="px-5 py-3">

--- a/src/renderer/src/lib/migrations.ts
+++ b/src/renderer/src/lib/migrations.ts
@@ -1,0 +1,112 @@
+import {
+  DEFAULT_PROFILE_ID,
+  createDefaultProfile,
+  getHighestCustomSlot,
+  getUtilities,
+  migrateProfileToUtilityOrder,
+  type GameProfile,
+  type GameProfileSet
+} from './config'
+import { getMigrationFlags, saveProfiles, saveSettings, setMigrationFlags } from './store'
+
+const LEGACY_UTILITY_KEYS = [
+  'simhub',
+  'crewchief',
+  'tradingpaints',
+  'garage61',
+  'secondmonitor',
+  'customapp1',
+  'customapp2',
+  'customapp3',
+  'customapp4',
+  'customapp5'
+]
+
+const LEGACY_GAME_KEYS = [
+  'ac',
+  'acc',
+  'acevo',
+  'acrally',
+  'ams',
+  'ams2',
+  'beamng',
+  'dcsw',
+  'dirtrally',
+  'dirtrally2',
+  'eawrc',
+  'f124',
+  'f125',
+  'iracing',
+  'lmu',
+  'pmr',
+  'raceroom',
+  'rbr',
+  'rennsport',
+  'rf1',
+  'rf2'
+]
+
+export async function migrateFromLocalStorage() {
+  const flags = await getMigrationFlags()
+  if (flags.migrated) return
+
+  const patch: Partial<WritableSettings> = {}
+
+  const appPathsRaw = localStorage.getItem('simLauncherAppPaths')
+  const gamePathsRaw = localStorage.getItem('simLauncherGamePaths')
+  let appPaths: Record<string, unknown> = {}
+
+  if (appPathsRaw) {
+    appPaths = JSON.parse(appPathsRaw)
+    patch.appPaths = appPaths as Record<string, string>
+  }
+
+  if (gamePathsRaw) patch.gamePaths = JSON.parse(gamePathsRaw)
+
+  const accentPreset = localStorage.getItem('simLauncherAccentPreset')
+  const accentCustom = localStorage.getItem('simLauncherAccentCustom')
+  if (accentPreset) patch.accentPreset = accentPreset
+  if (accentCustom) patch.accentCustom = accentCustom
+
+  const appNames: Record<string, string> = {}
+  for (const key of LEGACY_UTILITY_KEYS) {
+    const name = localStorage.getItem(`simLauncherAppName_${key}`)
+    if (name) appNames[key] = name
+  }
+  if (Object.keys(appNames).length > 0) patch.appNames = appNames
+
+  const profiles: Record<string, GameProfile> = {}
+  for (const key of LEGACY_GAME_KEYS) {
+    const raw = localStorage.getItem(`profile_${key}`)
+    if (raw) profiles[key] = JSON.parse(raw)
+  }
+
+  const migratedCustomSlots = getHighestCustomSlot(appPaths, appNames, ...Object.values(profiles))
+  const utilities = getUtilities(migratedCustomSlots)
+  const migratedProfiles: Record<string, GameProfileSet> = Object.fromEntries(
+    Object.entries(profiles).map(([gameKey, profile]) => [
+      gameKey,
+      {
+        activeProfileId: DEFAULT_PROFILE_ID,
+        profiles: [createDefaultProfile(migrateProfileToUtilityOrder(profile, utilities))]
+      }
+    ])
+  ) as Record<string, GameProfileSet>
+
+  if (migratedCustomSlots > 1) patch.customSlots = migratedCustomSlots
+  if (Object.keys(patch).length > 0) await saveSettings(patch)
+  if (Object.keys(migratedProfiles).length > 0) await saveProfiles(migratedProfiles)
+
+  await setMigrationFlags({
+    profileUtilityOrderMigrated: true,
+    migrated: true
+  })
+}
+
+export async function runStartupMigrations() {
+  try {
+    await migrateFromLocalStorage()
+  } catch (err) {
+    console.error('Failed to run startup migrations', err)
+  }
+}


### PR DESCRIPTION
Closes #191
Closes #207
Closes #154

- Merged three separate getSettings() calls in GameList into one loadInitialSettings effect
- Added appArgs store field and UI input for custom app slots; args parsed and passed through regular and elevated launch paths
- Extracted localStorage migration logic from App.tsx into lib/migrations.ts

Co-Authored-By: Shieldxx <davkohout@gmail.com>