### PR TITLE
fix: generalize async save race protection and add IPC surface audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+.test-out/
 
 # Gatsby files
 .cache/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
+    "test": "npm run test:unit",
+    "test:unit": "node scripts/run-node-tests.mjs",
     "build": "electron-vite build",
     "dist": "npm run build && electron-builder",
     "dist:win": "npm run build && electron-builder --win",

--- a/scripts/run-node-tests.mjs
+++ b/scripts/run-node-tests.mjs
@@ -1,0 +1,58 @@
+import { readFile, mkdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+import ts from 'typescript'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const require = createRequire(import.meta.url)
+const outdir = path.join(root, '.test-out')
+const files = [
+  'src/renderer/src/components/settings/saveRace.ts',
+  'tests/settingsSaveRace.test.ts',
+  'tests/electronApiSurface.test.ts'
+]
+const testFiles = ['tests/settingsSaveRace.test.ts', 'tests/electronApiSurface.test.ts']
+
+await rm(outdir, { recursive: true, force: true })
+await mkdir(outdir, { recursive: true })
+
+for (const file of files) {
+  const sourcePath = path.join(root, file)
+  const outputPath = path.join(outdir, file).replace(/\.ts$/, '.js')
+  const source = await readFile(sourcePath, 'utf8')
+  const result = ts.transpileModule(source, {
+    fileName: sourcePath,
+    reportDiagnostics: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      sourceMap: false,
+      inlineSourceMap: true
+    }
+  })
+
+  const diagnostics = result.diagnostics?.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error
+  )
+
+  if (diagnostics?.length) {
+    const host = {
+      getCanonicalFileName: (diagnosticFile) => diagnosticFile,
+      getCurrentDirectory: () => root,
+      getNewLine: () => '\n'
+    }
+    console.error(ts.formatDiagnosticsWithColorAndContext(diagnostics, host))
+    process.exit(1)
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, result.outputText, 'utf8')
+}
+
+const compiledTests = testFiles.map((file) => path.join(outdir, file).replace(/\.ts$/, '.js'))
+
+for (const testFile of compiledTests) {
+  require(testFile)
+}

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -127,8 +127,4 @@ export function registerLaunchHandlers() {
   ipcMain.handle('kill-launched-apps', (_event, gameKey?: string) => {
     return killLaunchedApps(gameKey)
   })
-
-  ipcMain.handle('kill-profile-apps', (_event, gameKey: string, appPathsToKill: string[]) => {
-    return killProfileApps(gameKey, Array.isArray(appPathsToKill) ? appPathsToKill : [])
-  })
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -100,7 +100,6 @@ declare global {
       restartApp: () => Promise<void>
       getRunningApps: () => Promise<RunningApp[]>
       killLaunchedApps: (gameKey?: string) => Promise<KillResult>
-      killProfileApps: (gameKey: string, appPaths: string[]) => Promise<KillResult>
       onUpdateAvailable: (cb: (info: UpdateInfo) => void) => Unsubscribe
       onUpdateDownloaded: (cb: (info: UpdateInfo) => void) => Unsubscribe
       onUpdateNotAvailable: (cb: (info: UpdateInfo) => void) => Unsubscribe

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,8 +26,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // process monitoring
   getRunningApps: () => ipcRenderer.invoke('get-running-apps'),
   killLaunchedApps: (gameKey?: string) => ipcRenderer.invoke('kill-launched-apps', gameKey),
-  killProfileApps: (gameKey: string, appPaths: string[]) =>
-    ipcRenderer.invoke('kill-profile-apps', gameKey, appPaths),
 
   // updater
   onUpdateAvailable: (cb: (info: UpdateInfo) => void) => {

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -29,6 +29,13 @@ import {
   shiftProfileCustomSlots
 } from './settings/customSlots'
 import { GamesSection } from './settings/GamesSection'
+import {
+  createSettingsObjectVersions,
+  getSettingsObjectChangesDuringSave,
+  resolveSettingsObjectsAfterSave,
+  type SettingsObjectField,
+  type SettingsObjectRecords
+} from './settings/saveRace'
 import { normalizeLaunchDelayMs } from './settings/settingsUtils'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
@@ -91,16 +98,26 @@ export function SettingsView({
   const [appIcons, setAppIcons] = useState<Record<string, string>>({})
   const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
   const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
-  const appPathEditVersion = useRef(0)
-  const gamePathEditVersion = useRef(0)
-  const latestAppPaths = useRef(appPaths)
-  const latestGamePaths = useRef(gamePaths)
+  const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
+  const latestSettingsObjects = useRef<SettingsObjectRecords>({
+    appPaths,
+    appNames,
+    appArgs,
+    gamePaths
+  })
 
   const updateStatus = useUpdateStatus({ updateInfo, notify })
 
   const loadSettingsFromStore = async () => {
     const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
     const typedProfiles = savedProfiles as Profiles
+
+    latestSettingsObjects.current = {
+      appPaths: settings.appPaths,
+      appNames: settings.appNames,
+      appArgs: settings.appArgs,
+      gamePaths: settings.gamePaths
+    }
 
     setAppPaths(settings.appPaths)
     setAppNames(settings.appNames)
@@ -157,12 +174,29 @@ export function SettingsView({
   }, [])
 
   useEffect(() => {
-    latestAppPaths.current = appPaths
-  }, [appPaths])
+    latestSettingsObjects.current = {
+      appPaths,
+      appNames,
+      appArgs,
+      gamePaths
+    }
+  }, [appPaths, appNames, appArgs, gamePaths])
 
-  useEffect(() => {
-    latestGamePaths.current = gamePaths
-  }, [gamePaths])
+  const updateSettingsObject = (
+    field: SettingsObjectField,
+    setter: React.Dispatch<React.SetStateAction<Record<string, string>>>,
+    updater: (current: Record<string, string>) => Record<string, string>
+  ) => {
+    settingsObjectEditVersions.current[field] += 1
+    setter((current) => {
+      const next = updater(current)
+      latestSettingsObjects.current = {
+        ...latestSettingsObjects.current,
+        [field]: next
+      }
+      return next
+    })
+  }
 
   const currentSettingsState = useMemo(
     () => ({
@@ -276,11 +310,15 @@ export function SettingsView({
     }
     if (result && result.filePath) {
       if (isGame) {
-        gamePathEditVersion.current += 1
-        setGamePaths((prev) => ({ ...prev, [key]: result.filePath }))
+        updateSettingsObject('gamePaths', setGamePaths, (prev) => ({
+          ...prev,
+          [key]: result.filePath
+        }))
       } else {
-        appPathEditVersion.current += 1
-        setAppPaths((prev) => ({ ...prev, [key]: result.filePath }))
+        updateSettingsObject('appPaths', setAppPaths, (prev) => ({
+          ...prev,
+          [key]: result.filePath
+        }))
         const icon = await getFileIcon(result.filePath)
         if (icon) {
           setAppIcons((prev) => ({ ...prev, [key]: icon }))
@@ -315,9 +353,15 @@ export function SettingsView({
       }
     }
 
-    setAppPaths((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
-    setAppNames((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
-    setAppArgs((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+    updateSettingsObject('appPaths', setAppPaths, (current) =>
+      shiftCustomSlotRecord(current, slotNumber, customSlots)
+    )
+    updateSettingsObject('appNames', setAppNames, (current) =>
+      shiftCustomSlotRecord(current, slotNumber, customSlots)
+    )
+    updateSettingsObject('appArgs', setAppArgs, (current) =>
+      shiftCustomSlotRecord(current, slotNumber, customSlots)
+    )
     setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
     setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
     setProfiles((current) => {
@@ -333,13 +377,11 @@ export function SettingsView({
   }
 
   const handleGamePathChange = (key: string, path: string) => {
-    gamePathEditVersion.current += 1
-    setGamePaths((prev) => ({ ...prev, [key]: path }))
+    updateSettingsObject('gamePaths', setGamePaths, (prev) => ({ ...prev, [key]: path }))
   }
 
   const handleAppPathChange = (key: string, path: string) => {
-    appPathEditVersion.current += 1
-    setAppPaths((prev) => ({ ...prev, [key]: path }))
+    updateSettingsObject('appPaths', setAppPaths, (prev) => ({ ...prev, [key]: path }))
     if (!path) {
       setAppIcons((prev) => {
         const next = { ...prev }
@@ -350,11 +392,11 @@ export function SettingsView({
   }
 
   const handleAppNameChange = (key: string, name: string) => {
-    setAppNames((prev) => ({ ...prev, [key]: name }))
+    updateSettingsObject('appNames', setAppNames, (prev) => ({ ...prev, [key]: name }))
   }
 
   const handleAppArgsChange = (key: string, args: string) => {
-    setAppArgs((prev) => ({ ...prev, [key]: args }))
+    updateSettingsObject('appArgs', setAppArgs, (prev) => ({ ...prev, [key]: args }))
   }
 
   const handleIconLoadError = (key: string) => {
@@ -416,15 +458,20 @@ export function SettingsView({
       const trimmedAppPaths = trimPathRecord(appPaths)
       const trimmedGamePaths = trimPathRecord(gamePaths)
       const trimmedAppArgs = trimStringRecord(appArgs)
-      const appPathEditVersionAtSave = appPathEditVersion.current
-      const gamePathEditVersionAtSave = gamePathEditVersion.current
+      const settingsObjectEditVersionsAtSave = { ...settingsObjectEditVersions.current }
+      const savedSettingsObjects = {
+        appPaths: trimmedAppPaths,
+        appNames,
+        appArgs: trimmedAppArgs,
+        gamePaths: trimmedGamePaths
+      }
 
       await Promise.all([
         saveSettings({
-          appPaths: trimmedAppPaths,
-          appNames,
-          appArgs: trimmedAppArgs,
-          gamePaths: trimmedGamePaths,
+          appPaths: savedSettingsObjects.appPaths,
+          appNames: savedSettingsObjects.appNames,
+          appArgs: savedSettingsObjects.appArgs,
+          gamePaths: savedSettingsObjects.gamePaths,
           customSlots,
           accentPreset,
           accentCustom,
@@ -440,27 +487,35 @@ export function SettingsView({
         }),
         saveProfiles(profiles)
       ])
-      const appPathsChangedDuringSave = appPathEditVersion.current !== appPathEditVersionAtSave
-      const gamePathsChangedDuringSave = gamePathEditVersion.current !== gamePathEditVersionAtSave
+      const changedDuringSave = getSettingsObjectChangesDuringSave(
+        settingsObjectEditVersionsAtSave,
+        settingsObjectEditVersions.current
+      )
+      const resetSettingsObjects = resolveSettingsObjectsAfterSave({
+        savedObjects: savedSettingsObjects,
+        latestObjects: latestSettingsObjects.current,
+        changedDuringSave
+      })
 
-      if (!appPathsChangedDuringSave) {
-        setAppPaths(trimmedAppPaths)
+      if (!changedDuringSave.appPaths) {
+        setAppPaths(savedSettingsObjects.appPaths)
       }
 
-      if (!gamePathsChangedDuringSave) {
-        setGamePaths(trimmedGamePaths)
+      if (!changedDuringSave.gamePaths) {
+        setGamePaths(savedSettingsObjects.gamePaths)
       }
 
-      setAppArgs(trimmedAppArgs)
+      if (!changedDuringSave.appArgs) {
+        setAppArgs(savedSettingsObjects.appArgs)
+      }
+
       setLaunchDelayMs(normalizedLaunchDelayMs)
 
       notify('Settings saved!', 'success', 2500)
 
       resetDirty({
         ...currentSettingsState,
-        appPaths: appPathsChangedDuringSave ? latestAppPaths.current : trimmedAppPaths,
-        appArgs: trimmedAppArgs,
-        gamePaths: gamePathsChangedDuringSave ? latestGamePaths.current : trimmedGamePaths,
+        ...resetSettingsObjects,
         launchDelayMs: normalizedLaunchDelayMs
       })
     } catch (err) {

--- a/src/renderer/src/components/settings/saveRace.ts
+++ b/src/renderer/src/components/settings/saveRace.ts
@@ -1,0 +1,41 @@
+export const SETTINGS_OBJECT_FIELDS = ['appPaths', 'appNames', 'appArgs', 'gamePaths'] as const
+
+export type SettingsObjectField = (typeof SETTINGS_OBJECT_FIELDS)[number]
+export type SettingsObjectRecords = Record<SettingsObjectField, Record<string, string>>
+export type SettingsObjectVersions = Record<SettingsObjectField, number>
+export type SettingsObjectChangeMap = Record<SettingsObjectField, boolean>
+
+export function createSettingsObjectVersions(): SettingsObjectVersions {
+  return {
+    appPaths: 0,
+    appNames: 0,
+    appArgs: 0,
+    gamePaths: 0
+  }
+}
+
+export function getSettingsObjectChangesDuringSave(
+  versionsAtSave: SettingsObjectVersions,
+  currentVersions: SettingsObjectVersions
+): SettingsObjectChangeMap {
+  return Object.fromEntries(
+    SETTINGS_OBJECT_FIELDS.map((field) => [field, currentVersions[field] !== versionsAtSave[field]])
+  ) as SettingsObjectChangeMap
+}
+
+export function resolveSettingsObjectsAfterSave({
+  savedObjects,
+  latestObjects,
+  changedDuringSave
+}: {
+  savedObjects: SettingsObjectRecords
+  latestObjects: SettingsObjectRecords
+  changedDuringSave: SettingsObjectChangeMap
+}): SettingsObjectRecords {
+  return Object.fromEntries(
+    SETTINGS_OBJECT_FIELDS.map((field) => [
+      field,
+      changedDuringSave[field] ? latestObjects[field] : savedObjects[field]
+    ])
+  ) as SettingsObjectRecords
+}

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -23,8 +23,6 @@ export const restartApp = () => window.electronAPI.restartApp()
 export const getRunningApps = () => window.electronAPI.getRunningApps()
 export const killLaunchedApps: typeof window.electronAPI.killLaunchedApps = (gameKey) =>
   window.electronAPI.killLaunchedApps(gameKey)
-export const killProfileApps: typeof window.electronAPI.killProfileApps = (gameKey, appPaths) =>
-  window.electronAPI.killProfileApps(gameKey, appPaths)
 export const onUpdateAvailable: typeof window.electronAPI.onUpdateAvailable = (cb) =>
   window.electronAPI.onUpdateAvailable(cb)
 export const onUpdateDownloaded: typeof window.electronAPI.onUpdateDownloaded = (cb) =>

--- a/tests/electronApiSurface.test.ts
+++ b/tests/electronApiSurface.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const root = process.cwd()
+
+function read(relativePath: string) {
+  return readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+function listFiles(directory: string): string[] {
+  return readdirSync(path.join(root, directory)).flatMap((entry) => {
+    const relativePath = path.join(directory, entry)
+    const absolutePath = path.join(root, relativePath)
+
+    return statSync(absolutePath).isDirectory() ? listFiles(relativePath) : relativePath
+  })
+}
+
+function matches(source: string, pattern: RegExp) {
+  return [...source.matchAll(pattern)].map((match) => match[1])
+}
+
+function toPosix(relativePath: string) {
+  return relativePath.replace(/\\/g, '/')
+}
+
+test('every invoked IPC channel has a main-process handler and no stale handler remains', () => {
+  const sourceFiles = listFiles('src').filter(
+    (file) => file.endsWith('.ts') || file.endsWith('.tsx')
+  )
+  const source = sourceFiles.map(read).join('\n')
+  const invokedChannels = new Set(matches(source, /ipcRenderer\.invoke\(\s*'([^']+)'/g))
+  const handledChannels = new Set(matches(source, /ipcMain\.handle\(\s*'([^']+)'/g))
+
+  assert.deepEqual(
+    [...invokedChannels].filter((channel) => !handledChannels.has(channel)).sort(),
+    []
+  )
+  assert.deepEqual(
+    [...handledChannels].filter((channel) => !invokedChannels.has(channel)).sort(),
+    []
+  )
+  assert.ok(invokedChannels.has('restart-app'))
+})
+
+test('preload declarations stay aligned with exposed Electron APIs', () => {
+  const preload = read('src/preload/index.ts')
+  const declarations = read('src/preload/index.d.ts')
+  const exposedApiNames = new Set(matches(preload, /^\s{2}([A-Za-z]\w*):/gm))
+  const declaredApiNames = new Set(matches(declarations, /^\s{6}([A-Za-z]\w*):/gm))
+
+  assert.deepEqual(
+    [...exposedApiNames].filter((apiName) => !declaredApiNames.has(apiName)).sort(),
+    []
+  )
+  assert.deepEqual(
+    [...declaredApiNames].filter((apiName) => !exposedApiNames.has(apiName)).sort(),
+    []
+  )
+  assert.ok(exposedApiNames.has('restartApp'))
+})
+
+test('renderer wrapper exports are called outside their wrapper modules', () => {
+  const wrapperFiles = ['src/renderer/src/lib/electron.ts', 'src/renderer/src/lib/store.ts']
+  const wrappers = wrapperFiles.map(read).join('\n')
+  const wrapperExportNames = new Set(matches(wrappers, /export const ([A-Za-z]\w*)/g))
+  const rendererSource = listFiles('src/renderer/src')
+    .filter((file) => {
+      const normalizedFile = toPosix(file)
+
+      return (
+        (normalizedFile.endsWith('.ts') || normalizedFile.endsWith('.tsx')) &&
+        !wrapperFiles.includes(normalizedFile)
+      )
+    })
+    .map(read)
+    .join('\n')
+
+  assert.deepEqual(
+    [...wrapperExportNames]
+      .filter((apiName) => !new RegExp(`\\b${apiName}\\b`).test(rendererSource))
+      .sort(),
+    []
+  )
+})

--- a/tests/settingsSaveRace.test.ts
+++ b/tests/settingsSaveRace.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createSettingsObjectVersions,
+  getSettingsObjectChangesDuringSave,
+  resolveSettingsObjectsAfterSave,
+  type SettingsObjectRecords
+} from '../src/renderer/src/components/settings/saveRace'
+
+const savedObjects: SettingsObjectRecords = {
+  appPaths: { crewChief: 'C:\\Apps\\CrewChief.exe' },
+  appNames: { custom1: 'Spotter' },
+  appArgs: { custom1: '--old' },
+  gamePaths: { ams2: 'C:\\Games\\AMS2.exe' }
+}
+
+const latestObjects: SettingsObjectRecords = {
+  appPaths: { crewChief: 'D:\\Apps\\CrewChief.exe' },
+  appNames: { custom1: 'Telemetry' },
+  appArgs: { custom1: '--new' },
+  gamePaths: { ams2: 'D:\\Games\\AMS2.exe' }
+}
+
+test('settings save race resolution keeps app path edits made while save is in flight', () => {
+  const versionsAtSave = createSettingsObjectVersions()
+  const currentVersions = { ...versionsAtSave, appPaths: versionsAtSave.appPaths + 1 }
+  const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
+
+  const resolved = resolveSettingsObjectsAfterSave({
+    savedObjects,
+    latestObjects,
+    changedDuringSave
+  })
+
+  assert.deepEqual(resolved.appPaths, latestObjects.appPaths)
+  assert.deepEqual(resolved.appNames, savedObjects.appNames)
+  assert.deepEqual(resolved.appArgs, savedObjects.appArgs)
+  assert.deepEqual(resolved.gamePaths, savedObjects.gamePaths)
+})
+
+test('settings save race resolution keeps game path edits made while save is in flight', () => {
+  const versionsAtSave = createSettingsObjectVersions()
+  const currentVersions = { ...versionsAtSave, gamePaths: versionsAtSave.gamePaths + 1 }
+  const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
+
+  const resolved = resolveSettingsObjectsAfterSave({
+    savedObjects,
+    latestObjects,
+    changedDuringSave
+  })
+
+  assert.deepEqual(resolved.gamePaths, latestObjects.gamePaths)
+  assert.deepEqual(resolved.appPaths, savedObjects.appPaths)
+})
+
+test('settings save race resolution keeps app name edits made while save is in flight', () => {
+  const versionsAtSave = createSettingsObjectVersions()
+  const currentVersions = { ...versionsAtSave, appNames: versionsAtSave.appNames + 1 }
+  const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
+
+  const resolved = resolveSettingsObjectsAfterSave({
+    savedObjects,
+    latestObjects,
+    changedDuringSave
+  })
+
+  assert.deepEqual(resolved.appNames, latestObjects.appNames)
+  assert.deepEqual(resolved.appArgs, savedObjects.appArgs)
+})
+
+test('settings save race resolution keeps app argument edits made while save is in flight', () => {
+  const versionsAtSave = createSettingsObjectVersions()
+  const currentVersions = { ...versionsAtSave, appArgs: versionsAtSave.appArgs + 1 }
+  const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
+
+  const resolved = resolveSettingsObjectsAfterSave({
+    savedObjects,
+    latestObjects,
+    changedDuringSave
+  })
+
+  assert.deepEqual(resolved.appArgs, latestObjects.appArgs)
+  assert.deepEqual(resolved.appNames, savedObjects.appNames)
+})


### PR DESCRIPTION
Closes #222
Closes #221
Closes #218

- Extracted saveRace.ts with version-based change detection; all four object fields (appPaths, appNames, appArgs, gamePaths) now covered uniformly via updateSettingsObject helper
- Added regression tests for save race resolution per field (settingsSaveRace.test.ts)
- Added static IPC surface audit tests: invoke/handle symmetry, preload/declaration alignment, wrapper export usage (electronApiSurface.test.ts)
- Removed stale kill-profile-apps IPC surface (handler, preload, declaration, electron.ts export)

Co-Authored-By: Shieldxx <davkohout@gmail.com>