### PR TITLE
fix: sync profile editor utility list with live Settings changes (#319)

### DIFF
--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -5,7 +5,6 @@ import {
   getUtilities,
   normalizeGameProfileSet,
   normalizeProfileUtilities,
-  resolveCustomSlots,
   type ProfileUtility,
   type Profiles,
   type Utility
@@ -13,6 +12,8 @@ import {
 import { useNotify } from '../components/Notify'
 import { getSettings, getProfiles, saveProfile } from '../lib/store'
 import { getFileIcon, browsePath } from '../lib/electron'
+import { useAppsSettings } from '../components/settings/AppsContext'
+import { syncProfileUtilitiesWithSettings } from '../lib/profileEditorSettingsSync'
 
 export interface ProfileEditorProps {
   gameKey: string
@@ -28,6 +29,11 @@ export function useProfileEditor({
   onClose
 }: ProfileEditorProps) {
   const { notify } = useNotify()
+  const {
+    appPaths: settingsAppPaths,
+    appNames: settingsAppNames,
+    customSlots: settingsCustomSlots
+  } = useAppsSettings()
   const [loading, setLoading] = useState(true)
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
   const [appNames, setAppNames] = useState<Record<string, string>>({})
@@ -67,8 +73,11 @@ export function useProfileEditor({
       const profile =
         profileSet.profiles.find((entry) => entry.id === activeProfileId) ||
         getActiveGameProfile(profileSet)
-      const resolvedUtilities = getUtilities(
-        resolveCustomSlots(savedCustomSlots, paths, names, profile)
+      const { utilities: resolvedUtilities } = syncProfileUtilitiesWithSettings(
+        Array.isArray(profile.utilities) ? profile.utilities : [],
+        savedCustomSlots,
+        paths,
+        names
       )
 
       setAppPaths(paths)
@@ -110,6 +119,28 @@ export function useProfileEditor({
 
     loadData()
   }, [gameKey, activeProfileId])
+
+  useEffect(() => {
+    const { utilities: resolvedUtilities } = syncProfileUtilitiesWithSettings(
+      [],
+      settingsCustomSlots,
+      settingsAppPaths,
+      settingsAppNames
+    )
+
+    setAppPaths(settingsAppPaths)
+    setAppNames(settingsAppNames)
+    setUtilities(resolvedUtilities)
+    setProfileUtilities(
+      (currentUtilities) =>
+        syncProfileUtilitiesWithSettings(
+          currentUtilities,
+          settingsCustomSlots,
+          settingsAppPaths,
+          settingsAppNames
+        ).profileUtilities
+    )
+  }, [settingsAppNames, settingsAppPaths, settingsCustomSlots])
 
   const currentProfileState = useMemo(
     () => ({

--- a/src/renderer/src/lib/profileEditorSettingsSync.ts
+++ b/src/renderer/src/lib/profileEditorSettingsSync.ts
@@ -1,0 +1,22 @@
+import {
+  getUtilities,
+  normalizeProfileUtilities,
+  resolveCustomSlots,
+  type ProfileUtility
+} from './config'
+
+export function syncProfileUtilitiesWithSettings(
+  currentUtilities: ProfileUtility[],
+  settingsCustomSlots: number,
+  settingsAppPaths: Record<string, string>,
+  settingsAppNames: Record<string, string>
+) {
+  const resolvedUtilities = getUtilities(
+    resolveCustomSlots(settingsCustomSlots, settingsAppPaths, settingsAppNames)
+  )
+
+  return {
+    utilities: resolvedUtilities,
+    profileUtilities: normalizeProfileUtilities({ utilities: currentUtilities }, resolvedUtilities)
+  }
+}

--- a/tests/renderer/profileEditorSettingsSync.test.ts
+++ b/tests/renderer/profileEditorSettingsSync.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+
+import { syncProfileUtilitiesWithSettings } from '../../src/renderer/src/lib/profileEditorSettingsSync'
+
+describe('syncProfileUtilitiesWithSettings', () => {
+  test('adds a newly configured custom app without resetting existing profile utility state', () => {
+    const currentUtilities = [
+      { id: 'simhub', enabled: true },
+      { id: 'customapp1', enabled: true }
+    ]
+
+    const result = syncProfileUtilitiesWithSettings(
+      currentUtilities,
+      2,
+      {
+        customapp1: 'C:/Apps/First.exe',
+        customapp2: 'C:/Apps/Second.exe'
+      },
+      {}
+    )
+
+    expect(result.utilities.some((utility) => utility.key === 'customapp2')).toBe(true)
+    expect(result.profileUtilities).toContainEqual({ id: 'simhub', enabled: true })
+    expect(result.profileUtilities).toContainEqual({ id: 'customapp1', enabled: true })
+    expect(result.profileUtilities).toContainEqual({ id: 'customapp2', enabled: false })
+  })
+
+  test('keeps renamed custom app slots in resolved utilities', () => {
+    const result = syncProfileUtilitiesWithSettings(
+      [{ id: 'customapp1', enabled: false }],
+      1,
+      {},
+      { customapp1: 'Telemetry Overlay' }
+    )
+
+    expect(result.utilities.some((utility) => utility.key === 'customapp1')).toBe(true)
+    expect(result.profileUtilities).toContainEqual({ id: 'customapp1', enabled: false })
+  })
+})


### PR DESCRIPTION
## Summary
- Profile editor now subscribes to Settings app state via `useAppsSettings()`
- New `syncProfileUtilitiesWithSettings()` helper recomputes available utilities when `customSlots`, `appPaths`, or `appNames` change
- Existing profile editor edits are preserved — only the utility list is normalized, not reset
- Focused test coverage for new-slot visibility and rename sync

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)