### PR TITLE
refactor: replace bg-tint-change event listener with ThemeContext

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,15 +4,13 @@ import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
 import { ConfirmDialog } from './components/ConfirmDialog'
-import { getSettings } from './lib/store'
-import { getUpdateInfo, onUpdateAvailable, setZoom } from './lib/electron'
-import { DEFAULT_ACCENT_COLOR } from './lib/config'
-import { applyAccentTheme, applyThemeMode, normalizeThemeMode } from './lib/theme'
+import { getUpdateInfo, onUpdateAvailable } from './lib/electron'
 import { runStartupMigrations } from './lib/migrations'
+import { useTheme } from './contexts/ThemeContext'
 
 export default function App() {
   const [view, setView] = useState<'games' | 'settings'>('games')
-  const [bgTinted, setBgTinted] = useState(false)
+  const { accentBgTint, syncThemeFromStore } = useTheme()
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
   const [showImportWarning, setShowImportWarning] = useState(false)
   const [settingsDirty, setSettingsDirty] = useState(false)
@@ -24,36 +22,10 @@ export default function App() {
     runStartupMigrations()
   }, [])
 
-  const syncThemeFromStore = async () => {
-    try {
-      const settings = await getSettings()
-      const preset = settings.accentPreset || DEFAULT_ACCENT_COLOR
-      const custom = settings.accentCustom
-      const tint = settings.accentBgTint || false
-      const themeMode = normalizeThemeMode(settings.themeMode)
-
-      setBgTinted(tint)
-      applyThemeMode(themeMode)
-
-      const hex = preset === 'custom' ? custom : preset
-      if (hex) {
-        applyAccentTheme(hex)
-      }
-
-      if (Number.isFinite(settings.zoomFactor)) {
-        setZoom(settings.zoomFactor)
-      }
-    } catch (err) {
-      console.error('Failed to sync theme', err)
-    }
-  }
-
   useEffect(() => {
-    syncThemeFromStore()
-
-    // Listen for custom events to update bgTint from SettingsView without reload
-    const handleTintChange = (e: CustomEvent) => setBgTinted(e.detail)
-    window.addEventListener('bg-tint-change', handleTintChange as EventListener)
+    syncThemeFromStore().catch((err) => {
+      console.error('Failed to sync theme', err)
+    })
 
     const applyUpdateInfo = (info: { version?: string } | null) => {
       if (info?.version) setUpdateInfo({ version: info.version })
@@ -63,19 +35,18 @@ export default function App() {
     const unsubscribe = onUpdateAvailable(applyUpdateInfo)
     let cancelled = false
     getUpdateInfo()
-      .then((info) => {
+      .then((info: { version?: string } | null) => {
         if (!cancelled) applyUpdateInfo(info)
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         console.error('Failed to load update info', err)
       })
 
     return () => {
       cancelled = true
-      window.removeEventListener('bg-tint-change', handleTintChange as EventListener)
       unsubscribe()
     }
-  }, [])
+  }, [syncThemeFromStore])
 
   const handleNavigate = (nextView: 'games' | 'settings') => {
     if (view === nextView) return
@@ -114,7 +85,7 @@ export default function App() {
   return (
     <NotifyProvider>
       <div
-        className={`h-screen overflow-hidden relative transition-colors duration-500 ${bgTinted ? 'bg-tinted' : ''}`}
+        className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
       >
         <div className="absolute top-0 left-0 w-full z-20 header-glass">
           <WindowControls view={view} onNavigate={handleNavigate} updateInfo={updateInfo} />

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -29,12 +29,8 @@ import {
   saveProfiles,
   saveSettings as persistSettings
 } from '../../lib/store'
-import {
-  applyAccentTheme,
-  applyThemeMode,
-  normalizeThemeMode,
-  type ThemeMode
-} from '../../lib/theme'
+import { normalizeThemeMode, type ThemeMode } from '../../lib/theme'
+import { useTheme } from '../../contexts/ThemeContext'
 import { useNotify } from '../Notify'
 import { shiftCustomSlotRecord, shiftCustomSlotSet, shiftProfileCustomSlots } from './customSlots'
 import {
@@ -135,6 +131,7 @@ export function SettingsProvider({
   onConfigImported?: () => void
 }) {
   const { notify } = useNotify()
+  const theme = useTheme()
   const [loading, setLoading] = useState(true)
 
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
@@ -199,7 +196,7 @@ export function SettingsProvider({
     setAccentCustom(settings.accentCustom || '')
     setAccentBgTint(settings.accentBgTint || false)
     setThemeMode(loadedThemeMode)
-    applyThemeMode(loadedThemeMode)
+    theme.setThemeMode(loadedThemeMode)
     setFocusActiveTitle(settings.focusActiveTitle !== false)
     setLaunchDelayMs(normalizeLaunchDelayMs(settings.launchDelayMs))
     setStartWithWindows(settings.startWithWindows || false)
@@ -228,7 +225,7 @@ export function SettingsProvider({
     setGameIcons(gIcons)
 
     setLoading(false)
-  }, [])
+  }, [theme])
 
   useEffect(() => {
     loadSettingsFromStore()
@@ -309,41 +306,43 @@ export function SettingsProvider({
     onDirtyChange?.(isDirty)
   }, [isDirty, onDirtyChange])
 
-  const updateAccentCSS = useCallback((hex: string) => {
-    if (hex) applyAccentTheme(hex)
-  }, [])
-
   const handleAccentChange = useCallback(
     (presetHex: string) => {
       setAccentPreset(presetHex)
       if (presetHex !== 'custom') {
         setIsCustomColor(false)
-        updateAccentCSS(presetHex)
+        theme.setAccentPreset(presetHex)
       } else {
         setIsCustomColor(true)
-        if (accentCustom) updateAccentCSS(accentCustom)
+        theme.setAccentPreset(presetHex)
       }
     },
-    [accentCustom, updateAccentCSS]
+    [theme]
   )
 
   const handleCustomColorChange = useCallback(
     (hex: string) => {
       setAccentCustom(hex)
-      updateAccentCSS(hex)
+      theme.setAccentCustom(hex)
     },
-    [updateAccentCSS]
+    [theme]
   )
 
-  const handleAccentBgTintChange = useCallback((checked: boolean) => {
-    setAccentBgTint(checked)
-    window.dispatchEvent(new CustomEvent('bg-tint-change', { detail: checked }))
-  }, [])
+  const handleAccentBgTintChange = useCallback(
+    (checked: boolean) => {
+      setAccentBgTint(checked)
+      theme.setAccentBgTint(checked)
+    },
+    [theme]
+  )
 
-  const handleThemeModeChange = useCallback((mode: ThemeMode) => {
-    setThemeMode(mode)
-    applyThemeMode(mode)
-  }, [])
+  const handleThemeModeChange = useCallback(
+    (mode: ThemeMode) => {
+      setThemeMode(mode)
+      theme.setThemeMode(mode)
+    },
+    [theme]
+  )
 
   const handleZoomFactorChange = useCallback((factor: number) => {
     setZoomFactor(factor)

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -1,0 +1,125 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react'
+import { DEFAULT_ACCENT_COLOR } from '../lib/config'
+import { setZoom } from '../lib/electron'
+import { getSettings } from '../lib/store'
+import { applyAccentTheme, applyThemeMode, normalizeThemeMode, type ThemeMode } from '../lib/theme'
+
+interface ThemeContextValue {
+  accentPreset: string
+  accentCustom: string
+  accentBgTint: boolean
+  themeMode: ThemeMode
+  resolvedAccent: string
+  setAccentPreset: (preset: string) => void
+  setAccentCustom: (hex: string) => void
+  setAccentBgTint: (checked: boolean) => void
+  setThemeMode: (mode: ThemeMode) => void
+  syncThemeFromStore: () => Promise<void>
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider')
+  }
+
+  return context
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [accentPreset, setAccentPresetState] = useState(DEFAULT_ACCENT_COLOR)
+  const [accentCustom, setAccentCustomState] = useState('')
+  const [accentBgTint, setAccentBgTintState] = useState(false)
+  const [themeMode, setThemeModeState] = useState<ThemeMode>('dark')
+
+  const applyAccent = useCallback((preset: string, custom: string) => {
+    const hex = preset === 'custom' ? custom : preset
+
+    if (hex) {
+      applyAccentTheme(hex)
+    }
+  }, [])
+
+  const setAccentPreset = useCallback(
+    (preset: string) => {
+      setAccentPresetState(preset)
+      applyAccent(preset, accentCustom)
+    },
+    [accentCustom, applyAccent]
+  )
+
+  const setAccentCustom = useCallback(
+    (hex: string) => {
+      setAccentCustomState(hex)
+      applyAccent(accentPreset, hex)
+    },
+    [accentPreset, applyAccent]
+  )
+
+  const setThemeMode = useCallback((mode: ThemeMode) => {
+    setThemeModeState(mode)
+    applyThemeMode(mode)
+  }, [])
+
+  const syncThemeFromStore = useCallback(async () => {
+    const settings = await getSettings()
+    const preset = settings.accentPreset || DEFAULT_ACCENT_COLOR
+    const custom = settings.accentCustom || ''
+    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
+
+    setAccentPresetState(preset)
+    setAccentCustomState(custom)
+    setAccentBgTintState(settings.accentBgTint || false)
+    setThemeModeState(loadedThemeMode)
+    applyThemeMode(loadedThemeMode)
+    applyAccent(preset, custom)
+
+    if (Number.isFinite(settings.zoomFactor)) {
+      setZoom(settings.zoomFactor)
+    }
+  }, [applyAccent])
+
+  useEffect(() => {
+    syncThemeFromStore().catch((err) => {
+      console.error('Failed to sync theme', err)
+    })
+  }, [syncThemeFromStore])
+
+  const value = useMemo(
+    () => ({
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      resolvedAccent: accentPreset === 'custom' ? accentCustom : accentPreset,
+      setAccentPreset,
+      setAccentCustom,
+      setAccentBgTint: setAccentBgTintState,
+      setThemeMode,
+      syncThemeFromStore
+    }),
+    [
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      setAccentPreset,
+      setAccentCustom,
+      setThemeMode,
+      syncThemeFromStore
+    ]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,9 +3,12 @@ import ReactDOM from 'react-dom/client'
 import './App.css'
 import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <ErrorBoundary>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </ErrorBoundary>
 )


### PR DESCRIPTION
Closes #155

Replaces the `bg-tint-change` custom DOM event pattern with a proper `ThemeContext`.

## Changes
- New `src/renderer/src/contexts/ThemeContext.tsx` — manages accent color, theme mode, background tint, and zoom via React context; loads initial state from store via `syncThemeFromStore()`
- `App.tsx` — consumes `accentBgTint` from `useTheme()`, removed DOM event listener
- `SettingsContext.tsx` — calls `theme.set*` methods directly instead of dispatching custom events or calling `applyAccentTheme`/`applyThemeMode` inline
- `main.tsx` — wraps app in `ThemeProvider`