### PR TITLE
feat: IPC push for running apps + config import preview

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -1,4 +1,5 @@
-import { app, dialog, ipcMain } from 'electron'
+import { app, dialog, ipcMain, type OpenDialogOptions } from 'electron'
+import crypto from 'crypto'
 import fs from 'fs'
 
 import { migrateProfilesToNamedSets } from '../migrator'
@@ -17,6 +18,31 @@ import { isRecord } from '../utils'
 import { applyRuntimeConfigSettings, getMainWindow, sendToRenderer } from '../window'
 
 const STORE_CONFIG_CHANGED_CHANNEL = 'store-config-changed'
+const IMPORT_PREVIEW_TOKEN_BYTES = 24
+const IMPORT_PREVIEW_TTL_MS = 5 * 60 * 1000
+
+interface ConfigImportPreviewEntry {
+  key: string
+  path?: string
+  args?: string
+}
+
+interface ConfigImportPreviewSummary {
+  changedKeys: string[]
+  gamePaths: ConfigImportPreviewEntry[]
+  appPaths: ConfigImportPreviewEntry[]
+  trackedProcessPaths: ConfigImportPreviewEntry[]
+  customAppArgs: ConfigImportPreviewEntry[]
+  droppedCount: number
+  warnings: string[]
+}
+
+let pendingImport: {
+  token: string
+  filePath: string
+  config: Record<string, unknown>
+  expiresAt: number
+} | null = null
 
 type StoreConfigChangeReason =
   | 'import-config'
