### PR TITLE
style(notify): restore glassmorphism to toasts

### DIFF
--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -103,10 +103,10 @@ const TOAST_ICONS: Record<ToastType, ReactNode> = {
 
 const TOAST_STYLES: Record<ToastType, string> = {
   success:
-    'border-(--success-border) text-(--success-text) [--glass-surface-fill:var(--success-surface)]',
-  warn: 'border-(--warning-border) text-(--warning-text) [--glass-surface-fill:var(--warning-surface)]',
+    'border-(--success-border) text-(--success-text) [--glass-surface-fill:color-mix(in_srgb,var(--success-surface),var(--glass-bg-elevated))]',
+  warn: 'border-(--warning-border) text-(--warning-text) [--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]',
   error:
-    'border-(--danger-border) text-(--danger-text) [--glass-surface-fill:var(--danger-surface)]'
+    'border-(--danger-border) text-(--danger-text) [--glass-surface-fill:color-mix(in_srgb,var(--danger-surface),var(--glass-bg-elevated))]'
 }
 
 function ToastCard({
@@ -217,7 +217,7 @@ export function NotifyProvider({ children }: { children: ReactNode }) {
   }, [])
 
   useEffect(() => {
-    return onAppLaunchError((data) => {
+    return onAppLaunchError((data: unknown) => {
       notify(formatLaunchErrorToast(data), 'error', 5000)
     })
   }, [notify])


### PR DESCRIPTION
## Summary

Toast notifications were rendering with a solid semantic color fill, overriding the glassmorphism background and making the text hard to read against certain UI layers.

Fix: use `color-mix(in srgb, ...)` to blend each semantic surface color with `--glass-bg-elevated`, restoring the translucent glass effect while preserving the color-coded intent.

## Changes

- `Notify.tsx`: all three toast variants (success, warn, error) now use `color-mix` for `--glass-surface-fill` instead of a direct semantic surface override
- `Notify.tsx`: added `unknown` type annotation to `onAppLaunchError` callback (TypeScript cleanup)

## Test plan

- [x] Trigger a success toast (e.g. import config) — verify glass background visible, green tint present
- [x] Trigger a warning toast — verify glass + yellow tint
- [x] Trigger an error toast — verify glass + red tint
- [x] Check both light and dark mode

Refs #249