### PR TITLE
fix: process test setup, type predicate, and settings hook deps

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -69,7 +69,7 @@ function runTaskkill(args: string[], description: string) {
   })
 }
 
-function isFullExePath(appPath: string | undefined) {
+function isFullExePath(appPath: string | undefined): appPath is string {
   return (
     typeof appPath === 'string' && path.basename(appPath) !== appPath && isValidExePath(appPath)
   )
@@ -188,7 +188,7 @@ async function killProcessByImageName(
   }
 
   if (isFullExePath(appPath)) {
-    const targetAppPath = appPath as string
+    const targetAppPath = appPath
     const { processIds, detail, accessDenied } = await findProcessIdsByExecutablePath(
       processName,
       targetAppPath

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -124,7 +124,31 @@ export function useSettingsLoad({
     setGameIcons(gIcons)
 
     setLoading(false)
-  }, [latestSettingsObjects, themeRef])
+  }, [
+    latestSettingsObjects,
+    setAccentBgTint,
+    setAccentCustom,
+    setAccentPreset,
+    setAppArgs,
+    setAppIcons,
+    setAppNames,
+    setAppPaths,
+    setAutoCheckUpdates,
+    setCustomSlots,
+    setFocusActiveTitle,
+    setGameIcons,
+    setGamePaths,
+    setIsCustomColor,
+    setLaunchDelayMs,
+    setLoading,
+    setMinimizeToTray,
+    setProfiles,
+    setStartMinimized,
+    setStartWithWindows,
+    setThemeMode,
+    setZoomFactor,
+    themeRef
+  ])
 
   useEffect(() => {
     loadSettingsFromStore()

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -39,18 +39,37 @@ async function loadProcessModules() {
       set(key: string, value: unknown) {
         storeData[key] = value
       }
+
+      clear() {
+        Object.keys(storeData).forEach((key) => delete storeData[key])
+      }
     }
   }))
 
   vi.doMock('fs', () => ({
     default: {
-      existsSync: (filePath: string) => existingPaths.has(filePath.replace(/\\/g, '/').trim())
+      existsSync: (filePath: string) => {
+        const normalizedPath = filePath.replace(/\\/g, '/').trim()
+        const drivePath = normalizedPath.match(/[A-Z]:\/.*$/i)?.[0] || normalizedPath
+
+        return existingPaths.has(drivePath)
+      }
     }
   }))
 
   vi.doMock('child_process', () => ({
     execFile: vi.fn((command, args, options, callback) => {
       execFileCalls.push({ command, args, options })
+      if (command === 'tasklist') {
+        callback(
+          null,
+          Array.from(processNames)
+            .map((processName) => `"${processName}","1234","Console","1","1,024 K"`)
+            .join('\n'),
+          ''
+        )
+        return
+      }
       if (command === 'powershell.exe') {
         const pids = []
         if (processNames.has('simhub.exe')) {
@@ -96,19 +115,27 @@ async function loadProcessModules() {
     })
   }))
 
-  vi.doMock('../../src/main/processes/tasklist', () => ({
+  const tasklistMock = {
     invalidateProcessNameCache: invalidateProcessNameCacheMock,
     readRunningProcessNames: vi.fn(() => Promise.resolve(new Set(processNames)))
-  }))
+  }
+  vi.doMock('../../src/main/processes/tasklist', () => tasklistMock)
+  vi.doMock('../../src/main/processes/tasklist.ts', () => tasklistMock)
 
-  vi.doMock('../../src/main/store', () => ({
+  const storeMock = {
     store: {
+      store: storeData,
       get: vi.fn((key: string) => storeData[key]),
       set: vi.fn((key: string, value: unknown) => {
         storeData[key] = value
+      }),
+      clear: vi.fn(() => {
+        Object.keys(storeData).forEach((key) => delete storeData[key])
       })
     }
-  }))
+  }
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
 
   vi.doMock('../../src/main/profiles', () => ({
     getActiveStoredProfile: vi.fn((p: { activeProfileId: string; profiles: { id: string }[] }) =>


### PR DESCRIPTION
## Summary
- Add `appPath is string` type predicate to `isFullExePath()`, remove now-redundant `as string` cast (#292)
- Stub electron-store and fix path normalization in `processes.test.ts` so suite runs without Electron context (#287)
- Add stable `useState` setters to `useCallback` dep array in `useSettingsLoad.ts`, fixing exhaustive-deps warning (#296)

## Milestone
0.9.5

Closes #292, closes #287, closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)