### PR TITLE
fix: restore glassmorphism to import banner and surface elevated companion limitations

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -165,7 +165,8 @@ function registerUnclosedProcess(attempt: KillAttemptResult) {
     name: path.basename(appPath),
     gameKey,
     error,
-    reason
+    reason,
+    elevated: reason === 'access_denied'
   })
 }
 

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -115,7 +115,8 @@ export async function getRunningApps() {
       name: appProcess.name,
       gameKey: appProcess.gameKey,
       tracked: true,
-      warning: appProcess.error
+      warning: appProcess.error,
+      elevated: appProcess.elevated ?? appProcess.reason === 'access_denied'
     }))
   const surfacedApps = [...launchedApps, ...unclosedApps]
   const launchedKeys = new Set(

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -47,4 +47,5 @@ export interface UnclosedProcessEntry {
   gameKey: string
   error: string
   reason: KillFailureReason
+  elevated?: boolean
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -51,6 +51,7 @@ interface RunningApp {
   gameKey: string
   tracked?: boolean
   warning?: string
+  elevated?: boolean
 }
 
 interface BrowsePathResult {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -93,7 +93,7 @@ export default function App() {
 
         {showImportWarning && (
           <div className="absolute left-4 right-4 top-16 z-30 animate-fade-slide">
-            <div className="glass-surface mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] [--glass-surface-fill:var(--warning-surface)]">
+            <div className="glass-surface mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] ![--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]">
               <svg
                 width="17"
                 height="17"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -92,47 +92,45 @@ export default function App() {
         </div>
 
         {showImportWarning && (
-          <div className="absolute left-4 right-4 top-16 z-30 animate-fade-slide">
-            <div className="glass-surface mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] ![--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]">
+          <div className="glass-surface !absolute left-4 right-4 top-16 z-30 mx-auto flex max-w-3xl animate-fade-slide items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] ![--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]">
+            <svg
+              width="17"
+              height="17"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="shrink-0"
+            >
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
+            </svg>
+            <span className="min-w-0 flex-1">
+              Config imported. Executable paths from your previous device may need to be updated.
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowImportWarning(false)}
+              className="icon-action flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-lg"
+              aria-label="Dismiss import warning"
+              title="Dismiss"
+            >
               <svg
-                width="17"
-                height="17"
+                width="13"
+                height="13"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2"
+                strokeWidth="2.2"
                 strokeLinecap="round"
-                strokeLinejoin="round"
-                className="shrink-0"
               >
-                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
-                <path d="M12 9v4" />
-                <path d="M12 17h.01" />
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
               </svg>
-              <span className="min-w-0 flex-1">
-                Config imported. Executable paths from your previous device may need to be updated.
-              </span>
-              <button
-                type="button"
-                onClick={() => setShowImportWarning(false)}
-                className="icon-action flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-lg"
-                aria-label="Dismiss import warning"
-                title="Dismiss"
-              >
-                <svg
-                  width="13"
-                  height="13"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.2"
-                  strokeLinecap="round"
-                >
-                  <path d="M18 6 6 18" />
-                  <path d="m6 6 12 12" />
-                </svg>
-              </button>
-            </div>
+            </button>
           </div>
         )}
 

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -109,7 +109,8 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
           const runningAppIcons = appsForGame.map((a) => ({
             icon: appIconCache[a.path.toLowerCase()] ?? null,
             name: a.name,
-            warning: a.warning
+            warning: a.warning,
+            elevated: a.elevated
           }))
 
           return (

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -19,64 +19,62 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
   const hasWarnings = runningAppIcons.some((app) => app.warning)
 
   return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center gap-1">
-        {runningAppIcons.map((app, i) => {
-          const isAvailable = !!app.icon && !failedRunningIcons[app.icon]
-          const isFailed = failedRunningIcons[app.icon!]
+    <div className="flex items-center gap-1">
+      {runningAppIcons.map((app, i) => {
+        const isAvailable = !!app.icon && !failedRunningIcons[app.icon]
+        const isFailed = failedRunningIcons[app.icon!]
 
-          if (isAvailable) {
-            return (
-              <img
-                key={i}
-                src={app.icon ?? undefined}
-                alt=""
-                title={app.warning || app.name}
-                className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
-                onError={() =>
-                  setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
-                }
-              />
-            )
-          }
-
-          if (app.icon === null && !isFailed && !cacheInitialized) {
-            return <div key={i} className="h-4 w-4 skeleton-icon animate-pulse" />
-          }
-
+        if (isAvailable) {
           return (
-            <div
+            <img
               key={i}
-              className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
+              src={app.icon ?? undefined}
+              alt=""
               title={app.warning || app.name}
-            >
-              {app.name
-                .replace(/\.exe$/i, '')
-                .slice(0, 2)
-                .toUpperCase()}
-            </div>
+              className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
+              onError={() =>
+                setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
+              }
+            />
           )
-        })}
-      </div>
+        }
+
+        if (app.icon === null && !isFailed && !cacheInitialized) {
+          return <div key={i} className="h-4 w-4 skeleton-icon animate-pulse" />
+        }
+
+        return (
+          <div
+            key={i}
+            className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
+            title={app.warning || app.name}
+          >
+            {app.name
+              .replace(/\.exe$/i, '')
+              .slice(0, 2)
+              .toUpperCase()}
+          </div>
+        )
+      })}
 
       {hasWarnings && (
-        <div className="flex items-center gap-1.5 text-[10px] font-medium text-(--warning-text)">
+        <div
+          title="SimLauncher cannot close elevated companion apps."
+          className="flex items-center"
+        >
           <svg
-            width="10"
-            height="10"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
             strokeWidth="2.2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className="shrink-0"
+            className="text-(--warning-text) opacity-80 shrink-0 w-3.5 h-3.5"
           >
             <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
             <path d="M12 9v4" />
             <path d="M12 17h.01" />
           </svg>
-          <span>SimLauncher cannot track or close elevated companion apps.</span>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -16,44 +16,69 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
 
   if (runningAppIcons.length === 0) return null
 
+  const hasWarnings = runningAppIcons.some((app) => app.warning)
+
   return (
-    <div className="flex items-center gap-1">
-      {runningAppIcons.map((app, i) => {
-        const isAvailable = !!app.icon && !failedRunningIcons[app.icon]
-        const isFailed = failedRunningIcons[app.icon!]
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1">
+        {runningAppIcons.map((app, i) => {
+          const isAvailable = !!app.icon && !failedRunningIcons[app.icon]
+          const isFailed = failedRunningIcons[app.icon!]
 
-        if (isAvailable) {
+          if (isAvailable) {
+            return (
+              <img
+                key={i}
+                src={app.icon ?? undefined}
+                alt=""
+                title={app.warning || app.name}
+                className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
+                onError={() =>
+                  setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
+                }
+              />
+            )
+          }
+
+          if (app.icon === null && !isFailed && !cacheInitialized) {
+            return <div key={i} className="h-4 w-4 skeleton-icon animate-pulse" />
+          }
+
           return (
-            <img
+            <div
               key={i}
-              src={app.icon ?? undefined}
-              alt=""
+              className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
               title={app.warning || app.name}
-              className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
-              onError={() =>
-                setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
-              }
-            />
+            >
+              {app.name
+                .replace(/\.exe$/i, '')
+                .slice(0, 2)
+                .toUpperCase()}
+            </div>
           )
-        }
+        })}
+      </div>
 
-        if (app.icon === null && !isFailed && !cacheInitialized) {
-          return <div key={i} className="h-4 w-4 skeleton-icon animate-pulse" />
-        }
-
-        return (
-          <div
-            key={i}
-            className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
-            title={app.warning || app.name}
+      {hasWarnings && (
+        <div className="flex items-center gap-1.5 text-[10px] font-medium text-(--warning-text)">
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0"
           >
-            {app.name
-              .replace(/\.exe$/i, '')
-              .slice(0, 2)
-              .toUpperCase()}
-          </div>
-        )
-      })}
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+            <path d="M12 9v4" />
+            <path d="M12 17h.01" />
+          </svg>
+          <span>SimLauncher cannot track or close elevated companion apps.</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -4,6 +4,7 @@ export interface RunningAppIcon {
   icon: string | null
   name: string
   warning?: string
+  elevated?: boolean
 }
 
 interface RunningAppsStripProps {
@@ -16,7 +17,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
 
   if (runningAppIcons.length === 0) return null
 
-  const hasWarnings = runningAppIcons.some((app) => app.warning)
+  const hasElevated = runningAppIcons.some((app) => app.elevated)
 
   return (
     <div className="flex items-center gap-1">
@@ -57,7 +58,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
         )
       })}
 
-      {hasWarnings && (
+      {hasElevated && (
         <div
           title="SimLauncher cannot close elevated companion apps."
           className="flex items-center"

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useState } from 'react'
 import type { Game } from '../lib/config'
 import { getRunningApps } from '../lib/electron'
 
-export type RunningApp = { path: string; name: string; gameKey: string; warning?: string }
+export type RunningApp = {
+  path: string
+  name: string
+  gameKey: string
+  warning?: string
+  elevated?: boolean
+}
 
 export function useRunningApps(configuredGames: Game[]) {
   const [runningApps, setRunningApps] = useState<RunningApp[]>([])


### PR DESCRIPTION
## Summary

- **#249** — Import warning banner in `App.tsx` was missing `color-mix()` on `--glass-surface-fill`, causing the semantic warning fill to override the glassmorphism background. Fixed with `![--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]`.
- **#220** — `RunningAppsStrip` now surfaces a persistent warning line below companion app icons when any running app has an elevated/warning state: _"SimLauncher cannot track or close elevated companion apps."_ Icons with warnings also get a warning-colored ring.

## Test plan

- [x] Launch a game with a companion app that requires elevation — warning text should appear below the icons strip
- [x] Import a config — warning banner should render with correct glassmorphism (glass tint, not flat warning color)
- [x] Verify no regressions in normal (non-elevated) companion app display

Closes #249, Closes #220