### PR TITLE
Fix duplicate launches for wrapper executables

### DIFF
--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -6,7 +6,13 @@ import { store } from '../store'
 import { getExeName, isValidExePath } from '../utils'
 
 import { pruneUnclosedProcesses } from './kill'
-import { pruneStoppedRunningProcesses, runningProcesses, unclosedProcesses } from './state'
+import {
+  processNameMismatchWarnings,
+  pruneExpiredProcessNameMismatchWarnings,
+  pruneStoppedRunningProcesses,
+  runningProcesses,
+  unclosedProcesses
+} from './state'
 import { readRunningProcessNames } from './tasklist'
 
 export interface RunningApp {
@@ -125,6 +131,7 @@ export async function getRunningApps(): Promise<RunningApp[]> {
   const processNames = await readRunningProcessNames()
   pruneStoppedRunningProcesses(processNames)
   pruneUnclosedProcesses(processNames)
+  pruneExpiredProcessNameMismatchWarnings()
 
   const launchedApps = Array.from(runningProcesses.entries()).map(([appPath, appProcess]) => ({
     path: appPath,
@@ -143,6 +150,18 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       elevated: appProcess.elevated ?? appProcess.reason === 'access_denied'
     }))
   const surfacedApps = [...launchedApps, ...unclosedApps]
+  const mismatchWarnings = Array.from(processNameMismatchWarnings.values())
+    .filter((entry) => !processNames.has(getExeName(entry.path)))
+    .map((entry) => ({
+      path: entry.path,
+      name: entry.name,
+      gameKey: entry.gameKey,
+      tracked: false,
+      warning: entry.warning
+    }))
+  const warningKeys = new Set(
+    mismatchWarnings.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+  )
   const launchedKeys = new Set(
     surfacedApps.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
   )
@@ -174,7 +193,15 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       !launchedExeNames.has(path.basename(appProcess.path).toLowerCase())
   )
 
-  return [...surfacedApps, ...trackedApps]
+  return [
+    ...surfacedApps,
+    ...mismatchWarnings.filter(
+      (appProcess) => !launchedKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+    ),
+    ...trackedApps.filter(
+      (appProcess) => !warningKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+    )
+  ]
 }
 
 function normalizeRunningAppsSnapshot(apps: RunningApp[]) {

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -171,7 +171,9 @@ export async function getRunningApps(): Promise<RunningApp[]> {
   const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
   const appPaths = store.get('appPaths') as Record<string, string> | undefined
   const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
-  const launchedGameKeys = new Set(surfacedApps.map((appProcess) => appProcess.gameKey))
+  const launchedGameKeys = new Set(
+    [...surfacedApps, ...mismatchWarnings].map((appProcess) => appProcess.gameKey)
+  )
   const adoptedGameKeys = getExternallyAdoptableGameKeys(
     processNames,
     profiles,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -6,13 +6,14 @@ import path from 'path'
 import { store } from '../store'
 import { getErrorCode, getErrorMessage, getExeName, isValidExePath, wait } from '../utils'
 
-import { runningProcesses } from './state'
+import { processNameMismatchWarnings, runningProcesses } from './state'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { AppLaunchResult, LaunchResult } from './types'
 import { publishRunningApps } from './running'
 
 const activeLaunches = new Set<string>()
 const POST_LAUNCH_BLOCK_MS = 10000
+const PROCESS_NAME_MISMATCH_WARNING_MS = 30000
 let launchBlockedUntil = 0
 
 export async function launchProfileApps(
@@ -324,6 +325,13 @@ function spawnDetachedApp(
 
       child.once('exit', () => {
         runningProcesses.delete(appPath)
+        processNameMismatchWarnings.set(appPath.toLowerCase(), {
+          path: appPath,
+          name: path.basename(appPath),
+          gameKey,
+          warning: `${path.basename(appPath)} exited shortly after launch. If it starts another process with a different name, add that executable under tracked processes to prevent duplicate launches.`,
+          expiresAt: Date.now() + PROCESS_NAME_MISMATCH_WARNING_MS
+        })
         invalidateProcessNameCache()
         publishRunningApps('exit').catch((err) => {
           console.error('Failed to publish running apps after exit:', err)

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -272,6 +272,7 @@ function spawnDetachedApp(
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined
+    const launchStartedAt = Date.now()
 
     const resolveOnce = (result: AppLaunchResult) => {
       if (!settled) {
@@ -325,13 +326,17 @@ function spawnDetachedApp(
 
       child.once('exit', () => {
         runningProcesses.delete(appPath)
-        processNameMismatchWarnings.set(appPath.toLowerCase(), {
-          path: appPath,
-          name: path.basename(appPath),
-          gameKey,
-          warning: `${path.basename(appPath)} exited shortly after launch. If it starts another process with a different name, add that executable under tracked processes to prevent duplicate launches.`,
-          expiresAt: Date.now() + PROCESS_NAME_MISMATCH_WARNING_MS
-        })
+        const exitedDuringPostLaunchWindow = Date.now() - launchStartedAt <= POST_LAUNCH_BLOCK_MS
+
+        if (exitedDuringPostLaunchWindow) {
+          processNameMismatchWarnings.set(appPath.toLowerCase(), {
+            path: appPath,
+            name: path.basename(appPath),
+            gameKey,
+            warning: `${path.basename(appPath)} exited shortly after launch. If it starts another process with a different name, add that executable under tracked processes to prevent duplicate launches.`,
+            expiresAt: Date.now() + PROCESS_NAME_MISMATCH_WARNING_MS
+          })
+        }
         invalidateProcessNameCache()
         publishRunningApps('exit').catch((err) => {
           console.error('Failed to publish running apps after exit:', err)

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -1,14 +1,27 @@
 import { getExeName } from '../utils'
 
-import type { RunningProcessEntry, UnclosedProcessEntry } from './types'
+import type {
+  ProcessNameMismatchWarningEntry,
+  RunningProcessEntry,
+  UnclosedProcessEntry
+} from './types'
 
 export const runningProcesses = new Map<string, RunningProcessEntry>()
 export const unclosedProcesses = new Map<string, UnclosedProcessEntry>()
+export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWarningEntry>()
 
 export function pruneStoppedRunningProcesses(processNames: Set<string>) {
   runningProcesses.forEach((_appProcess, appPath) => {
     if (!processNames.has(getExeName(appPath))) {
       runningProcesses.delete(appPath)
+    }
+  })
+}
+
+export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()) {
+  processNameMismatchWarnings.forEach((entry, key) => {
+    if (entry.expiresAt <= now) {
+      processNameMismatchWarnings.delete(key)
     }
   })
 }

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -41,6 +41,14 @@ export interface RunningProcessEntry {
   isGame: boolean
 }
 
+export interface ProcessNameMismatchWarningEntry {
+  path: string
+  name: string
+  gameKey: string
+  warning: string
+  expiresAt: number
+}
+
 export interface UnclosedProcessEntry {
   path: string
   name: string

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -303,6 +303,45 @@ test('getRunningApps surfaces a warning when a launched wrapper exits before its
   )
 })
 
+test('getRunningApps does not warn when a launched process exits after the post-launch window', async () => {
+  const dateNow = vi.spyOn(Date, 'now')
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  dateNow.mockReturnValue(1000)
+  markExistingPath('C:/Program Files/CrewChief/CrewChief.exe')
+  const { launchProfileApps, getRunningApps } = await loadProcessModules()
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', [
+    'C:/Program Files/CrewChief/CrewChief.exe'
+  ])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  dateNow.mockReturnValue(11001)
+  processNames.delete('crewchief.exe')
+  childHandlers.get('exit')?.()
+
+  await expect(getRunningApps()).resolves.not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        path: 'C:/Program Files/CrewChief/CrewChief.exe',
+        warning: expect.any(String)
+      })
+    ])
+  )
+  dateNow.mockRestore()
+})
+
 test('launchProfileApps rejects empty launches when every configured executable is invalid or missing', async () => {
   const { launchProfileApps } = await loadProcessModules()
 

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -212,6 +212,7 @@ async function loadProcessModules() {
     killLaunchedApps: killModule.killLaunchedApps,
     killProfileApps: killModule.killProfileApps,
     pruneUnclosedProcesses: killModule.pruneUnclosedProcesses,
+    processNameMismatchWarnings: stateModule.processNameMismatchWarnings,
     runningProcesses: stateModule.runningProcesses,
     unclosedProcesses: stateModule.unclosedProcesses,
     getRunningApps: (await import('../../src/main/processes/running')).getRunningApps,
@@ -243,7 +244,8 @@ const sender = {
 } as unknown as WebContents & { send: ReturnType<typeof vi.fn> }
 
 beforeEach(async () => {
-  const { runningProcesses, unclosedProcesses } = await loadProcessModules()
+  const { processNameMismatchWarnings, runningProcesses, unclosedProcesses } =
+    await loadProcessModules()
 
   existingPaths.clear()
   processNames.clear()
@@ -256,10 +258,49 @@ beforeEach(async () => {
   spawnCalls.length = 0
   spawnErrors.clear()
   invalidateProcessNameCacheMock.mockClear()
+  processNameMismatchWarnings.clear()
   runningProcesses.clear()
   unclosedProcesses.clear()
   Object.keys(storeData).forEach((key) => delete storeData[key])
   storeData.launchDelayMs = 0
+})
+
+test('getRunningApps surfaces a warning when a launched wrapper exits before its configured process is found', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  markExistingPath('C:/Program Files/Cheat Engine/Cheat Engine.exe')
+  const { launchProfileApps, getRunningApps } = await loadProcessModules()
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', [
+    'C:/Program Files/Cheat Engine/Cheat Engine.exe'
+  ])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  processNames.delete('cheat engine.exe')
+  processNames.add('cheatengine-x86_64-sse4-avx2.exe')
+  childHandlers.get('exit')?.()
+
+  await expect(getRunningApps()).resolves.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        path: 'C:/Program Files/Cheat Engine/Cheat Engine.exe',
+        name: 'Cheat Engine.exe',
+        gameKey: 'ac',
+        warning: expect.stringContaining('starts another process with a different name')
+      })
+    ])
+  )
 })
 
 test('launchProfileApps rejects empty launches when every configured executable is invalid or missing', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -191,10 +191,14 @@ async function loadProcessModules() {
     getProfileTrackablePaths: vi.fn(
       (
         gameKey: string,
-        _profile: unknown,
+        profile: { trackedProcessPaths?: string[] } | undefined,
         appPaths: Record<string, string> | undefined,
         gamePaths: Record<string, string> | undefined
-      ) => [...(gamePaths?.[gameKey] ? [gamePaths[gameKey]] : []), ...Object.values(appPaths || {})]
+      ) => [
+        ...(gamePaths?.[gameKey] ? [gamePaths[gameKey]] : []),
+        ...Object.values(appPaths || {}),
+        ...(profile?.trackedProcessPaths || [])
+      ]
     )
   }
   vi.doMock('../profiles', () => profilesMock)
@@ -298,6 +302,58 @@ test('getRunningApps surfaces a warning when a launched wrapper exits before its
         name: 'Cheat Engine.exe',
         gameKey: 'ac',
         warning: expect.stringContaining('starts another process with a different name')
+      })
+    ])
+  )
+})
+
+test('getRunningApps adopts tracked child processes while a wrapper warning is active', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  markExistingPath('C:/Program Files/Cheat Engine/Cheat Engine.exe')
+  const { launchProfileApps, getRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [
+          {
+            id: 'default',
+            name: 'Default',
+            trackedProcessPaths: ['C:/Program Files/Cheat Engine/cheatengine-x86_64-sse4-avx2.exe']
+          }
+        ]
+      }
+    },
+    gamePaths: { ac: 'C:/Program Files/Cheat Engine/Cheat Engine.exe' }
+  })
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', [
+    'C:/Program Files/Cheat Engine/Cheat Engine.exe'
+  ])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  processNames.delete('cheat engine.exe')
+  processNames.add('cheatengine-x86_64-sse4-avx2.exe')
+  childHandlers.get('exit')?.()
+
+  await expect(getRunningApps()).resolves.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        path: 'C:/Program Files/Cheat Engine/cheatengine-x86_64-sse4-avx2.exe',
+        name: 'cheatengine-x86_64-sse4-avx2.exe',
+        gameKey: 'ac',
+        tracked: true
       })
     ])
   )


### PR DESCRIPTION
## Summary
- Add a 30s process-name mismatch warning when a configured launcher exits shortly after spawn.
- Surface the warning through the existing running-apps pipeline so users can add the actual executable under tracked processes.
- Cover a Cheat Engine-style wrapper scenario with a regression test.

## Tests
- npm test -- --run tests/main/processes.test.ts
- npm run typecheck

Closes #314


<!-- auto-closes -->
Closes #314
<!-- auto-closes -->