### PR TITLE
perf: eliminate double stringify in dirty tracking and debounce profile focus reload

### DIFF
--- a/src/renderer/src/hooks/useDirtyTracking.ts
+++ b/src/renderer/src/hooks/useDirtyTracking.ts
@@ -6,26 +6,23 @@ import { useEffect, useRef, useState } from 'react'
  */
 export function useDirtyTracking<T>(currentState: T, loading: boolean = false) {
   const [isDirty, setIsDirty] = useState(false)
-  const initialState = useRef<T | null>(null)
+  const initialSnapshot = useRef<string | null>(null)
 
   useEffect(() => {
     // Capture initial state once loading is finished
-    if (!loading && initialState.current === null) {
-      initialState.current = JSON.parse(JSON.stringify(currentState))
+    if (!loading && initialSnapshot.current === null) {
+      initialSnapshot.current = JSON.stringify(currentState)
     }
   }, [loading, currentState])
 
   useEffect(() => {
-    if (initialState.current === null) return
+    if (initialSnapshot.current === null) return
 
-    const currentStr = JSON.stringify(currentState)
-    const initialStr = JSON.stringify(initialState.current)
-
-    setIsDirty(currentStr !== initialStr)
+    setIsDirty(JSON.stringify(currentState) !== initialSnapshot.current)
   }, [currentState])
 
   const resetDirty = (newState?: T) => {
-    initialState.current = JSON.parse(JSON.stringify(newState ?? currentState))
+    initialSnapshot.current = JSON.stringify(newState ?? currentState)
     setIsDirty(false)
   }
 

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -12,6 +12,26 @@ type ProfileState = {
   relaunchControlsEnabled: boolean
 }
 
+const FOCUS_DEBOUNCE_MS = 300
+const PROFILE_FOCUS_EVENT = 'simlauncher:profile-focus-reload'
+
+let focusListenerActive = false
+let focusDebounceTimer: ReturnType<typeof setTimeout> | undefined
+
+function ensureFocusListener() {
+  if (focusListenerActive) {
+    return
+  }
+
+  focusListenerActive = true
+  window.addEventListener('focus', () => {
+    clearTimeout(focusDebounceTimer)
+    focusDebounceTimer = setTimeout(() => {
+      window.dispatchEvent(new Event(PROFILE_FOCUS_EVENT))
+    }, FOCUS_DEBOUNCE_MS)
+  })
+}
+
 const getProfileState = (profileSet: GameProfileSet): ProfileState => {
   const profile = getActiveGameProfile(profileSet)
 
@@ -60,11 +80,12 @@ export function useGameProfile(gameKey: string, isActive: boolean, activeProfile
     }
 
     load()
-    window.addEventListener('focus', load)
+    ensureFocusListener()
+    window.addEventListener(PROFILE_FOCUS_EVENT, load)
 
     return () => {
       mounted = false
-      window.removeEventListener('focus', load)
+      window.removeEventListener(PROFILE_FOCUS_EVENT, load)
     }
   }, [activeProfileId, applyProfileSet, isActive, readProfileSet])
 


### PR DESCRIPTION
## Summary

- `useDirtyTracking`: store initial state as pre-serialized string, cutting `JSON.stringify` calls from 2 to 1 per comparison; removes unnecessary deep-clone
- `useGameProfile`: replace N per-instance `window.addEventListener('focus')` with a single shared module-level listener that dispatches a custom event after 300ms debounce — alt-tab now triggers 1 event instead of N racing `getProfiles()` IPC calls

Closes #276

## Test plan
- [x] All 36 tests pass (`npx vitest run`)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [x] Settings dirty state works correctly after edits
- [x] Profile reloads on window focus (single IPC call with multiple games configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #276
<!-- auto-closes -->