### PR TITLE
perf: cache readRunningProcessNames with 500ms TTL and in-flight coalescing

### DIFF
--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -6,6 +6,6 @@ export {
   unsubscribeRunningApps
 } from './processes/running'
 export { launchProfileApps, isRunningExePath } from './processes/spawn'
-export { readRunningProcessNames } from './processes/tasklist'
+export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'
 export type { KillFailure, KillFailureReason, KillResult, LaunchResult } from './processes/types'

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -12,7 +12,7 @@ import { getErrorMessage, getExeName, isValidExePath } from '../utils'
 
 import { runningProcesses, unclosedProcesses } from './state'
 import { publishRunningApps } from './running'
-import { readRunningProcessNames } from './tasklist'
+import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { KillFailure, KillFailureReason, KillResult } from './types'
 
 interface KillAttemptResult {
@@ -318,6 +318,7 @@ async function finalizeKillAttempts(attempts: KillAttemptResult[]): Promise<Kill
     }
   }
 
+  invalidateProcessNameCache()
   const processNamesAfterKill = await readRunningProcessNames()
   const finalizedAttempts = await Promise.all(
     attempts.map(async (attempt) => {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -7,7 +7,7 @@ import { store } from '../store'
 import { getErrorCode, getErrorMessage, getExeName, isValidExePath, wait } from '../utils'
 
 import { runningProcesses } from './state'
-import { readRunningProcessNames } from './tasklist'
+import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { AppLaunchResult, LaunchResult } from './types'
 import { publishRunningApps } from './running'
 
@@ -294,6 +294,7 @@ function spawnDetachedApp(
 
       child.once('spawn', () => {
         child.unref()
+        invalidateProcessNameCache()
         publishRunningApps('launch').catch((err) => {
           console.error('Failed to publish running apps after launch:', err)
         })
@@ -323,6 +324,7 @@ function spawnDetachedApp(
 
       child.once('exit', () => {
         runningProcesses.delete(appPath)
+        invalidateProcessNameCache()
         publishRunningApps('exit').catch((err) => {
           console.error('Failed to publish running apps after exit:', err)
         })

--- a/src/main/processes/tasklist.ts
+++ b/src/main/processes/tasklist.ts
@@ -1,6 +1,12 @@
 import { execFile } from 'child_process'
 
-export function readRunningProcessNames() {
+const CACHE_TTL_MS = 500
+
+let cachedResult: Set<string> | undefined
+let cachedAt = 0
+let inflight: Promise<Set<string>> | undefined
+
+function spawnTasklist(): Promise<Set<string>> {
   return new Promise<Set<string>>((resolve) => {
     execFile('tasklist', ['/fo', 'csv', '/nh'], { windowsHide: true }, (error, stdout) => {
       if (error) {
@@ -19,4 +25,31 @@ export function readRunningProcessNames() {
       resolve(names)
     })
   })
+}
+
+export function readRunningProcessNames(): Promise<Set<string>> {
+  if (cachedResult && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return Promise.resolve(cachedResult)
+  }
+
+  if (inflight) {
+    return inflight
+  }
+
+  inflight = spawnTasklist()
+    .then((names) => {
+      cachedResult = names
+      cachedAt = Date.now()
+      return names
+    })
+    .finally(() => {
+      inflight = undefined
+    })
+
+  return inflight
+}
+
+export function invalidateProcessNameCache() {
+  cachedResult = undefined
+  cachedAt = 0
 }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -16,6 +16,7 @@ const nullExecutablePathPids = new Set<string>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnErrors = new Map<string, NodeJS.ErrnoException>()
+const invalidateProcessNameCacheMock = vi.fn()
 
 function makeAccessDeniedError() {
   const error = new Error('Access is denied.') as NodeJS.ErrnoException
@@ -96,6 +97,7 @@ async function loadProcessModules() {
   }))
 
   vi.doMock('../../src/main/processes/tasklist', () => ({
+    invalidateProcessNameCache: invalidateProcessNameCacheMock,
     readRunningProcessNames: vi.fn(() => Promise.resolve(new Set(processNames)))
   }))
 
@@ -166,6 +168,7 @@ beforeEach(async () => {
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
+  invalidateProcessNameCacheMock.mockClear()
   runningProcesses.clear()
   unclosedProcesses.clear()
   Object.keys(storeData).forEach((key) => delete storeData[key])
@@ -217,6 +220,7 @@ test('launchProfileApps parses custom app arguments with quoted paths and escape
     appPath: 'C:/Tools/Custom Tool.exe',
     args: ['--config', 'C:/Users/Driver/Sim Configs/main profile.json', '--label', 'Crew "Chief"']
   })
+  expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
 })
 
 test('launchProfileApps treats PowerShell-sensitive custom argument characters as literal spawn args', async () => {
@@ -378,6 +382,7 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
       expect.objectContaining({ command: 'taskkill', args: ['/IM', 'simhub.exe', '/T', '/F'] })
     ])
   )
+  expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
 })
 
 test('killProfileApps includes processes with null executable paths when resolving PIDs', async () => {

--- a/tests/main/tasklist.test.ts
+++ b/tests/main/tasklist.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+let tasklistCallCount = 0
+let tasklistOutput =
+  '"SimHub.exe","1234","Console","1","50,000 K"\r\n"CrewChief.exe","5678","Console","1","30,000 K"'
+
+async function loadTasklistModule() {
+  vi.resetModules()
+
+  vi.doMock('child_process', () => ({
+    execFile: vi.fn((_command, _args, _options, callback) => {
+      tasklistCallCount += 1
+      callback(null, tasklistOutput, '')
+    })
+  }))
+
+  return await import('../../src/main/processes/tasklist')
+}
+
+beforeEach(() => {
+  tasklistCallCount = 0
+  tasklistOutput =
+    '"SimHub.exe","1234","Console","1","50,000 K"\r\n"CrewChief.exe","5678","Console","1","30,000 K"'
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('readRunningProcessNames parses tasklist CSV output into lowercase process names', async () => {
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const names = await readRunningProcessNames()
+
+  expect(names).toBeInstanceOf(Set)
+  expect(names.has('simhub.exe')).toBe(true)
+  expect(names.has('crewchief.exe')).toBe(true)
+  expect(tasklistCallCount).toBe(1)
+})
+
+test('concurrent calls coalesce into a single tasklist invocation', async () => {
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const [first, second, third] = await Promise.all([
+    readRunningProcessNames(),
+    readRunningProcessNames(),
+    readRunningProcessNames()
+  ])
+
+  expect(tasklistCallCount).toBe(1)
+  expect(first).toBe(second)
+  expect(second).toBe(third)
+})
+
+test('cached result is returned within TTL window', async () => {
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const first = await readRunningProcessNames()
+  const second = await readRunningProcessNames()
+
+  expect(tasklistCallCount).toBe(1)
+  expect(first).toBe(second)
+})
+
+test('cache expires after TTL and spawns a fresh tasklist', async () => {
+  vi.useFakeTimers()
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  await readRunningProcessNames()
+  expect(tasklistCallCount).toBe(1)
+
+  // Advance past the 500ms TTL
+  vi.advanceTimersByTime(600)
+
+  await readRunningProcessNames()
+  expect(tasklistCallCount).toBe(2)
+
+  vi.useRealTimers()
+})
+
+test('invalidateProcessNameCache forces a fresh read on next call', async () => {
+  const { readRunningProcessNames, invalidateProcessNameCache } = await loadTasklistModule()
+
+  const first = await readRunningProcessNames()
+  expect(tasklistCallCount).toBe(1)
+  expect(first.has('simhub.exe')).toBe(true)
+
+  tasklistOutput = '"NewApp.exe","9999","Console","1","10,000 K"'
+  invalidateProcessNameCache()
+
+  const second = await readRunningProcessNames()
+  expect(tasklistCallCount).toBe(2)
+  expect(second.has('newapp.exe')).toBe(true)
+  expect(second.has('simhub.exe')).toBe(false)
+})


### PR DESCRIPTION
## Summary

- Add 500ms TTL cache to `readRunningProcessNames()` so callers within the same cycle share one `tasklist.exe` invocation
- Coalesce concurrent in-flight calls to prevent parallel spawns
- Export `invalidateProcessNameCache()` for manual busting
- 5 new tests covering caching, coalescing, TTL expiry, and invalidation

Closes #275

## Test plan
- [x] All 41 tests pass (`npx vitest run`)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [x] Launch + kill cycle works as expected in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #275
<!-- auto-closes -->