### PR TITLE
refactor: split SettingsContext into focused hooks

### DIFF
--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -11,59 +11,20 @@ import {
   type SetStateAction
 } from 'react'
 import { useDirtyTracking } from '../../hooks/useDirtyTracking'
-import {
-  DEFAULT_ACCENT_COLOR,
-  GAMES,
-  getCustomUtilityKey,
-  getUtilities,
-  resolveCustomSlots,
-  type Profiles,
-  type Utility
-} from '../../lib/config'
-import { browsePath, getAssetData, getFileIcon, setLoginItem, setZoom } from '../../lib/electron'
-import {
-  applyImportConfig,
-  cancelImportConfig,
-  exportConfig,
-  getProfiles,
-  getSettings,
-  onStoreConfigChanged,
-  previewImportConfig,
-  saveProfiles,
-  saveSettings as persistSettings
-} from '../../lib/store'
-import { normalizeThemeMode, type ThemeMode } from '../../lib/theme'
+import { DEFAULT_ACCENT_COLOR, getUtilities, type Profiles, type Utility } from '../../lib/config'
+import { browsePath, getFileIcon, setLoginItem, setZoom } from '../../lib/electron'
+import type { ThemeMode } from '../../lib/theme'
 import { useTheme } from '../../contexts/ThemeContext'
 import { useNotify } from '../Notify'
-import { ConfirmDialog } from '../ConfirmDialog'
-import { shiftCustomSlotRecord, shiftCustomSlotSet, shiftProfileCustomSlots } from './customSlots'
 import {
   createSettingsObjectVersions,
-  getSettingsObjectChangesDuringSave,
-  resolveSettingsObjectsAfterSave,
   type SettingsObjectField,
   type SettingsObjectRecords
 } from './saveRace'
