### PR TITLE
security(spawn): use encoded PowerShell command for elevated launches (#244)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -211,19 +211,33 @@ function isElevatedLaunchError(err: unknown) {
   return process.platform === 'win32' && getErrorCode(err) === 'EACCES'
 }
 
+function encodePowerShellCommand(command: string) {
+  return Buffer.from(command, 'utf16le').toString('base64')
+}
+
+function createElevatedLaunchCommand(appPath: string, args: string[]) {
+  const payload = JSON.stringify({ filePath: appPath, args })
+
+  return encodePowerShellCommand(
+    [
+      "$ErrorActionPreference = 'Stop'",
+      "$payload = ConvertFrom-Json @'",
+      payload,
+      "'@",
+      'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -Verb RunAs'
+    ].join('\n')
+  )
+}
+
 function launchElevated(appPath: string, args: string[] = []) {
   return new Promise<AppLaunchResult>((resolve) => {
-    const escapedAppPath = appPath.replace(/'/g, "''")
-    const escapedArgs = args.map((arg) => `'${arg.replace(/'/g, "''")}'`).join(', ')
-    const argumentList = escapedArgs ? ` -ArgumentList @(${escapedArgs})` : ''
-
     execFile(
       'powershell.exe',
       [
         '-NoProfile',
         '-NonInteractive',
-        '-Command',
-        `Start-Process -FilePath '${escapedAppPath}'${argumentList} -Verb RunAs`
+        '-EncodedCommand',
+        createElevatedLaunchCommand(appPath, args)
       ],
       { windowsHide: true },
       (error) => {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -217,6 +217,10 @@ function encodePowerShellCommand(command: string) {
 
 function createElevatedLaunchCommand(appPath: string, args: string[]) {
   const payload = JSON.stringify({ filePath: appPath, args })
+  const startProcessCommand =
+    args.length > 0
+      ? 'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -Verb RunAs'
+      : 'Start-Process -FilePath $payload.filePath -Verb RunAs'
 
   return encodePowerShellCommand(
     [
@@ -224,7 +228,7 @@ function createElevatedLaunchCommand(appPath: string, args: string[]) {
       "$payload = ConvertFrom-Json @'",
       payload,
       "'@",
-      'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -Verb RunAs'
+      startProcessCommand
     ].join('\n')
   )
 }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -292,6 +292,35 @@ test('launchProfileApps uses encoded PowerShell command for elevated launches wi
   })
 })
 
+test('launchProfileApps omits PowerShell ArgumentList for elevated launches without custom args', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  existingPaths.add('C:/Tools/Admin Tool.exe')
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])).resolves.toMatchObject(
+    {
+      success: true,
+      launchedCount: 1,
+      elevatedCount: 1
+    }
+  )
+
+  const elevatedCall = execFileCalls.find((call) => call.command === 'powershell.exe')
+  expect(elevatedCall).toMatchObject({
+    args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', expect.any(String)],
+    options: { windowsHide: true }
+  })
+
+  const decodedCommand = Buffer.from(elevatedCall!.args[3], 'base64').toString('utf16le')
+  expect(decodedCommand).toContain('Start-Process -FilePath $payload.filePath -Verb RunAs')
+  expect(decodedCommand).not.toContain('-ArgumentList')
+  expect(JSON.parse(decodedCommand.split("@'\n")[1].split("\n'@")[0])).toEqual({
+    filePath: 'C:/Tools/Admin Tool.exe',
+    args: []
+  })
+})
+
 test('killLaunchedApps returns a no-op kill result when no companion apps are running', async () => {
   const { killLaunchedApps } = await loadProcessModules()
 

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -14,8 +14,19 @@ const processNames = new Set<string>()
 const accessDeniedPids = new Set<string>()
 const nullExecutablePathPids = new Set<string>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
+const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
+const spawnErrors = new Map<string, NodeJS.ErrnoException>()
+
+function makeAccessDeniedError() {
+  const error = new Error('Access is denied.') as NodeJS.ErrnoException
+
+  error.code = 'EACCES'
+  return error
+}
 
 async function loadProcessModules() {
+  vi.resetModules()
+
   vi.doMock('electron-store', () => ({
     default: class MockStore {
       store = storeData
@@ -60,13 +71,17 @@ async function loadProcessModules() {
       }
       callback(null, '', '')
     }),
-    spawn: vi.fn((appPath: string) => {
+    spawn: vi.fn((appPath: string, args: string[] = [], options: Record<string, unknown> = {}) => {
+      spawnCalls.push({ appPath, args, options })
       const handlers = new Map<string, (...args: unknown[]) => void>()
       const child = {
         pid: 1234,
         once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
           handlers.set(event, handler)
-          if (event === 'spawn') {
+          if (event === 'error' && spawnErrors.has(appPath)) {
+            queueMicrotask(() => handler(spawnErrors.get(appPath)!))
+          }
+          if (event === 'spawn' && !spawnErrors.has(appPath)) {
             queueMicrotask(handler)
           }
           return child
@@ -149,6 +164,8 @@ beforeEach(async () => {
   accessDeniedPids.clear()
   nullExecutablePathPids.clear()
   execFileCalls.length = 0
+  spawnCalls.length = 0
+  spawnErrors.clear()
   runningProcesses.clear()
   unclosedProcesses.clear()
   Object.keys(storeData).forEach((key) => delete storeData[key])
@@ -177,6 +194,101 @@ test('launchProfileApps skips profile apps that are already running', async () =
     launchedCount: 0,
     skippedCount: 1,
     message: 'All profile applications are already running.'
+  })
+})
+
+test('launchProfileApps parses custom app arguments with quoted paths and escaped quotes', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  existingPaths.add('C:/Tools/Custom Tool.exe')
+  storeData.appPaths = { customapp1: 'C:/Tools/Custom Tool.exe' }
+  storeData.appArgs = {
+    customapp1: String.raw`--config "C:/Users/Driver/Sim Configs/main profile.json" --label "Crew \"Chief\""`
+  }
+
+  await expect(
+    launchProfileApps(sender, 'ac', ['C:/Tools/Custom Tool.exe'])
+  ).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  expect(spawnCalls[0]).toMatchObject({
+    appPath: 'C:/Tools/Custom Tool.exe',
+    args: ['--config', 'C:/Users/Driver/Sim Configs/main profile.json', '--label', 'Crew "Chief"']
+  })
+})
+
+test('launchProfileApps treats PowerShell-sensitive custom argument characters as literal spawn args', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  existingPaths.add('C:/Tools/Custom Tool.exe')
+  existingPaths.add('C:/Tools/Custom Tool.exe --flag ^caret')
+  storeData.appPaths = { customapp1: 'C:/Tools/Custom Tool.exe' }
+  storeData.appArgs = {
+    customapp1:
+      '--name "literal & value" --pattern "$(Get-Process); | %{rm} `whoami`" --flag "^caret"'
+  }
+
+  await expect(
+    launchProfileApps(sender, 'ac', ['C:/Tools/Custom Tool.exe'])
+  ).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  expect(spawnCalls[0]).toMatchObject({
+    appPath: 'C:/Tools/Custom Tool.exe',
+    args: [
+      '--name',
+      'literal & value',
+      '--pattern',
+      '$(Get-Process); | %{rm} `whoami`',
+      '--flag',
+      '^caret'
+    ]
+  })
+})
+
+test('launchProfileApps uses encoded PowerShell command for elevated launches with literal custom args', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  existingPaths.add('C:/Tools/Admin Tool.exe')
+  existingPaths.add(`C:/Tools/Admin Tool.exe --literal "$(Start-Process calc); 'single' & value"`)
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+  storeData.appPaths = { customapp1: 'C:/Tools/Admin Tool.exe' }
+  storeData.appArgs = {
+    customapp1: `--path "C:/Users/Driver/Sim Configs" --literal "$(Start-Process calc); 'single' & value"`
+  }
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])).resolves.toMatchObject(
+    {
+      success: true,
+      launchedCount: 1,
+      elevatedCount: 1
+    }
+  )
+
+  const elevatedCall = execFileCalls.find((call) => call.command === 'powershell.exe')
+  expect(elevatedCall).toMatchObject({
+    args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', expect.any(String)],
+    options: { windowsHide: true }
+  })
+  expect(elevatedCall?.args.join(' ')).not.toContain('Start-Process -FilePath')
+
+  const decodedCommand = Buffer.from(elevatedCall!.args[3], 'base64').toString('utf16le')
+  expect(decodedCommand).toContain("$payload = ConvertFrom-Json @'")
+  expect(decodedCommand).toContain(
+    'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -Verb RunAs'
+  )
+  expect(JSON.parse(decodedCommand.split("@'\n")[1].split("\n'@")[0])).toEqual({
+    filePath: 'C:/Tools/Admin Tool.exe',
+    args: [
+      '--path',
+      'C:/Users/Driver/Sim Configs',
+      '--literal',
+      "$(Start-Process calc); 'single' & value"
+    ]
   })
 })
 


### PR DESCRIPTION
## Summary
- Replaces inline PowerShell string interpolation in `launchElevated` with `-EncodedCommand` + base64 UTF-16LE encoded script
- Args and file path passed as JSON payload via here-string (`@'...'@`), decoded with `ConvertFrom-Json` — eliminates injection risk from paths/args containing `'`, `$()`, `&`, `;`, backticks, `^`
- Tests added for quoted paths with spaces, escaped quotes, PowerShell-sensitive literal chars, and elevated launch with base64 payload verification

## Test plan
- [x] `npm run test -- tests/main/processes.test.ts` passes
- [x] `npm run typecheck` passes
- [x] Elevated launch (UAC prompt) triggers correctly for an admin app
- [x] Custom args with special characters pass through literally to the launched process

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #244
<!-- auto-closes -->