### PR TITLE
fix: centralize icon cache and parallelize icon loading

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { WarningTriangleIcon, CloseIcon } from './components/icons'
 import { getUpdateInfo, onUpdateAvailable } from './lib/electron'
 import { runStartupMigrations } from './lib/migrations'
 import { useTheme } from './contexts/ThemeContext'
+import { SettingsProvider } from './components/settings/SettingsContext'
 
 export default function App() {
   const [view, setView] = useState<'games' | 'settings'>('games')
@@ -110,47 +111,47 @@ export default function App() {
           </div>
         )}
 
-        <main className="h-full relative overflow-hidden">
-          {/* Games View */}
-          <div
-            className={`h-full flex flex-col transition-all duration-300 ${
-              view === 'games'
-                ? 'opacity-100 scale-100 pointer-events-auto'
-                : 'opacity-0 scale-95 pointer-events-none'
-            }`}
-          >
-            <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
-              <GameList key={refreshKey} onNavigate={handleNavigate} />
+        <SettingsProvider
+          onDirtyChange={setSettingsDirty}
+          shouldSaveTrigger={saveRequested}
+          onConfigImported={handleConfigImported}
+          onSaved={() => {
+            setSaveRequested(false)
+            setRefreshKey((k) => k + 1)
+            if (pendingView) {
+              setView(pendingView)
+              setPendingView(null)
+            }
+          }}
+        >
+          <main className="h-full relative overflow-hidden">
+            {/* Games View */}
+            <div
+              className={`h-full flex flex-col transition-all duration-300 ${
+                view === 'games'
+                  ? 'opacity-100 scale-100 pointer-events-auto'
+                  : 'opacity-0 scale-95 pointer-events-none'
+              }`}
+            >
+              <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
+                <GameList key={refreshKey} onNavigate={handleNavigate} />
+              </div>
             </div>
-          </div>
 
-          {/* Settings View */}
-          <div
-            className={`absolute inset-0 z-10 h-full flex flex-col transition-all duration-300 ${
-              view === 'settings'
-                ? 'opacity-100 scale-100 pointer-events-auto'
-                : 'opacity-0 scale-95 pointer-events-none'
-            }`}
-          >
-            <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
-              <SettingsView
-                onClose={() => handleNavigate('games')}
-                updateInfo={updateInfo}
-                onDirtyChange={setSettingsDirty}
-                shouldSaveTrigger={saveRequested}
-                onConfigImported={handleConfigImported}
-                onSaved={() => {
-                  setSaveRequested(false)
-                  setRefreshKey((k) => k + 1)
-                  if (pendingView) {
-                    setView(pendingView)
-                    setPendingView(null)
-                  }
-                }}
-              />
+            {/* Settings View */}
+            <div
+              className={`absolute inset-0 z-10 h-full flex flex-col transition-all duration-300 ${
+                view === 'settings'
+                  ? 'opacity-100 scale-100 pointer-events-auto'
+                  : 'opacity-0 scale-95 pointer-events-none'
+              }`}
+            >
+              <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
+                <SettingsView onClose={() => handleNavigate('games')} updateInfo={updateInfo} />
+              </div>
             </div>
-          </div>
-        </main>
+          </main>
+        </SettingsProvider>
 
         <ConfirmDialog
           isOpen={pendingView !== null}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -4,6 +4,7 @@ import { getSettings } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
+import { useSettings } from './settings/SettingsContext'
 import { EmptyState } from './EmptyState'
 import { GameRow } from './game-list/GameRow'
 import { GamepadIcon } from './icons'
@@ -19,6 +20,7 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
   const [focusActiveTitle, setFocusActiveTitle] = useState(true)
   const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock()
   const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
