### PR TITLE
fix: type executable picker dialog options

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, screen } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, screen, type OpenDialogOptions } from 'electron'
 import path from 'path'
 
 import { getIsQuitting, setIsQuitting } from './app-state'
@@ -179,9 +179,9 @@ export function registerWindowHandlers() {
    */
   ipcMain.handle('browse-path', async (_event, inputId) => {
     try {
-      const options = {
+      const options: OpenDialogOptions = {
         title: 'Select Executable File (.exe)',
-        properties: ['openFile'] as const,
+        properties: ['openFile'],
         filters: [{ name: 'Executable Files', extensions: ['exe'] }]
       }
       const result =


### PR DESCRIPTION
## Summary
- Import `OpenDialogOptions` from electron and apply it to the `showOpenDialog` options object, removing `as const` from `properties` array which caused ts(2345) in the IDE checker (#299)

## Milestone
0.9.5

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)