### PR TITLE
refactor: split SettingsContext into 5 narrower contexts (#273)

### DIFF
--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -4,7 +4,7 @@ import { getSettings } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
-import { useSettings } from './settings/SettingsContext'
+import { useGamesSettings } from './settings/GamesContext'
 import { EmptyState } from './EmptyState'
 import { GameRow } from './game-list/GameRow'
 import { GamepadIcon } from './icons'
@@ -20,7 +20,7 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
   const [focusActiveTitle, setFocusActiveTitle] = useState(true)
   const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock()
   const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
-  const { gameIcons } = useSettings()
+  const { gameIcons } = useGamesSettings()
 
   useEffect(() => {
     let mounted = true

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -7,7 +7,7 @@ import { BehaviorSection } from './settings/BehaviorSection'
 import { ConfigSection } from './settings/ConfigSection'
 import { GamesSection } from './settings/GamesSection'
 import { SettingsSection } from './settings/SettingsSection'
-import { useSettings } from './settings/SettingsContext'
+import { useSettingsMeta } from './settings/SettingsMetaContext'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
 
@@ -29,7 +29,7 @@ function SettingsViewContent({
   updateInfo: UpdateInfo
 }) {
   const { notify } = useNotify()
-  const { loading, isDirty, saveSettings } = useSettings()
+  const { loading, isDirty, saveSettings } = useSettingsMeta()
   const [expandedSections, setExpandedSections] = useState({
     about: true,
     appearance: true,

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -1,5 +1,5 @@
 import { Toggle } from '../Toggle'
-import { useSettings } from './SettingsContext'
+import { useSettingsMeta } from './SettingsMetaContext'
 import type { UpdateInfo, UpdateStatus } from './types'
 
 interface AboutSectionProps {
@@ -23,7 +23,7 @@ export function AboutSection({
   onManualCheck,
   onInstallUpdate
 }: AboutSectionProps) {
-  const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettings()
+  const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettingsMeta()
 
   return (
     <>

--- a/src/renderer/src/components/settings/AppearanceContext.tsx
+++ b/src/renderer/src/components/settings/AppearanceContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react'
+import type { ThemeMode } from '../../lib/theme'
+
+export interface AppearanceContextValue {
+  accentPreset: string
+  accentCustom: string
+  accentBgTint: boolean
+  themeMode: ThemeMode
+  focusActiveTitle: boolean
+  zoomFactor: number
+  isCustomColor: boolean
+  onAccentChange: (presetHex: string) => void
+  onCustomColorChange: (hex: string) => void
+  onAccentBgTintChange: (checked: boolean) => void
+  onThemeModeChange: (mode: ThemeMode) => void
+  onFocusActiveTitleChange: (checked: boolean) => void
+  onZoomFactorChange: (factor: number) => void
+}
+
+export const AppearanceContext = createContext<AppearanceContextValue | null>(null)
+
+export function useAppearanceSettings() {
+  const context = useContext(AppearanceContext)
+
+  if (!context) {
+    throw new Error('useAppearanceSettings must be used within SettingsProvider')
+  }
+
+  return context
+}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_ACCENT_COLOR } from '../../lib/config'
 import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
 import { ColorPickerPopover } from '../ColorPickerPopover'
-import { useSettings } from './SettingsContext'
+import { useAppearanceSettings } from './AppearanceContext'
 
 const ZOOM_PRESETS = [
   { label: '100%', factor: 1.0 },
@@ -44,7 +44,7 @@ export function AppearanceSection() {
     onThemeModeChange,
     onFocusActiveTitleChange,
     onZoomFactorChange
-  } = useSettings()
+  } = useAppearanceSettings()
 
   return (
     <>

--- a/src/renderer/src/components/settings/AppsContext.tsx
+++ b/src/renderer/src/components/settings/AppsContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from 'react'
+import type { Profiles, Utility } from '../../lib/config'
+
+export interface AppsContextValue {
+  appPaths: Record<string, string>
+  appNames: Record<string, string>
+  appArgs: Record<string, string>
+  appIcons: Record<string, string>
+  iconLoadErrors: Set<string>
+  customSlots: number
+  utilities: Utility[]
+  profiles: Profiles
+  onBrowse: (key: string, isGame: boolean) => void
+  onAppNameChange: (key: string, name: string) => void
+  onAppPathChange: (key: string, path: string) => void
+  onAppArgsChange: (key: string, args: string) => void
+  onIconLoadError: (key: string) => void
+  onAddCustomSlot: () => void
+  onRemoveCustomSlot: (slotNumber: number) => void
+}
+
+export const AppsContext = createContext<AppsContextValue | null>(null)
+
+export function useAppsSettings() {
+  const context = useContext(AppsContext)
+
+  if (!context) {
+    throw new Error('useAppsSettings must be used within SettingsProvider')
+  }
+
+  return context
+}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -1,5 +1,5 @@
 import { MAX_CUSTOM_SLOTS } from '../../lib/config'
-import { useSettings } from './SettingsContext'
+import { useAppsSettings } from './AppsContext'
 
 function getInitials(label: string) {
   const words = label.trim().split(/\s+/).filter(Boolean)
@@ -35,7 +35,7 @@ export function AppsSection() {
     onBrowse,
     onAddCustomSlot,
     onRemoveCustomSlot
-  } = useSettings()
+  } = useAppsSettings()
 
   return (
     <>

--- a/src/renderer/src/components/settings/BehaviorContext.tsx
+++ b/src/renderer/src/components/settings/BehaviorContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react'
+
+export interface BehaviorContextValue {
+  startWithWindows: boolean
+  startMinimized: boolean
+  minimizeToTray: boolean
+  launchDelayMs: number
+  onStartWithWindowsChange: (checked: boolean) => void
+  onStartMinimizedChange: (checked: boolean) => void
+  onMinimizeToTrayChange: (checked: boolean) => void
+  onLaunchDelayMsChange: (delayMs: number) => void
+}
+
+export const BehaviorContext = createContext<BehaviorContextValue | null>(null)
+
+export function useBehaviorSettings() {
+  const context = useContext(BehaviorContext)
+
+  if (!context) {
+    throw new Error('useBehaviorSettings must be used within SettingsProvider')
+  }
+
+  return context
+}

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -1,5 +1,5 @@
 import { Toggle } from '../Toggle'
-import { useSettings } from './SettingsContext'
+import { useBehaviorSettings } from './BehaviorContext'
 import { normalizeLaunchDelayMs } from './settingsUtils'
 
 const DELAY_PRESETS = [
@@ -18,7 +18,7 @@ export function BehaviorSection() {
     onStartMinimizedChange,
     onMinimizeToTrayChange,
     onLaunchDelayMsChange
-  } = useSettings()
+  } = useBehaviorSettings()
   const isPreset = DELAY_PRESETS.some((p) => p.value === launchDelayMs)
 
   return (

--- a/src/renderer/src/components/settings/ConfigSection.tsx
+++ b/src/renderer/src/components/settings/ConfigSection.tsx
@@ -1,7 +1,7 @@
-import { useSettings } from './SettingsContext'
+import { useSettingsMeta } from './SettingsMetaContext'
 
 export function ConfigSection() {
-  const { exportingConfig, importingConfig, onExportConfig, onImportConfig } = useSettings()
+  const { exportingConfig, importingConfig, onExportConfig, onImportConfig } = useSettingsMeta()
 
   return (
     <div className="p-5">

--- a/src/renderer/src/components/settings/GamesContext.tsx
+++ b/src/renderer/src/components/settings/GamesContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+
+export interface GamesContextValue {
+  gamePaths: Record<string, string>
+  gameIcons: Record<string, string>
+  onBrowse: (key: string, isGame: boolean) => void
+  onGamePathChange: (key: string, path: string) => void
+}
+
+export const GamesContext = createContext<GamesContextValue | null>(null)
+
+export function useGamesSettings() {
+  const context = useContext(GamesContext)
+
+  if (!context) {
+    throw new Error('useGamesSettings must be used within SettingsProvider')
+  }
+
+  return context
+}

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -1,8 +1,8 @@
 import { GAMES } from '../../lib/config'
-import { useSettings } from './SettingsContext'
+import { useGamesSettings } from './GamesContext'
 
 export function GamesSection() {
-  const { gamePaths, gameIcons, onBrowse, onGamePathChange } = useSettings()
+  const { gamePaths, gameIcons, onBrowse, onGamePathChange } = useGamesSettings()
 
   return (
     <>

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -1,7 +1,5 @@
 import {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -11,11 +9,16 @@ import {
   type SetStateAction
 } from 'react'
 import { useDirtyTracking } from '../../hooks/useDirtyTracking'
-import { DEFAULT_ACCENT_COLOR, getUtilities, type Profiles, type Utility } from '../../lib/config'
+import { DEFAULT_ACCENT_COLOR, getUtilities, type Profiles } from '../../lib/config'
 import { browsePath, getFileIcon, setLoginItem, setZoom } from '../../lib/electron'
 import type { ThemeMode } from '../../lib/theme'
 import { useTheme } from '../../contexts/ThemeContext'
 import { useNotify } from '../Notify'
+import { AppearanceContext, type AppearanceContextValue } from './AppearanceContext'
+import { AppsContext, type AppsContextValue } from './AppsContext'
+import { BehaviorContext, type BehaviorContextValue } from './BehaviorContext'
+import { GamesContext, type GamesContextValue } from './GamesContext'
+import { SettingsMetaContext, type SettingsMetaContextValue } from './SettingsMetaContext'
 import {
   createSettingsObjectVersions,
   type SettingsObjectField,
@@ -25,69 +28,6 @@ import { useConfigIO } from './useConfigIO'
 import { useCustomSlots } from './useCustomSlots'
 import { useSettingsLoad } from './useSettingsLoad'
 import { useSettingsSave } from './useSettingsSave'
-
-interface SettingsContextValue {
-  loading: boolean
-  isDirty: boolean
-  appPaths: Record<string, string>
-  appNames: Record<string, string>
-  appArgs: Record<string, string>
-  profiles: Profiles
-  gamePaths: Record<string, string>
-  customSlots: number
-  accentPreset: string
-  accentCustom: string
-  accentBgTint: boolean
-  themeMode: ThemeMode
-  focusActiveTitle: boolean
-  launchDelayMs: number
-  startWithWindows: boolean
-  startMinimized: boolean
-  minimizeToTray: boolean
-  autoCheckUpdates: boolean
-  zoomFactor: number
-  exportingConfig: boolean
-  importingConfig: boolean
-  isCustomColor: boolean
-  appIcons: Record<string, string>
-  gameIcons: Record<string, string>
-  iconLoadErrors: Set<string>
-  utilities: Utility[]
-  onAutoCheckUpdatesChange: (checked: boolean) => void
-  onAccentChange: (presetHex: string) => void
-  onCustomColorChange: (hex: string) => void
-  onAccentBgTintChange: (checked: boolean) => void
-  onThemeModeChange: (mode: ThemeMode) => void
-  onFocusActiveTitleChange: (checked: boolean) => void
-  onZoomFactorChange: (factor: number) => void
-  onStartWithWindowsChange: (checked: boolean) => void
-  onStartMinimizedChange: (checked: boolean) => void
-  onMinimizeToTrayChange: (checked: boolean) => void
-  onLaunchDelayMsChange: (delayMs: number) => void
-  onExportConfig: () => void
-  onImportConfig: () => void
-  onBrowse: (key: string, isGame: boolean) => void
-  onGamePathChange: (key: string, path: string) => void
-  onAppNameChange: (key: string, name: string) => void
-  onAppPathChange: (key: string, path: string) => void
-  onAppArgsChange: (key: string, args: string) => void
-  onIconLoadError: (key: string) => void
-  onAddCustomSlot: () => void
-  onRemoveCustomSlot: (slotNumber: number) => void
-  saveSettings: () => Promise<void>
-}
-
-const SettingsContext = createContext<SettingsContextValue | null>(null)
-
-export function useSettings() {
-  const context = useContext(SettingsContext)
-
-  if (!context) {
-    throw new Error('useSettings must be used within SettingsProvider')
-  }
-
-  return context
-}
 
 export function SettingsProvider({
   children,
@@ -406,109 +346,136 @@ export function SettingsProvider({
 
   const utilities = useMemo(() => getUtilities(customSlots), [customSlots])
 
-  const value: SettingsContextValue = useMemo(
+  const appearanceValue: AppearanceContextValue = useMemo(
     () => ({
-      loading,
-      isDirty,
-      appPaths,
-      appNames,
-      appArgs,
-      profiles,
-      gamePaths,
-      customSlots,
       accentPreset,
       accentCustom,
       accentBgTint,
       themeMode,
       focusActiveTitle,
-      launchDelayMs,
-      startWithWindows,
-      startMinimized,
-      minimizeToTray,
-      autoCheckUpdates,
       zoomFactor,
-      exportingConfig,
-      importingConfig,
       isCustomColor,
-      appIcons,
-      gameIcons,
-      iconLoadErrors,
-      utilities,
-      onAutoCheckUpdatesChange: setAutoCheckUpdates,
       onAccentChange: handleAccentChange,
       onCustomColorChange: handleCustomColorChange,
       onAccentBgTintChange: handleAccentBgTintChange,
       onThemeModeChange: handleThemeModeChange,
       onFocusActiveTitleChange: setFocusActiveTitle,
-      onZoomFactorChange: handleZoomFactorChange,
-      onStartWithWindowsChange: handleStartWithWindowsChange,
-      onStartMinimizedChange: setStartMinimized,
-      onMinimizeToTrayChange: setMinimizeToTray,
-      onLaunchDelayMsChange: setLaunchDelayMs,
-      onExportConfig: handleExportConfig,
-      onImportConfig: handleImportConfig,
-      onBrowse: handleBrowse,
-      onGamePathChange: handleGamePathChange,
-      onAppNameChange: handleAppNameChange,
-      onAppPathChange: handleAppPathChange,
-      onAppArgsChange: handleAppArgsChange,
-      onIconLoadError: handleIconLoadError,
-      onAddCustomSlot: handleAddCustomSlot,
-      onRemoveCustomSlot: handleRemoveCustomSlot,
-      saveSettings: handleSave
+      onZoomFactorChange: handleZoomFactorChange
     }),
     [
-      loading,
-      isDirty,
-      appPaths,
-      appNames,
-      appArgs,
-      profiles,
-      gamePaths,
-      customSlots,
       accentPreset,
       accentCustom,
       accentBgTint,
       themeMode,
       focusActiveTitle,
-      launchDelayMs,
-      startWithWindows,
-      startMinimized,
-      minimizeToTray,
-      autoCheckUpdates,
       zoomFactor,
-      exportingConfig,
-      importingConfig,
       isCustomColor,
-      appIcons,
-      gameIcons,
-      iconLoadErrors,
-      utilities,
       handleAccentChange,
       handleCustomColorChange,
       handleAccentBgTintChange,
       handleThemeModeChange,
-      handleZoomFactorChange,
-      handleStartWithWindowsChange,
-      handleExportConfig,
-      handleImportConfig,
+      handleZoomFactorChange
+    ]
+  )
+
+  const appsValue: AppsContextValue = useMemo(
+    () => ({
+      appPaths,
+      appNames,
+      appArgs,
+      appIcons,
+      iconLoadErrors,
+      customSlots,
+      utilities,
+      profiles,
+      onBrowse: handleBrowse,
+      onAppNameChange: handleAppNameChange,
+      onAppPathChange: handleAppPathChange,
+      onAppArgsChange: handleAppArgsChange,
+      onIconLoadError: handleIconLoadError,
+      onAddCustomSlot: handleAddCustomSlot,
+      onRemoveCustomSlot: handleRemoveCustomSlot
+    }),
+    [
+      appPaths,
+      appNames,
+      appArgs,
+      appIcons,
+      iconLoadErrors,
+      customSlots,
+      utilities,
+      profiles,
       handleBrowse,
-      handleGamePathChange,
       handleAppNameChange,
       handleAppPathChange,
       handleAppArgsChange,
       handleIconLoadError,
       handleAddCustomSlot,
-      handleRemoveCustomSlot,
+      handleRemoveCustomSlot
+    ]
+  )
+
+  const gamesValue: GamesContextValue = useMemo(
+    () => ({
+      gamePaths,
+      gameIcons,
+      onBrowse: handleBrowse,
+      onGamePathChange: handleGamePathChange
+    }),
+    [gamePaths, gameIcons, handleBrowse, handleGamePathChange]
+  )
+
+  const behaviorValue: BehaviorContextValue = useMemo(
+    () => ({
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      launchDelayMs,
+      onStartWithWindowsChange: handleStartWithWindowsChange,
+      onStartMinimizedChange: setStartMinimized,
+      onMinimizeToTrayChange: setMinimizeToTray,
+      onLaunchDelayMsChange: setLaunchDelayMs
+    }),
+    [startWithWindows, startMinimized, minimizeToTray, launchDelayMs, handleStartWithWindowsChange]
+  )
+
+  const settingsMetaValue: SettingsMetaContextValue = useMemo(
+    () => ({
+      loading,
+      isDirty,
+      saveSettings: handleSave,
+      exportingConfig,
+      importingConfig,
+      autoCheckUpdates,
+      onExportConfig: handleExportConfig,
+      onImportConfig: handleImportConfig,
+      onAutoCheckUpdatesChange: setAutoCheckUpdates
+    }),
+    [
+      loading,
+      isDirty,
+      autoCheckUpdates,
+      exportingConfig,
+      importingConfig,
+      handleExportConfig,
+      handleImportConfig,
       handleSave
     ]
   )
 
   return (
-    <SettingsContext.Provider value={value}>
-      {children}
-      {customSlotRemoveDialog}
-      {configImportDialogs}
-    </SettingsContext.Provider>
+    <SettingsMetaContext.Provider value={settingsMetaValue}>
+      <AppearanceContext.Provider value={appearanceValue}>
+        <BehaviorContext.Provider value={behaviorValue}>
+          <GamesContext.Provider value={gamesValue}>
+            <AppsContext.Provider value={appsValue}>
+              {children}
+              {customSlotRemoveDialog}
+              {configImportDialogs}
+            </AppsContext.Provider>
+          </GamesContext.Provider>
+        </BehaviorContext.Provider>
+      </AppearanceContext.Provider>
+    </SettingsMetaContext.Provider>
   )
 }

--- a/src/renderer/src/components/settings/SettingsMetaContext.tsx
+++ b/src/renderer/src/components/settings/SettingsMetaContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+
+export interface SettingsMetaContextValue {
+  loading: boolean
+  isDirty: boolean
+  saveSettings: () => Promise<void>
+  exportingConfig: boolean
+  importingConfig: boolean
+  autoCheckUpdates: boolean
+  onExportConfig: () => void
+  onImportConfig: () => void
+  onAutoCheckUpdatesChange: (checked: boolean) => void
+}
+
+export const SettingsMetaContext = createContext<SettingsMetaContextValue | null>(null)
+
+export function useSettingsMeta() {
+  const context = useContext(SettingsMetaContext)
+
+  if (!context) {
+    throw new Error('useSettingsMeta must be used within SettingsProvider')
+  }
+
+  return context
+}


### PR DESCRIPTION
## Summary
- Add `AppearanceContext`, `AppsContext`, `GamesContext`, `BehaviorContext`, `SettingsMetaContext` — each with typed value interface, `useMemo` isolation, and throw-if-outside-provider hook
- `SettingsProvider` composes all five providers; state ownership stays in `SettingsContext.tsx`
- Migrate all `useSettings()` consumers to their narrower hook; remove legacy `useSettings()` export
- 69 tests passing

## Milestone
v0.9.6

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #273
<!-- auto-closes -->