### PR TITLE
fix(kill): fail-closed on unreadable ExecutablePath

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -112,7 +112,7 @@ function findProcessIdsByExecutablePath(processName: string, appPath: string) {
       `$name = '${escapeWmiString(processName)}'`,
       '$targetPath = [System.IO.Path]::GetFullPath($target)',
       'Get-CimInstance Win32_Process -Filter "Name = \'$name\'" |',
-      '  Where-Object { (-not $_.ExecutablePath) -or ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
+      '  Where-Object { $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
       '  Select-Object -ExpandProperty ProcessId |',
       '  ConvertTo-Json -Compress'
     ].join('\n')


### PR DESCRIPTION
## Summary

- Changes `(-not $_.ExecutablePath) -or` to `$_.ExecutablePath -and` in `findProcessIdsByExecutablePath` (`kill.ts:115`)
- Processes whose `ExecutablePath` is unreadable (elevated/system processes) are now excluded instead of matching by name alone
- Found in 0.9.0 security audit (Gemini + Codex)

## Test plan

- [ ] Launch an app configured with the same basename as a system process and verify SimLauncher does not terminate the unrelated process
- [ ] Normal kill flow still terminates the correct process by path

Closes #285

<!-- auto-closes -->
Closes #285
<!-- auto-closes -->