### PR TITLE
fix(ui): resolve narrow-width overflow in settings sections

### DIFF
--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -48,7 +48,7 @@ export function AppearanceSection() {
 
   return (
     <>
-      <div className="settings-row">
+      <div className="settings-row settings-row-responsive">
         <label className="settings-label text-(--text-secondary)">Theme</label>
         <div className="settings-control">
           {THEME_MODE_OPTIONS.map((option) => (
@@ -68,7 +68,7 @@ export function AppearanceSection() {
         </div>
       </div>
 
-      <div className="settings-row">
+      <div className="settings-row settings-row-responsive">
         <label className="settings-label text-(--text-secondary)">Accent Color</label>
         <div className="settings-control">
           {ACCENT_PRESETS.map((preset) => (
@@ -143,7 +143,7 @@ export function AppearanceSection() {
         />
       </div>
 
-      <div className="settings-row">
+      <div className="settings-row settings-row-responsive">
         <label className="settings-label text-(--text-secondary)">UI Scale</label>
         <div className="settings-control">
           {ZOOM_PRESETS.map((preset) => (

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -98,7 +98,7 @@ export function AppsSection() {
               value={appPaths[utility.key] || ''}
               onChange={(e) => onAppPathChange(utility.key, e.target.value)}
               placeholder="No executable path set"
-              className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+              className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
             />
 
             {utility.isCustom && (

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -44,7 +44,7 @@ export function GamesSection() {
               value={gamePaths[game.key] || ''}
               onChange={(e) => onGamePathChange(game.key, e.target.value)}
               placeholder="No game path set"
-              className="glass-recessed flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+              className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
             />
 
             <button


### PR DESCRIPTION
## Summary
- Add `settings-row-responsive` class to Appearance section rows (Theme, Accent Color, UI Scale) so pill controls wrap at narrow widths
- Add `min-w-0` to path inputs in AppsSection and GamesSection to prevent flex children from overflowing their container

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #321
<!-- auto-closes -->