+  const { gameIcons } = useSettings()
 
   useEffect(() => {
     let mounted = true
@@ -133,6 +135,7 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
             <GameRow
               key={game.key}
               game={game}
+              gameIconUrl={gameIcons[game.key]}
               isActive={activeEditorKey === game.key}
               isRunning={!!runningStatus[game.key]}
               runningAppIcons={runningAppIcons}

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -7,35 +7,18 @@ import { BehaviorSection } from './settings/BehaviorSection'
 import { ConfigSection } from './settings/ConfigSection'
 import { GamesSection } from './settings/GamesSection'
 import { SettingsSection } from './settings/SettingsSection'
-import { SettingsProvider, useSettings } from './settings/SettingsContext'
+import { useSettings } from './settings/SettingsContext'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
 
 export function SettingsView({
   onClose,
-  updateInfo,
-  onDirtyChange,
-  shouldSaveTrigger,
-  onSaved,
-  onConfigImported
+  updateInfo
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
-  onDirtyChange?: (isDirty: boolean) => void
-  shouldSaveTrigger?: boolean
-  onSaved?: () => void
-  onConfigImported?: () => void
 }) {
-  return (
-    <SettingsProvider
-      onDirtyChange={onDirtyChange}
-      shouldSaveTrigger={shouldSaveTrigger}
-      onSaved={onSaved}
-      onConfigImported={onConfigImported}
-    >
-      <SettingsViewContent onClose={onClose} updateInfo={updateInfo} />
-    </SettingsProvider>
-  )
+  return <SettingsViewContent onClose={onClose} updateInfo={updateInfo} />
 }
 
 function SettingsViewContent({

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -1,25 +1,18 @@
 import { useEffect, useState } from 'react'
 import type { Game } from '../../lib/config'
-import { getAssetData } from '../../lib/electron'
 
 interface GameIconProps {
   game: Game
   isRunning: boolean
+  iconUrl?: string
 }
 
-export function GameIcon({ game, isRunning }: GameIconProps) {
-  const [iconUrl, setIconUrl] = useState<string | null>(null)
+export function GameIcon({ game, isRunning, iconUrl }: GameIconProps) {
   const [iconLoadFailed, setIconLoadFailed] = useState(false)
 
   useEffect(() => {
-    async function resolveIcon() {
-      const filename = game.icon.split('/').pop() || ''
-      const data = await getAssetData(filename)
-      setIconLoadFailed(false)
-      setIconUrl(data)
-    }
-    resolveIcon()
-  }, [game.icon])
+    setIconLoadFailed(false)
+  }, [iconUrl])
 
   return (
     <div className="relative flex h-12 w-12 shrink-0 items-center justify-center">

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -37,6 +37,7 @@ export function GameRow({
   isActive,
   isRunning,
   runningAppIcons,
+  gameIconUrl,
   isDimmed,
   isLaunching,
   isLaunchBlocked,
@@ -50,6 +51,7 @@ export function GameRow({
   isActive: boolean
   isRunning: boolean
   runningAppIcons: RunningAppIcon[]
+  gameIconUrl?: string
   isDimmed: boolean
   isLaunching: boolean
   isLaunchBlocked: boolean
@@ -322,7 +324,7 @@ export function GameRow({
         className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? 'isolation-auto! z-20' : 'z-0'}`}
       >
         <div className="flex items-center gap-5">
-          <GameIcon game={game} isRunning={isRunning} />
+          <GameIcon game={game} isRunning={isRunning} iconUrl={gameIconUrl} />
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
               <h3 className="game-title font-normal text-(--text-primary)">{game.name}</h3>

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -106,20 +106,26 @@ export function useSettingsLoad({
 
     setIsCustomColor(settings.accentPreset === 'custom')
 
+    const iconEntries = await Promise.all(
+      Object.entries(settings.appPaths)
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(async ([key, path]) => [key, await getFileIcon(path)] as const)
+    )
     const icons: Record<string, string> = {}
-    for (const [key, path] of Object.entries(settings.appPaths)) {
-      if (path) {
-        const icon = await getFileIcon(path)
-        if (icon) icons[key] = icon
-      }
+    for (const [key, icon] of iconEntries) {
+      if (icon) icons[key] = icon
     }
     setAppIcons(icons)
 
+    const gameIconEntries = await Promise.all(
+      GAMES.map(async (game) => {
+        const filename = game.icon.split('/').pop() || ''
+        return [game.key, await getAssetData(filename)] as const
+      })
+    )
     const gIcons: Record<string, string> = {}
-    for (const game of GAMES) {
-      const filename = game.icon.split('/').pop() || ''
-      const data = await getAssetData(filename)
-      if (data) gIcons[game.key] = data
+    for (const [key, data] of gameIconEntries) {
+      if (data) gIcons[key] = data
     }
     setGameIcons(gIcons)
 


### PR DESCRIPTION
## Summary
- `GameIcon` no longer fetches asset data URLs independently via IPC - reads `iconUrl` prop from pre-loaded `gameIcons` in `SettingsContext`
- `SettingsProvider` moved up so both game list and settings view share one icon cache
- `iconUrl` passed through `GameList` and `GameRow` into `GameIcon`
- Both app-icon and game-icon loops in `useSettingsLoad.ts` replaced with `Promise.all` for parallel loading
- Cancellation guard no longer needed - no async effect in `GameIcon`

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)