### PR TITLE
Fix three post-merge review findings (#237, #238, #239)

### DIFF
--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -12,7 +12,7 @@ export function ProfileEditor(props: ProfileEditorProps) {
   if (editor.loading) return null
 
   return (
-    <div className="glass-surface-elevated animate-fade-slide overflow-hidden rounded-[20px] p-5">
+    <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5">
       <div className="mb-5">
         <h2 className="text-lg font-semibold text-(--text-primary)">Edit Profile</h2>
       </div>

--- a/src/renderer/src/components/settings/saveRace.ts
+++ b/src/renderer/src/components/settings/saveRace.ts
@@ -24,18 +24,11 @@ export function getSettingsObjectChangesDuringSave(
 }
 
 export function resolveSettingsObjectsAfterSave({
-  savedObjects,
-  latestObjects,
-  changedDuringSave
+  savedObjects
 }: {
   savedObjects: SettingsObjectRecords
   latestObjects: SettingsObjectRecords
   changedDuringSave: SettingsObjectChangeMap
 }): SettingsObjectRecords {
-  return Object.fromEntries(
-    SETTINGS_OBJECT_FIELDS.map((field) => [
-      field,
-      changedDuringSave[field] ? latestObjects[field] : savedObjects[field]
-    ])
-  ) as SettingsObjectRecords
+  return savedObjects
 }

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -73,27 +73,29 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const syncThemeFromStore = useCallback(async () => {
-    const settings = await getSettings()
-    const preset = settings.accentPreset || DEFAULT_ACCENT_COLOR
-    const custom = settings.accentCustom || ''
-    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
+    try {
+      const settings = await getSettings()
+      const preset = settings.accentPreset || DEFAULT_ACCENT_COLOR
+      const custom = settings.accentCustom || ''
+      const loadedThemeMode = normalizeThemeMode(settings.themeMode)
 
-    setAccentPresetState(preset)
-    setAccentCustomState(custom)
-    setAccentBgTintState(settings.accentBgTint || false)
-    setThemeModeState(loadedThemeMode)
-    applyThemeMode(loadedThemeMode)
-    applyAccent(preset, custom)
+      setAccentPresetState(preset)
+      setAccentCustomState(custom)
+      setAccentBgTintState(settings.accentBgTint || false)
+      setThemeModeState(loadedThemeMode)
+      applyThemeMode(loadedThemeMode)
+      applyAccent(preset, custom)
 
-    if (Number.isFinite(settings.zoomFactor)) {
-      setZoom(settings.zoomFactor)
+      if (Number.isFinite(settings.zoomFactor)) {
+        setZoom(settings.zoomFactor)
+      }
+    } catch (err) {
+      console.error('Failed to sync theme from store', err)
     }
   }, [applyAccent])
 
   useEffect(() => {
-    syncThemeFromStore().catch((err) => {
-      console.error('Failed to sync theme', err)
-    })
+    syncThemeFromStore()
   }, [syncThemeFromStore])
 
   const value = useMemo(

--- a/tests/settingsSaveRace.test.ts
+++ b/tests/settingsSaveRace.test.ts
@@ -22,7 +22,23 @@ const latestObjects: SettingsObjectRecords = {
   gamePaths: { ams2: 'D:\\Games\\AMS2.exe' }
 }
 
-test('settings save race resolution keeps app path edits made while save is in flight', () => {
+test('resolveSettingsObjectsAfterSave returns savedObjects as dirty baseline when nothing changed during save', () => {
+  const versionsAtSave = createSettingsObjectVersions()
+  const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, versionsAtSave)
+
+  const resolved = resolveSettingsObjectsAfterSave({
+    savedObjects,
+    latestObjects,
+    changedDuringSave
+  })
+
+  assert.deepEqual(resolved.appPaths, savedObjects.appPaths)
+  assert.deepEqual(resolved.appNames, savedObjects.appNames)
+  assert.deepEqual(resolved.appArgs, savedObjects.appArgs)
+  assert.deepEqual(resolved.gamePaths, savedObjects.gamePaths)
+})
+
+test('resolveSettingsObjectsAfterSave returns savedObjects as dirty baseline when app paths changed during save', () => {
   const versionsAtSave = createSettingsObjectVersions()
   const currentVersions = { ...versionsAtSave, appPaths: versionsAtSave.appPaths + 1 }
   const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
@@ -33,13 +49,13 @@ test('settings save race resolution keeps app path edits made while save is in f
     changedDuringSave
   })
 
-  assert.deepEqual(resolved.appPaths, latestObjects.appPaths)
+  assert.deepEqual(resolved.appPaths, savedObjects.appPaths)
   assert.deepEqual(resolved.appNames, savedObjects.appNames)
   assert.deepEqual(resolved.appArgs, savedObjects.appArgs)
   assert.deepEqual(resolved.gamePaths, savedObjects.gamePaths)
 })
 
-test('settings save race resolution keeps game path edits made while save is in flight', () => {
+test('resolveSettingsObjectsAfterSave returns savedObjects as dirty baseline when game paths changed during save', () => {
   const versionsAtSave = createSettingsObjectVersions()
   const currentVersions = { ...versionsAtSave, gamePaths: versionsAtSave.gamePaths + 1 }
   const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
@@ -50,13 +66,18 @@ test('settings save race resolution keeps game path edits made while save is in 
     changedDuringSave
   })
 
-  assert.deepEqual(resolved.gamePaths, latestObjects.gamePaths)
+  assert.deepEqual(resolved.gamePaths, savedObjects.gamePaths)
   assert.deepEqual(resolved.appPaths, savedObjects.appPaths)
 })
 
-test('settings save race resolution keeps app name edits made while save is in flight', () => {
+test('resolveSettingsObjectsAfterSave returns savedObjects as dirty baseline when all fields changed during save', () => {
   const versionsAtSave = createSettingsObjectVersions()
-  const currentVersions = { ...versionsAtSave, appNames: versionsAtSave.appNames + 1 }
+  const currentVersions = {
+    appPaths: versionsAtSave.appPaths + 1,
+    appNames: versionsAtSave.appNames + 1,
+    appArgs: versionsAtSave.appArgs + 1,
+    gamePaths: versionsAtSave.gamePaths + 1
+  }
   const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
 
   const resolved = resolveSettingsObjectsAfterSave({
@@ -65,21 +86,5 @@ test('settings save race resolution keeps app name edits made while save is in f
     changedDuringSave
   })
 
-  assert.deepEqual(resolved.appNames, latestObjects.appNames)
-  assert.deepEqual(resolved.appArgs, savedObjects.appArgs)
-})
-
-test('settings save race resolution keeps app argument edits made while save is in flight', () => {
-  const versionsAtSave = createSettingsObjectVersions()
-  const currentVersions = { ...versionsAtSave, appArgs: versionsAtSave.appArgs + 1 }
-  const changedDuringSave = getSettingsObjectChangesDuringSave(versionsAtSave, currentVersions)
-
-  const resolved = resolveSettingsObjectsAfterSave({
-    savedObjects,
-    latestObjects,
-    changedDuringSave
-  })
-
-  assert.deepEqual(resolved.appArgs, latestObjects.appArgs)
-  assert.deepEqual(resolved.appNames, savedObjects.appNames)
+  assert.deepEqual(resolved, savedObjects)
 })


### PR DESCRIPTION
## Summary
- **#237** — `syncThemeFromStore` wrapped in try/catch; IPC failures now log instead of producing unhandled rejections at call sites
- **#238** — `overflow-hidden` removed from `ProfileEditor` root so `ConfirmDialog` is no longer clipped by the `will-change: transform` CSS containing block
- **#239** — `resolveSettingsObjectsAfterSave` now always returns `savedObjects` as the dirty-tracking baseline; previously it returned the in-flight value for fields edited during save, causing `isDirty` to silently become `false` even when the store held a different value than the UI

All three were identified by Codex Connector in post-merge reviews of PRs #235, #216, and #217.

Closes #237, Closes #238, Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #237
Closes #238
Closes #239
<!-- auto-closes -->