### PR TITLE
chore(ci): add explicit permissions block to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` at workflow level to limit GITHUB_TOKEN scope
- Fixes CodeQL code scanning alert #1

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #290
<!-- auto-closes -->