### PR TITLE
fix: resolve config import and toast styling issues

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -185,16 +185,22 @@ function applySanitizedConfig(supportedConfig: Record<string, unknown>) {
 
   try {
     store.clear()
-    store.set(supportedConfig)
+    setStoreEntries(supportedConfig)
     migrateProfilesToNamedSets()
     applyRuntimeConfigSettings()
     notifyStoreConfigChanged({ reason: 'import-config', keys: ['*'] })
   } catch (err) {
     store.clear()
-    store.set(snapshot as Record<string, unknown>)
+    setStoreEntries(snapshot)
     applyRuntimeConfigSettings()
     throw err
   }
+}
+
+function setStoreEntries(values: Record<string, unknown>) {
+  Object.entries(values).forEach(([key, value]) => {
+    store.set(key, value)
+  })
 }
 
 export function registerConfigHandlers() {
@@ -406,7 +412,7 @@ export function registerConfigHandlers() {
     }
     const changedKeys = Object.keys(safe)
     if (changedKeys.length > 0) {
-      store.set(safe)
+      setStoreEntries(safe)
       notifyStoreConfigChanged({ reason: 'save-settings', keys: changedKeys })
     }
   })
@@ -459,7 +465,7 @@ export function registerConfigHandlers() {
     }
     const changedKeys = Object.keys(safe)
     if (changedKeys.length > 0) {
-      store.set(safe)
+      setStoreEntries(safe)
       notifyStoreConfigChanged({ reason: 'set-migration-flags', keys: changedKeys })
     }
   })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -93,7 +93,7 @@ export default function App() {
         </div>
 
         {showImportWarning && (
-          <div className="glass-surface !absolute left-4 right-4 top-16 z-30 mx-auto flex max-w-3xl animate-fade-slide items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] ![--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]">
+          <div className="glass-surface absolute! left-4 right-4 top-16 z-30 mx-auto flex max-w-3xl animate-fade-slide items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] [--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]!">
             <WarningTriangleIcon width={17} height={17} className="shrink-0" />
             <span className="min-w-0 flex-1">
               Config imported. Executable paths from your previous device may need to be updated.

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -101,7 +101,7 @@ function ToastCard({
   return (
     <button
       type="button"
-      className={`toast-card glass-surface overflow-hidden relative rounded-[18px] text-left border px-[16px] py-[14px] min-w-[280px] max-w-[400px] shadow-[0_8px_30px_#00000050] transition-all duration-250 ease-out ${TOAST_STYLES[toast.type]} ${isDismissing ? 'toast-card-dismissing opacity-0 translate-x-5 scale-95' : 'opacity-100 translate-x-0 scale-100'}`}
+      className={`toast-card glass-surface overflow-hidden relative rounded-[18px] text-left px-[16px] py-[14px] min-w-[280px] max-w-[400px] shadow-[0_8px_30px_#00000050] transition-all duration-250 ease-out ${TOAST_STYLES[toast.type]} ${isDismissing ? 'toast-card-dismissing opacity-0 translate-x-5 scale-95' : 'opacity-100 translate-x-0 scale-100'}`}
       onClick={() => onDismiss(toast.id)}
     >
       <div className="flex items-start gap-3.5">

--- a/src/renderer/src/components/settings/ImportPreviewDialog.tsx
+++ b/src/renderer/src/components/settings/ImportPreviewDialog.tsx
@@ -94,7 +94,7 @@ export function ImportPreviewDialog({
           />
 
           {summary.warnings.length > 0 ? (
-            <ul className="space-y-1 rounded-xl border border-yellow-400/20 bg-yellow-400/10 p-3 text-xs text-yellow-100">
+            <ul className="space-y-1 rounded-xl border border-(--warning-border) bg-(--warning-surface) p-3 text-xs text-(--warning-text)">
               {summary.warnings.map((warning) => (
                 <li key={warning}>{warning}</li>
               ))}


### PR DESCRIPTION
## Summary
- Replace object-form `store.set(obj)` with per-key writes via `setStoreEntries()` helper (#293)
- Remove duplicate `border` utility from toast cards (#281)
- Replace hardcoded warning colors with `--warning-border`, `--warning-surface`, `--warning-text` tokens in ImportPreviewDialog (#280)
- Fix Tailwind v4 important modifier syntax: `!absolute` → `absolute!` (#294)

## Milestone
0.9.5

Closes #281, closes #280, closes #293, closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)