### PR TITLE
fix(ui): behavior section overflow and custom app name casing (#316, #318)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -696,6 +696,7 @@ textarea {
 
 .settings-row-responsive .settings-control {
   flex: 1 1 17rem;
+  flex-wrap: wrap;
   justify-content: flex-end;
 }
 

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -209,6 +209,7 @@ textarea {
 .drag-region {
   -webkit-app-region: drag;
 }
+
 .no-drag {
   -webkit-app-region: no-drag;
 }
@@ -504,9 +505,11 @@ textarea {
   display: grid;
   transition: grid-template-rows 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
+
 .profile-editor-closed {
   grid-template-rows: 0fr;
 }
+
 .profile-editor-open {
   grid-template-rows: 1fr;
 }
@@ -520,6 +523,7 @@ textarea {
     opacity: 0;
     transform: translateY(-8px);
   }
+
   to {
     opacity: 1;
     transform: none;
@@ -535,6 +539,7 @@ textarea {
     opacity: 0;
     transform: translateX(-10px);
   }
+
   to {
     opacity: 1;
     transform: translateX(0);
@@ -550,6 +555,7 @@ textarea {
   100% {
     opacity: 1;
   }
+
   50% {
     opacity: 0.4;
   }
@@ -602,10 +608,12 @@ textarea {
     opacity: 0;
     transform: translateX(30px) scale(0.92);
   }
+
   60% {
     opacity: 1;
     transform: translateX(0px) scale(1.03);
   }
+
   100% {
     opacity: 1;
     transform: translateX(0px) scale(1);
@@ -677,6 +685,18 @@ textarea {
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.settings-row-responsive {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.settings-row-responsive .settings-control {
+  flex: 1 1 17rem;
+  justify-content: flex-end;
 }
 
 .settings-control-pill {

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -65,7 +65,7 @@ export function AppsSection() {
                   type="text"
                   value={appNames[utility.key] || utility.name}
                   onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                  className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                  className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
                   placeholder="App Name"
                   aria-label={`${utility.name} name`}
                   title="Editable app name"

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -65,7 +65,7 @@ export function AppsSection() {
                   type="text"
                   value={appNames[utility.key] || utility.name}
                   onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                  className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                  className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold normal-case tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
                   placeholder="App Name"
                   aria-label={`${utility.name} name`}
                   title="Editable app name"

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -58,7 +58,7 @@ export function BehaviorSection() {
           aria-label="Minimize to tray on close"
         />
       </div>
-      <div className="settings-row">
+      <div className="settings-row settings-row-responsive">
         <div className="settings-label-group">
           <span className="settings-label">Launch delay between apps</span>
           <span className="settings-sublabel">Wait time before starting the next app</span>

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -38,7 +38,9 @@ export function SettingsSection({ title, open, onOpenChange, children }: Setting
         className={`grid transition-all duration-300 ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
       >
         <div className={open ? undefined : 'overflow-hidden'} inert={open ? undefined : true}>
-          <div className="glass-surface rounded-2xl flex flex-col pt-1">{children}</div>
+          <div className="glass-surface rounded-2xl flex flex-col pt-1 overflow-hidden">
+            {children}
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add `settings-row-responsive` CSS class with safe `max-width`/`min-width` to prevent the launch-delay row overflowing the settings panel (#316)
- Remove forced `uppercase` and ease letter spacing on custom app name input so it matches what the user typed (#318)

## Milestone
v0.9.6

Closes #316
Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #316
Closes #318
<!-- auto-closes -->