-import { normalizeLaunchDelayMs } from './settingsUtils'
-import { ImportPreviewDialog, type ConfigImportPreviewSummary } from './ImportPreviewDialog'
-
-type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] extends (
-  payload: infer Payload
-) => void
-  ? Payload
-  : never
-
-function trimPathRecord(paths: Record<string, string>) {
-  return Object.fromEntries(Object.entries(paths).map(([key, value]) => [key, value.trim()]))
-}
-
-function trimStringRecord(values: Record<string, string>) {
-  return Object.fromEntries(
-    Object.entries(values)
-      .map(([key, value]) => [key, value.trim()])
-      .filter(([, value]) => value.length > 0)
-  )
-}
+import { useConfigIO } from './useConfigIO'
+import { useCustomSlots } from './useCustomSlots'
+import { useSettingsLoad } from './useSettingsLoad'
+import { useSettingsSave } from './useSettingsSave'
 
 interface SettingsContextValue {
   loading: boolean
@@ -165,22 +126,10 @@ export function SettingsProvider({
   const [autoCheckUpdates, setAutoCheckUpdates] = useState<boolean>(true)
   const [zoomFactor, setZoomFactor] = useState<number>(1.0)
 
-  const [exportingConfig, setExportingConfig] = useState(false)
-  const [importingConfig, setImportingConfig] = useState(false)
   const [isCustomColor, setIsCustomColor] = useState(false)
   const [appIcons, setAppIcons] = useState<Record<string, string>>({})
   const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
   const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
-  const [customSlotRemoveConfirm, setCustomSlotRemoveConfirm] = useState<{
-    slotNumber: number
-    slotName: string
-  } | null>(null)
-  const [importConfirmOpen, setImportConfirmOpen] = useState(false)
-  const [importPreview, setImportPreview] = useState<{
-    token: string
-    filePath?: string
-    summary: ConfigImportPreviewSummary
-  } | null>(null)
   const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
   const latestSettingsObjects = useRef<SettingsObjectRecords>({
     appPaths,
@@ -188,80 +137,6 @@ export function SettingsProvider({
     appArgs,
     gamePaths
   })
-
-  const loadSettingsFromStore = useCallback(async () => {
-    const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
-    const typedProfiles = savedProfiles as Profiles
-
-    latestSettingsObjects.current = {
-      appPaths: settings.appPaths,
-      appNames: settings.appNames,
-      appArgs: settings.appArgs,
-      gamePaths: settings.gamePaths
-    }
-
-    setAppPaths(settings.appPaths)
-    setAppNames(settings.appNames)
-    setAppArgs(settings.appArgs)
-    setProfiles(typedProfiles)
-    setGamePaths(settings.gamePaths)
-    setCustomSlots(
-      resolveCustomSlots(
-        settings.customSlots,
-        settings.appPaths,
-        settings.appNames,
-        ...(Object.values(typedProfiles) as Record<string, unknown>[])
-      )
-    )
-    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
-
-    setAccentPreset(settings.accentPreset || DEFAULT_ACCENT_COLOR)
-    setAccentCustom(settings.accentCustom || '')
-    setAccentBgTint(settings.accentBgTint || false)
-    setThemeMode(loadedThemeMode)
-    themeRef.current.setThemeMode(loadedThemeMode)
-    setFocusActiveTitle(settings.focusActiveTitle !== false)
-    setLaunchDelayMs(normalizeLaunchDelayMs(settings.launchDelayMs))
-    setStartWithWindows(settings.startWithWindows || false)
-    setStartMinimized(settings.startMinimized || false)
-    setMinimizeToTray(settings.minimizeToTray || false)
-    setAutoCheckUpdates(settings.autoCheckUpdates !== false)
-    setZoomFactor(Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0)
-
-    setIsCustomColor(settings.accentPreset === 'custom')
-
-    const icons: Record<string, string> = {}
-    for (const [key, path] of Object.entries(settings.appPaths)) {
-      if (path) {
-        const icon = await getFileIcon(path)
-        if (icon) icons[key] = icon
-      }
-    }
-    setAppIcons(icons)
-
-    const gIcons: Record<string, string> = {}
-    for (const game of GAMES) {
-      const filename = game.icon.split('/').pop() || ''
-      const data = await getAssetData(filename)
-      if (data) gIcons[game.key] = data
-    }
-    setGameIcons(gIcons)
-
-    setLoading(false)
-  }, [])
-
-  useEffect(() => {
-    loadSettingsFromStore()
-  }, [loadSettingsFromStore])
-
-  useEffect(() => {
-    latestSettingsObjects.current = {
-      appPaths,
-      appNames,
-      appArgs,
-      gamePaths
-    }
-  }, [appPaths, appNames, appArgs, gamePaths])
 
   const updateSettingsObject = useCallback(
     (
@@ -325,12 +200,32 @@ export function SettingsProvider({
 
   const { isDirty, resetDirty } = useDirtyTracking(currentSettingsState, loading)
 
-  useEffect(() => {
-    return onStoreConfigChanged((payload: StoreConfigChangePayload) => {
-      if (payload.reason === 'save-settings' || payload.reason === 'save-profiles') return
-      void loadSettingsFromStore().then(() => resetDirty())
-    })
-  }, [loadSettingsFromStore, resetDirty])
+  useSettingsLoad({
+    themeRef,
+    latestSettingsObjects,
+    resetDirty,
+    setLoading,
+    setAppPaths,
+    setAppNames,
+    setAppArgs,
+    setProfiles,
+    setGamePaths,
+    setCustomSlots,
+    setAccentPreset,
+    setAccentCustom,
+    setAccentBgTint,
+    setThemeMode,
+    setFocusActiveTitle,
+    setLaunchDelayMs,
+    setStartWithWindows,
+    setStartMinimized,
+    setMinimizeToTray,
+    setAutoCheckUpdates,
+    setZoomFactor,
+    setIsCustomColor,
+    setAppIcons,
+    setGameIcons
+  })
 
   useEffect(() => {
     onDirtyChange?.(isDirty)
@@ -416,88 +311,6 @@ export function SettingsProvider({
     [updateSettingsObject]
   )
 
-  const handleAddCustomSlot = useCallback(() => {
-    setCustomSlots((current) => current + 1)
-  }, [])
-
-  const removeCustomSlot = useCallback(
-    (slotNumber: number) => {
-      if (customSlots <= 1) {
-        notify('At least one custom app slot is required', 'warn')
-        return
-      }
-
-      const slotKey = getCustomUtilityKey(slotNumber)
-      const slotName = appNames[slotKey] || `Custom App ${slotNumber}`
-
-      if (appPaths[slotKey]) {
-        setCustomSlotRemoveConfirm({ slotNumber, slotName })
-        return
-      }
-
-      setCustomSlotRemoveConfirm(null)
-
-      updateSettingsObject('appPaths', setAppPaths, (current) =>
-        shiftCustomSlotRecord(current, slotNumber, customSlots)
-      )
-      updateSettingsObject('appNames', setAppNames, (current) =>
-        shiftCustomSlotRecord(current, slotNumber, customSlots)
-      )
-      updateSettingsObject('appArgs', setAppArgs, (current) =>
-        shiftCustomSlotRecord(current, slotNumber, customSlots)
-      )
-      setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
-      setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
-      setProfiles((current) => {
-        const nextProfiles: Profiles = {}
-
-        Object.entries(current).forEach(([gameKey, profile]) => {
-          nextProfiles[gameKey] = shiftProfileCustomSlots(profile, slotNumber, customSlots)
-        })
-
-        return nextProfiles
-      })
-      setCustomSlots((current) => Math.max(1, current - 1))
-    },
-    [appNames, appPaths, customSlots, notify, updateSettingsObject]
-  )
-
-  const handleRemoveCustomSlot = useCallback(
-    (slotNumber: number) => {
-      removeCustomSlot(slotNumber)
-    },
-    [removeCustomSlot]
-  )
-
-  const handleConfirmRemoveCustomSlot = useCallback(() => {
-    if (!customSlotRemoveConfirm) return
-
-    const slotNumber = customSlotRemoveConfirm.slotNumber
-    setCustomSlotRemoveConfirm(null)
-
-    updateSettingsObject('appPaths', setAppPaths, (current) =>
-      shiftCustomSlotRecord(current, slotNumber, customSlots)
-    )
-    updateSettingsObject('appNames', setAppNames, (current) =>
-      shiftCustomSlotRecord(current, slotNumber, customSlots)
-    )
-    updateSettingsObject('appArgs', setAppArgs, (current) =>
-      shiftCustomSlotRecord(current, slotNumber, customSlots)
-    )
-    setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
-    setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
-    setProfiles((current) => {
-      const nextProfiles: Profiles = {}
-
-      Object.entries(current).forEach(([gameKey, profile]) => {
-        nextProfiles[gameKey] = shiftProfileCustomSlots(profile, slotNumber, customSlots)
-      })
-
-      return nextProfiles
-    })
-    setCustomSlots((current) => Math.max(1, current - 1))
-  }, [customSlotRemoveConfirm, customSlots, updateSettingsObject])
-
   const handleGamePathChange = useCallback(
     (key: string, path: string) => {
       updateSettingsObject('gamePaths', setGamePaths, (prev) => ({ ...prev, [key]: path }))
@@ -537,185 +350,59 @@ export function SettingsProvider({
     setIconLoadErrors((prev) => new Set([...prev, key]))
   }, [])
 
-  const handleExportConfig = useCallback(async () => {
-    setExportingConfig(true)
-
-    try {
-      const result = await exportConfig()
-
-      if (result.success) {
-        notify('Config exported', 'success', 2500)
-      } else if (!result.canceled) {
-        notify(result.error || 'Failed to export config', 'error')
-      }
-    } catch (err) {
-      notify('Failed to export config', 'error')
-      console.error(err)
-    } finally {
-      setExportingConfig(false)
-    }
-  }, [notify])
-
-  const handleImportConfig = useCallback(async () => {
-    setImportConfirmOpen(true)
-  }, [])
-
-  const handleConfirmImportConfig = useCallback(async () => {
-    setImportConfirmOpen(false)
-
-    setImportingConfig(true)
-
-    try {
-      const result = await previewImportConfig()
-
-      if (result.success && result.token && result.summary) {
-        setImportPreview({
-          token: result.token,
-          filePath: result.filePath,
-          summary: result.summary
-        })
-      } else if (!result.canceled) {
-        notify(result.error || 'Failed to preview config import', 'error')
-      }
-    } catch (err) {
-      notify('Failed to preview config import', 'error')
-      console.error(err)
-    } finally {
-      setImportingConfig(false)
-    }
-  }, [notify])
-
-  const handleApplyImportConfig = useCallback(async () => {
-    if (!importPreview) return
-
-    setImportingConfig(true)
-
-    try {
-      const result = await applyImportConfig(importPreview.token)
-
-      if (result.success) {
-        setImportPreview(null)
-        onConfigImported?.()
-        notify('Config imported', 'success', 2500)
-      } else {
-        notify(result.error || 'Failed to import config', 'error')
-      }
-    } catch (err) {
-      notify('Failed to import config', 'error')
-      console.error(err)
-    } finally {
-      setImportingConfig(false)
-    }
-  }, [importPreview, notify, onConfigImported])
-
-  const handleCancelImportConfig = useCallback(() => {
-    if (importPreview) {
-      void cancelImportConfig(importPreview.token)
-    }
-
-    setImportPreview(null)
-  }, [importPreview])
-
-  const handleSave = useCallback(async () => {
-    try {
-      const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
-      const trimmedAppPaths = trimPathRecord(appPaths)
-      const trimmedGamePaths = trimPathRecord(gamePaths)
-      const trimmedAppArgs = trimStringRecord(appArgs)
-      const settingsObjectEditVersionsAtSave = { ...settingsObjectEditVersions.current }
-      const savedSettingsObjects = {
-        appPaths: trimmedAppPaths,
-        appNames,
-        appArgs: trimmedAppArgs,
-        gamePaths: trimmedGamePaths
-      }
-
-      await Promise.all([
-        persistSettings({
-          appPaths: savedSettingsObjects.appPaths,
-          appNames: savedSettingsObjects.appNames,
-          appArgs: savedSettingsObjects.appArgs,
-          gamePaths: savedSettingsObjects.gamePaths,
-          customSlots,
-          accentPreset,
-          accentCustom,
-          accentBgTint,
-          themeMode,
-          focusActiveTitle,
-          launchDelayMs: normalizedLaunchDelayMs,
-          startMinimized,
-          minimizeToTray,
-          autoCheckUpdates,
-          startWithWindows,
-          zoomFactor
-        }),
-        saveProfiles(profiles)
-      ])
-      const changedDuringSave = getSettingsObjectChangesDuringSave(
-        settingsObjectEditVersionsAtSave,
-        settingsObjectEditVersions.current
-      )
-      const resetSettingsObjects = resolveSettingsObjectsAfterSave({
-        savedObjects: savedSettingsObjects,
-        latestObjects: latestSettingsObjects.current,
-        changedDuringSave
-      })
-
-      if (!changedDuringSave.appPaths) {
-        setAppPaths(savedSettingsObjects.appPaths)
-      }
-
-      if (!changedDuringSave.gamePaths) {
-        setGamePaths(savedSettingsObjects.gamePaths)
-      }
-
-      if (!changedDuringSave.appArgs) {
-        setAppArgs(savedSettingsObjects.appArgs)
-      }
-
-      setLaunchDelayMs(normalizedLaunchDelayMs)
-
-      notify('Settings saved!', 'success', 2500)
-
-      resetDirty({
-        ...currentSettingsState,
-        ...resetSettingsObjects,
-        launchDelayMs: normalizedLaunchDelayMs
-      })
-    } catch (err) {
-      notify('Failed to save settings', 'error')
-      console.error(err)
-    }
-  }, [
-    appArgs,
+  const { handleAddCustomSlot, handleRemoveCustomSlot, customSlotRemoveDialog } = useCustomSlots({
     appNames,
     appPaths,
-    accentBgTint,
-    accentCustom,
-    accentPreset,
-    autoCheckUpdates,
-    currentSettingsState,
     customSlots,
-    focusActiveTitle,
-    gamePaths,
-    launchDelayMs,
-    minimizeToTray,
     notify,
-    profiles,
-    resetDirty,
-    startMinimized,
-    startWithWindows,
-    themeMode,
-    zoomFactor
-  ])
+    updateSettingsObject,
+    setAppPaths,
+    setAppNames,
+    setAppArgs,
+    setAppIcons,
+    setIconLoadErrors,
+    setProfiles,
+    setCustomSlots
+  })
 
-  useEffect(() => {
-    if (shouldSaveTrigger) {
-      handleSave().then(() => {
-        onSaved?.()
-      })
-    }
-  }, [handleSave, onSaved, shouldSaveTrigger])
+  const {
+    exportingConfig,
+    importingConfig,
+    handleExportConfig,
+    handleImportConfig,
+    configImportDialogs
+  } = useConfigIO({ notify, onConfigImported })
+
+  const { handleSave } = useSettingsSave({
+    appPaths,
+    appNames,
+    appArgs,
+    profiles,
+    gamePaths,
+    customSlots,
+    accentPreset,
+    accentCustom,
+    accentBgTint,
+    themeMode,
+    focusActiveTitle,
+    launchDelayMs,
+    startMinimized,
+    minimizeToTray,
+    autoCheckUpdates,
+    startWithWindows,
+    zoomFactor,
+    currentSettingsState,
+    settingsObjectEditVersions,
+    latestSettingsObjects,
+    notify,
+    resetDirty,
+    setAppPaths,
+    setGamePaths,
+    setAppArgs,
+    setLaunchDelayMs,
+    shouldSaveTrigger,
+    onSaved
+  })
 
   const utilities = useMemo(() => getUtilities(customSlots), [customSlots])
 
@@ -820,40 +507,8 @@ export function SettingsProvider({
   return (
     <SettingsContext.Provider value={value}>
       {children}
-
-      <ConfirmDialog
-        isOpen={customSlotRemoveConfirm !== null}
-        title="Remove Custom App"
-        message={`Remove ${customSlotRemoveConfirm?.slotName || 'this custom app'} and its executable path?`}
-        saveLabel="Remove App"
-        discardLabel="Keep App"
-        saveClassName="danger-action"
-        discardClassName="neutral-action"
-        onSave={handleConfirmRemoveCustomSlot}
-        onDiscard={() => setCustomSlotRemoveConfirm(null)}
-        onCancel={() => setCustomSlotRemoveConfirm(null)}
-      />
-
-      <ConfirmDialog
-        isOpen={importConfirmOpen}
-        title="Import Config"
-        message="Importing a config file will replace your current SimLauncher settings. Continue?"
-        saveLabel="Import Config"
-        discardLabel="Cancel Import"
-        saveClassName="danger-action"
-        discardClassName="neutral-action"
-        onSave={handleConfirmImportConfig}
-        onDiscard={() => setImportConfirmOpen(false)}
-        onCancel={() => setImportConfirmOpen(false)}
-      />
-
-      <ImportPreviewDialog
-        isOpen={importPreview !== null}
-        filePath={importPreview?.filePath}
-        summary={importPreview?.summary}
-        onImport={handleApplyImportConfig}
-        onCancel={handleCancelImportConfig}
-      />
+      {customSlotRemoveDialog}
+      {configImportDialogs}
     </SettingsContext.Provider>
   )
 }

--- a/src/renderer/src/components/settings/useConfigIO.tsx
+++ b/src/renderer/src/components/settings/useConfigIO.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useState } from 'react'
+import {
+  applyImportConfig,
+  cancelImportConfig,
+  exportConfig,
+  previewImportConfig
+} from '../../lib/store'
+import { ConfirmDialog } from '../ConfirmDialog'
+import { ImportPreviewDialog, type ConfigImportPreviewSummary } from './ImportPreviewDialog'
+
+interface UseConfigIOArgs {
+  notify: (message: string, type: 'success' | 'error' | 'warn', duration?: number) => void
+  onConfigImported?: () => void
+}
+
+export function useConfigIO({ notify, onConfigImported }: UseConfigIOArgs) {
+  const [exportingConfig, setExportingConfig] = useState(false)
+  const [importingConfig, setImportingConfig] = useState(false)
+  const [importConfirmOpen, setImportConfirmOpen] = useState(false)
+  const [importPreview, setImportPreview] = useState<{
+    token: string
+    filePath?: string
+    summary: ConfigImportPreviewSummary
+  } | null>(null)
+
+  const handleExportConfig = useCallback(async () => {
+    setExportingConfig(true)
+
+    try {
+      const result = await exportConfig()
+
+      if (result.success) {
+        notify('Config exported', 'success', 2500)
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to export config', 'error')
+      }
+    } catch (err) {
+      notify('Failed to export config', 'error')
+      console.error(err)
+    } finally {
+      setExportingConfig(false)
+    }
+  }, [notify])
+
+  const handleImportConfig = useCallback(async () => {
+    setImportConfirmOpen(true)
+  }, [])
+
+  const handleConfirmImportConfig = useCallback(async () => {
+    setImportConfirmOpen(false)
+    setImportingConfig(true)
+
+    try {
+      const result = await previewImportConfig()
+
+      if (result.success && result.token && result.summary) {
+        setImportPreview({
+          token: result.token,
+          filePath: result.filePath,
+          summary: result.summary
+        })
+      } else if (!result.canceled) {
+        notify(result.error || 'Failed to preview config import', 'error')
+      }
+    } catch (err) {
+      notify('Failed to preview config import', 'error')
+      console.error(err)
+    } finally {
+      setImportingConfig(false)
+    }
+  }, [notify])
+
+  const handleApplyImportConfig = useCallback(async () => {
+    if (!importPreview) return
+
+    setImportingConfig(true)
+
+    try {
+      const result = await applyImportConfig(importPreview.token)
+
+      if (result.success) {
+        setImportPreview(null)
+        onConfigImported?.()
+        notify('Config imported', 'success', 2500)
+      } else {
+        notify(result.error || 'Failed to import config', 'error')
+      }
+    } catch (err) {
+      notify('Failed to import config', 'error')
+      console.error(err)
+    } finally {
+      setImportingConfig(false)
+    }
+  }, [importPreview, notify, onConfigImported])
+
+  const handleCancelImportConfig = useCallback(() => {
+    if (importPreview) {
+      void cancelImportConfig(importPreview.token)
+    }
+
+    setImportPreview(null)
+  }, [importPreview])
+
+  const configImportDialogs = (
+    <>
+      <ConfirmDialog
+        isOpen={importConfirmOpen}
+        title="Import Config"
+        message="Importing a config file will replace your current SimLauncher settings. Continue?"
+        saveLabel="Import Config"
+        discardLabel="Cancel Import"
+        saveClassName="danger-action"
+        discardClassName="neutral-action"
+        onSave={handleConfirmImportConfig}
+        onDiscard={() => setImportConfirmOpen(false)}
+        onCancel={() => setImportConfirmOpen(false)}
+      />
+
+      <ImportPreviewDialog
+        isOpen={importPreview !== null}
+        filePath={importPreview?.filePath}
+        summary={importPreview?.summary}
+        onImport={handleApplyImportConfig}
+        onCancel={handleCancelImportConfig}
+      />
+    </>
+  )
+
+  return {
+    exportingConfig,
+    importingConfig,
+    handleExportConfig,
+    handleImportConfig,
+    configImportDialogs
+  }
+}

--- a/src/renderer/src/components/settings/useCustomSlots.tsx
+++ b/src/renderer/src/components/settings/useCustomSlots.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react'
+import { getCustomUtilityKey, type Profiles } from '../../lib/config'
+import { ConfirmDialog } from '../ConfirmDialog'
+import { shiftCustomSlotRecord, shiftCustomSlotSet, shiftProfileCustomSlots } from './customSlots'
+import type { SettingsObjectField } from './saveRace'
+
+interface UseCustomSlotsArgs {
+  appNames: Record<string, string>
+  appPaths: Record<string, string>
+  customSlots: number
+  notify: (message: string, type: 'success' | 'error' | 'warn', duration?: number) => void
+  updateSettingsObject: (
+    field: SettingsObjectField,
+    setter: Dispatch<SetStateAction<Record<string, string>>>,
+    updater: (current: Record<string, string>) => Record<string, string>
+  ) => void
+  setAppPaths: Dispatch<SetStateAction<Record<string, string>>>
+  setAppNames: Dispatch<SetStateAction<Record<string, string>>>
+  setAppArgs: Dispatch<SetStateAction<Record<string, string>>>
+  setAppIcons: Dispatch<SetStateAction<Record<string, string>>>
+  setIconLoadErrors: Dispatch<SetStateAction<Set<string>>>
+  setProfiles: Dispatch<SetStateAction<Profiles>>
+  setCustomSlots: Dispatch<SetStateAction<number>>
+}
+
+export function useCustomSlots({
+  appNames,
+  appPaths,
+  customSlots,
+  notify,
+  updateSettingsObject,
+  setAppPaths,
+  setAppNames,
+  setAppArgs,
+  setAppIcons,
+  setIconLoadErrors,
+  setProfiles,
+  setCustomSlots
+}: UseCustomSlotsArgs) {
+  const [customSlotRemoveConfirm, setCustomSlotRemoveConfirm] = useState<{
+    slotNumber: number
+    slotName: string
+  } | null>(null)
+
+  const removeSlotData = useCallback(
+    (slotNumber: number) => {
+      updateSettingsObject('appPaths', setAppPaths, (current) =>
+        shiftCustomSlotRecord(current, slotNumber, customSlots)
+      )
+      updateSettingsObject('appNames', setAppNames, (current) =>
+        shiftCustomSlotRecord(current, slotNumber, customSlots)
+      )
+      updateSettingsObject('appArgs', setAppArgs, (current) =>
+        shiftCustomSlotRecord(current, slotNumber, customSlots)
+      )
+      setAppIcons((current) => shiftCustomSlotRecord(current, slotNumber, customSlots))
+      setIconLoadErrors((current) => shiftCustomSlotSet(current, slotNumber, customSlots))
+      setProfiles((current) => {
+        const nextProfiles: Profiles = {}
+
+        Object.entries(current).forEach(([gameKey, profile]) => {
+          nextProfiles[gameKey] = shiftProfileCustomSlots(profile, slotNumber, customSlots)
+        })
+
+        return nextProfiles
+      })
+      setCustomSlots((current) => Math.max(1, current - 1))
+    },
+    [
+      customSlots,
+      setAppArgs,
+      setAppIcons,
+      setAppNames,
+      setAppPaths,
+      setCustomSlots,
+      setIconLoadErrors,
+      setProfiles,
+      updateSettingsObject
+    ]
+  )
+
+  const handleAddCustomSlot = useCallback(() => {
+    setCustomSlots((current) => current + 1)
+  }, [setCustomSlots])
+
+  const handleRemoveCustomSlot = useCallback(
+    (slotNumber: number) => {
+      if (customSlots <= 1) {
+        notify('At least one custom app slot is required', 'warn')
+        return
+      }
+
+      const slotKey = getCustomUtilityKey(slotNumber)
+      const slotName = appNames[slotKey] || `Custom App ${slotNumber}`
+
+      if (appPaths[slotKey]) {
+        setCustomSlotRemoveConfirm({ slotNumber, slotName })
+        return
+      }
+
+      setCustomSlotRemoveConfirm(null)
+      removeSlotData(slotNumber)
+    },
+    [appNames, appPaths, customSlots, notify, removeSlotData]
+  )
+
+  const handleConfirmRemoveCustomSlot = useCallback(() => {
+    if (!customSlotRemoveConfirm) return
+
+    const slotNumber = customSlotRemoveConfirm.slotNumber
+    setCustomSlotRemoveConfirm(null)
+    removeSlotData(slotNumber)
+  }, [customSlotRemoveConfirm, removeSlotData])
+
+  const customSlotRemoveDialog = (
+    <ConfirmDialog
+      isOpen={customSlotRemoveConfirm !== null}
+      title="Remove Custom App"
+      message={`Remove ${customSlotRemoveConfirm?.slotName || 'this custom app'} and its executable path?`}
+      saveLabel="Remove App"
+      discardLabel="Keep App"
+      saveClassName="danger-action"
+      discardClassName="neutral-action"
+      onSave={handleConfirmRemoveCustomSlot}
+      onDiscard={() => setCustomSlotRemoveConfirm(null)}
+      onCancel={() => setCustomSlotRemoveConfirm(null)}
+    />
+  )
+
+  return { handleAddCustomSlot, handleRemoveCustomSlot, customSlotRemoveDialog }
+}

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, type MutableRefObject } from 'react'
+import { DEFAULT_ACCENT_COLOR, GAMES, resolveCustomSlots, type Profiles } from '../../lib/config'
+import { getAssetData, getFileIcon } from '../../lib/electron'
+import { getProfiles, getSettings, onStoreConfigChanged } from '../../lib/store'
+import { normalizeThemeMode, type ThemeMode } from '../../lib/theme'
+import { normalizeLaunchDelayMs } from './settingsUtils'
+import type { SettingsObjectRecords } from './saveRace'
+
+type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] extends (
+  payload: infer Payload
+) => void
+  ? Payload
+  : never
+
+interface UseSettingsLoadArgs {
+  themeRef: MutableRefObject<{ setThemeMode: (mode: ThemeMode) => void }>
+  latestSettingsObjects: MutableRefObject<SettingsObjectRecords>
+  resetDirty: () => void
+  setLoading: (loading: boolean) => void
+  setAppPaths: (appPaths: Record<string, string>) => void
+  setAppNames: (appNames: Record<string, string>) => void
+  setAppArgs: (appArgs: Record<string, string>) => void
+  setProfiles: (profiles: Profiles) => void
+  setGamePaths: (gamePaths: Record<string, string>) => void
+  setCustomSlots: (customSlots: number) => void
+  setAccentPreset: (accentPreset: string) => void
+  setAccentCustom: (accentCustom: string) => void
+  setAccentBgTint: (accentBgTint: boolean) => void
+  setThemeMode: (themeMode: ThemeMode) => void
+  setFocusActiveTitle: (focusActiveTitle: boolean) => void
+  setLaunchDelayMs: (launchDelayMs: number) => void
+  setStartWithWindows: (startWithWindows: boolean) => void
+  setStartMinimized: (startMinimized: boolean) => void
+  setMinimizeToTray: (minimizeToTray: boolean) => void
+  setAutoCheckUpdates: (autoCheckUpdates: boolean) => void
+  setZoomFactor: (zoomFactor: number) => void
+  setIsCustomColor: (isCustomColor: boolean) => void
+  setAppIcons: (appIcons: Record<string, string>) => void
+  setGameIcons: (gameIcons: Record<string, string>) => void
+}
+
+export function useSettingsLoad({
+  themeRef,
+  latestSettingsObjects,
+  resetDirty,
+  setLoading,
+  setAppPaths,
+  setAppNames,
+  setAppArgs,
+  setProfiles,
+  setGamePaths,
+  setCustomSlots,
+  setAccentPreset,
+  setAccentCustom,
+  setAccentBgTint,
+  setThemeMode,
+  setFocusActiveTitle,
+  setLaunchDelayMs,
+  setStartWithWindows,
+  setStartMinimized,
+  setMinimizeToTray,
+  setAutoCheckUpdates,
+  setZoomFactor,
+  setIsCustomColor,
+  setAppIcons,
+  setGameIcons
+}: UseSettingsLoadArgs) {
+  const loadSettingsFromStore = useCallback(async () => {
+    const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
+    const typedProfiles = savedProfiles as Profiles
+
+    latestSettingsObjects.current = {
+      appPaths: settings.appPaths,
+      appNames: settings.appNames,
+      appArgs: settings.appArgs,
+      gamePaths: settings.gamePaths
+    }
+
+    setAppPaths(settings.appPaths)
+    setAppNames(settings.appNames)
+    setAppArgs(settings.appArgs)
+    setProfiles(typedProfiles)
+    setGamePaths(settings.gamePaths)
+    setCustomSlots(
+      resolveCustomSlots(
+        settings.customSlots,
+        settings.appPaths,
+        settings.appNames,
+        ...(Object.values(typedProfiles) as Record<string, unknown>[])
+      )
+    )
+    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
+
+    setAccentPreset(settings.accentPreset || DEFAULT_ACCENT_COLOR)
+    setAccentCustom(settings.accentCustom || '')
+    setAccentBgTint(settings.accentBgTint || false)
+    setThemeMode(loadedThemeMode)
+    themeRef.current.setThemeMode(loadedThemeMode)
+    setFocusActiveTitle(settings.focusActiveTitle !== false)
+    setLaunchDelayMs(normalizeLaunchDelayMs(settings.launchDelayMs))
+    setStartWithWindows(settings.startWithWindows || false)
+    setStartMinimized(settings.startMinimized || false)
+    setMinimizeToTray(settings.minimizeToTray || false)
+    setAutoCheckUpdates(settings.autoCheckUpdates !== false)
+    setZoomFactor(Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0)
+
+    setIsCustomColor(settings.accentPreset === 'custom')
+
+    const icons: Record<string, string> = {}
+    for (const [key, path] of Object.entries(settings.appPaths)) {
+      if (path) {
+        const icon = await getFileIcon(path)
+        if (icon) icons[key] = icon
+      }
+    }
+    setAppIcons(icons)
+
+    const gIcons: Record<string, string> = {}
+    for (const game of GAMES) {
+      const filename = game.icon.split('/').pop() || ''
+      const data = await getAssetData(filename)
+      if (data) gIcons[game.key] = data
+    }
+    setGameIcons(gIcons)
+
+    setLoading(false)
+  }, [latestSettingsObjects, themeRef])
+
+  useEffect(() => {
+    loadSettingsFromStore()
+  }, [loadSettingsFromStore])
+
+  useEffect(() => {
+    return onStoreConfigChanged((payload: StoreConfigChangePayload) => {
+      if (payload.reason === 'save-settings' || payload.reason === 'save-profiles') return
+      void loadSettingsFromStore().then(() => resetDirty())
+    })
+  }, [loadSettingsFromStore, resetDirty])
+
+  return { loadSettingsFromStore }
+}

--- a/src/renderer/src/components/settings/useSettingsSave.ts
+++ b/src/renderer/src/components/settings/useSettingsSave.ts
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, type MutableRefObject } from 'react'
+import { saveProfiles, saveSettings as persistSettings } from '../../lib/store'
+import type { Profiles } from '../../lib/config'
+import type { ThemeMode } from '../../lib/theme'
+import {
+  getSettingsObjectChangesDuringSave,
+  resolveSettingsObjectsAfterSave,
+  type SettingsObjectRecords,
+  type SettingsObjectVersions
+} from './saveRace'
+import { normalizeLaunchDelayMs } from './settingsUtils'
+
+interface SettingsStateSnapshot {
+  appPaths: Record<string, string>
+  appNames: Record<string, string>
+  appArgs: Record<string, string>
+  profiles: Profiles
+  gamePaths: Record<string, string>
+  customSlots: number
+  accentPreset: string
+  accentCustom: string
+  accentBgTint: boolean
+  themeMode: ThemeMode
+  focusActiveTitle: boolean
+  launchDelayMs: number
+  startWithWindows: boolean
+  startMinimized: boolean
+  minimizeToTray: boolean
+  autoCheckUpdates: boolean
+  zoomFactor: number
+}
+
+function trimPathRecord(paths: Record<string, string>) {
+  return Object.fromEntries(Object.entries(paths).map(([key, value]) => [key, value.trim()]))
+}
+
+function trimStringRecord(values: Record<string, string>) {
+  return Object.fromEntries(
+    Object.entries(values)
+      .map(([key, value]) => [key, value.trim()])
+      .filter(([, value]) => value.length > 0)
+  )
+}
+
+interface UseSettingsSaveArgs {
+  appPaths: Record<string, string>
+  appNames: Record<string, string>
+  appArgs: Record<string, string>
+  profiles: Profiles
+  gamePaths: Record<string, string>
+  customSlots: number
+  accentPreset: string
+  accentCustom: string
+  accentBgTint: boolean
+  themeMode: ThemeMode
+  focusActiveTitle: boolean
+  launchDelayMs: number
+  startMinimized: boolean
+  minimizeToTray: boolean
+  autoCheckUpdates: boolean
+  startWithWindows: boolean
+  zoomFactor: number
+  currentSettingsState: SettingsStateSnapshot
+  settingsObjectEditVersions: MutableRefObject<SettingsObjectVersions>
+  latestSettingsObjects: MutableRefObject<SettingsObjectRecords>
+  notify: (message: string, type: 'success' | 'error' | 'warn', duration?: number) => void
+  resetDirty: (state?: SettingsStateSnapshot) => void
+  setAppPaths: (appPaths: Record<string, string>) => void
+  setGamePaths: (gamePaths: Record<string, string>) => void
+  setAppArgs: (appArgs: Record<string, string>) => void
+  setLaunchDelayMs: (launchDelayMs: number) => void
+  shouldSaveTrigger?: boolean
+  onSaved?: () => void
+}
+
+export function useSettingsSave({
+  appPaths,
+  appNames,
+  appArgs,
+  profiles,
+  gamePaths,
+  customSlots,
+  accentPreset,
+  accentCustom,
+  accentBgTint,
+  themeMode,
+  focusActiveTitle,
+  launchDelayMs,
+  startMinimized,
+  minimizeToTray,
+  autoCheckUpdates,
+  startWithWindows,
+  zoomFactor,
+  currentSettingsState,
+  settingsObjectEditVersions,
+  latestSettingsObjects,
+  notify,
+  resetDirty,
+  setAppPaths,
+  setGamePaths,
+  setAppArgs,
+  setLaunchDelayMs,
+  shouldSaveTrigger,
+  onSaved
+}: UseSettingsSaveArgs) {
+  const handleSave = useCallback(async () => {
+    try {
+      const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
+      const trimmedAppPaths = trimPathRecord(appPaths)
+      const trimmedGamePaths = trimPathRecord(gamePaths)
+      const trimmedAppArgs = trimStringRecord(appArgs)
+      const settingsObjectEditVersionsAtSave = { ...settingsObjectEditVersions.current }
+      const savedSettingsObjects = {
+        appPaths: trimmedAppPaths,
+        appNames,
+        appArgs: trimmedAppArgs,
+        gamePaths: trimmedGamePaths
+      }
+
+      await Promise.all([
+        persistSettings({
+          appPaths: savedSettingsObjects.appPaths,
+          appNames: savedSettingsObjects.appNames,
+          appArgs: savedSettingsObjects.appArgs,
+          gamePaths: savedSettingsObjects.gamePaths,
+          customSlots,
+          accentPreset,
+          accentCustom,
+          accentBgTint,
+          themeMode,
+          focusActiveTitle,
+          launchDelayMs: normalizedLaunchDelayMs,
+          startMinimized,
+          minimizeToTray,
+          autoCheckUpdates,
+          startWithWindows,
+          zoomFactor
+        }),
+        saveProfiles(profiles)
+      ])
+      const changedDuringSave = getSettingsObjectChangesDuringSave(
+        settingsObjectEditVersionsAtSave,
+        settingsObjectEditVersions.current
+      )
+      const resetSettingsObjects = resolveSettingsObjectsAfterSave({
+        savedObjects: savedSettingsObjects,
+        latestObjects: latestSettingsObjects.current,
+        changedDuringSave
+      })
+
+      if (!changedDuringSave.appPaths) setAppPaths(savedSettingsObjects.appPaths)
+      if (!changedDuringSave.gamePaths) setGamePaths(savedSettingsObjects.gamePaths)
+      if (!changedDuringSave.appArgs) setAppArgs(savedSettingsObjects.appArgs)
+
+      setLaunchDelayMs(normalizedLaunchDelayMs)
+      notify('Settings saved!', 'success', 2500)
+      resetDirty({
+        ...currentSettingsState,
+        ...resetSettingsObjects,
+        launchDelayMs: normalizedLaunchDelayMs
+      })
+    } catch (err) {
+      notify('Failed to save settings', 'error')
+      console.error(err)
+    }
+  }, [
+    appArgs,
+    appNames,
+    appPaths,
+    accentBgTint,
+    accentCustom,
+    accentPreset,
+    autoCheckUpdates,
+    currentSettingsState,
+    customSlots,
+    focusActiveTitle,
+    gamePaths,
+    launchDelayMs,
+    minimizeToTray,
+    notify,
+    profiles,
+    resetDirty,
+    startMinimized,
+    startWithWindows,
+    themeMode,
+    zoomFactor,
+    settingsObjectEditVersions,
+    latestSettingsObjects,
+    setAppPaths,
+    setGamePaths,
+    setAppArgs,
+    setLaunchDelayMs
+  ])
+
+  useEffect(() => {
+    if (shouldSaveTrigger) {
+      handleSave().then(() => {
+        onSaved?.()
+      })
+    }
+  }, [handleSave, onSaved, shouldSaveTrigger])
+
+  return { handleSave }
+}


### PR DESCRIPTION
## Summary

- Extracts `loadSettingsFromStore` and store config listener into `useSettingsLoad.ts`
- Extracts `handleSave` and save-race logic into `useSettingsSave.ts`
- Extracts custom slot add/remove/confirm handlers and dialog into `useCustomSlots.tsx`
- Extracts config export/import handlers and dialogs into `useConfigIO.tsx`
- `SettingsContext.tsx` reduced from 860 → 511 lines; public API (`useSettings`, `SettingsProvider`) unchanged

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 36/36 tests pass
- [x] Manual smoke test: open Settings, change a value, save, confirm dirty-state prompt works

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #230
<!-- auto-closes -->