### PR TITLE
feat: prompt to save or discard profile changes before launching (#315)

### DIFF
--- a/src/renderer/src/components/ConfirmDialog.tsx
+++ b/src/renderer/src/components/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 
 interface ConfirmDialogProps {
   isOpen: boolean
@@ -41,7 +42,7 @@ export function ConfirmDialog({
 
   if (!isOpen) return null
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-100 flex items-center justify-center p-4 backdrop-blur-md">
       {/* Backdrop overlay */}
       <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
@@ -78,6 +79,7 @@ export function ConfirmDialog({
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -65,7 +65,6 @@ export function ProfileEditor(props: ProfileEditorProps) {
           isDirty={editor.isDirty}
           canDeleteProfile={editor.profileCount > 1}
           onSave={() => editor.handleSave(false)}
-          onLaunch={editor.handleLaunch}
           onCloseAttempt={editor.handleCloseAttempt}
           onDeleteProfile={editor.handleDeleteProfile}
         />

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -87,11 +87,9 @@ export function ProfileEditor(props: ProfileEditorProps) {
         title="Unsaved Changes"
         message="You have unsaved changes in this profile. Do you want to save them before launching?"
         saveLabel="Save Changes & Launch"
+        discardLabel="Launch Without Saving"
         onSave={() => editor.handleSave(true)}
-        onDiscard={() => {
-          editor.setShowLaunchConfirm(false)
-          props.onClose()
-        }}
+        onDiscard={editor.handleDiscardAndLaunch}
         onCancel={() => editor.setShowLaunchConfirm(false)}
       />
 

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -64,7 +64,8 @@ export function ProfileEditor(props: ProfileEditorProps) {
         <ProfileEditorActions
           isDirty={editor.isDirty}
           canDeleteProfile={editor.profileCount > 1}
-          onSave={editor.handleSave}
+          onSave={() => editor.handleSave(false)}
+          onLaunch={editor.handleLaunch}
           onCloseAttempt={editor.handleCloseAttempt}
           onDeleteProfile={editor.handleDeleteProfile}
         />
@@ -74,12 +75,25 @@ export function ProfileEditor(props: ProfileEditorProps) {
         isOpen={editor.showConfirm}
         title="Unsaved Changes"
         message="You have unsaved changes in this profile. Do you want to save them before leaving?"
-        onSave={editor.handleSave}
+        onSave={() => editor.handleSave(false)}
         onDiscard={() => {
           editor.setShowConfirm(false)
           props.onClose()
         }}
         onCancel={() => editor.setShowConfirm(false)}
+      />
+
+      <ConfirmDialog
+        isOpen={editor.showLaunchConfirm}
+        title="Unsaved Changes"
+        message="You have unsaved changes in this profile. Do you want to save them before launching?"
+        saveLabel="Save Changes & Launch"
+        onSave={() => editor.handleSave(true)}
+        onDiscard={() => {
+          editor.setShowLaunchConfirm(false)
+          props.onClose()
+        }}
+        onCancel={() => editor.setShowLaunchConfirm(false)}
       />
 
       <ConfirmDialog

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -219,7 +219,14 @@ export function GameRow({
     closeProfileMenu(true)
   }
 
+  const handleLaunchRequest = useRef<(() => void) | null>(null)
+
   const handleLaunch = async () => {
+    if (isActive && handleLaunchRequest.current) {
+      handleLaunchRequest.current()
+      return
+    }
+
     if (isLaunchBlocked) {
       return
     }
@@ -534,6 +541,9 @@ export function GameRow({
                 activeProfileId={profileSet.activeProfileId}
                 onProfilesChanged={loadProfileSet}
                 onClose={onToggleEditor}
+                onLaunchRequest={(launcher) => {
+                  handleLaunchRequest.current = launcher
+                }}
               />
             </div>
           )}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -544,6 +544,8 @@ export function GameRow({
                 onLaunchRequest={(launcher) => {
                   handleLaunchRequest.current = launcher
                 }}
+                onLaunchStart={() => onLaunchStart(game.key)}
+                onLaunchEnd={(cooldownMs) => onLaunchEnd(game.key, cooldownMs)}
               />
             </div>
           )}

--- a/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
@@ -2,6 +2,7 @@ interface ProfileEditorActionsProps {
   isDirty: boolean
   canDeleteProfile: boolean
   onSave: () => void
+  onLaunch: () => void
   onCloseAttempt: () => void
   onDeleteProfile: () => void
 }
@@ -10,57 +11,70 @@ export function ProfileEditorActions({
   isDirty,
   canDeleteProfile,
   onSave,
+  onLaunch,
   onCloseAttempt,
   onDeleteProfile
 }: ProfileEditorActionsProps) {
   return (
-    <div className="flex gap-3 pt-2">
-      <button
-        type="button"
-        onClick={onSave}
-        className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm relative overflow-hidden"
-      >
-        {isDirty && (
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 flex h-2 w-2">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-(--accent) opacity-75"></span>
-            <span className="relative inline-flex rounded-full h-2 w-2 bg-(--accent)"></span>
-          </span>
-        )}
-        Save Profile
-      </button>
-      <button
-        type="button"
-        onClick={onCloseAttempt}
-        className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm font-semibold"
-      >
-        Cancel
-      </button>
-      {canDeleteProfile && (
+    <div className="flex flex-col gap-3 pt-2">
+      <div className="flex gap-3">
         <button
           type="button"
-          onClick={onDeleteProfile}
-          className="danger-action action-hover-scale flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
-          title="Delete profile"
-          aria-label="Delete profile"
+          onClick={onLaunch}
+          className="accent-action action-hover-scale flex-[2] cursor-pointer rounded-xl py-2.5 text-sm font-bold"
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M3 6h18" />
-            <path d="M8 6V4h8v2" />
-            <path d="M19 6l-1 14H6L5 6" />
-            <path d="M10 11v5" />
-            <path d="M14 11v5" />
-          </svg>
+          Launch
         </button>
-      )}
+        <button
+          type="button"
+          onClick={onSave}
+          className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm relative overflow-hidden"
+        >
+          {isDirty && (
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-(--accent) opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-(--accent)"></span>
+            </span>
+          )}
+          Save
+        </button>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onCloseAttempt}
+          className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm font-semibold"
+        >
+          Cancel
+        </button>
+        {canDeleteProfile && (
+          <button
+            type="button"
+            onClick={onDeleteProfile}
+            className="danger-action action-hover-scale flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
+            title="Delete profile"
+            aria-label="Delete profile"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 6h18" />
+              <path d="M8 6V4h8v2" />
+              <path d="M19 6l-1 14H6L5 6" />
+              <path d="M10 11v5" />
+              <path d="M14 11v5" />
+            </svg>
+          </button>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
@@ -2,7 +2,6 @@ interface ProfileEditorActionsProps {
   isDirty: boolean
   canDeleteProfile: boolean
   onSave: () => void
-  onLaunch: () => void
   onCloseAttempt: () => void
   onDeleteProfile: () => void
 }
@@ -11,70 +10,57 @@ export function ProfileEditorActions({
   isDirty,
   canDeleteProfile,
   onSave,
-  onLaunch,
   onCloseAttempt,
   onDeleteProfile
 }: ProfileEditorActionsProps) {
   return (
-    <div className="flex flex-col gap-3 pt-2">
-      <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={onLaunch}
-          className="accent-action action-hover-scale flex-[2] cursor-pointer rounded-xl py-2.5 text-sm font-bold"
-        >
-          Launch
-        </button>
-        <button
-          type="button"
-          onClick={onSave}
-          className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm relative overflow-hidden"
-        >
-          {isDirty && (
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 flex h-2 w-2">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-(--accent) opacity-75"></span>
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-(--accent)"></span>
-            </span>
-          )}
-          Save
-        </button>
-      </div>
-
-      <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={onCloseAttempt}
-          className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm font-semibold"
-        >
-          Cancel
-        </button>
-        {canDeleteProfile && (
-          <button
-            type="button"
-            onClick={onDeleteProfile}
-            className="danger-action action-hover-scale flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
-            title="Delete profile"
-            aria-label="Delete profile"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M3 6h18" />
-              <path d="M8 6V4h8v2" />
-              <path d="M19 6l-1 14H6L5 6" />
-              <path d="M10 11v5" />
-              <path d="M14 11v5" />
-            </svg>
-          </button>
+    <div className="flex gap-3 pt-2">
+      <button
+        type="button"
+        onClick={onSave}
+        className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm relative overflow-hidden"
+      >
+        {isDirty && (
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-(--accent) opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-(--accent)"></span>
+          </span>
         )}
-      </div>
+        Save Profile
+      </button>
+      <button
+        type="button"
+        onClick={onCloseAttempt}
+        className="accent-surface-action action-hover-scale flex-1 cursor-pointer rounded-xl py-2.5 text-sm font-semibold"
+      >
+        Cancel
+      </button>
+      {canDeleteProfile && (
+        <button
+          type="button"
+          onClick={onDeleteProfile}
+          className="danger-action action-hover-scale flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
+          title="Delete profile"
+          aria-label="Delete profile"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M3 6h18" />
+            <path d="M8 6V4h8v2" />
+            <path d="M19 6l-1 14H6L5 6" />
+            <path d="M10 11v5" />
+            <path d="M14 11v5" />
+          </svg>
+        </button>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -21,6 +21,8 @@ export interface ProfileEditorProps {
   onProfilesChanged: () => Promise<unknown>
   onClose: () => void
   onLaunchRequest?: (handleLaunch: () => void) => void
+  onLaunchStart?: () => void
+  onLaunchEnd?: (cooldownMs: number) => void
 }
 
 export function useProfileEditor({
@@ -28,7 +30,9 @@ export function useProfileEditor({
   activeProfileId,
   onProfilesChanged,
   onClose,
-  onLaunchRequest
+  onLaunchRequest,
+  onLaunchStart,
+  onLaunchEnd
 }: ProfileEditorProps) {
   const { notify } = useNotify()
   const {
@@ -287,15 +291,25 @@ export function useProfileEditor({
   const executeLaunch = async () => {
     setShowLaunchConfirm(false)
     onClose()
-    const { launchProfile } = await import('../lib/electron')
-    const result = await launchProfile(gameKey)
-    if (!result.success) {
-      notify(result.error || 'Failed to launch profile', 'error')
-    } else {
-      notify(
-        result.warning || result.message || 'Launching profile',
-        result.warning ? 'warn' : 'success'
-      )
+    onLaunchStart?.()
+    let cooldownMs = 0
+    try {
+      const { launchProfile } = await import('../lib/electron')
+      const result = await launchProfile(gameKey)
+      cooldownMs = result.launchedCount === 0 ? 0 : 10000
+      if (!result.success) {
+        notify(result.error || 'Failed to launch profile', 'error')
+      } else {
+        notify(
+          result.warning || result.message || 'Launching profile',
+          result.warning ? 'warn' : 'success'
+        )
+      }
+    } catch (err) {
+      notify('Failed to launch profile', 'error')
+      console.error(err)
+    } finally {
+      onLaunchEnd?.(cooldownMs)
     }
   }
 

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -288,7 +288,7 @@ export function useProfileEditor({
     setTrackedProcessPaths((prev) => prev.filter((_, currentIndex) => currentIndex !== index))
   }
 
-  const executeLaunch = async () => {
+  const executeLaunch = useCallback(async () => {
     setShowLaunchConfirm(false)
     onClose()
     onLaunchStart?.()
@@ -311,15 +311,15 @@ export function useProfileEditor({
     } finally {
       onLaunchEnd?.(cooldownMs)
     }
-  }
+  }, [gameKey, notify, onClose, onLaunchEnd, onLaunchStart, setShowLaunchConfirm])
 
-  const handleLaunch = async () => {
+  const handleLaunch = useCallback(async () => {
     if (isDirty) {
       setShowLaunchConfirm(true)
     } else {
       await executeLaunch()
     }
-  }
+  }, [isDirty, executeLaunch, setShowLaunchConfirm])
 
   const handleSave = async (shouldLaunch = false) => {
     if (shouldLaunch) setShowLaunchConfirm(false)

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -322,6 +322,7 @@ export function useProfileEditor({
   }
 
   const handleSave = async (shouldLaunch = false) => {
+    if (shouldLaunch) setShowLaunchConfirm(false)
     const allProfiles = await getProfiles()
     const profileSet = normalizeGameProfileSet(allProfiles[gameKey] as Profiles[string] | undefined)
     const activeProfile =

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -182,13 +182,13 @@ export function useProfileEditor({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === 'Escape' && !showLaunchConfirm && !profileDeleteConfirm) {
         handleCloseAttempt()
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [handleCloseAttempt])
+  }, [handleCloseAttempt, showLaunchConfirm, profileDeleteConfirm])
 
   const handleToggleUtility = (key: string) => {
     setProfileUtilities((currentUtilities) => {

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -284,21 +284,25 @@ export function useProfileEditor({
     setTrackedProcessPaths((prev) => prev.filter((_, currentIndex) => currentIndex !== index))
   }
 
+  const executeLaunch = async () => {
+    const { launchProfile } = await import('../lib/electron')
+    const result = await launchProfile(gameKey)
+    if (!result.success) {
+      notify(result.error || 'Failed to launch profile', 'error')
+    } else {
+      notify(
+        result.warning || result.message || 'Launching profile',
+        result.warning ? 'warn' : 'success'
+      )
+    }
+    onClose()
+  }
+
   const handleLaunch = async () => {
     if (isDirty) {
       setShowLaunchConfirm(true)
     } else {
-      const { launchProfile } = await import('../lib/electron')
-      const result = await launchProfile(gameKey)
-      if (!result.success) {
-        notify(result.error || 'Failed to launch profile', 'error')
-      } else {
-        notify(
-          result.warning || result.message || `Launching profile`,
-          result.warning ? 'warn' : 'success'
-        )
-      }
-      onClose()
+      await executeLaunch()
     }
   }
 
@@ -338,34 +342,15 @@ export function useProfileEditor({
     notify('Profile saved!', 'success', 2500)
 
     if (shouldLaunch) {
-      const { launchProfile } = await import('../lib/electron')
-      const result = await launchProfile(gameKey)
-      if (!result.success) {
-        notify(result.error || 'Failed to launch profile', 'error')
-      } else {
-        notify(
-          result.warning || result.message || `Launching profile`,
-          result.warning ? 'warn' : 'success'
-        )
-      }
+      await executeLaunch()
+    } else {
+      onClose()
     }
-
-    onClose()
   }
 
   const handleDiscardAndLaunch = async () => {
     setShowLaunchConfirm(false)
-    const { launchProfile } = await import('../lib/electron')
-    const result = await launchProfile(gameKey)
-    if (!result.success) {
-      notify(result.error || 'Failed to launch profile', 'error')
-    } else {
-      notify(
-        result.warning || result.message || `Launching profile`,
-        result.warning ? 'warn' : 'success'
-      )
-    }
-    onClose()
+    await executeLaunch()
   }
 
   const handleDeleteProfile = async () => {

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -353,6 +353,21 @@ export function useProfileEditor({
     onClose()
   }
 
+  const handleDiscardAndLaunch = async () => {
+    setShowLaunchConfirm(false)
+    const { launchProfile } = await import('../lib/electron')
+    const result = await launchProfile(gameKey)
+    if (!result.success) {
+      notify(result.error || 'Failed to launch profile', 'error')
+    } else {
+      notify(
+        result.warning || result.message || `Launching profile`,
+        result.warning ? 'warn' : 'success'
+      )
+    }
+    onClose()
+  }
+
   const handleDeleteProfile = async () => {
     const allProfiles = await getProfiles()
     const profileSet = normalizeGameProfileSet(allProfiles[gameKey] as Profiles[string] | undefined)
@@ -451,6 +466,7 @@ export function useProfileEditor({
     handleIconFailed: (utilityKey: string) =>
       setFailedIcons((prev) => ({ ...prev, [utilityKey]: true })),
     handleLaunch,
+    handleDiscardAndLaunch,
     handleSave,
     handleDeleteProfile,
     confirmDeleteProfile,

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -20,13 +20,15 @@ export interface ProfileEditorProps {
   activeProfileId: string
   onProfilesChanged: () => Promise<unknown>
   onClose: () => void
+  onLaunchRequest?: (handleLaunch: () => void) => void
 }
 
 export function useProfileEditor({
   gameKey,
   activeProfileId,
   onProfilesChanged,
-  onClose
+  onClose,
+  onLaunchRequest
 }: ProfileEditorProps) {
   const { notify } = useNotify()
   const {
@@ -393,6 +395,12 @@ export function useProfileEditor({
     notify('Profile deleted', 'warn', 2500)
     onClose()
   }
+
+  useEffect(() => {
+    if (onLaunchRequest) {
+      onLaunchRequest(handleLaunch)
+    }
+  }, [onLaunchRequest, handleLaunch])
 
   const utilityByKey = new Map(utilities.map((utility) => [utility.key, utility]))
   const availableUtilityEntries = profileUtilities.filter(

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -285,6 +285,8 @@ export function useProfileEditor({
   }
 
   const executeLaunch = async () => {
+    setShowLaunchConfirm(false)
+    onClose()
     const { launchProfile } = await import('../lib/electron')
     const result = await launchProfile(gameKey)
     if (!result.success) {
@@ -295,7 +297,6 @@ export function useProfileEditor({
         result.warning ? 'warn' : 'success'
       )
     }
-    onClose()
   }
 
   const handleLaunch = async () => {
@@ -342,15 +343,14 @@ export function useProfileEditor({
     notify('Profile saved!', 'success', 2500)
 
     if (shouldLaunch) {
-      await executeLaunch()
+      executeLaunch()
     } else {
       onClose()
     }
   }
 
-  const handleDiscardAndLaunch = async () => {
-    setShowLaunchConfirm(false)
-    await executeLaunch()
+  const handleDiscardAndLaunch = () => {
+    executeLaunch()
   }
 
   const handleDeleteProfile = async () => {

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -55,6 +55,7 @@ export function useProfileEditor({
   const [failedIcons, setFailedIcons] = useState<Record<string, boolean>>({})
   const [fetchingIcons, setFetchingIcons] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
+  const [showLaunchConfirm, setShowLaunchConfirm] = useState(false)
   const [profileDeleteConfirm, setProfileDeleteConfirm] = useState<{
     profileId: string
     profileName: string
@@ -281,7 +282,25 @@ export function useProfileEditor({
     setTrackedProcessPaths((prev) => prev.filter((_, currentIndex) => currentIndex !== index))
   }
 
-  const handleSave = async () => {
+  const handleLaunch = async () => {
+    if (isDirty) {
+      setShowLaunchConfirm(true)
+    } else {
+      const { launchProfile } = await import('../lib/electron')
+      const result = await launchProfile(gameKey)
+      if (!result.success) {
+        notify(result.error || 'Failed to launch profile', 'error')
+      } else {
+        notify(
+          result.warning || result.message || `Launching profile`,
+          result.warning ? 'warn' : 'success'
+        )
+      }
+      onClose()
+    }
+  }
+
+  const handleSave = async (shouldLaunch = false) => {
     const allProfiles = await getProfiles()
     const profileSet = normalizeGameProfileSet(allProfiles[gameKey] as Profiles[string] | undefined)
     const activeProfile =
@@ -315,6 +334,20 @@ export function useProfileEditor({
     resetDirty()
 
     notify('Profile saved!', 'success', 2500)
+
+    if (shouldLaunch) {
+      const { launchProfile } = await import('../lib/electron')
+      const result = await launchProfile(gameKey)
+      if (!result.success) {
+        notify(result.error || 'Failed to launch profile', 'error')
+      } else {
+        notify(
+          result.warning || result.message || `Launching profile`,
+          result.warning ? 'warn' : 'success'
+        )
+      }
+    }
+
     onClose()
   }
 
@@ -393,6 +426,8 @@ export function useProfileEditor({
     fetchingIcons,
     showConfirm,
     setShowConfirm,
+    showLaunchConfirm,
+    setShowLaunchConfirm,
     profileDeleteConfirm,
     setProfileDeleteConfirm,
     setDragUtilityId,
@@ -407,6 +442,7 @@ export function useProfileEditor({
     handleRemoveTrackedProcess,
     handleIconFailed: (utilityKey: string) =>
       setFailedIcons((prev) => ({ ...prev, [utilityKey]: true })),
+    handleLaunch,
     handleSave,
     handleDeleteProfile,
     confirmDeleteProfile,


### PR DESCRIPTION
## Summary

Prompts the user when launching a profile while the editor has unsaved changes, with three options:
- **Save Changes & Launch** — saves profile then launches
- **Launch Without Saving** — discards changes and launches immediately
- **Cancel** — returns to the editor

## Changes

### Core logic (useProfileEditor.tsx)
- Added \executeLaunch\ helper (DRY — single launch + notify + close flow)
- \handleLaunch\ checks dirty state and shows confirm dialog or launches directly
- \handleDiscardAndLaunch\ launches without saving
- \handleSave(shouldLaunch)\ parameter enables save-then-launch flow
- \onLaunchRequest\ callback lets parent trigger the dirty-check from the Play button

### UI integration
- \GameRow.tsx\ — Play button delegates to editor's \handleLaunch\ when editor is active
- \ProfileEditor.tsx\ — launch-specific \ConfirmDialog\ with appropriate copy
- \ProfileEditorActions.tsx\ — reverted to original single-row layout (no redundant Launch button)

### Bug fix: ConfirmDialog fullscreen overlay
- \ConfirmDialog.tsx\ — wrapped in \createPortal(document.body)\ to escape \will-change: transform\ stacking context from \glass-surface-elevated\

### UX polish
- Dialog + editor close instantly on user choice; launch IPC runs in background

Closes #315

<!-- auto-closes -->
Closes #315
<!-- auto-closes -->