### PR TITLE
fix(store): add projectName to electron-store constructor

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -53,6 +53,7 @@ const StoreConstructor =
   typeof Store === 'function' ? Store : (Store as unknown as { default: typeof Store }).default
 
 export const store = new StoreConstructor({
+  projectName: 'SimLauncher',
   schema: {
     appPaths: { type: 'object', default: {} },
     gamePaths: { type: 'object', default: {} },
@@ -76,7 +77,7 @@ export const store = new StoreConstructor({
     profileSetsMigrated: { type: 'boolean', default: false },
     migrated: { type: 'boolean', default: false }
   }
-})
+} as ConstructorParameters<typeof StoreConstructor>[0] & { projectName: string })
 
 export const CONFIG_FILE_NAME = 'simlauncher-config.json'
 export const EXPECTED_CONFIG_KEYS = new Set([

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -52,10 +52,10 @@ async function loadProcessModules() {
     execFile: vi.fn((command, args, options, callback) => {
       execFileCalls.push({ command, args, options })
       if (command === 'powershell.exe') {
-        const pids = [
-          ...(processNames.has('simhub.exe') ? ['4321'] : []),
-          ...Array.from(nullExecutablePathPids)
-        ]
+        const pids = []
+        if (processNames.has('simhub.exe')) {
+          pids.push('4321')
+        }
         callback(null, pids.length ? JSON.stringify(pids.map(Number)) : '', '')
         return
       }
@@ -385,7 +385,7 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
   expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
 })
 
-test('killProfileApps includes processes with null executable paths when resolving PIDs', async () => {
+test('killProfileApps excludes processes with null executable paths when resolving PIDs', async () => {
   const { killProfileApps } = await loadProcessModules()
 
   existingPaths.add('C:/Tools/SimHub.exe')
@@ -403,17 +403,20 @@ test('killProfileApps includes processes with null executable paths when resolvi
     expect.arrayContaining([
       expect.objectContaining({
         command: 'powershell.exe',
-        args: expect.arrayContaining([expect.stringContaining('(-not $_.ExecutablePath) -or')])
+        args: expect.arrayContaining([expect.stringContaining('$_.ExecutablePath -and')])
       }),
       expect.objectContaining({
         command: 'taskkill',
-        args: ['/PID', '9876', '/T', '/F']
+        args: ['/PID', '4321', '/T', '/F']
       })
     ])
   )
   expect(execFileCalls).not.toEqual(
     expect.arrayContaining([
-      expect.objectContaining({ command: 'taskkill', args: ['/IM', 'simhub.exe', '/T', '/F'] })
+      expect.objectContaining({
+        command: 'taskkill',
+        args: ['/PID', '9876', '/T', '/F']
+      })
     ])
   )
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,14 @@ export default defineConfig({
       {
         test: { name: 'renderer', environment: 'jsdom', include: rendererTests, pool: 'vmThreads' }
       },
-      { test: { name: 'main', environment: 'node', include: mainProcessTests, pool: 'vmThreads' } }
+      {
+        test: {
+          name: 'main',
+          environment: 'node',
+          include: mainProcessTests,
+          pool: 'vmThreads'
+        }
+      }
     ]
   }
 })


### PR DESCRIPTION
## Summary

- Adds `projectName: 'SimLauncher'` to the `electron-store` constructor in `store.ts`
- Fixes crash `Please specify the projectName option` when `processes.test.ts` runs outside Electron context
- Updates kill null-path test to assert fail-closed behavior from #285

## Verification

- `npm exec vitest run tests/main/processes.test.ts` now runs past the blocker — 6 tests pass, 8 pre-existing failures remain (unrelated)
- `npm run typecheck:tsc` passes

Refs #287