### PR TITLE
docs(kill): add invariant comments for WMI elevation edge cases

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -206,6 +206,8 @@ async function killProcessByImageName(
     }
 
     if (processIds.length === 0) {
+      // Elevated processes can expose null ExecutablePath in WMI, so they are silently
+      // filtered out by the Where-Object clause; treat this as notFound rather than error.
       return { processName, appPath: targetAppPath, gameKey, success: true, notFound: true }
     }
 
@@ -330,6 +332,8 @@ async function finalizeKillAttempts(attempts: KillAttemptResult[]): Promise<Kill
           attempt.appPath
         )
         const nameStillRunning = processNamesAfterKill.has(attempt.processName)
+        // Heuristic: if WMI found no PID (notFound) but image still appears in tasklist,
+        // the process is likely elevated and inaccessible to WMI; approximate, fix in #307.
         isElevatedInconclusive = attempt.notFound === true && nameStillRunning
         stillRunning =
           processIds.length > 0 ||


### PR DESCRIPTION
Adds two inline comments explaining non-obvious invariants in `kill.ts` to prevent future regressions.

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #304
<!-- auto-closes -->