### PR TITLE
Refactor Settings sections into reusable collapsible components

### DIFF
--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -6,6 +6,7 @@ import { AppsSection } from './settings/AppsSection'
 import { BehaviorSection } from './settings/BehaviorSection'
 import { ConfigSection } from './settings/ConfigSection'
 import { GamesSection } from './settings/GamesSection'
+import { SettingsSection } from './settings/SettingsSection'
 import { SettingsProvider, useSettings } from './settings/SettingsContext'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
@@ -46,9 +47,19 @@ function SettingsViewContent({
 }) {
   const { notify } = useNotify()
   const { loading, isDirty, saveSettings } = useSettings()
-  const [appsOpen, setAppsOpen] = useState(false)
-  const [gamesOpen, setGamesOpen] = useState(false)
+  const [expandedSections, setExpandedSections] = useState({
+    about: true,
+    appearance: true,
+    behavior: true,
+    config: true,
+    games: false,
+    apps: false
+  })
   const updateStatus = useUpdateStatus({ updateInfo, notify })
+
+  const setSectionOpen = (section: keyof typeof expandedSections, open: boolean) => {
+    setExpandedSections((current) => ({ ...current, [section]: open }))
+  }
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -64,26 +75,62 @@ function SettingsViewContent({
 
   return (
     <div className="animate-fade-slide space-y-8 pb-10">
-      <AboutSection
-        appVersion={updateStatus.appVersion}
-        updateInfo={updateInfo}
-        checkingUpdate={updateStatus.checkingUpdate}
-        installingUpdate={updateStatus.installingUpdate}
-        updateProgress={updateStatus.updateProgress}
-        updateStatus={updateStatus.updateStatus}
-        onManualCheck={updateStatus.handleManualCheck}
-        onInstallUpdate={updateStatus.handleInstallUpdate}
-      />
+      <SettingsSection
+        title="About"
+        open={expandedSections.about}
+        onOpenChange={(open) => setSectionOpen('about', open)}
+      >
+        <AboutSection
+          appVersion={updateStatus.appVersion}
+          updateInfo={updateInfo}
+          checkingUpdate={updateStatus.checkingUpdate}
+          installingUpdate={updateStatus.installingUpdate}
+          updateProgress={updateStatus.updateProgress}
+          updateStatus={updateStatus.updateStatus}
+          onManualCheck={updateStatus.handleManualCheck}
+          onInstallUpdate={updateStatus.handleInstallUpdate}
+        />
+      </SettingsSection>
 
-      <AppearanceSection />
+      <SettingsSection
+        title="Appearance"
+        open={expandedSections.appearance}
+        onOpenChange={(open) => setSectionOpen('appearance', open)}
+      >
+        <AppearanceSection />
+      </SettingsSection>
 
-      <BehaviorSection />
+      <SettingsSection
+        title="Behavior"
+        open={expandedSections.behavior}
+        onOpenChange={(open) => setSectionOpen('behavior', open)}
+      >
+        <BehaviorSection />
+      </SettingsSection>
 
-      <ConfigSection />
+      <SettingsSection
+        title="Config"
+        open={expandedSections.config}
+        onOpenChange={(open) => setSectionOpen('config', open)}
+      >
+        <ConfigSection />
+      </SettingsSection>
 
-      <GamesSection open={gamesOpen} onOpenChange={setGamesOpen} />
+      <SettingsSection
+        title="Games"
+        open={expandedSections.games}
+        onOpenChange={(open) => setSectionOpen('games', open)}
+      >
+        <GamesSection />
+      </SettingsSection>
 
-      <AppsSection open={appsOpen} onOpenChange={setAppsOpen} />
+      <SettingsSection
+        title="Utility Apps"
+        open={expandedSections.apps}
+        onOpenChange={(open) => setSectionOpen('apps', open)}
+      >
+        <AppsSection />
+      </SettingsSection>
 
       <div className="flex gap-4 pt-4 px-1">
         <button

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -26,61 +26,58 @@ export function AboutSection({
   const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettings()
 
   return (
-    <section className="space-y-4">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">About</h3>
-      <div className="glass-surface rounded-2xl flex flex-col pt-1">
-        <div className="settings-row">
-          <span className="settings-label text-(--text-secondary)">Installed Version</span>
-          <span className="text-xs font-mono text-(--text-muted)">v{appVersion}</span>
-        </div>
-
-        <div className="settings-row">
-          <div className="settings-label-group">
-            <span className="settings-label">Automatically check for updates</span>
-            <span className="settings-sublabel">Check on startup when enabled</span>
-          </div>
-          <Toggle
-            checked={autoCheckUpdates}
-            onChange={onAutoCheckUpdatesChange}
-            aria-label="Automatically check for updates"
-          />
-        </div>
-
-        <div className="flex flex-col gap-2 p-5 border-t border-(--header-glass-border)">
-          {updateInfo ? (
-            <button
-              onClick={onInstallUpdate}
-              disabled={installingUpdate}
-              className="accent-surface-action action-hover-scale w-full cursor-pointer rounded-xl py-2.5 text-xs font-semibold"
-            >
-              {installingUpdate
-                ? updateProgress !== null
-                  ? `Downloading ${Math.round(updateProgress)}%`
-                  : 'Preparing update...'
-                : `Download & Install (v${updateInfo.version})`}
-            </button>
-          ) : (
-            <button
-              onClick={onManualCheck}
-              disabled={checkingUpdate}
-              className="accent-surface-action action-hover-scale w-full cursor-pointer rounded-xl py-2.5 text-xs font-semibold"
-            >
-              {checkingUpdate ? 'Checking for updates...' : 'Check for Updates'}
-            </button>
-          )}
-
-          {updateStatus === 'up-to-date' && (
-            <p className="text-[10px] text-center text-(--status-success) animate-fade-slide">
-              SimLauncher is up to date!
-            </p>
-          )}
-          {updateStatus === 'error' && (
-            <p className="text-[10px] text-center text-red-400 animate-fade-slide">
-              Update failed. Try again later.
-            </p>
-          )}
-        </div>
+    <>
+      <div className="settings-row">
+        <span className="settings-label text-(--text-secondary)">Installed Version</span>
+        <span className="text-xs font-mono text-(--text-muted)">v{appVersion}</span>
       </div>
-    </section>
+
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <span className="settings-label">Automatically check for updates</span>
+          <span className="settings-sublabel">Check on startup when enabled</span>
+        </div>
+        <Toggle
+          checked={autoCheckUpdates}
+          onChange={onAutoCheckUpdatesChange}
+          aria-label="Automatically check for updates"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 p-5 border-t border-(--header-glass-border)">
+        {updateInfo ? (
+          <button
+            onClick={onInstallUpdate}
+            disabled={installingUpdate}
+            className="accent-surface-action action-hover-scale w-full cursor-pointer rounded-xl py-2.5 text-xs font-semibold"
+          >
+            {installingUpdate
+              ? updateProgress !== null
+                ? `Downloading ${Math.round(updateProgress)}%`
+                : 'Preparing update...'
+              : `Download & Install (v${updateInfo.version})`}
+          </button>
+        ) : (
+          <button
+            onClick={onManualCheck}
+            disabled={checkingUpdate}
+            className="accent-surface-action action-hover-scale w-full cursor-pointer rounded-xl py-2.5 text-xs font-semibold"
+          >
+            {checkingUpdate ? 'Checking for updates...' : 'Check for Updates'}
+          </button>
+        )}
+
+        {updateStatus === 'up-to-date' && (
+          <p className="text-[10px] text-center text-(--status-success) animate-fade-slide">
+            SimLauncher is up to date!
+          </p>
+        )}
+        {updateStatus === 'error' && (
+          <p className="text-[10px] text-center text-red-400 animate-fade-slide">
+            Update failed. Try again later.
+          </p>
+        )}
+      </div>
+    </>
   )
 }

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -47,125 +47,120 @@ export function AppearanceSection() {
   } = useSettings()
 
   return (
-    <section className="space-y-4">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
-        Appearance
-      </h3>
-      <div className="glass-surface rounded-2xl flex flex-col pt-1">
-        <div className="settings-row">
-          <label className="settings-label text-(--text-secondary)">Theme</label>
-          <div className="settings-control">
-            {THEME_MODE_OPTIONS.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => onThemeModeChange(option.value)}
-                className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
-                  themeMode === option.value
-                    ? 'selected-surface text-(--text-primary)'
-                    : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
+    <>
+      <div className="settings-row">
+        <label className="settings-label text-(--text-secondary)">Theme</label>
+        <div className="settings-control">
+          {THEME_MODE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onThemeModeChange(option.value)}
+              className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
+                themeMode === option.value
+                  ? 'selected-surface text-(--text-primary)'
+                  : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
         </div>
+      </div>
 
-        <div className="settings-row">
-          <label className="settings-label text-(--text-secondary)">Accent Color</label>
-          <div className="settings-control">
-            {ACCENT_PRESETS.map((preset) => (
-              <button
-                key={preset.hex}
-                type="button"
-                onClick={() => onAccentChange(preset.hex)}
-                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
-                style={{ '--preset-color': preset.hex } as CSSProperties}
-                title={preset.name}
-              />
-            ))}
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => {
-                  setShowPicker(!showPicker)
-                  if (!isCustomColor) onAccentChange('custom')
+      <div className="settings-row">
+        <label className="settings-label text-(--text-secondary)">Accent Color</label>
+        <div className="settings-control">
+          {ACCENT_PRESETS.map((preset) => (
+            <button
+              key={preset.hex}
+              type="button"
+              onClick={() => onAccentChange(preset.hex)}
+              className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
+              style={{ '--preset-color': preset.hex } as CSSProperties}
+              title={preset.name}
+            />
+          ))}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                setShowPicker(!showPicker)
+                if (!isCustomColor) onAccentChange('custom')
+              }}
+              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
+                isCustomColor ? 'scale-110' : ''
+              }`}
+              title="Custom Color"
+            >
+              {/* Background gradient/color */}
+              <div
+                className="absolute inset-0 rounded-full"
+                style={{
+                  background: isCustomColor
+                    ? accentCustom || '#ad46ff'
+                    : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
                 }}
-                className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
-                  isCustomColor ? 'scale-110' : ''
-                }`}
-                title="Custom Color"
-              >
-                {/* Background gradient/color */}
-                <div
-                  className="absolute inset-0 rounded-full"
-                  style={{
-                    background: isCustomColor
-                      ? accentCustom || '#ad46ff'
-                      : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
-                  }}
-                />
+              />
 
-                {/* Glass overlay for unselected state */}
-                {!isCustomColor && (
-                  <div className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none" />
-                )}
-
-                {/* Border to match presets */}
-                <div
-                  className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
-                />
-              </button>
-
-              {showPicker && (
-                <ColorPickerPopover
-                  color={accentCustom || '#ad46ff'}
-                  onChange={onCustomColorChange}
-                  onClose={() => setShowPicker(false)}
-                />
+              {/* Glass overlay for unselected state */}
+              {!isCustomColor && (
+                <div className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none" />
               )}
-            </div>
-          </div>
-        </div>
 
-        <div className="settings-row">
-          <label className="settings-label text-(--text-secondary)">Accent Glow Background</label>
-          <Toggle
-            checked={accentBgTint}
-            onChange={onAccentBgTintChange}
-            aria-label="Toggle accent glow background"
-          />
-        </div>
+              {/* Border to match presets */}
+              <div
+                className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
+              />
+            </button>
 
-        <div className="settings-row">
-          <label className="settings-label text-(--text-secondary)">Focus active title</label>
-          <Toggle
-            checked={focusActiveTitle}
-            onChange={onFocusActiveTitleChange}
-            aria-label="Focus active title"
-          />
-        </div>
-
-        <div className="settings-row">
-          <label className="settings-label text-(--text-secondary)">UI Scale</label>
-          <div className="settings-control">
-            {ZOOM_PRESETS.map((preset) => (
-              <button
-                key={preset.factor}
-                onClick={() => onZoomFactorChange(preset.factor)}
-                className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
-                  zoomFactor === preset.factor
-                    ? 'selected-surface text-(--text-primary)'
-                    : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
-                }`}
-              >
-                {preset.label}
-              </button>
-            ))}
+            {showPicker && (
+              <ColorPickerPopover
+                color={accentCustom || '#ad46ff'}
+                onChange={onCustomColorChange}
+                onClose={() => setShowPicker(false)}
+              />
+            )}
           </div>
         </div>
       </div>
-    </section>
+
+      <div className="settings-row">
+        <label className="settings-label text-(--text-secondary)">Accent Glow Background</label>
+        <Toggle
+          checked={accentBgTint}
+          onChange={onAccentBgTintChange}
+          aria-label="Toggle accent glow background"
+        />
+      </div>
+
+      <div className="settings-row">
+        <label className="settings-label text-(--text-secondary)">Focus active title</label>
+        <Toggle
+          checked={focusActiveTitle}
+          onChange={onFocusActiveTitleChange}
+          aria-label="Focus active title"
+        />
+      </div>
+
+      <div className="settings-row">
+        <label className="settings-label text-(--text-secondary)">UI Scale</label>
+        <div className="settings-control">
+          {ZOOM_PRESETS.map((preset) => (
+            <button
+              key={preset.factor}
+              onClick={() => onZoomFactorChange(preset.factor)}
+              className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
+                zoomFactor === preset.factor
+                  ? 'selected-surface text-(--text-primary)'
+                  : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
   )
 }

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -19,12 +19,7 @@ function getCustomSlotNumber(key: string) {
   return Number(key.replace('customapp', ''))
 }
 
-interface AppsSectionProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}
-
-export function AppsSection({ open, onOpenChange }: AppsSectionProps) {
+export function AppsSection() {
   const {
     utilities,
     appPaths,
@@ -43,149 +38,77 @@ export function AppsSection({ open, onOpenChange }: AppsSectionProps) {
   } = useSettings()
 
   return (
-    <section className="space-y-4">
-      <button
-        type="button"
-        onClick={() => onOpenChange(!open)}
-        className="flex w-full cursor-pointer items-center gap-2 px-1"
-      >
-        <h3 className="flex-1 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
-          Utility Apps
-        </h3>
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={`text-(--text-subtle) transition-transform duration-300 ${open ? 'rotate-0' : '-rotate-90'}`}
+    <>
+      {utilities.map((utility) => (
+        <div
+          key={utility.key}
+          className="flex flex-col gap-2.5 border-b border-(--header-glass-border) px-5 py-4"
         >
-          <path d="M3 6l5 5 5-5" />
-        </svg>
-      </button>
-      <div
-        className={`grid transition-all duration-300 ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
-      >
-        <div className="overflow-hidden">
-          <div className="glass-surface rounded-2xl flex flex-col pt-1">
-            {utilities.map((utility) => (
-              <div
-                key={utility.key}
-                className="flex flex-col gap-2.5 border-b border-(--header-glass-border) px-5 py-4"
-              >
-                <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
-                  {utility.isCustom ? (
-                    <div className="flex items-center gap-2">
-                      <svg
-                        width="11"
-                        height="11"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="shrink-0 text-(--accent)"
-                      >
-                        <path d="M12 20h9" />
-                        <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
-                      </svg>
-                      <input
-                        type="text"
-                        value={appNames[utility.key] || utility.name}
-                        onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                        className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
-                        placeholder="App Name"
-                        aria-label={`${utility.name} name`}
-                        title="Editable app name"
-                      />
-                    </div>
-                  ) : (
-                    utility.name
-                  )}
-                </div>
-
-                <div className="flex items-center gap-4">
-                  {appIcons[utility.key] && !iconLoadErrors.has(utility.key) ? (
-                    <img
-                      src={appIcons[utility.key]}
-                      alt="Icon"
-                      className="h-8 w-8 object-contain drop-shadow-md shrink-0"
-                      onError={() => onIconLoadError(utility.key)}
-                    />
-                  ) : (
-                    <div
-                      className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
-                      title={`${appNames[utility.key] || utility.name} icon fallback`}
-                    >
-                      {getInitials(appNames[utility.key] || utility.name)}
-                    </div>
-                  )}
-
-                  <input
-                    type="text"
-                    value={appPaths[utility.key] || ''}
-                    onChange={(e) => onAppPathChange(utility.key, e.target.value)}
-                    placeholder="No executable path set"
-                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
-                  />
-
-                  {utility.isCustom && (
-                    <button
-                      type="button"
-                      onClick={() => onRemoveCustomSlot(getCustomSlotNumber(utility.key))}
-                      disabled={customSlots <= 1}
-                      className="danger-action action-hover-scale flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
-                      title={`Remove ${appNames[utility.key] || utility.name}`}
-                      aria-label={`Remove ${appNames[utility.key] || utility.name}`}
-                    >
-                      <svg
-                        width="15"
-                        height="15"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M3 6h18" />
-                        <path d="M8 6V4h8v2" />
-                        <path d="M19 6l-1 14H6L5 6" />
-                        <path d="M10 11v5" />
-                        <path d="M14 11v5" />
-                      </svg>
-                    </button>
-                  )}
-                  <button
-                    onClick={() => onBrowse(utility.key, false)}
-                    className="accent-surface-action action-hover-scale cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
-                  >
-                    Browse
-                  </button>
-                </div>
-
-                {utility.isCustom && (
-                  <input
-                    type="text"
-                    value={appArgs[utility.key] || ''}
-                    onChange={(e) => onAppArgsChange(utility.key, e.target.value)}
-                    placeholder="Optional command line arguments"
-                    className="glass-recessed rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
-                    aria-label={`${appNames[utility.key] || utility.name} command line arguments`}
-                  />
-                )}
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
+            {utility.isCustom ? (
+              <div className="flex items-center gap-2">
+                <svg
+                  width="11"
+                  height="11"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="shrink-0 text-(--accent)"
+                >
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+                <input
+                  type="text"
+                  value={appNames[utility.key] || utility.name}
+                  onChange={(e) => onAppNameChange(utility.key, e.target.value)}
+                  className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                  placeholder="App Name"
+                  aria-label={`${utility.name} name`}
+                  title="Editable app name"
+                />
               </div>
-            ))}
-            <div className="px-5 py-3">
+            ) : (
+              utility.name
+            )}
+          </div>
+
+          <div className="flex items-center gap-4">
+            {appIcons[utility.key] && !iconLoadErrors.has(utility.key) ? (
+              <img
+                src={appIcons[utility.key]}
+                alt="Icon"
+                className="h-8 w-8 object-contain drop-shadow-md shrink-0"
+                onError={() => onIconLoadError(utility.key)}
+              />
+            ) : (
+              <div
+                className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
+                title={`${appNames[utility.key] || utility.name} icon fallback`}
+              >
+                {getInitials(appNames[utility.key] || utility.name)}
+              </div>
+            )}
+
+            <input
+              type="text"
+              value={appPaths[utility.key] || ''}
+              onChange={(e) => onAppPathChange(utility.key, e.target.value)}
+              placeholder="No executable path set"
+              className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+            />
+
+            {utility.isCustom && (
               <button
                 type="button"
-                onClick={onAddCustomSlot}
-                disabled={customSlots >= MAX_CUSTOM_SLOTS}
-                className="accent-surface-action action-hover-scale flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold"
+                onClick={() => onRemoveCustomSlot(getCustomSlotNumber(utility.key))}
+                disabled={customSlots <= 1}
+                className="danger-action action-hover-scale flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
+                title={`Remove ${appNames[utility.key] || utility.name}`}
+                aria-label={`Remove ${appNames[utility.key] || utility.name}`}
               >
                 <svg
                   width="15"
@@ -193,18 +116,60 @@ export function AppsSection({ open, onOpenChange }: AppsSectionProps) {
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                  strokeWidth="2.2"
+                  strokeWidth="2"
                   strokeLinecap="round"
+                  strokeLinejoin="round"
                 >
-                  <path d="M12 5v14" />
-                  <path d="M5 12h14" />
+                  <path d="M3 6h18" />
+                  <path d="M8 6V4h8v2" />
+                  <path d="M19 6l-1 14H6L5 6" />
+                  <path d="M10 11v5" />
+                  <path d="M14 11v5" />
                 </svg>
-                Add slot
               </button>
-            </div>
+            )}
+            <button
+              onClick={() => onBrowse(utility.key, false)}
+              className="accent-surface-action action-hover-scale cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
+            >
+              Browse
+            </button>
           </div>
+
+          {utility.isCustom && (
+            <input
+              type="text"
+              value={appArgs[utility.key] || ''}
+              onChange={(e) => onAppArgsChange(utility.key, e.target.value)}
+              placeholder="Optional command line arguments"
+              className="glass-recessed rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+              aria-label={`${appNames[utility.key] || utility.name} command line arguments`}
+            />
+          )}
         </div>
+      ))}
+      <div className="px-5 py-3">
+        <button
+          type="button"
+          onClick={onAddCustomSlot}
+          disabled={customSlots >= MAX_CUSTOM_SLOTS}
+          className="accent-surface-action action-hover-scale flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold"
+        >
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+          >
+            <path d="M12 5v14" />
+            <path d="M5 12h14" />
+          </svg>
+          Add slot
+        </button>
       </div>
-    </section>
+    </>
   )
 }

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -22,104 +22,99 @@ export function BehaviorSection() {
   const isPreset = DELAY_PRESETS.some((p) => p.value === launchDelayMs)
 
   return (
-    <section className="space-y-4">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
-        Behavior
-      </h3>
-      <div className="glass-surface rounded-2xl flex flex-col pt-1">
-        <div className="settings-row">
-          <div className="settings-label-group">
-            <span className="settings-label">Start with Windows</span>
-            <span className="settings-sublabel">Launch SimLauncher automatically at login</span>
-          </div>
-          <Toggle
-            checked={startWithWindows}
-            onChange={onStartWithWindowsChange}
-            aria-label="Start with Windows"
-          />
+    <>
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <span className="settings-label">Start with Windows</span>
+          <span className="settings-sublabel">Launch SimLauncher automatically at login</span>
         </div>
-        <div className="settings-row">
-          <div className="settings-label-group">
-            <span className="settings-label">Start minimized</span>
-            <span className="settings-sublabel">Start hidden in the system tray</span>
-          </div>
-          <Toggle
-            checked={startMinimized}
-            onChange={onStartMinimizedChange}
-            aria-label="Start minimized"
-          />
+        <Toggle
+          checked={startWithWindows}
+          onChange={onStartWithWindowsChange}
+          aria-label="Start with Windows"
+        />
+      </div>
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <span className="settings-label">Start minimized</span>
+          <span className="settings-sublabel">Start hidden in the system tray</span>
         </div>
-        <div className="settings-row">
-          <div className="settings-label-group">
-            <span className="settings-label">Minimize to tray on close</span>
-            <span className="settings-sublabel">
-              Keep SimLauncher running when the window is closed
-            </span>
-          </div>
-          <Toggle
-            checked={minimizeToTray}
-            onChange={onMinimizeToTrayChange}
-            aria-label="Minimize to tray on close"
-          />
+        <Toggle
+          checked={startMinimized}
+          onChange={onStartMinimizedChange}
+          aria-label="Start minimized"
+        />
+      </div>
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <span className="settings-label">Minimize to tray on close</span>
+          <span className="settings-sublabel">
+            Keep SimLauncher running when the window is closed
+          </span>
         </div>
-        <div className="settings-row">
-          <div className="settings-label-group">
-            <span className="settings-label">Launch delay between apps</span>
-            <span className="settings-sublabel">Wait time before starting the next app</span>
-          </div>
-          <div className="settings-control">
-            {DELAY_PRESETS.map((preset) => (
-              <button
-                key={preset.value}
-                onClick={() => onLaunchDelayMsChange(preset.value)}
-                className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
-                  launchDelayMs === preset.value
-                    ? 'selected-surface text-(--text-primary)'
-                    : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
-                }`}
-              >
-                {preset.label}
-              </button>
-            ))}
-            <div
-              className={`settings-control-pill settings-control-pill-input settings-control-preset glass-surface action-hover-scale transition-all duration-200 ${
-                !isPreset ? 'selected-surface' : ''
+        <Toggle
+          checked={minimizeToTray}
+          onChange={onMinimizeToTrayChange}
+          aria-label="Minimize to tray on close"
+        />
+      </div>
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <span className="settings-label">Launch delay between apps</span>
+          <span className="settings-sublabel">Wait time before starting the next app</span>
+        </div>
+        <div className="settings-control">
+          {DELAY_PRESETS.map((preset) => (
+            <button
+              key={preset.value}
+              onClick={() => onLaunchDelayMsChange(preset.value)}
+              className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
+                launchDelayMs === preset.value
+                  ? 'selected-surface text-(--text-primary)'
+                  : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
               }`}
             >
-              <svg
-                width="8"
-                height="8"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="ml-1 shrink-0 text-(--text-subtle) opacity-50"
-              >
-                <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-              </svg>
-              <input
-                type="number"
-                min="0"
-                max="30"
-                step="0.1"
-                value={Number.isFinite(launchDelayMs) ? launchDelayMs / 1000 : ''}
-                onChange={(e) => {
-                  const val = parseFloat(e.target.value)
-                  if (!isNaN(val)) {
-                    onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
-                  }
-                }}
-                className="w-full bg-transparent pl-1 text-right text-[11px] font-semibold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                placeholder="0.0"
-              />
-              <div className="mx-1 h-4 w-px bg-(--glass-border) opacity-35" />
-              <span className="pr-1 text-[9px] font-semibold text-(--text-muted) uppercase">s</span>
-            </div>
+              {preset.label}
+            </button>
+          ))}
+          <div
+            className={`settings-control-pill settings-control-pill-input settings-control-preset glass-surface action-hover-scale transition-all duration-200 ${
+              !isPreset ? 'selected-surface' : ''
+            }`}
+          >
+            <svg
+              width="8"
+              height="8"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="ml-1 shrink-0 text-(--text-subtle) opacity-50"
+            >
+              <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+            </svg>
+            <input
+              type="number"
+              min="0"
+              max="30"
+              step="0.1"
+              value={Number.isFinite(launchDelayMs) ? launchDelayMs / 1000 : ''}
+              onChange={(e) => {
+                const val = parseFloat(e.target.value)
+                if (!isNaN(val)) {
+                  onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
+                }
+              }}
+              className="w-full bg-transparent pl-1 text-right text-[11px] font-semibold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              placeholder="0.0"
+            />
+            <div className="mx-1 h-4 w-px bg-(--glass-border) opacity-35" />
+            <span className="pr-1 text-[9px] font-semibold text-(--text-muted) uppercase">s</span>
           </div>
         </div>
       </div>
-    </section>
+    </>
   )
 }

--- a/src/renderer/src/components/settings/ConfigSection.tsx
+++ b/src/renderer/src/components/settings/ConfigSection.tsx
@@ -4,67 +4,62 @@ export function ConfigSection() {
   const { exportingConfig, importingConfig, onExportConfig, onImportConfig } = useSettings()
 
   return (
-    <section className="space-y-4">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-(--accent) px-1">
-        Config
-      </h3>
-      <div className="glass-surface rounded-2xl p-5">
-        <div className="flex flex-col gap-5">
-          <div className="settings-label-group">
-            <span className="settings-label">Backup and migration</span>
-            <span className="settings-sublabel">
-              Export or replace the complete SimLauncher JSON config
-            </span>
-          </div>
+    <div className="p-5">
+      <div className="flex flex-col gap-5">
+        <div className="settings-label-group">
+          <span className="settings-label">Backup and migration</span>
+          <span className="settings-sublabel">
+            Export or replace the complete SimLauncher JSON config
+          </span>
+        </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <button
-              type="button"
-              onClick={onExportConfig}
-              disabled={exportingConfig || importingConfig}
-              className="accent-surface-action action-hover-scale flex cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold transition-all active:scale-[0.98]"
+        <div className="grid grid-cols-2 gap-4">
+          <button
+            type="button"
+            onClick={onExportConfig}
+            disabled={exportingConfig || importingConfig}
+            className="accent-surface-action action-hover-scale flex cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold transition-all active:scale-[0.98]"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              {exportingConfig ? 'Exporting...' : 'Export config'}
-            </button>
-            <button
-              type="button"
-              onClick={onImportConfig}
-              disabled={exportingConfig || importingConfig}
-              className="accent-surface-action action-hover-scale flex cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold transition-all active:scale-[0.98]"
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            {exportingConfig ? 'Exporting...' : 'Export config'}
+          </button>
+          <button
+            type="button"
+            onClick={onImportConfig}
+            disabled={exportingConfig || importingConfig}
+            className="accent-surface-action action-hover-scale flex cursor-pointer items-center justify-center gap-2 rounded-xl py-2.5 text-xs font-semibold transition-all active:scale-[0.98]"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="17 8 12 3 7 8" />
-                <line x1="12" y1="3" x2="12" y2="15" />
-              </svg>
-              {importingConfig ? 'Importing...' : 'Import config'}
-            </button>
-          </div>
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="17 8 12 3 7 8" />
+              <line x1="12" y1="3" x2="12" y2="15" />
+            </svg>
+            {importingConfig ? 'Importing...' : 'Import config'}
+          </button>
         </div>
       </div>
-    </section>
+    </div>
   )
 }

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -1,96 +1,61 @@
 import { GAMES } from '../../lib/config'
 import { useSettings } from './SettingsContext'
 
-interface GamesSectionProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}
-
-export function GamesSection({ open, onOpenChange }: GamesSectionProps) {
+export function GamesSection() {
   const { gamePaths, gameIcons, onBrowse, onGamePathChange } = useSettings()
 
   return (
-    <section className="space-y-4">
-      <button
-        type="button"
-        onClick={() => onOpenChange(!open)}
-        className="flex w-full cursor-pointer items-center gap-2 px-1"
-      >
-        <h3 className="flex-1 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
-          Games
-        </h3>
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={`text-(--text-subtle) transition-transform duration-300 ${open ? 'rotate-0' : '-rotate-90'}`}
+    <>
+      {GAMES.map((game, index) => (
+        <div
+          key={game.key}
+          className={`flex flex-col gap-2 px-5 py-3 ${index !== GAMES.length - 1 ? 'border-b border-(--header-glass-border)' : ''}`}
         >
-          <path d="M3 6l5 5 5-5" />
-        </svg>
-      </button>
-      <div
-        className={`grid transition-all duration-300 ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
-      >
-        <div className="overflow-hidden">
-          <div className="glass-surface rounded-2xl flex flex-col pt-1">
-            {GAMES.map((game, index) => (
-              <div
-                key={game.key}
-                className={`flex flex-col gap-2 px-5 py-3 ${index !== GAMES.length - 1 ? 'border-b border-(--header-glass-border)' : ''}`}
-              >
-                <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
-                  {game.name}
-                </div>
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
+            {game.name}
+          </div>
 
-                <div className="flex items-center gap-4">
-                  {gameIcons[game.key] ? (
-                    <img
-                      src={gameIcons[game.key]}
-                      alt={game.name}
-                      className="w-8 h-8 object-contain drop-shadow-md shrink-0"
-                    />
-                  ) : (
-                    <div className="w-8 h-8 rounded shrink-0 bg-(--glass-bg) border border-(--glass-border) flex items-center justify-center text-(--text-subtle)">
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <rect x="3" y="3" width="18" height="18" rx="2" />
-                      </svg>
-                    </div>
-                  )}
-
-                  <input
-                    type="text"
-                    value={gamePaths[game.key] || ''}
-                    onChange={(e) => onGamePathChange(game.key, e.target.value)}
-                    placeholder="No game path set"
-                    className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
-                  />
-
-                  <button
-                    onClick={() => onBrowse(game.key, true)}
-                    className="accent-surface-action action-hover-scale cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
-                  >
-                    Browse
-                  </button>
-                </div>
+          <div className="flex items-center gap-4">
+            {gameIcons[game.key] ? (
+              <img
+                src={gameIcons[game.key]}
+                alt={game.name}
+                className="w-8 h-8 object-contain drop-shadow-md shrink-0"
+              />
+            ) : (
+              <div className="w-8 h-8 rounded shrink-0 bg-(--glass-bg) border border-(--glass-border) flex items-center justify-center text-(--text-subtle)">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                </svg>
               </div>
-            ))}
+            )}
+
+            <input
+              type="text"
+              value={gamePaths[game.key] || ''}
+              onChange={(e) => onGamePathChange(game.key, e.target.value)}
+              placeholder="No game path set"
+              className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+            />
+
+            <button
+              onClick={() => onBrowse(game.key, true)}
+              className="accent-surface-action action-hover-scale cursor-pointer shrink-0 rounded-xl px-4 py-2 text-xs font-semibold"
+            >
+              Browse
+            </button>
           </div>
         </div>
-      </div>
-    </section>
+      ))}
+    </>
   )
 }

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -37,7 +37,7 @@ export function SettingsSection({ title, open, onOpenChange, children }: Setting
       <div
         className={`grid transition-all duration-300 ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
       >
-        <div className="overflow-hidden">
+        <div className={open ? undefined : 'overflow-hidden'} inert={open ? undefined : true}>
           <div className="glass-surface rounded-2xl flex flex-col pt-1">{children}</div>
         </div>
       </div>

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+interface SettingsSectionProps {
+  title: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: ReactNode
+}
+
+export function SettingsSection({ title, open, onOpenChange, children }: SettingsSectionProps) {
+  return (
+    <section className="space-y-4">
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        className="flex w-full cursor-pointer items-center gap-2 px-1"
+        aria-expanded={open}
+      >
+        <h3 className="flex-1 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
+          {title}
+        </h3>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-(--text-subtle) transition-transform duration-300 ${open ? 'rotate-0' : '-rotate-90'}`}
+          aria-hidden="true"
+        >
+          <path d="M3 6l5 5 5-5" />
+        </svg>
+      </button>
+      <div
+        className={`grid transition-all duration-300 ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
+      >
+        <div className="overflow-hidden">
+          <div className="glass-surface rounded-2xl flex flex-col pt-1">{children}</div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `SettingsSection.tsx` — controlled wrapper handling header, chevron, and `grid-rows` height transition
- Refactors all 6 settings sections (About, Appearance, Behavior, Config, Games, Apps) to use the shared wrapper
- Moves expanded/collapsed state to `SettingsView`, removing duplicated logic from individual section files

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)