### PR TITLE
refactor: centralize Settings state with React Context

### DIFF
--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -1,57 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useDirtyTracking } from '../hooks/useDirtyTracking'
-import {
-  DEFAULT_ACCENT_COLOR,
-  GAMES,
-  getCustomUtilityKey,
-  getUtilities,
-  resolveCustomSlots,
-  type Profiles
-} from '../lib/config'
-import { browsePath, getAssetData, getFileIcon, setLoginItem, setZoom } from '../lib/electron'
-import {
-  exportConfig,
-  getProfiles,
-  getSettings,
-  importConfig,
-  saveProfiles,
-  saveSettings
-} from '../lib/store'
+import { useEffect, useState } from 'react'
 import { useNotify } from './Notify'
 import { AboutSection } from './settings/AboutSection'
 import { AppearanceSection } from './settings/AppearanceSection'
 import { AppsSection } from './settings/AppsSection'
 import { BehaviorSection } from './settings/BehaviorSection'
 import { ConfigSection } from './settings/ConfigSection'
-import {
-  shiftCustomSlotRecord,
-  shiftCustomSlotSet,
-  shiftProfileCustomSlots
-} from './settings/customSlots'
 import { GamesSection } from './settings/GamesSection'
-import {
-  createSettingsObjectVersions,
-  getSettingsObjectChangesDuringSave,
-  resolveSettingsObjectsAfterSave,
-  type SettingsObjectField,
-  type SettingsObjectRecords
-} from './settings/saveRace'
-import { normalizeLaunchDelayMs } from './settings/settingsUtils'
+import { SettingsProvider, useSettings } from './settings/SettingsContext'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
-import { applyAccentTheme, applyThemeMode, normalizeThemeMode, type ThemeMode } from '../lib/theme'
-
-function trimPathRecord(paths: Record<string, string>) {
-  return Object.fromEntries(Object.entries(paths).map(([key, value]) => [key, value.trim()]))
-}
-
-function trimStringRecord(values: Record<string, string>) {
-  return Object.fromEntries(
-    Object.entries(values)
-      .map(([key, value]) => [key, value.trim()])
-      .filter(([_key, value]) => value.length > 0)
-  )
-}
 
 export function SettingsView({
   onClose,
@@ -68,190 +25,30 @@ export function SettingsView({
   onSaved?: () => void
   onConfigImported?: () => void
 }) {
+  return (
+    <SettingsProvider
+      onDirtyChange={onDirtyChange}
+      shouldSaveTrigger={shouldSaveTrigger}
+      onSaved={onSaved}
+      onConfigImported={onConfigImported}
+    >
+      <SettingsViewContent onClose={onClose} updateInfo={updateInfo} />
+    </SettingsProvider>
+  )
+}
+
+function SettingsViewContent({
+  onClose,
+  updateInfo
+}: {
+  onClose: () => void
+  updateInfo: UpdateInfo
+}) {
   const { notify } = useNotify()
-  const [loading, setLoading] = useState(true)
-
-  const [appPaths, setAppPaths] = useState<Record<string, string>>({})
-  const [appNames, setAppNames] = useState<Record<string, string>>({})
-  const [appArgs, setAppArgs] = useState<Record<string, string>>({})
-  const [profiles, setProfiles] = useState<Profiles>({})
-  const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
-  const [customSlots, setCustomSlots] = useState(1)
-  const [accentPreset, setAccentPreset] = useState<string>(DEFAULT_ACCENT_COLOR)
-  const [accentCustom, setAccentCustom] = useState<string>('')
-  const [accentBgTint, setAccentBgTint] = useState<boolean>(false)
-  const [themeMode, setThemeMode] = useState<ThemeMode>('dark')
-  const [focusActiveTitle, setFocusActiveTitle] = useState<boolean>(true)
-  const [launchDelayMs, setLaunchDelayMs] = useState<number>(1000)
-  const [startWithWindows, setStartWithWindows] = useState<boolean>(false)
-  const [startMinimized, setStartMinimized] = useState<boolean>(false)
-  const [minimizeToTray, setMinimizeToTray] = useState<boolean>(false)
-  const [autoCheckUpdates, setAutoCheckUpdates] = useState<boolean>(true)
-  const [zoomFactor, setZoomFactor] = useState<number>(1.0)
-
-  const [exportingConfig, setExportingConfig] = useState(false)
-  const [importingConfig, setImportingConfig] = useState(false)
-  const [isCustomColor, setIsCustomColor] = useState(false)
+  const { loading, isDirty, saveSettings } = useSettings()
   const [appsOpen, setAppsOpen] = useState(false)
   const [gamesOpen, setGamesOpen] = useState(false)
-
-  const [appIcons, setAppIcons] = useState<Record<string, string>>({})
-  const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
-  const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
-  const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
-  const latestSettingsObjects = useRef<SettingsObjectRecords>({
-    appPaths,
-    appNames,
-    appArgs,
-    gamePaths
-  })
-
   const updateStatus = useUpdateStatus({ updateInfo, notify })
-
-  const loadSettingsFromStore = async () => {
-    const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
-    const typedProfiles = savedProfiles as Profiles
-
-    latestSettingsObjects.current = {
-      appPaths: settings.appPaths,
-      appNames: settings.appNames,
-      appArgs: settings.appArgs,
-      gamePaths: settings.gamePaths
-    }
-
-    setAppPaths(settings.appPaths)
-    setAppNames(settings.appNames)
-    setAppArgs(settings.appArgs)
-    setProfiles(typedProfiles)
-    setGamePaths(settings.gamePaths)
-    setCustomSlots(
-      resolveCustomSlots(
-        settings.customSlots,
-        settings.appPaths,
-        settings.appNames,
-        ...(Object.values(typedProfiles) as Record<string, unknown>[])
-      )
-    )
-    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
-
-    setAccentPreset(settings.accentPreset || DEFAULT_ACCENT_COLOR)
-    setAccentCustom(settings.accentCustom || '')
-    setAccentBgTint(settings.accentBgTint || false)
-    setThemeMode(loadedThemeMode)
-    applyThemeMode(loadedThemeMode)
-    setFocusActiveTitle(settings.focusActiveTitle !== false)
-    setLaunchDelayMs(normalizeLaunchDelayMs(settings.launchDelayMs))
-    setStartWithWindows(settings.startWithWindows || false)
-    setStartMinimized(settings.startMinimized || false)
-    setMinimizeToTray(settings.minimizeToTray || false)
-    setAutoCheckUpdates(settings.autoCheckUpdates !== false)
-    setZoomFactor(Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0)
-
-    setIsCustomColor(settings.accentPreset === 'custom')
-
-    const icons: Record<string, string> = {}
-    for (const [key, path] of Object.entries(settings.appPaths)) {
-      if (path) {
-        const icon = await getFileIcon(path)
-        if (icon) icons[key] = icon
-      }
-    }
-    setAppIcons(icons)
-
-    const gIcons: Record<string, string> = {}
-    for (const game of GAMES) {
-      const filename = game.icon.split('/').pop() || ''
-      const data = await getAssetData(filename)
-      if (data) gIcons[game.key] = data
-    }
-    setGameIcons(gIcons)
-
-    setLoading(false)
-  }
-
-  useEffect(() => {
-    loadSettingsFromStore()
-  }, [])
-
-  useEffect(() => {
-    latestSettingsObjects.current = {
-      appPaths,
-      appNames,
-      appArgs,
-      gamePaths
-    }
-  }, [appPaths, appNames, appArgs, gamePaths])
-
-  const updateSettingsObject = (
-    field: SettingsObjectField,
-    setter: React.Dispatch<React.SetStateAction<Record<string, string>>>,
-    updater: (current: Record<string, string>) => Record<string, string>
-  ) => {
-    settingsObjectEditVersions.current[field] += 1
-    setter((current) => {
-      const next = updater(current)
-      latestSettingsObjects.current = {
-        ...latestSettingsObjects.current,
-        [field]: next
-      }
-      return next
-    })
-  }
-
-  const currentSettingsState = useMemo(
-    () => ({
-      appPaths,
-      appNames,
-      appArgs,
-      profiles,
-      gamePaths,
-      customSlots,
-      accentPreset,
-      accentCustom,
-      accentBgTint,
-      themeMode,
-      focusActiveTitle,
-      launchDelayMs,
-      startWithWindows,
-      startMinimized,
-      minimizeToTray,
-      autoCheckUpdates,
-      zoomFactor
-    }),
-    [
-      appPaths,
-      appNames,
-      appArgs,
-      profiles,
-      gamePaths,
-      customSlots,
-      accentPreset,
-      accentCustom,
-      accentBgTint,
-      themeMode,
-      focusActiveTitle,
-      launchDelayMs,
-      startWithWindows,
-      startMinimized,
-      minimizeToTray,
-      autoCheckUpdates,
-      zoomFactor
-    ]
-  )
-
-  const { isDirty, resetDirty } = useDirtyTracking(currentSettingsState, loading)
-
-  useEffect(() => {
-    onDirtyChange?.(isDirty)
-  }, [isDirty, onDirtyChange])
-
-  useEffect(() => {
-    if (shouldSaveTrigger) {
-      handleSave().then(() => {
-        onSaved?.()
-      })
-    }
-  }, [shouldSaveTrigger])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -263,351 +60,34 @@ export function SettingsView({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
-  const updateAccentCSS = (hex: string) => {
-    if (hex) applyAccentTheme(hex)
-  }
-
-  const handleAccentChange = (presetHex: string) => {
-    setAccentPreset(presetHex)
-    if (presetHex !== 'custom') {
-      setIsCustomColor(false)
-      updateAccentCSS(presetHex)
-    } else {
-      setIsCustomColor(true)
-      if (accentCustom) updateAccentCSS(accentCustom)
-    }
-  }
-
-  const handleCustomColorChange = (hex: string) => {
-    setAccentCustom(hex)
-    updateAccentCSS(hex)
-  }
-
-  const handleAccentBgTintChange = (checked: boolean) => {
-    setAccentBgTint(checked)
-    window.dispatchEvent(new CustomEvent('bg-tint-change', { detail: checked }))
-  }
-
-  const handleThemeModeChange = (mode: ThemeMode) => {
-    setThemeMode(mode)
-    applyThemeMode(mode)
-  }
-
-  const handleZoomFactorChange = (factor: number) => {
-    setZoomFactor(factor)
-    setZoom(factor)
-  }
-
-  const handleStartWithWindowsChange = (checked: boolean) => {
-    setStartWithWindows(checked)
-    setLoginItem(checked)
-  }
-
-  const handleBrowse = async (key: string, isGame: boolean) => {
-    const result = (await browsePath(key)) as {
-      filePath: string
-      inputId: string
-    }
-    if (result && result.filePath) {
-      if (isGame) {
-        updateSettingsObject('gamePaths', setGamePaths, (prev) => ({
-          ...prev,
-          [key]: result.filePath
-        }))
-      } else {
-        updateSettingsObject('appPaths', setAppPaths, (prev) => ({
-          ...prev,
-          [key]: result.filePath
-        }))
-        const icon = await getFileIcon(result.filePath)
-        if (icon) {
-          setAppIcons((prev) => ({ ...prev, [key]: icon }))
-          setIconLoadErrors((prev) => {
-            const next = new Set(prev)
-            next.delete(key)
-            return next
-          })
-        }
-      }
-    }
-  }
-
-  const handleAddCustomSlot = () => {
-    setCustomSlots((current) => current + 1)
-  }
-
-  const handleRemoveCustomSlot = (slotNumber: number) => {
-    if (customSlots <= 1) {
-      notify('At least one custom app slot is required', 'warn')
-      return
-    }
-
-    const slotKey = getCustomUtilityKey(slotNumber)
-    const slotName = appNames[slotKey] || `Custom App ${slotNumber}`
-
-    if (appPaths[slotKey]) {
-      const confirmed = window.confirm(`Remove ${slotName} and its executable path?`)
-
-      if (!confirmed) {
-        return
-      }
-    }
-
-    updateSettingsObject('appPaths', setAppPaths, (current) =>
-      shiftCustomSlotRecord(current, slotNumber, customSlots)
-    )
-    updateSettingsObject('appNames', setAppNames, (current) =>
-      shiftCustomSlotRecord(current, slotNumber, customSlots)
-    )
-    updateSettingsObject('appArgs', setAppArgs, (current) =>
-      shiftCustomSlotRecord(current, slotNumber, customSlots)
-    )
-    setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
-    setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
-    setProfiles((current) => {
-      const nextProfiles: Profiles = {}
-
-      Object.entries(current).forEach(([gameKey, profile]) => {
-        nextProfiles[gameKey] = shiftProfileCustomSlots(profile, slotNumber, customSlots)
-      })
-
-      return nextProfiles
-    })
-    setCustomSlots((current) => Math.max(1, current - 1))
-  }
-
-  const handleGamePathChange = (key: string, path: string) => {
-    updateSettingsObject('gamePaths', setGamePaths, (prev) => ({ ...prev, [key]: path }))
-  }
-
-  const handleAppPathChange = (key: string, path: string) => {
-    updateSettingsObject('appPaths', setAppPaths, (prev) => ({ ...prev, [key]: path }))
-    if (!path) {
-      setAppIcons((prev) => {
-        const next = { ...prev }
-        delete next[key]
-        return next
-      })
-    }
-  }
-
-  const handleAppNameChange = (key: string, name: string) => {
-    updateSettingsObject('appNames', setAppNames, (prev) => ({ ...prev, [key]: name }))
-  }
-
-  const handleAppArgsChange = (key: string, args: string) => {
-    updateSettingsObject('appArgs', setAppArgs, (prev) => ({ ...prev, [key]: args }))
-  }
-
-  const handleIconLoadError = (key: string) => {
-    setIconLoadErrors((prev) => new Set([...prev, key]))
-  }
-
-  const handleExportConfig = async () => {
-    setExportingConfig(true)
-
-    try {
-      const result = await exportConfig()
-
-      if (result.success) {
-        notify('Config exported', 'success', 2500)
-      } else if (!result.canceled) {
-        notify(result.error || 'Failed to export config', 'error')
-      }
-    } catch (err) {
-      notify('Failed to export config', 'error')
-      console.error(err)
-    } finally {
-      setExportingConfig(false)
-    }
-  }
-
-  const handleImportConfig = async () => {
-    const confirmed = window.confirm(
-      'Importing a config file will replace your current SimLauncher settings. Continue?'
-    )
-
-    if (!confirmed) {
-      return
-    }
-
-    setImportingConfig(true)
-
-    try {
-      const result = await importConfig()
-
-      if (result.success) {
-        await loadSettingsFromStore()
-        resetDirty()
-        onConfigImported?.()
-        notify('Config imported', 'success', 2500)
-      } else if (!result.canceled) {
-        notify(result.error || 'Failed to import config', 'error')
-      }
-    } catch (err) {
-      notify('Failed to import config', 'error')
-      console.error(err)
-    } finally {
-      setImportingConfig(false)
-    }
-  }
-
-  const handleSave = async () => {
-    try {
-      const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
-      const trimmedAppPaths = trimPathRecord(appPaths)
-      const trimmedGamePaths = trimPathRecord(gamePaths)
-      const trimmedAppArgs = trimStringRecord(appArgs)
-      const settingsObjectEditVersionsAtSave = { ...settingsObjectEditVersions.current }
-      const savedSettingsObjects = {
-        appPaths: trimmedAppPaths,
-        appNames,
-        appArgs: trimmedAppArgs,
-        gamePaths: trimmedGamePaths
-      }
-
-      await Promise.all([
-        saveSettings({
-          appPaths: savedSettingsObjects.appPaths,
-          appNames: savedSettingsObjects.appNames,
-          appArgs: savedSettingsObjects.appArgs,
-          gamePaths: savedSettingsObjects.gamePaths,
-          customSlots,
-          accentPreset,
-          accentCustom,
-          accentBgTint,
-          themeMode,
-          focusActiveTitle,
-          launchDelayMs: normalizedLaunchDelayMs,
-          startMinimized,
-          minimizeToTray,
-          autoCheckUpdates,
-          startWithWindows,
-          zoomFactor
-        }),
-        saveProfiles(profiles)
-      ])
-      const changedDuringSave = getSettingsObjectChangesDuringSave(
-        settingsObjectEditVersionsAtSave,
-        settingsObjectEditVersions.current
-      )
-      const resetSettingsObjects = resolveSettingsObjectsAfterSave({
-        savedObjects: savedSettingsObjects,
-        latestObjects: latestSettingsObjects.current,
-        changedDuringSave
-      })
-
-      if (!changedDuringSave.appPaths) {
-        setAppPaths(savedSettingsObjects.appPaths)
-      }
-
-      if (!changedDuringSave.gamePaths) {
-        setGamePaths(savedSettingsObjects.gamePaths)
-      }
-
-      if (!changedDuringSave.appArgs) {
-        setAppArgs(savedSettingsObjects.appArgs)
-      }
-
-      setLaunchDelayMs(normalizedLaunchDelayMs)
-
-      notify('Settings saved!', 'success', 2500)
-
-      resetDirty({
-        ...currentSettingsState,
-        ...resetSettingsObjects,
-        launchDelayMs: normalizedLaunchDelayMs
-      })
-    } catch (err) {
-      notify('Failed to save settings', 'error')
-      console.error(err)
-    }
-  }
-
-  const utilities = getUtilities(customSlots)
-
   if (loading) return null
 
   return (
     <div className="animate-fade-slide space-y-8 pb-10">
       <AboutSection
         appVersion={updateStatus.appVersion}
-        autoCheckUpdates={autoCheckUpdates}
         updateInfo={updateInfo}
         checkingUpdate={updateStatus.checkingUpdate}
         installingUpdate={updateStatus.installingUpdate}
         updateProgress={updateStatus.updateProgress}
         updateStatus={updateStatus.updateStatus}
-        onAutoCheckUpdatesChange={setAutoCheckUpdates}
         onManualCheck={updateStatus.handleManualCheck}
         onInstallUpdate={updateStatus.handleInstallUpdate}
       />
 
-      <AppearanceSection
-        accentPreset={accentPreset}
-        accentCustom={accentCustom}
-        accentBgTint={accentBgTint}
-        themeMode={themeMode}
-        focusActiveTitle={focusActiveTitle}
-        zoomFactor={zoomFactor}
-        isCustomColor={isCustomColor}
-        onAccentChange={handleAccentChange}
-        onCustomColorChange={handleCustomColorChange}
-        onAccentBgTintChange={handleAccentBgTintChange}
-        onThemeModeChange={handleThemeModeChange}
-        onFocusActiveTitleChange={setFocusActiveTitle}
-        onZoomFactorChange={handleZoomFactorChange}
-      />
+      <AppearanceSection />
 
-      <BehaviorSection
-        startWithWindows={startWithWindows}
-        startMinimized={startMinimized}
-        minimizeToTray={minimizeToTray}
-        launchDelayMs={launchDelayMs}
-        onStartWithWindowsChange={handleStartWithWindowsChange}
-        onStartMinimizedChange={setStartMinimized}
-        onMinimizeToTrayChange={setMinimizeToTray}
-        onLaunchDelayMsChange={setLaunchDelayMs}
-      />
+      <BehaviorSection />
 
-      <ConfigSection
-        exportingConfig={exportingConfig}
-        importingConfig={importingConfig}
-        onExportConfig={handleExportConfig}
-        onImportConfig={handleImportConfig}
-      />
+      <ConfigSection />
 
-      <GamesSection
-        open={gamesOpen}
-        gamePaths={gamePaths}
-        gameIcons={gameIcons}
-        onOpenChange={setGamesOpen}
-        onBrowse={(key) => handleBrowse(key, true)}
-        onGamePathChange={handleGamePathChange}
-      />
+      <GamesSection open={gamesOpen} onOpenChange={setGamesOpen} />
 
-      <AppsSection
-        open={appsOpen}
-        utilities={utilities}
-        appPaths={appPaths}
-        appNames={appNames}
-        appArgs={appArgs}
-        appIcons={appIcons}
-        iconLoadErrors={iconLoadErrors}
-        customSlots={customSlots}
-        onOpenChange={setAppsOpen}
-        onAppNameChange={handleAppNameChange}
-        onAppPathChange={handleAppPathChange}
-        onAppArgsChange={handleAppArgsChange}
-        onIconLoadError={handleIconLoadError}
-        onBrowse={(key) => handleBrowse(key, false)}
-        onAddCustomSlot={handleAddCustomSlot}
-        onRemoveCustomSlot={handleRemoveCustomSlot}
-      />
+      <AppsSection open={appsOpen} onOpenChange={setAppsOpen} />
 
       <div className="flex gap-4 pt-4 px-1">
         <button
-          onClick={handleSave}
+          onClick={() => void saveSettings()}
           className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-3 text-sm font-semibold relative overflow-hidden"
         >
           {isDirty && (

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -1,31 +1,30 @@
 import { Toggle } from '../Toggle'
+import { useSettings } from './SettingsContext'
 import type { UpdateInfo, UpdateStatus } from './types'
 
 interface AboutSectionProps {
   appVersion: string
-  autoCheckUpdates: boolean
   updateInfo: UpdateInfo
   checkingUpdate: boolean
   installingUpdate: boolean
   updateProgress: number | null
   updateStatus: UpdateStatus
-  onAutoCheckUpdatesChange: (checked: boolean) => void
   onManualCheck: () => void
   onInstallUpdate: () => void
 }
 
 export function AboutSection({
   appVersion,
-  autoCheckUpdates,
   updateInfo,
   checkingUpdate,
   installingUpdate,
   updateProgress,
   updateStatus,
-  onAutoCheckUpdatesChange,
   onManualCheck,
   onInstallUpdate
 }: AboutSectionProps) {
+  const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettings()
+
   return (
     <section className="space-y-4">
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">About</h3>

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_ACCENT_COLOR } from '../../lib/config'
 import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
 import { ColorPickerPopover } from '../ColorPickerPopover'
+import { useSettings } from './SettingsContext'
 
 const ZOOM_PRESETS = [
   { label: '100%', factor: 1.0 },
@@ -27,38 +28,23 @@ const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
   { label: 'System', value: 'system' }
 ]
 
-interface AppearanceSectionProps {
-  accentPreset: string
-  accentCustom: string
-  accentBgTint: boolean
-  themeMode: ThemeMode
-  focusActiveTitle: boolean
-  zoomFactor: number
-  isCustomColor: boolean
-  onAccentChange: (presetHex: string) => void
-  onCustomColorChange: (hex: string) => void
-  onAccentBgTintChange: (checked: boolean) => void
-  onThemeModeChange: (mode: ThemeMode) => void
-  onFocusActiveTitleChange: (checked: boolean) => void
-  onZoomFactorChange: (factor: number) => void
-}
-
-export function AppearanceSection({
-  accentPreset,
-  accentCustom,
-  accentBgTint,
-  themeMode,
-  focusActiveTitle,
-  zoomFactor,
-  isCustomColor,
-  onAccentChange,
-  onCustomColorChange,
-  onAccentBgTintChange,
-  onThemeModeChange,
-  onFocusActiveTitleChange,
-  onZoomFactorChange
-}: AppearanceSectionProps) {
+export function AppearanceSection() {
   const [showPicker, setShowPicker] = useState(false)
+  const {
+    accentPreset,
+    accentCustom,
+    accentBgTint,
+    themeMode,
+    focusActiveTitle,
+    zoomFactor,
+    isCustomColor,
+    onAccentChange,
+    onCustomColorChange,
+    onAccentBgTintChange,
+    onThemeModeChange,
+    onFocusActiveTitleChange,
+    onZoomFactorChange
+  } = useSettings()
 
   return (
     <section className="space-y-4">

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -1,4 +1,5 @@
-import { MAX_CUSTOM_SLOTS, type Utility } from '../../lib/config'
+import { MAX_CUSTOM_SLOTS } from '../../lib/config'
+import { useSettings } from './SettingsContext'
 
 function getInitials(label: string) {
   const words = label.trim().split(/\s+/).filter(Boolean)
@@ -20,41 +21,27 @@ function getCustomSlotNumber(key: string) {
 
 interface AppsSectionProps {
   open: boolean
-  utilities: Utility[]
-  appPaths: Record<string, string>
-  appNames: Record<string, string>
-  appArgs: Record<string, string>
-  appIcons: Record<string, string>
-  iconLoadErrors: Set<string>
-  customSlots: number
   onOpenChange: (open: boolean) => void
-  onAppNameChange: (key: string, name: string) => void
-  onAppPathChange: (key: string, path: string) => void
-  onAppArgsChange: (key: string, args: string) => void
-  onIconLoadError: (key: string) => void
-  onBrowse: (key: string) => void
-  onAddCustomSlot: () => void
-  onRemoveCustomSlot: (slotNumber: number) => void
 }
 
-export function AppsSection({
-  open,
-  utilities,
-  appPaths,
-  appNames,
-  appArgs,
-  appIcons,
-  iconLoadErrors,
-  customSlots,
-  onOpenChange,
-  onAppNameChange,
-  onAppPathChange,
-  onAppArgsChange,
-  onIconLoadError,
-  onBrowse,
-  onAddCustomSlot,
-  onRemoveCustomSlot
-}: AppsSectionProps) {
+export function AppsSection({ open, onOpenChange }: AppsSectionProps) {
+  const {
+    utilities,
+    appPaths,
+    appNames,
+    appArgs,
+    appIcons,
+    iconLoadErrors,
+    customSlots,
+    onAppNameChange,
+    onAppPathChange,
+    onAppArgsChange,
+    onIconLoadError,
+    onBrowse,
+    onAddCustomSlot,
+    onRemoveCustomSlot
+  } = useSettings()
+
   return (
     <section className="space-y-4">
       <button
@@ -174,7 +161,7 @@ export function AppsSection({
                     </button>
                   )}
                   <button
-                    onClick={() => onBrowse(utility.key)}
+                    onClick={() => onBrowse(utility.key, false)}
                     className="accent-surface-action action-hover-scale cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
                   >
                     Browse

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -1,16 +1,6 @@
 import { Toggle } from '../Toggle'
+import { useSettings } from './SettingsContext'
 import { normalizeLaunchDelayMs } from './settingsUtils'
-
-interface BehaviorSectionProps {
-  startWithWindows: boolean
-  startMinimized: boolean
-  minimizeToTray: boolean
-  launchDelayMs: number
-  onStartWithWindowsChange: (checked: boolean) => void
-  onStartMinimizedChange: (checked: boolean) => void
-  onMinimizeToTrayChange: (checked: boolean) => void
-  onLaunchDelayMsChange: (delayMs: number) => void
-}
 
 const DELAY_PRESETS = [
   { label: '1s', value: 1000 },
@@ -18,16 +8,17 @@ const DELAY_PRESETS = [
   { label: '2s', value: 2000 }
 ]
 
-export function BehaviorSection({
-  startWithWindows,
-  startMinimized,
-  minimizeToTray,
-  launchDelayMs,
-  onStartWithWindowsChange,
-  onStartMinimizedChange,
-  onMinimizeToTrayChange,
-  onLaunchDelayMsChange
-}: BehaviorSectionProps) {
+export function BehaviorSection() {
+  const {
+    startWithWindows,
+    startMinimized,
+    minimizeToTray,
+    launchDelayMs,
+    onStartWithWindowsChange,
+    onStartMinimizedChange,
+    onMinimizeToTrayChange,
+    onLaunchDelayMsChange
+  } = useSettings()
   const isPreset = DELAY_PRESETS.some((p) => p.value === launchDelayMs)
 
   return (

--- a/src/renderer/src/components/settings/ConfigSection.tsx
+++ b/src/renderer/src/components/settings/ConfigSection.tsx
@@ -1,16 +1,8 @@
-interface ConfigSectionProps {
-  exportingConfig: boolean
-  importingConfig: boolean
-  onExportConfig: () => void
-  onImportConfig: () => void
-}
+import { useSettings } from './SettingsContext'
 
-export function ConfigSection({
-  exportingConfig,
-  importingConfig,
-  onExportConfig,
-  onImportConfig
-}: ConfigSectionProps) {
+export function ConfigSection() {
+  const { exportingConfig, importingConfig, onExportConfig, onImportConfig } = useSettings()
+
   return (
     <section className="space-y-4">
       <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -1,22 +1,14 @@
 import { GAMES } from '../../lib/config'
+import { useSettings } from './SettingsContext'
 
 interface GamesSectionProps {
   open: boolean
-  gamePaths: Record<string, string>
-  gameIcons: Record<string, string>
   onOpenChange: (open: boolean) => void
-  onBrowse: (key: string) => void
-  onGamePathChange: (key: string, path: string) => void
 }
 
-export function GamesSection({
-  open,
-  gamePaths,
-  gameIcons,
-  onOpenChange,
-  onBrowse,
-  onGamePathChange
-}: GamesSectionProps) {
+export function GamesSection({ open, onOpenChange }: GamesSectionProps) {
+  const { gamePaths, gameIcons, onBrowse, onGamePathChange } = useSettings()
+
   return (
     <section className="space-y-4">
       <button
@@ -88,7 +80,7 @@ export function GamesSection({
                   />
 
                   <button
-                    onClick={() => onBrowse(game.key)}
+                    onClick={() => onBrowse(game.key, true)}
                     className="accent-surface-action action-hover-scale cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
                   >
                     Browse

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -1,0 +1,631 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction
+} from 'react'
+import { useDirtyTracking } from '../../hooks/useDirtyTracking'
+import {
+  DEFAULT_ACCENT_COLOR,
+  GAMES,
+  getCustomUtilityKey,
+  getUtilities,
+  resolveCustomSlots,
+  type Profiles,
+  type Utility
+} from '../../lib/config'
+import { browsePath, getAssetData, getFileIcon, setLoginItem, setZoom } from '../../lib/electron'
+import {
+  exportConfig,
+  getProfiles,
+  getSettings,
+  importConfig,
+  saveProfiles,
+  saveSettings as persistSettings
+} from '../../lib/store'
+import {
+  applyAccentTheme,
+  applyThemeMode,
+  normalizeThemeMode,
+  type ThemeMode
+} from '../../lib/theme'
+import { useNotify } from '../Notify'
+import { shiftCustomSlotRecord, shiftCustomSlotSet, shiftProfileCustomSlots } from './customSlots'
+import {
+  createSettingsObjectVersions,
+  getSettingsObjectChangesDuringSave,
+  resolveSettingsObjectsAfterSave,
+  type SettingsObjectField,
+  type SettingsObjectRecords
+} from './saveRace'
+import { normalizeLaunchDelayMs } from './settingsUtils'
+
+function trimPathRecord(paths: Record<string, string>) {
+  return Object.fromEntries(Object.entries(paths).map(([key, value]) => [key, value.trim()]))
+}
+
+function trimStringRecord(values: Record<string, string>) {
+  return Object.fromEntries(
+    Object.entries(values)
+      .map(([key, value]) => [key, value.trim()])
+      .filter(([_key, value]) => value.length > 0)
+  )
+}
+
+interface SettingsContextValue {
+  loading: boolean
+  isDirty: boolean
+  appPaths: Record<string, string>
+  appNames: Record<string, string>
+  appArgs: Record<string, string>
+  profiles: Profiles
+  gamePaths: Record<string, string>
+  customSlots: number
+  accentPreset: string
+  accentCustom: string
+  accentBgTint: boolean
+  themeMode: ThemeMode
+  focusActiveTitle: boolean
+  launchDelayMs: number
+  startWithWindows: boolean
+  startMinimized: boolean
+  minimizeToTray: boolean
+  autoCheckUpdates: boolean
+  zoomFactor: number
+  exportingConfig: boolean
+  importingConfig: boolean
+  isCustomColor: boolean
+  appIcons: Record<string, string>
+  gameIcons: Record<string, string>
+  iconLoadErrors: Set<string>
+  utilities: Utility[]
+  onAutoCheckUpdatesChange: (checked: boolean) => void
+  onAccentChange: (presetHex: string) => void
+  onCustomColorChange: (hex: string) => void
+  onAccentBgTintChange: (checked: boolean) => void
+  onThemeModeChange: (mode: ThemeMode) => void
+  onFocusActiveTitleChange: (checked: boolean) => void
+  onZoomFactorChange: (factor: number) => void
+  onStartWithWindowsChange: (checked: boolean) => void
+  onStartMinimizedChange: (checked: boolean) => void
+  onMinimizeToTrayChange: (checked: boolean) => void
+  onLaunchDelayMsChange: (delayMs: number) => void
+  onExportConfig: () => void
+  onImportConfig: () => void
+  onBrowse: (key: string, isGame: boolean) => void
+  onGamePathChange: (key: string, path: string) => void
+  onAppNameChange: (key: string, name: string) => void
+  onAppPathChange: (key: string, path: string) => void
+  onAppArgsChange: (key: string, args: string) => void
+  onIconLoadError: (key: string) => void
+  onAddCustomSlot: () => void
+  onRemoveCustomSlot: (slotNumber: number) => void
+  saveSettings: () => Promise<void>
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null)
+
+export function useSettings() {
+  const context = useContext(SettingsContext)
+
+  if (!context) {
+    throw new Error('useSettings must be used within SettingsProvider')
+  }
+
+  return context
+}
+
+export function SettingsProvider({
+  children,
+  onDirtyChange,
+  shouldSaveTrigger,
+  onSaved,
+  onConfigImported
+}: {
+  children: ReactNode
+  onDirtyChange?: (isDirty: boolean) => void
+  shouldSaveTrigger?: boolean
+  onSaved?: () => void
+  onConfigImported?: () => void
+}) {
+  const { notify } = useNotify()
+  const [loading, setLoading] = useState(true)
+
+  const [appPaths, setAppPaths] = useState<Record<string, string>>({})
+  const [appNames, setAppNames] = useState<Record<string, string>>({})
+  const [appArgs, setAppArgs] = useState<Record<string, string>>({})
+  const [profiles, setProfiles] = useState<Profiles>({})
+  const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
+  const [customSlots, setCustomSlots] = useState(1)
+  const [accentPreset, setAccentPreset] = useState<string>(DEFAULT_ACCENT_COLOR)
+  const [accentCustom, setAccentCustom] = useState<string>('')
+  const [accentBgTint, setAccentBgTint] = useState<boolean>(false)
+  const [themeMode, setThemeMode] = useState<ThemeMode>('dark')
+  const [focusActiveTitle, setFocusActiveTitle] = useState<boolean>(true)
+  const [launchDelayMs, setLaunchDelayMs] = useState<number>(1000)
+  const [startWithWindows, setStartWithWindows] = useState<boolean>(false)
+  const [startMinimized, setStartMinimized] = useState<boolean>(false)
+  const [minimizeToTray, setMinimizeToTray] = useState<boolean>(false)
+  const [autoCheckUpdates, setAutoCheckUpdates] = useState<boolean>(true)
+  const [zoomFactor, setZoomFactor] = useState<number>(1.0)
+
+  const [exportingConfig, setExportingConfig] = useState(false)
+  const [importingConfig, setImportingConfig] = useState(false)
+  const [isCustomColor, setIsCustomColor] = useState(false)
+  const [appIcons, setAppIcons] = useState<Record<string, string>>({})
+  const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
+  const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
+  const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
+  const latestSettingsObjects = useRef<SettingsObjectRecords>({
+    appPaths,
+    appNames,
+    appArgs,
+    gamePaths
+  })
+
+  const loadSettingsFromStore = async () => {
+    const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
+    const typedProfiles = savedProfiles as Profiles
+
+    latestSettingsObjects.current = {
+      appPaths: settings.appPaths,
+      appNames: settings.appNames,
+      appArgs: settings.appArgs,
+      gamePaths: settings.gamePaths
+    }
+
+    setAppPaths(settings.appPaths)
+    setAppNames(settings.appNames)
+    setAppArgs(settings.appArgs)
+    setProfiles(typedProfiles)
+    setGamePaths(settings.gamePaths)
+    setCustomSlots(
+      resolveCustomSlots(
+        settings.customSlots,
+        settings.appPaths,
+        settings.appNames,
+        ...(Object.values(typedProfiles) as Record<string, unknown>[])
+      )
+    )
+    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
+
+    setAccentPreset(settings.accentPreset || DEFAULT_ACCENT_COLOR)
+    setAccentCustom(settings.accentCustom || '')
+    setAccentBgTint(settings.accentBgTint || false)
+    setThemeMode(loadedThemeMode)
+    applyThemeMode(loadedThemeMode)
+    setFocusActiveTitle(settings.focusActiveTitle !== false)
+    setLaunchDelayMs(normalizeLaunchDelayMs(settings.launchDelayMs))
+    setStartWithWindows(settings.startWithWindows || false)
+    setStartMinimized(settings.startMinimized || false)
+    setMinimizeToTray(settings.minimizeToTray || false)
+    setAutoCheckUpdates(settings.autoCheckUpdates !== false)
+    setZoomFactor(Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0)
+
+    setIsCustomColor(settings.accentPreset === 'custom')
+
+    const icons: Record<string, string> = {}
+    for (const [key, path] of Object.entries(settings.appPaths)) {
+      if (path) {
+        const icon = await getFileIcon(path)
+        if (icon) icons[key] = icon
+      }
+    }
+    setAppIcons(icons)
+
+    const gIcons: Record<string, string> = {}
+    for (const game of GAMES) {
+      const filename = game.icon.split('/').pop() || ''
+      const data = await getAssetData(filename)
+      if (data) gIcons[game.key] = data
+    }
+    setGameIcons(gIcons)
+
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    loadSettingsFromStore()
+  }, [])
+
+  useEffect(() => {
+    latestSettingsObjects.current = {
+      appPaths,
+      appNames,
+      appArgs,
+      gamePaths
+    }
+  }, [appPaths, appNames, appArgs, gamePaths])
+
+  const updateSettingsObject = (
+    field: SettingsObjectField,
+    setter: Dispatch<SetStateAction<Record<string, string>>>,
+    updater: (current: Record<string, string>) => Record<string, string>
+  ) => {
+    settingsObjectEditVersions.current[field] += 1
+    setter((current) => {
+      const next = updater(current)
+      latestSettingsObjects.current = {
+        ...latestSettingsObjects.current,
+        [field]: next
+      }
+      return next
+    })
+  }
+
+  const currentSettingsState = useMemo(
+    () => ({
+      appPaths,
+      appNames,
+      appArgs,
+      profiles,
+      gamePaths,
+      customSlots,
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      focusActiveTitle,
+      launchDelayMs,
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      autoCheckUpdates,
+      zoomFactor
+    }),
+    [
+      appPaths,
+      appNames,
+      appArgs,
+      profiles,
+      gamePaths,
+      customSlots,
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      focusActiveTitle,
+      launchDelayMs,
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      autoCheckUpdates,
+      zoomFactor
+    ]
+  )
+
+  const { isDirty, resetDirty } = useDirtyTracking(currentSettingsState, loading)
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+
+  const updateAccentCSS = (hex: string) => {
+    if (hex) applyAccentTheme(hex)
+  }
+
+  const handleAccentChange = (presetHex: string) => {
+    setAccentPreset(presetHex)
+    if (presetHex !== 'custom') {
+      setIsCustomColor(false)
+      updateAccentCSS(presetHex)
+    } else {
+      setIsCustomColor(true)
+      if (accentCustom) updateAccentCSS(accentCustom)
+    }
+  }
+
+  const handleCustomColorChange = (hex: string) => {
+    setAccentCustom(hex)
+    updateAccentCSS(hex)
+  }
+
+  const handleAccentBgTintChange = (checked: boolean) => {
+    setAccentBgTint(checked)
+    window.dispatchEvent(new CustomEvent('bg-tint-change', { detail: checked }))
+  }
+
+  const handleThemeModeChange = (mode: ThemeMode) => {
+    setThemeMode(mode)
+    applyThemeMode(mode)
+  }
+
+  const handleZoomFactorChange = (factor: number) => {
+    setZoomFactor(factor)
+    setZoom(factor)
+  }
+
+  const handleStartWithWindowsChange = (checked: boolean) => {
+    setStartWithWindows(checked)
+    setLoginItem(checked)
+  }
+
+  const handleBrowse = async (key: string, isGame: boolean) => {
+    const result = (await browsePath(key)) as {
+      filePath: string
+      inputId: string
+    }
+    if (result && result.filePath) {
+      if (isGame) {
+        updateSettingsObject('gamePaths', setGamePaths, (prev) => ({
+          ...prev,
+          [key]: result.filePath
+        }))
+      } else {
+        updateSettingsObject('appPaths', setAppPaths, (prev) => ({
+          ...prev,
+          [key]: result.filePath
+        }))
+        const icon = await getFileIcon(result.filePath)
+        if (icon) {
+          setAppIcons((prev) => ({ ...prev, [key]: icon }))
+          setIconLoadErrors((prev) => {
+            const next = new Set(prev)
+            next.delete(key)
+            return next
+          })
+        }
+      }
+    }
+  }
+
+  const handleAddCustomSlot = () => {
+    setCustomSlots((current) => current + 1)
+  }
+
+  const handleRemoveCustomSlot = (slotNumber: number) => {
+    if (customSlots <= 1) {
+      notify('At least one custom app slot is required', 'warn')
+      return
+    }
+
+    const slotKey = getCustomUtilityKey(slotNumber)
+    const slotName = appNames[slotKey] || `Custom App ${slotNumber}`
+
+    if (appPaths[slotKey]) {
+      const confirmed = window.confirm(`Remove ${slotName} and its executable path?`)
+
+      if (!confirmed) {
+        return
+      }
+    }
+
+    updateSettingsObject('appPaths', setAppPaths, (current) =>
+      shiftCustomSlotRecord(current, slotNumber, customSlots)
+    )
+    updateSettingsObject('appNames', setAppNames, (current) =>
+      shiftCustomSlotRecord(current, slotNumber, customSlots)
+    )
+    updateSettingsObject('appArgs', setAppArgs, (current) =>
+      shiftCustomSlotRecord(current, slotNumber, customSlots)
+    )
+    setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+    setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
+    setProfiles((current) => {
+      const nextProfiles: Profiles = {}
+
+      Object.entries(current).forEach(([gameKey, profile]) => {
+        nextProfiles[gameKey] = shiftProfileCustomSlots(profile, slotNumber, customSlots)
+      })
+
+      return nextProfiles
+    })
+    setCustomSlots((current) => Math.max(1, current - 1))
+  }
+
+  const handleGamePathChange = (key: string, path: string) => {
+    updateSettingsObject('gamePaths', setGamePaths, (prev) => ({ ...prev, [key]: path }))
+  }
+
+  const handleAppPathChange = (key: string, path: string) => {
+    updateSettingsObject('appPaths', setAppPaths, (prev) => ({ ...prev, [key]: path }))
+    if (!path) {
+      setAppIcons((prev) => {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    }
+  }
+
+  const handleAppNameChange = (key: string, name: string) => {
+    updateSettingsObject('appNames', setAppNames, (prev) => ({ ...prev, [key]: name }))
+  }
+
+  const handleAppArgsChange = (key: string, args: string) => {
+    updateSettingsObject('appArgs', setAppArgs, (prev) => ({ ...prev, [key]: args }))
+  }
+
+  const handleIconLoadError = (key: string) => {
+    setIconLoadErrors((prev) => new Set([...prev, key]))
+  }
+
+  const handleExportConfig = async () => {
+    setExportingConfig(true)
+
+    try {
+      const result = await exportConfig()
+
+      if (result.success) {
+        notify('Config exported', 'success', 2500)
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to export config', 'error')
+      }
+    } catch (err) {
+      notify('Failed to export config', 'error')
+      console.error(err)
+    } finally {
+      setExportingConfig(false)
+    }
+  }
+
+  const handleImportConfig = async () => {
+    const confirmed = window.confirm(
+      'Importing a config file will replace your current SimLauncher settings. Continue?'
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    setImportingConfig(true)
+
+    try {
+      const result = await importConfig()
+
+      if (result.success) {
+        await loadSettingsFromStore()
+        resetDirty()
+        onConfigImported?.()
+        notify('Config imported', 'success', 2500)
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to import config', 'error')
+      }
+    } catch (err) {
+      notify('Failed to import config', 'error')
+      console.error(err)
+    } finally {
+      setImportingConfig(false)
+    }
+  }
+
+  const handleSave = async () => {
+    try {
+      const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
+      const trimmedAppPaths = trimPathRecord(appPaths)
+      const trimmedGamePaths = trimPathRecord(gamePaths)
+      const trimmedAppArgs = trimStringRecord(appArgs)
+      const settingsObjectEditVersionsAtSave = { ...settingsObjectEditVersions.current }
+      const savedSettingsObjects = {
+        appPaths: trimmedAppPaths,
+        appNames,
+        appArgs: trimmedAppArgs,
+        gamePaths: trimmedGamePaths
+      }
+
+      await Promise.all([
+        persistSettings({
+          appPaths: savedSettingsObjects.appPaths,
+          appNames: savedSettingsObjects.appNames,
+          appArgs: savedSettingsObjects.appArgs,
+          gamePaths: savedSettingsObjects.gamePaths,
+          customSlots,
+          accentPreset,
+          accentCustom,
+          accentBgTint,
+          themeMode,
+          focusActiveTitle,
+          launchDelayMs: normalizedLaunchDelayMs,
+          startMinimized,
+          minimizeToTray,
+          autoCheckUpdates,
+          startWithWindows,
+          zoomFactor
+        }),
+        saveProfiles(profiles)
+      ])
+      const changedDuringSave = getSettingsObjectChangesDuringSave(
+        settingsObjectEditVersionsAtSave,
+        settingsObjectEditVersions.current
+      )
+      const resetSettingsObjects = resolveSettingsObjectsAfterSave({
+        savedObjects: savedSettingsObjects,
+        latestObjects: latestSettingsObjects.current,
+        changedDuringSave
+      })
+
+      if (!changedDuringSave.appPaths) {
+        setAppPaths(savedSettingsObjects.appPaths)
+      }
+
+      if (!changedDuringSave.gamePaths) {
+        setGamePaths(savedSettingsObjects.gamePaths)
+      }
+
+      if (!changedDuringSave.appArgs) {
+        setAppArgs(savedSettingsObjects.appArgs)
+      }
+
+      setLaunchDelayMs(normalizedLaunchDelayMs)
+
+      notify('Settings saved!', 'success', 2500)
+
+      resetDirty({
+        ...currentSettingsState,
+        ...resetSettingsObjects,
+        launchDelayMs: normalizedLaunchDelayMs
+      })
+    } catch (err) {
+      notify('Failed to save settings', 'error')
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    if (shouldSaveTrigger) {
+      handleSave().then(() => {
+        onSaved?.()
+      })
+    }
+  }, [shouldSaveTrigger])
+
+  const utilities = useMemo(() => getUtilities(customSlots), [customSlots])
+
+  const value: SettingsContextValue = {
+    loading,
+    isDirty,
+    appPaths,
+    appNames,
+    appArgs,
+    profiles,
+    gamePaths,
+    customSlots,
+    accentPreset,
+    accentCustom,
+    accentBgTint,
+    themeMode,
+    focusActiveTitle,
+    launchDelayMs,
+    startWithWindows,
+    startMinimized,
+    minimizeToTray,
+    autoCheckUpdates,
+    zoomFactor,
+    exportingConfig,
+    importingConfig,
+    isCustomColor,
+    appIcons,
+    gameIcons,
+    iconLoadErrors,
+    utilities,
+    onAutoCheckUpdatesChange: setAutoCheckUpdates,
+    onAccentChange: handleAccentChange,
+    onCustomColorChange: handleCustomColorChange,
+    onAccentBgTintChange: handleAccentBgTintChange,
+    onThemeModeChange: handleThemeModeChange,
+    onFocusActiveTitleChange: setFocusActiveTitle,
+    onZoomFactorChange: handleZoomFactorChange,
+    onStartWithWindowsChange: handleStartWithWindowsChange,
+    onStartMinimizedChange: setStartMinimized,
+    onMinimizeToTrayChange: setMinimizeToTray,
+    onLaunchDelayMsChange: setLaunchDelayMs,
+    onExportConfig: handleExportConfig,
+    onImportConfig: handleImportConfig,
+    onBrowse: handleBrowse,
+    onGamePathChange: handleGamePathChange,
+    onAppNameChange: handleAppNameChange,
+    onAppPathChange: handleAppPathChange,
+    onAppArgsChange: handleAppArgsChange,
+    onIconLoadError: handleIconLoadError,
+    onAddCustomSlot: handleAddCustomSlot,
+    onRemoveCustomSlot: handleRemoveCustomSlot,
+    saveSettings: handleSave
+  }
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}


### PR DESCRIPTION
Closes #193

Replaces prop drilling in SettingsView (~44 props across 6 sections) with a `SettingsContext`.

## Changes
- New `SettingsContext.tsx` holds settings data, dirty state, field handlers, import/export, and `saveSettings()`
- `SettingsView.tsx` trimmed from 630 → 110 lines (provider mount + save button + local accordion state)
- All section components (About, Appearance, Behavior, Config, Games, Apps) consume via `useSettings()` instead of props
- Save race protection refs from #222 stay internal to the provider (not exposed in context value)
- Accordion open/close state stays local to SettingsView

## Verified
- Smoke tested: changed accent color + launch delay, restarted app, settings persisted
- typecheck, build, format, vitest all pass

## Follow-up
- #227 filed for context value memoization (low-priority perf optimization)