@@ -32,6 +58,143 @@ interface StoreConfigChangePayload {
 
 function notifyStoreConfigChanged(payload: StoreConfigChangePayload) {
   sendToRenderer(STORE_CONFIG_CHANGED_CHANNEL, payload)
+}
+
+function clearPendingImport() {
+  pendingImport = null
+}
+
+function countImportedPreviewItems(config: Record<string, unknown>) {
+  let count = 0
+  const countRecordItems = (value: unknown) => {
+    if (isRecord(value)) count += Object.keys(value).length
+  }
+
+  countRecordItems(config.gamePaths)
+  countRecordItems(config.appPaths)
+  countRecordItems(config.appArgs)
+
+  if (isRecord(config.profiles)) {
+    Object.values(config.profiles).forEach((profileEntry) => {
+      if (!isRecord(profileEntry)) return
+
+      if (Array.isArray(profileEntry.trackedProcessPaths)) {
+        count += profileEntry.trackedProcessPaths.length
+      }
+
+      if (Array.isArray(profileEntry.profiles)) {
+        profileEntry.profiles.forEach((profile) => {
+          if (isRecord(profile) && Array.isArray(profile.trackedProcessPaths)) {
+            count += profile.trackedProcessPaths.length
+          }
+        })
+      }
+    })
+  }
+
+  return count
+}
+
+function collectTrackedProcessPathPreviews(profiles: unknown): ConfigImportPreviewEntry[] {
+  if (!isRecord(profiles)) return []
+
+  const entries: ConfigImportPreviewEntry[] = []
+  Object.entries(profiles).forEach(([gameKey, profileEntry]) => {
+    if (!isRecord(profileEntry)) return
+
+    const addPaths = (paths: unknown, suffix = '') => {
+      if (!Array.isArray(paths)) return
+      paths.forEach((path) => {
+        if (typeof path === 'string') entries.push({ key: `${gameKey}${suffix}`, path })
+      })
+    }
+
+    addPaths(profileEntry.trackedProcessPaths)
+
+    if (Array.isArray(profileEntry.profiles)) {
+      profileEntry.profiles.forEach((profile) => {
+        if (!isRecord(profile)) return
+        const profileName = typeof profile.name === 'string' ? `/${profile.name}` : ''
+        addPaths(profile.trackedProcessPaths, profileName)
+      })
+    }
+  })
+
+  return entries
+}
+
+export function buildImportPreviewSummary(
+  rawConfig: Record<string, unknown>,
+  supportedConfig: Record<string, unknown>
+): ConfigImportPreviewSummary {
+  const gamePaths = isRecord(supportedConfig.gamePaths)
+    ? Object.entries(supportedConfig.gamePaths).flatMap(([key, path]) =>
+        typeof path === 'string' ? [{ key, path }] : []
+      )
+    : []
+  const appPaths = isRecord(supportedConfig.appPaths)
+    ? Object.entries(supportedConfig.appPaths).flatMap(([key, path]) =>
+        typeof path === 'string' ? [{ key, path }] : []
+      )
+    : []
+  const customAppArgs = isRecord(supportedConfig.appArgs)
+    ? Object.entries(supportedConfig.appArgs).flatMap(([key, args]) =>
+        typeof args === 'string' ? [{ key, args }] : []
+      )
+    : []
+  const trackedProcessPaths = collectTrackedProcessPathPreviews(supportedConfig.profiles)
+  const previewItemCount =
+    gamePaths.length + appPaths.length + customAppArgs.length + trackedProcessPaths.length
+  const droppedCount = Math.max(0, countImportedPreviewItems(rawConfig) - previewItemCount)
+  const warnings =
+    droppedCount > 0
+      ? [`${droppedCount} unsupported or invalid path/argument entries were dropped.`]
+      : []
+
+  return {
+    changedKeys: Object.keys(supportedConfig).sort(),
+    gamePaths,
+    appPaths,
+    trackedProcessPaths,
+    customAppArgs,
+    droppedCount,
+    warnings
+  }
+}
+
+async function readAndSanitizeConfig(filePath: string) {
+  const stat = await fs.promises.stat(filePath)
+
+  if (stat.size > MAX_CONFIG_IMPORT_BYTES) {
+    throw new Error('Config file exceeds the 1 MB size limit.')
+  }
+
+  const rawConfig = await fs.promises.readFile(filePath, 'utf8')
+  const parsedConfig: unknown = JSON.parse(rawConfig)
+  const supportedConfig = sanitizeImportedConfig(parsedConfig)
+  const summary = buildImportPreviewSummary(
+    parsedConfig as Record<string, unknown>,
+    supportedConfig
+  )
+
+  return { supportedConfig, summary }
+}
+
+function applySanitizedConfig(supportedConfig: Record<string, unknown>) {
+  const snapshot = { ...store.store }
+
+  try {
+    store.clear()
+    store.set(supportedConfig)
+    migrateProfilesToNamedSets()
+    applyRuntimeConfigSettings()
+    notifyStoreConfigChanged({ reason: 'import-config', keys: ['*'] })
+  } catch (err) {
+    store.clear()
+    store.set(snapshot as Record<string, unknown>)
+    applyRuntimeConfigSettings()
+    throw err
+  }
 }
 
 export function registerConfigHandlers() {
@@ -66,9 +229,9 @@ export function registerConfigHandlers() {
 
   ipcMain.handle('import-config', async () => {
     try {
-      const options = {
+      const options: OpenDialogOptions = {
         title: 'Import SimLauncher Config',
-        properties: ['openFile'] as const,
+        properties: ['openFile'],
         filters: [{ name: 'JSON Files', extensions: ['json'] }]
       }
       const mainWindow = getMainWindow()
@@ -81,29 +244,8 @@ export function registerConfigHandlers() {
       }
 
       const filePath = result.filePaths[0]
-      const stat = await fs.promises.stat(filePath)
-
-      if (stat.size > MAX_CONFIG_IMPORT_BYTES) {
-        return { success: false, error: 'Config file exceeds the 1 MB size limit.' }
-      }
-
-      const rawConfig = await fs.promises.readFile(filePath, 'utf8')
-      const parsedConfig: unknown = JSON.parse(rawConfig)
-      const supportedConfig = sanitizeImportedConfig(parsedConfig)
-      const snapshot = { ...store.store }
-
-      try {
-        store.clear()
-        store.set(supportedConfig)
-        migrateProfilesToNamedSets()
-        applyRuntimeConfigSettings()
-        notifyStoreConfigChanged({ reason: 'import-config', keys: ['*'] })
-      } catch (err) {
-        store.clear()
-        store.set(snapshot)
-        applyRuntimeConfigSettings()
-        throw err
-      }
+      const { supportedConfig } = await readAndSanitizeConfig(filePath)
+      applySanitizedConfig(supportedConfig)
 
       return { success: true, filePath }
     } catch (err) {
@@ -111,6 +253,74 @@ export function registerConfigHandlers() {
       console.error('Failed to import config:', err)
       return { success: false, error: message }
     }
+  })
+
+  ipcMain.handle('preview-import-config', async () => {
+    try {
+      clearPendingImport()
+      const options: OpenDialogOptions = {
+        title: 'Import SimLauncher Config',
+        properties: ['openFile'],
+        filters: [{ name: 'JSON Files', extensions: ['json'] }]
+      }
+      const mainWindow = getMainWindow()
+      const result = mainWindow
+        ? await dialog.showOpenDialog(mainWindow, options)
+        : await dialog.showOpenDialog(options)
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { success: false, canceled: true }
+      }
+
+      const filePath = result.filePaths[0]
+      const { supportedConfig, summary } = await readAndSanitizeConfig(filePath)
+      const token = crypto.randomBytes(IMPORT_PREVIEW_TOKEN_BYTES).toString('base64url')
+      pendingImport = {
+        token,
+        filePath,
+        config: supportedConfig,
+        expiresAt: Date.now() + IMPORT_PREVIEW_TTL_MS
+      }
+
+      return { success: true, token, filePath, summary }
+    } catch (err) {
+      clearPendingImport()
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('Failed to preview config import:', err)
+      return { success: false, error: message }
+    }
+  })
+
+  ipcMain.handle('apply-import-config', async (_event, token: unknown) => {
+    try {
+      if (typeof token !== 'string' || !pendingImport || pendingImport.token !== token) {
+        return { success: false, error: 'Import preview expired or is no longer valid.' }
+      }
+
+      if (Date.now() > pendingImport.expiresAt) {
+        clearPendingImport()
+        return { success: false, error: 'Import preview expired. Please choose the config again.' }
+      }
+
+      const { filePath, config } = pendingImport
+      clearPendingImport()
+      applySanitizedConfig(config)
+
+      return { success: true, filePath }
+    } catch (err) {
+      clearPendingImport()
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('Failed to apply config import:', err)
+      return { success: false, error: message }
+    }
+  })
+
+  ipcMain.handle('cancel-import-config', async (_event, token: unknown) => {
+    if (typeof token === 'string' && pendingImport?.token === token) {
+      clearPendingImport()
+    }
+
+    return { success: true }
   })
 
   ipcMain.handle('get-version', () => {

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -8,7 +8,10 @@ import {
   killLaunchedApps,
   killProfileApps,
   launchProfileApps,
-  readRunningProcessNames
+  publishRunningApps,
+  readRunningProcessNames,
+  subscribeRunningApps,
+  unsubscribeRunningApps
 } from '../processes'
 import { store } from '../store'
 import { getExeName } from '../utils'
@@ -21,7 +24,9 @@ export function registerLaunchHandlers() {
       return { success: false, error: 'No executable paths configured for this profile.' }
     }
 
-    return launchProfileApps(event.sender, gameKey, profileApps)
+    const result = await launchProfileApps(event.sender, gameKey, profileApps)
+    await publishRunningApps('launch')
+    return result
   })
 
   ipcMain.handle('relaunch-missing-profile', async (event, gameKey: string) => {
@@ -43,7 +48,9 @@ export function registerLaunchHandlers() {
       }
     }
 
-    return launchProfileApps(event.sender, gameKey, missingPaths)
+    const result = await launchProfileApps(event.sender, gameKey, missingPaths)
+    await publishRunningApps('launch')
+    return result
   })
 
   ipcMain.handle(
@@ -93,6 +100,7 @@ export function registerLaunchHandlers() {
 
       if (pathsToStop.length > 0) {
         killResult = await killProfileApps(gameKey, pathsToStop)
+        await publishRunningApps('kill')
       }
 
       const processNamesAfterStop = await readRunningProcessNames()
@@ -110,6 +118,7 @@ export function registerLaunchHandlers() {
       }
 
       const launchResult = await launchProfileApps(event.sender, gameKey, pathsToStart)
+      await publishRunningApps('launch')
 
       return {
         ...launchResult,
@@ -123,7 +132,17 @@ export function registerLaunchHandlers() {
     return getRunningApps()
   })
 
-  ipcMain.handle('kill-launched-apps', (_event, gameKey?: string) => {
-    return killLaunchedApps(gameKey)
+  ipcMain.handle('subscribe-running-apps', async (event) => {
+    return subscribeRunningApps(event.sender)
+  })
+
+  ipcMain.handle('unsubscribe-running-apps', (event) => {
+    unsubscribeRunningApps(event.sender)
+  })
+
+  ipcMain.handle('kill-launched-apps', async (_event, gameKey?: string) => {
+    const result = await killLaunchedApps(gameKey)
+    await publishRunningApps('kill')
+    return result
   })
 }

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -1,5 +1,11 @@
 export { killLaunchedApps, killProfileApps } from './processes/kill'
-export { getRunningApps } from './processes/running'
+export {
+  getRunningApps,
+  publishRunningApps,
+  subscribeRunningApps,
+  unsubscribeRunningApps
+} from './processes/running'
 export { launchProfileApps, isRunningExePath } from './processes/spawn'
 export { readRunningProcessNames } from './processes/tasklist'
+export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'
 export type { KillFailure, KillFailureReason, KillResult, LaunchResult } from './processes/types'

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import type { WebContents } from 'electron'
 
 import { StoredProfileEntry, getActiveStoredProfile, getProfileTrackablePaths } from '../profiles'
 import { store } from '../store'
@@ -7,6 +8,29 @@ import { getExeName, isValidExePath } from '../utils'
 import { pruneUnclosedProcesses } from './kill'
 import { pruneStoppedRunningProcesses, runningProcesses, unclosedProcesses } from './state'
 import { readRunningProcessNames } from './tasklist'
+
+export interface RunningApp {
+  path: string
+  name: string
+  gameKey: string
+  tracked: boolean
+  warning?: string
+  elevated?: boolean
+}
+export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | 'config' | 'scan'
+
+export interface RunningAppsChangedPayload {
+  apps: RunningApp[]
+  reason: RunningAppsChangeReason
+  updatedAt: number
+}
+
+const RUNNING_APPS_CHANGED_CHANNEL = 'running-apps-changed'
+const RUNNING_APPS_SCAN_INTERVAL_MS = 2000
+const runningAppsSubscribers = new Set<WebContents>()
+let runningAppsMonitor: ReturnType<typeof setInterval> | undefined
+let lastRunningAppsSnapshot = ''
+let publishRunningAppsPromise: Promise<RunningAppsChangedPayload | null> | undefined
 
 function getExternallyAdoptableGameKeys(
   processNames: Set<string>,
@@ -97,7 +121,7 @@ async function getTrackedRunningApps(
   return trackedApps
 }
 
-export async function getRunningApps() {
+export async function getRunningApps(): Promise<RunningApp[]> {
   const processNames = await readRunningProcessNames()
   pruneStoppedRunningProcesses(processNames)
   pruneUnclosedProcesses(processNames)
@@ -151,4 +175,95 @@ export async function getRunningApps() {
   )
 
   return [...surfacedApps, ...trackedApps]
+}
+
+function normalizeRunningAppsSnapshot(apps: RunningApp[]) {
+  return JSON.stringify(
+    apps.map((app) => ({
+      elevated: app.elevated ?? false,
+      gameKey: app.gameKey,
+      name: app.name,
+      path: app.path,
+      tracked: app.tracked ?? false,
+      warning: app.warning ?? ''
+    }))
+  )
+}
+
+function removeRunningAppsSubscriber(webContents: WebContents) {
+  runningAppsSubscribers.delete(webContents)
+
+  if (runningAppsSubscribers.size === 0 && runningAppsMonitor) {
+    clearInterval(runningAppsMonitor)
+    runningAppsMonitor = undefined
+    lastRunningAppsSnapshot = ''
+  }
+}
+
+function emitRunningAppsChanged(payload: RunningAppsChangedPayload) {
+  runningAppsSubscribers.forEach((webContents) => {
+    if (webContents.isDestroyed()) {
+      removeRunningAppsSubscriber(webContents)
+      return
+    }
+
+    webContents.send(RUNNING_APPS_CHANGED_CHANNEL, payload)
+  })
+}
+
+async function publishRunningAppsInternal(
+  reason: RunningAppsChangeReason
+): Promise<RunningAppsChangedPayload | null> {
+  if (runningAppsSubscribers.size === 0) {
+    return null
+  }
+
+  const apps = await getRunningApps()
+  const snapshot = normalizeRunningAppsSnapshot(apps)
+
+  if (snapshot === lastRunningAppsSnapshot && reason === 'scan') {
+    return null
+  }
+
+  lastRunningAppsSnapshot = snapshot
+  const payload = { apps, reason, updatedAt: Date.now() }
+  emitRunningAppsChanged(payload)
+  return payload
+}
+
+export function publishRunningApps(reason: RunningAppsChangeReason = 'scan') {
+  publishRunningAppsPromise = (publishRunningAppsPromise || Promise.resolve(null))
+    .catch(() => null)
+    .then(() => publishRunningAppsInternal(reason))
+    .finally(() => {
+      publishRunningAppsPromise = undefined
+    })
+
+  return publishRunningAppsPromise
+}
+
+function startRunningAppsMonitor() {
+  if (runningAppsMonitor) {
+    return
+  }
+
+  runningAppsMonitor = setInterval(() => {
+    publishRunningApps('scan').catch((err) => {
+      console.error('Running apps monitor error:', err)
+    })
+  }, RUNNING_APPS_SCAN_INTERVAL_MS)
+}
+
+export async function subscribeRunningApps(webContents: WebContents) {
+  runningAppsSubscribers.add(webContents)
+  webContents.once('destroyed', () => removeRunningAppsSubscriber(webContents))
+  startRunningAppsMonitor()
+
+  const apps = await getRunningApps()
+  lastRunningAppsSnapshot = normalizeRunningAppsSnapshot(apps)
+  return { apps, reason: 'initial', updatedAt: Date.now() } satisfies RunningAppsChangedPayload
+}
+
+export function unsubscribeRunningApps(webContents: WebContents) {
+  removeRunningAppsSubscriber(webContents)
 }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -9,6 +9,7 @@ import { getErrorCode, getErrorMessage, getExeName, isValidExePath, wait } from 
 import { runningProcesses } from './state'
 import { readRunningProcessNames } from './tasklist'
 import type { AppLaunchResult, LaunchResult } from './types'
+import { publishRunningApps } from './running'
 
 const activeLaunches = new Set<string>()
 const POST_LAUNCH_BLOCK_MS = 10000
@@ -275,6 +276,9 @@ function spawnDetachedApp(
 
       child.once('spawn', () => {
         child.unref()
+        publishRunningApps('launch').catch((err) => {
+          console.error('Failed to publish running apps after launch:', err)
+        })
         resolveOnce({ status: 'launched', appPath })
       })
 
@@ -301,6 +305,9 @@ function spawnDetachedApp(
 
       child.once('exit', () => {
         runningProcesses.delete(appPath)
+        publishRunningApps('exit').catch((err) => {
+          console.error('Failed to publish running apps after exit:', err)
+        })
       })
 
       fallbackTimer = setTimeout(() => resolveOnce({ status: 'launched', appPath }), 500)

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -50,6 +50,14 @@ export interface RunningApp {
   elevated?: boolean
 }
 
+export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | 'config' | 'scan'
+
+export interface RunningAppsChangedPayload {
+  apps: RunningApp[]
+  reason: RunningAppsChangeReason
+  updatedAt: number
+}
+
 export interface BrowsePathResult {
   filePath: string | null
   inputId: string
@@ -91,6 +99,27 @@ export interface ConfigFileResult {
   filePath?: string
 }
 
+export interface ConfigImportPreviewEntry {
+  key: string
+  path?: string
+  args?: string
+}
+
+export interface ConfigImportPreviewSummary {
+  changedKeys: string[]
+  gamePaths: ConfigImportPreviewEntry[]
+  appPaths: ConfigImportPreviewEntry[]
+  trackedProcessPaths: ConfigImportPreviewEntry[]
+  customAppArgs: ConfigImportPreviewEntry[]
+  droppedCount: number
+  warnings: string[]
+}
+
+export interface ConfigImportPreviewResult extends ConfigFileResult {
+  token?: string
+  summary?: ConfigImportPreviewSummary
+}
+
 export interface UpdateAvailability {
   version: string
 }
@@ -115,6 +144,9 @@ export interface ElectronAPI {
   close: () => Promise<void>
   restartApp: () => Promise<void>
   getRunningApps: () => Promise<RunningApp[]>
+  subscribeRunningApps: () => Promise<RunningAppsChangedPayload>
+  unsubscribeRunningApps: () => Promise<void>
+  onRunningAppsChanged: (cb: (payload: RunningAppsChangedPayload) => void) => Unsubscribe
   killLaunchedApps: (gameKey?: string) => Promise<KillResult>
   onUpdateAvailable: (cb: (info: UpdateInfo) => void) => Unsubscribe
   onUpdateDownloaded: (cb: (info: UpdateInfo) => void) => Unsubscribe
@@ -134,6 +166,9 @@ export interface ElectronAPI {
   onStoreConfigChanged: (cb: (payload: StoreConfigChangePayload) => void) => Unsubscribe
   exportConfig: () => Promise<ConfigFileResult>
   importConfig: () => Promise<ConfigFileResult>
+  previewImportConfig: () => Promise<ConfigImportPreviewResult>
+  applyImportConfig: (token: string) => Promise<ConfigFileResult>
+  cancelImportConfig: (token: string) => Promise<ConfigFileResult>
   setLoginItem: (openAtLogin: boolean) => Promise<void>
   setZoom: (factor: number) => Promise<void>
   getAssetData: (filename: string) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { ProgressInfo, UpdateInfo } from 'electron-updater'
-import type { ElectronAPI } from './api'
+import type { ElectronAPI, RunningAppsChangedPayload, StoreConfigChangePayload } from './api'
 
 const electronAPI: ElectronAPI = {
   // launch
@@ -26,6 +26,13 @@ const electronAPI: ElectronAPI = {
 
   // process monitoring
   getRunningApps: () => ipcRenderer.invoke('get-running-apps'),
+  subscribeRunningApps: () => ipcRenderer.invoke('subscribe-running-apps'),
+  unsubscribeRunningApps: () => ipcRenderer.invoke('unsubscribe-running-apps'),
+  onRunningAppsChanged: (cb: (payload: RunningAppsChangedPayload) => void) => {
+    const handler = (_: unknown, payload: RunningAppsChangedPayload) => cb(payload)
+    ipcRenderer.on('running-apps-changed', handler)
+    return () => ipcRenderer.removeListener('running-apps-changed', handler)
+  },
   killLaunchedApps: (gameKey?: string) => ipcRenderer.invoke('kill-launched-apps', gameKey),
 
   // updater
@@ -71,13 +78,16 @@ const electronAPI: ElectronAPI = {
   saveProfiles: (profiles: unknown) => ipcRenderer.invoke('save-profiles', profiles),
   getMigrationFlags: () => ipcRenderer.invoke('get-migration-flags'),
   setMigrationFlags: (patch: unknown) => ipcRenderer.invoke('set-migration-flags', patch),
-  onStoreConfigChanged: (cb: (payload: unknown) => void) => {
-    const handler = (_: unknown, payload: unknown) => cb(payload)
+  onStoreConfigChanged: (cb: (payload: StoreConfigChangePayload) => void) => {
+    const handler = (_: unknown, payload: StoreConfigChangePayload) => cb(payload)
     ipcRenderer.on('store-config-changed', handler)
     return () => ipcRenderer.removeListener('store-config-changed', handler)
   },
   exportConfig: () => ipcRenderer.invoke('export-config'),
   importConfig: () => ipcRenderer.invoke('import-config'),
+  previewImportConfig: () => ipcRenderer.invoke('preview-import-config'),
+  applyImportConfig: (token: string) => ipcRenderer.invoke('apply-import-config', token),
+  cancelImportConfig: (token: string) => ipcRenderer.invoke('cancel-import-config', token),
   getAssetData: (filename: string) => ipcRenderer.invoke('get-asset-data', filename),
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
   getVersion: () => ipcRenderer.invoke('get-version')

--- a/src/renderer/src/components/settings/ImportPreviewDialog.tsx
+++ b/src/renderer/src/components/settings/ImportPreviewDialog.tsx
@@ -1,0 +1,124 @@
+export interface ConfigImportPreviewSummary {
+  changedKeys: string[]
+  gamePaths: Array<{ key: string; path?: string; args?: string }>
+  appPaths: Array<{ key: string; path?: string; args?: string }>
+  trackedProcessPaths: Array<{ key: string; path?: string; args?: string }>
+  customAppArgs: Array<{ key: string; path?: string; args?: string }>
+  droppedCount: number
+  warnings: string[]
+}
+
+interface ImportPreviewDialogProps {
+  isOpen: boolean
+  filePath?: string
+  summary?: ConfigImportPreviewSummary
+  onImport: () => void
+  onCancel: () => void
+}
+
+function PreviewSection({
+  title,
+  items,
+  valueKey
+}: {
+  title: string
+  items: Array<{ key: string; path?: string; args?: string }>
+  valueKey: 'path' | 'args'
+}) {
+  if (items.length === 0) return null
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-(--text-muted)">{title}</h3>
+      <ul className="max-h-28 space-y-1 overflow-auto rounded-xl bg-black/20 p-3 text-xs">
+        {items.map((item, index) => (
+          <li key={`${title}-${item.key}-${index}`} className="grid gap-1">
+            <span className="font-semibold text-(--text-secondary)">{item.key}</span>
+            <code className="break-all rounded-lg bg-black/20 px-2 py-1 text-(--text-primary)">
+              {item[valueKey]}
+            </code>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export function ImportPreviewDialog({
+  isOpen,
+  filePath,
+  summary,
+  onImport,
+  onCancel
+}: ImportPreviewDialogProps) {
+  if (!isOpen || !summary) return null
+
+  const previewCount =
+    summary.gamePaths.length +
+    summary.appPaths.length +
+    summary.trackedProcessPaths.length +
+    summary.customAppArgs.length
+
+  return (
+    <div className="fixed inset-0 z-100 flex items-center justify-center p-4 backdrop-blur-md">
+      <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
+
+      <div className="glass-surface-elevated animate-fade-slide relative w-full max-w-2xl rounded-[24px] p-6 shadow-[0_20px_50px_rgba(0,0,0,0.5)] isolation-auto">
+        <h2 className="mb-2 text-lg font-bold text-(--text-primary)">Trust Imported Config</h2>
+        <p className="mb-4 text-sm leading-relaxed text-(--text-secondary)">
+          Review executable paths and custom arguments before replacing your current settings.
+        </p>
+
+        {filePath ? <p className="mb-4 break-all text-xs text-(--text-muted)">{filePath}</p> : null}
+
+        <div className="mb-4 grid gap-2 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-(--text-secondary)">
+          <span>{summary.changedKeys.length} settings keys will be imported.</span>
+          <span>{previewCount} executable path or custom argument entries require trust.</span>
+          {summary.droppedCount > 0 ? (
+            <span>{summary.droppedCount} invalid entries were dropped.</span>
+          ) : null}
+        </div>
+
+        <div className="mb-6 grid max-h-[50vh] gap-4 overflow-auto pr-1">
+          <PreviewSection title="Game executable paths" items={summary.gamePaths} valueKey="path" />
+          <PreviewSection title="App executable paths" items={summary.appPaths} valueKey="path" />
+          <PreviewSection
+            title="Tracked process paths"
+            items={summary.trackedProcessPaths}
+            valueKey="path"
+          />
+          <PreviewSection
+            title="Custom app arguments"
+            items={summary.customAppArgs}
+            valueKey="args"
+          />
+
+          {summary.warnings.length > 0 ? (
+            <ul className="space-y-1 rounded-xl border border-yellow-400/20 bg-yellow-400/10 p-3 text-xs text-yellow-100">
+              {summary.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onImport}
+            className="danger-action action-hover-scale flex-1 cursor-pointer rounded-xl py-3 text-sm font-bold"
+          >
+            Trust and Import
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="neutral-action action-hover-scale flex-1 cursor-pointer rounded-xl py-3 text-sm font-semibold"
+          >
+            Cancel Import
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -22,11 +22,13 @@ import {
 } from '../../lib/config'
 import { browsePath, getAssetData, getFileIcon, setLoginItem, setZoom } from '../../lib/electron'
 import {
+  applyImportConfig,
+  cancelImportConfig,
   exportConfig,
   getProfiles,
   getSettings,
-  importConfig,
   onStoreConfigChanged,
+  previewImportConfig,
   saveProfiles,
   saveSettings as persistSettings
 } from '../../lib/store'
@@ -43,6 +45,13 @@ import {
   type SettingsObjectRecords
 } from './saveRace'
 import { normalizeLaunchDelayMs } from './settingsUtils'
+import { ImportPreviewDialog, type ConfigImportPreviewSummary } from './ImportPreviewDialog'
+
+type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] extends (
+  payload: infer Payload
+) => void
+  ? Payload
+  : never
 
 function trimPathRecord(paths: Record<string, string>) {
   return Object.fromEntries(Object.entries(paths).map(([key, value]) => [key, value.trim()]))
@@ -167,6 +176,11 @@ export function SettingsProvider({
     slotName: string
   } | null>(null)
   const [importConfirmOpen, setImportConfirmOpen] = useState(false)
+  const [importPreview, setImportPreview] = useState<{
+    token: string
+    filePath?: string
+    summary: ConfigImportPreviewSummary
+  } | null>(null)
   const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
   const latestSettingsObjects = useRef<SettingsObjectRecords>({
     appPaths,
@@ -552,12 +566,38 @@ export function SettingsProvider({
     setImportingConfig(true)
 
     try {
-      const result = await importConfig()
+      const result = await previewImportConfig()
+
+      if (result.success && result.token && result.summary) {
+        setImportPreview({
+          token: result.token,
+          filePath: result.filePath,
+          summary: result.summary
+        })
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to preview config import', 'error')
+      }
+    } catch (err) {
+      notify('Failed to preview config import', 'error')
+      console.error(err)
+    } finally {
+      setImportingConfig(false)
+    }
+  }, [notify])
+
+  const handleApplyImportConfig = useCallback(async () => {
+    if (!importPreview) return
+
+    setImportingConfig(true)
+
+    try {
+      const result = await applyImportConfig(importPreview.token)
 
       if (result.success) {
+        setImportPreview(null)
         onConfigImported?.()
         notify('Config imported', 'success', 2500)
-      } else if (!result.canceled) {
+      } else {
         notify(result.error || 'Failed to import config', 'error')
       }
     } catch (err) {
@@ -566,7 +606,15 @@ export function SettingsProvider({
     } finally {
       setImportingConfig(false)
     }
-  }, [notify, onConfigImported])
+  }, [importPreview, notify, onConfigImported])
+
+  const handleCancelImportConfig = useCallback(() => {
+    if (importPreview) {
+      void cancelImportConfig(importPreview.token)
+    }
+
+    setImportPreview(null)
+  }, [importPreview])
 
   const handleSave = useCallback(async () => {
     try {
@@ -797,6 +845,14 @@ export function SettingsProvider({
         onSave={handleConfirmImportConfig}
         onDiscard={() => setImportConfirmOpen(false)}
         onCancel={() => setImportConfirmOpen(false)}
+      />
+
+      <ImportPreviewDialog
+        isOpen={importPreview !== null}
+        filePath={importPreview?.filePath}
+        summary={importPreview?.summary}
+        onImport={handleApplyImportConfig}
+        onCancel={handleCancelImportConfig}
       />
     </SettingsContext.Provider>
   )

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { Game } from '../lib/config'
-import { getRunningApps } from '../lib/electron'
+import {
+  getRunningApps,
+  onRunningAppsChanged,
+  subscribeRunningApps,
+  unsubscribeRunningApps
+} from '../lib/electron'
 
 export type RunningApp = {
   path: string
@@ -8,6 +13,14 @@ export type RunningApp = {
   gameKey: string
   warning?: string
   elevated?: boolean
+}
+
+export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | 'config' | 'scan'
+
+export interface RunningAppsChangedPayload {
+  apps: RunningApp[]
+  reason: RunningAppsChangeReason
+  updatedAt: number
 }
 
 export function useRunningApps(configuredGames: Game[]) {
@@ -18,6 +31,20 @@ export function useRunningApps(configuredGames: Game[]) {
     setRunningApps((current) => (current.length === 0 ? current : []))
     setRunningStatus((current) => (Object.keys(current).length === 0 ? current : {}))
   }, [])
+
+  const applyRunningApps = useCallback(
+    (apps: RunningApp[] | undefined) => {
+      const nextApps: RunningApp[] = apps || []
+      setRunningApps(nextApps)
+
+      const newStatus: Record<string, boolean> = {}
+      configuredGames.forEach((game) => {
+        newStatus[game.key] = nextApps.some((app) => app.gameKey === game.key)
+      })
+      setRunningStatus(newStatus)
+    },
+    [configuredGames]
+  )
 
   const refreshRunningState = useCallback(
     async (isMounted: () => boolean = () => true) => {
@@ -32,19 +59,12 @@ export function useRunningApps(configuredGames: Game[]) {
         const apps = await getRunningApps()
         if (!isMounted()) return
 
-        const nextApps: RunningApp[] = apps || []
-        setRunningApps(nextApps)
-
-        const newStatus: Record<string, boolean> = {}
-        configuredGames.forEach((game) => {
-          newStatus[game.key] = nextApps.some((app) => app.gameKey === game.key)
-        })
-        setRunningStatus(newStatus)
+        applyRunningApps(apps)
       } catch (err) {
-        console.error('Consolidated polling error:', err)
+        console.error('Running apps refresh error:', err)
       }
     },
-    [clearRunningState, configuredGames]
+    [applyRunningApps, clearRunningState, configuredGames.length]
   )
 
   useEffect(() => {
@@ -58,14 +78,31 @@ export function useRunningApps(configuredGames: Game[]) {
       }
     }
 
-    refreshRunningState(isMounted)
-    const intervalId = window.setInterval(() => refreshRunningState(isMounted), 2000)
+    const unsubscribe = onRunningAppsChanged((payload: RunningAppsChangedPayload) => {
+      if (isMounted()) {
+        applyRunningApps(payload.apps)
+      }
+    })
+
+    subscribeRunningApps()
+      .then((payload: RunningAppsChangedPayload) => {
+        if (isMounted()) {
+          applyRunningApps(payload.apps)
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('Running apps subscription error:', err)
+        refreshRunningState(isMounted)
+      })
 
     return () => {
       mounted = false
-      window.clearInterval(intervalId)
+      unsubscribe()
+      unsubscribeRunningApps().catch((err: unknown) => {
+        console.error('Running apps unsubscribe error:', err)
+      })
     }
-  }, [clearRunningState, configuredGames.length, refreshRunningState])
+  }, [applyRunningApps, clearRunningState, configuredGames.length, refreshRunningState])
 
   return { runningApps, runningStatus, refreshRunningState }
 }

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -9,6 +9,9 @@ export const maximize = () => window.electronAPI.maximize()
 export const close = () => window.electronAPI.close()
 export const restartApp = () => window.electronAPI.restartApp()
 export const getRunningApps = () => window.electronAPI.getRunningApps()
+export const subscribeRunningApps = () => window.electronAPI.subscribeRunningApps()
+export const unsubscribeRunningApps = () => window.electronAPI.unsubscribeRunningApps()
+export const onRunningAppsChanged = window.electronAPI.onRunningAppsChanged
 export const killLaunchedApps = window.electronAPI.killLaunchedApps
 export const onUpdateAvailable = window.electronAPI.onUpdateAvailable
 export const onUpdateDownloaded = window.electronAPI.onUpdateDownloaded

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -7,4 +7,6 @@ export const getMigrationFlags = () => window.electronAPI.getMigrationFlags()
 export const setMigrationFlags = window.electronAPI.setMigrationFlags
 export const onStoreConfigChanged = window.electronAPI.onStoreConfigChanged
 export const exportConfig = () => window.electronAPI.exportConfig()
-export const importConfig = () => window.electronAPI.importConfig()
+export const previewImportConfig = () => window.electronAPI.previewImportConfig()
+export const applyImportConfig = window.electronAPI.applyImportConfig
+export const cancelImportConfig = window.electronAPI.cancelImportConfig

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -1,0 +1,202 @@
+import { expect, test, vi, beforeEach } from 'vitest'
+
+type MockIpcHandler = (...args: unknown[]) => unknown | Promise<unknown>
+type ConfigImportResult = {
+  success: boolean
+  canceled?: boolean
+  error?: string
+  filePath?: string
+  token?: string
+  summary?: {
+    gamePaths: { key: string; path?: string }[]
+  }
+}
+
+let mockIpcHandlers: Record<string, MockIpcHandler> = {}
+
+const mockStats = (size: number) =>
+  ({ size }) as Awaited<ReturnType<typeof import('fs').promises.stat>>
+
+async function invokeConfigHandler(channel: string, ...args: unknown[]) {
+  return (await mockIpcHandlers[channel](...args)) as ConfigImportResult
+}
+
+async function loadConfigModule() {
+  mockIpcHandlers = {}
+  vi.doMock('electron', () => ({
+    app: { getVersion: vi.fn().mockReturnValue('1.0.0') },
+    dialog: {
+      showOpenDialog: vi.fn(),
+      showSaveDialog: vi.fn()
+    },
+    ipcMain: {
+      handle: vi.fn((channel, handler) => {
+        mockIpcHandlers[channel] = handler
+      })
+    }
+  }))
+  vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
+  vi.doMock('../../src/main/profiles', () => ({ isStoredProfileSet: vi.fn() }))
+  vi.doMock('../../src/main/store', () => ({
+    CONFIG_FILE_NAME: 'simlauncher-config.json',
+    MAX_CONFIG_IMPORT_BYTES: 1_000_000,
+    MAX_CUSTOM_SLOTS: 20,
+    getSupportedConfigValues: vi.fn(),
+    getStoredZoomFactor: vi.fn(),
+    requireSafeZoomFactor: vi.fn(),
+    sanitizeImportedConfig: vi.fn((c) => c),
+    store: { store: {}, get: vi.fn(), set: vi.fn(), clear: vi.fn() }
+  }))
+  vi.doMock('../../src/main/window', () => ({
+    applyRuntimeConfigSettings: vi.fn(),
+    getMainWindow: vi.fn(),
+    sendToRenderer: vi.fn()
+  }))
+  vi.doMock('fs', () => ({
+    default: {
+      promises: {
+        stat: vi.fn(),
+        readFile: vi.fn(),
+        writeFile: vi.fn()
+      }
+    }
+  }))
+
+  const mod = await import('../../src/main/ipc/config')
+  mod.registerConfigHandlers()
+  return mod
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('buildImportPreviewSummary exposes only sanitized executable paths and custom args', async () => {
+  const { buildImportPreviewSummary } = await loadConfigModule()
+  const summary = buildImportPreviewSummary(
+    {
+      gamePaths: { ac: 'C:/Games/AssettoCorsa.exe', unknown: 'C:/Games/Unknown.exe' },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' },
+      appArgs: { customapp2: '--overlay', simhub: '--not-importable' },
+      profiles: {
+        ac: {
+          profiles: [
+            {
+              name: 'Default',
+              trackedProcessPaths: ['C:/Tools/SimHub.exe', 'C:/Tools/readme.txt']
+            }
+          ]
+        }
+      }
+    },
+    {
+      gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' },
+      appArgs: { customapp2: '--overlay' },
+      profiles: {
+        ac: {
+          profiles: [{ name: 'Default', trackedProcessPaths: ['C:/Tools/SimHub.exe'] }]
+        }
+      }
+    }
+  )
+
+  expect(summary.changedKeys).toEqual(['appArgs', 'appPaths', 'gamePaths', 'profiles'])
+  expect(summary.gamePaths).toEqual([{ key: 'ac', path: 'C:/Games/AssettoCorsa.exe' }])
+  expect(summary.appPaths).toEqual([
+    { key: 'simhub', path: 'C:/Tools/SimHub.exe' },
+    { key: 'customapp2', path: 'C:/Tools/Overlay.exe' }
+  ])
+  expect(summary.customAppArgs).toEqual([{ key: 'customapp2', args: '--overlay' }])
+  expect(summary.trackedProcessPaths).toEqual([{ key: 'ac/Default', path: 'C:/Tools/SimHub.exe' }])
+  expect(summary.droppedCount).toBe(3)
+  expect(summary.warnings).toHaveLength(1)
+})
+
+test('preview-import-config returns a token and stores pending import', async () => {
+  await loadConfigModule()
+  const { dialog } = await import('electron')
+  const fs = (await import('fs')).default
+
+  vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+    canceled: false,
+    filePaths: ['test-config.json']
+  })
+  vi.mocked(fs.promises.stat).mockResolvedValue(mockStats(500))
+  vi.mocked(fs.promises.readFile).mockResolvedValue(JSON.stringify({ gamePaths: { ac: 'path' } }))
+
+  const result = await invokeConfigHandler('preview-import-config')
+
+  expect(result.success).toBe(true)
+  expect(result.token).toBeDefined()
+  expect(result.filePath).toBe('test-config.json')
+  expect(result.summary?.gamePaths).toEqual([{ key: 'ac', path: 'path' }])
+})
+
+test('apply-import-config requires a valid token', async () => {
+  await loadConfigModule()
+  const result = await invokeConfigHandler('apply-import-config', {}, 'invalid-token')
+  expect(result.success).toBe(false)
+  expect(result.error).toContain('expired or is no longer valid')
+})
+
+test('apply-import-config clears pending import after use (single-use token)', async () => {
+  await loadConfigModule()
+  const { dialog } = await import('electron')
+  const fs = (await import('fs')).default
+
+  vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+    canceled: false,
+    filePaths: ['test-config.json']
+  })
+  vi.mocked(fs.promises.stat).mockResolvedValue(mockStats(500))
+  vi.mocked(fs.promises.readFile).mockResolvedValue(JSON.stringify({ gamePaths: { ac: 'path' } }))
+
+  const previewResult = await invokeConfigHandler('preview-import-config')
+  const token = previewResult.token
+
+  const applyResult1 = await invokeConfigHandler('apply-import-config', {}, token)
+  expect(applyResult1.success).toBe(true)
+
+  const applyResult2 = await invokeConfigHandler('apply-import-config', {}, token)
+  expect(applyResult2.success).toBe(false)
+  expect(applyResult2.error).toContain('expired or is no longer valid')
+})
+
+test('cancel-import-config clears pending import', async () => {
+  await loadConfigModule()
+  const { dialog } = await import('electron')
+  const fs = (await import('fs')).default
+
+  vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: ['f.json'] })
+  vi.mocked(fs.promises.stat).mockResolvedValue(mockStats(100))
+  vi.mocked(fs.promises.readFile).mockResolvedValue('{}')
+
+  const { token } = await invokeConfigHandler('preview-import-config')
+  await invokeConfigHandler('cancel-import-config', {}, token)
+
+  const applyResult = await invokeConfigHandler('apply-import-config', {}, token)
+  expect(applyResult.success).toBe(false)
+})
+
+test('new preview replacement: subsequent previews invalidate previous tokens', async () => {
+  await loadConfigModule()
+  const { dialog } = await import('electron')
+  const fs = (await import('fs')).default
+
+  vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: ['f.json'] })
+  vi.mocked(fs.promises.stat).mockResolvedValue(mockStats(100))
+  vi.mocked(fs.promises.readFile).mockResolvedValue('{}')
+
+  const res1 = await invokeConfigHandler('preview-import-config')
+  const res2 = await invokeConfigHandler('preview-import-config')
+
+  expect(res1.token).not.toBe(res2.token)
+
+  const apply1 = await invokeConfigHandler('apply-import-config', {}, res1.token)
+  expect(apply1.success).toBe(false)
+
+  const apply2 = await invokeConfigHandler('apply-import-config', {}, res2.token)
+  expect(apply2.success).toBe(true)
+})

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1,6 +1,12 @@
+import type { WebContents } from 'electron'
 import { beforeEach, expect, test, vi } from 'vitest'
 
 type StoreData = Record<string, unknown>
+type MockWebContents = {
+  isDestroyed: () => boolean
+  send: ReturnType<typeof vi.fn>
+  once: ReturnType<typeof vi.fn>
+}
 
 const storeData: StoreData = {}
 const existingPaths = new Set<string>()
@@ -32,11 +38,14 @@ async function loadProcessModules() {
     execFile: vi.fn((command, args, options, callback) => {
       execFileCalls.push({ command, args, options })
       if (command === 'powershell.exe') {
-        callback(null, '4321', '')
+        callback(null, processNames.has('simhub.exe') ? '[4321]' : '', '')
         return
       }
       if (command === 'taskkill' && args.includes('/PID')) {
-        processNames.delete('simhub.exe')
+        const pid = args[args.indexOf('/PID') + 1]
+        if (pid === '4321') {
+          processNames.delete('simhub.exe')
+        }
       }
       callback(null, '', '')
     }),
@@ -64,6 +73,29 @@ async function loadProcessModules() {
     readRunningProcessNames: vi.fn(() => Promise.resolve(new Set(processNames)))
   }))
 
+  vi.doMock('../../src/main/store', () => ({
+    store: {
+      get: vi.fn((key: string) => storeData[key]),
+      set: vi.fn((key: string, value: unknown) => {
+        storeData[key] = value
+      })
+    }
+  }))
+
+  vi.doMock('../../src/main/profiles', () => ({
+    getActiveStoredProfile: vi.fn((p: { activeProfileId: string; profiles: { id: string }[] }) =>
+      p.profiles.find((i) => i.id === p.activeProfileId)
+    ),
+    getProfileTrackablePaths: vi.fn(
+      (
+        gameKey: string,
+        _profile: unknown,
+        appPaths: Record<string, string> | undefined,
+        gamePaths: Record<string, string> | undefined
+      ) => [...(gamePaths?.[gameKey] ? [gamePaths[gameKey]] : []), ...Object.values(appPaths || {})]
+    )
+  }))
+
   const spawnModule = await import('../../src/main/processes/spawn')
   const killModule = await import('../../src/main/processes/kill')
   const stateModule = await import('../../src/main/processes/state')
@@ -73,8 +105,23 @@ async function loadProcessModules() {
     killLaunchedApps: killModule.killLaunchedApps,
     killProfileApps: killModule.killProfileApps,
     runningProcesses: stateModule.runningProcesses,
-    unclosedProcesses: stateModule.unclosedProcesses
+    unclosedProcesses: stateModule.unclosedProcesses,
+    getRunningApps: (await import('../../src/main/processes/running')).getRunningApps,
+    subscribeRunningApps: (await import('../../src/main/processes/running')).subscribeRunningApps,
+    publishRunningApps: (await import('../../src/main/processes/running')).publishRunningApps
   }
+}
+
+function createMockWebContents(): MockWebContents {
+  return {
+    isDestroyed: () => false,
+    send: vi.fn(),
+    once: vi.fn()
+  }
+}
+
+function asWebContents(webContents: MockWebContents) {
+  return webContents as unknown as WebContents
 }
 
 const sender = {
@@ -177,4 +224,54 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
       expect.objectContaining({ command: 'taskkill', args: ['/IM', 'simhub.exe', '/T', '/F'] })
     ])
   )
+})
+
+test('subscribeRunningApps returns initial snapshot and tracks subscriber', async () => {
+  const { subscribeRunningApps } = await loadProcessModules()
+  const webContents = createMockWebContents()
+
+  const snapshot = await subscribeRunningApps(asWebContents(webContents))
+  expect(snapshot.reason).toBe('initial')
+  expect(snapshot.apps).toEqual([])
+  expect(webContents.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
+})
+
+test('publishRunningApps emits changed event to subscribers when state changes', async () => {
+  const { subscribeRunningApps, publishRunningApps } = await loadProcessModules()
+  const webContents = createMockWebContents()
+
+  storeData.profiles = {
+    ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+  }
+  storeData.gamePaths = { ac: 'C:/Games/AssettoCorsa.exe' }
+  existingPaths.add('C:/Games/AssettoCorsa.exe')
+  await subscribeRunningApps(asWebContents(webContents))
+
+  // Change state: add a process
+  processNames.add('assettocorsa.exe')
+
+  await publishRunningApps('scan')
+
+  expect(webContents.send).toHaveBeenCalledWith(
+    'running-apps-changed',
+    expect.objectContaining({
+      reason: 'scan',
+      apps: expect.arrayContaining([
+        expect.objectContaining({ name: 'AssettoCorsa.exe', gameKey: 'ac', tracked: true })
+      ])
+    })
+  )
+})
+
+test('publishRunningApps deduplicates emissions if snapshot is identical', async () => {
+  const { subscribeRunningApps, publishRunningApps } = await loadProcessModules()
+  const webContents = createMockWebContents()
+
+  await subscribeRunningApps(asWebContents(webContents))
+  webContents.send.mockClear()
+
+  // No state change
+  await publishRunningApps('scan')
+
+  expect(webContents.send).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary

- **#192** — Replaces renderer-side `setInterval` polling with IPC push subscription. Main process manages subscribers, deduplicates scan emissions, and pushes `running-apps-changed` events on launch/exit/kill.
- **#242** — Adds a preview-trust dialog before applying an imported config. Main process issues a single-use in-memory token; renderer shows only sanitized exe paths and custom args before the user confirms.

## Notes

- #266 (publishRunningApps race fix) and #267 (double-emit on launch) are tracked separately and will come in a follow-up.

## Test plan

- [x] Launch a profile — running status updates without polling delay
- [x] Close an app manually — status clears within ~2s scan interval
- [x] Import a config — preview dialog appears showing exe paths before apply
- [x] Cancel import — no config changes applied
- [x] Import with invalid/expired token rejected by main process

🤖 Generated with [Claude Code](https://claude.com/claude-code)