### PR TITLE
feat: custom launch arguments for all apps (#317)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -191,19 +191,19 @@ function parseCommandLineArgs(input: string) {
   return args
 }
 
-function getCustomAppArgs(appPath: string) {
+function getAppArgs(appPath: string) {
   const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
   const appArgs = (store.get('appArgs') as Record<string, string> | undefined) || {}
   const normalizedAppPath = appPath.trim().toLowerCase()
-  const customAppEntry = Object.entries(appPaths).find(
-    ([key, value]) => /^customapp\d+$/.test(key) && value.trim().toLowerCase() === normalizedAppPath
+  const appEntry = Object.entries(appPaths).find(
+    ([, value]) => value.trim().toLowerCase() === normalizedAppPath
   )
 
-  if (!customAppEntry) {
+  if (!appEntry) {
     return []
   }
 
-  const args = appArgs[customAppEntry[0]]
+  const args = appArgs[appEntry[0]]
   return typeof args === 'string' && args.trim().length > 0 ? parseCommandLineArgs(args) : []
 }
 
@@ -296,7 +296,7 @@ function spawnDetachedApp(
     }
 
     try {
-      const args = getCustomAppArgs(appPath)
+      const args = getAppArgs(appPath)
       const child = spawn(appPath, args, { detached: true, stdio: 'ignore' })
       runningProcesses.set(appPath, {
         process: child,
@@ -328,7 +328,7 @@ function spawnDetachedApp(
         }
 
         if (isElevatedLaunchError(err)) {
-          resolveOnce(await launchElevated(appPath, args))
+          resolveOnce(await launchElevated(appPath, getAppArgs(appPath)))
           return
         }
 
@@ -368,7 +368,7 @@ function spawnDetachedApp(
       console.error(`Error launching ${appPath}: ${message}`)
 
       if (isElevatedLaunchError(err)) {
-        launchElevated(appPath, getCustomAppArgs(appPath)).then(resolveOnce)
+        launchElevated(appPath, getAppArgs(appPath)).then(resolveOnce)
         return
       }
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -554,10 +554,7 @@ export function getSupportedConfigValues(config: Record<string, unknown>) {
     }
 
     if (key === 'appArgs') {
-      const customUtilityKeys = new Set(
-        [...utilityKeys].filter((utilityKey) => /^customapp\d+$/.test(utilityKey))
-      )
-      const appArgs = sanitizeArgsRecord(value, customUtilityKeys)
+      const appArgs = sanitizeArgsRecord(value, utilityKeys)
 
       if (appArgs) {
         supportedConfig.appArgs = appArgs

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { MAX_CUSTOM_SLOTS } from '../../lib/config'
 import { useAppsSettings } from './AppsContext'
+import { Toggle } from '../Toggle'
 
 function getInitials(label: string) {
   const words = label.trim().split(/\s+/).filter(Boolean)
@@ -37,6 +39,12 @@ export function AppsSection() {
     onRemoveCustomSlot
   } = useAppsSettings()
 
+  const [showArgsMap, setShowArgsMap] = useState<Record<string, boolean>>({})
+
+  const toggleArgs = (key: string) => {
+    setShowArgsMap((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
   return (
     <>
       {utilities.map((utility) => (
@@ -44,35 +52,51 @@ export function AppsSection() {
           key={utility.key}
           className="flex flex-col gap-2.5 border-b border-(--header-glass-border) px-5 py-4"
         >
-          <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
-            {utility.isCustom ? (
+          <div className="flex items-center justify-between">
+            <div className="text-[10px] font-semibold uppercase tracking-widest text-(--text-secondary) opacity-80">
+              {utility.isCustom ? (
+                <div className="flex items-center gap-2">
+                  <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="shrink-0 text-(--accent)"
+                  >
+                    <path d="M12 20h9" />
+                    <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                  </svg>
+                  <input
+                    type="text"
+                    value={appNames[utility.key] || utility.name}
+                    onChange={(e) => onAppNameChange(utility.key, e.target.value)}
+                    className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold normal-case tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                    placeholder="App Name"
+                    aria-label={`${utility.name} name`}
+                    title="Editable app name"
+                  />
+                </div>
+              ) : (
+                utility.name
+              )}
+            </div>
+
+            {!utility.isCustom && (
               <div className="flex items-center gap-2">
-                <svg
-                  width="11"
-                  height="11"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="shrink-0 text-(--accent)"
-                >
-                  <path d="M12 20h9" />
-                  <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
-                </svg>
-                <input
-                  type="text"
-                  value={appNames[utility.key] || utility.name}
-                  onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                  className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold normal-case tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
-                  placeholder="App Name"
-                  aria-label={`${utility.name} name`}
-                  title="Editable app name"
+                <span className="text-[9px] font-bold tracking-tight text-(--text-subtle) uppercase opacity-60">
+                  Custom Args
+                </span>
+                <Toggle
+                  checked={!!showArgsMap[utility.key] || !!appArgs[utility.key]}
+                  onChange={() => toggleArgs(utility.key)}
+                  size="sm"
+                  aria-label={`Toggle custom arguments for ${utility.name}`}
                 />
               </div>
-            ) : (
-              utility.name
             )}
           </div>
 
@@ -136,7 +160,7 @@ export function AppsSection() {
             </button>
           </div>
 
-          {utility.isCustom && (
+          {(utility.isCustom || showArgsMap[utility.key] || appArgs[utility.key]) && (
             <input
               type="text"
               value={appArgs[utility.key] || ''}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -85,19 +85,17 @@ export function AppsSection() {
               )}
             </div>
 
-            {!utility.isCustom && (
-              <div className="flex items-center gap-2">
-                <span className="text-[9px] font-bold tracking-tight text-(--text-subtle) uppercase opacity-60">
-                  Custom Args
-                </span>
-                <Toggle
-                  checked={!!showArgsMap[utility.key] || !!appArgs[utility.key]}
-                  onChange={() => toggleArgs(utility.key)}
-                  size="sm"
-                  aria-label={`Toggle custom arguments for ${utility.name}`}
-                />
-              </div>
-            )}
+            <div className="flex items-center gap-2">
+              <span className="text-[9px] font-bold tracking-tight text-(--text-subtle) uppercase opacity-60">
+                Custom Args
+              </span>
+              <Toggle
+                checked={!!showArgsMap[utility.key] || !!appArgs[utility.key]}
+                onChange={() => toggleArgs(utility.key)}
+                size="sm"
+                aria-label={`Toggle custom arguments for ${utility.name}`}
+              />
+            </div>
           </div>
 
           <div className="flex items-center gap-4">
@@ -160,7 +158,7 @@ export function AppsSection() {
             </button>
           </div>
 
-          {(utility.isCustom || showArgsMap[utility.key] || appArgs[utility.key]) && (
+          {(showArgsMap[utility.key] || appArgs[utility.key]) && (
             <input
               type="text"
               value={appArgs[utility.key] || ''}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -92,7 +92,6 @@ export function AppsSection() {
               <Toggle
                 checked={!!showArgsMap[utility.key] || !!appArgs[utility.key]}
                 onChange={() => toggleArgs(utility.key)}
-                size="sm"
                 aria-label={`Toggle custom arguments for ${utility.name}`}
               />
             </div>

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { MAX_CUSTOM_SLOTS } from '../../lib/config'
 import { useAppsSettings } from './AppsContext'
-import { Toggle } from '../Toggle'
+import { ChevronDownIcon } from '../icons'
 
 function getInitials(label: string) {
   const words = label.trim().split(/\s+/).filter(Boolean)
@@ -92,16 +92,22 @@ export function AppsSection() {
               )}
             </div>
 
-            <div className="flex items-center gap-2">
-              <span className="text-[9px] font-bold tracking-tight text-(--text-subtle) uppercase opacity-60">
+            <button
+              type="button"
+              onClick={() => toggleArgs(utility.key)}
+              className="group flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 transition-colors hover:bg-(--glass-bg)"
+              aria-label={`Toggle custom arguments for ${utility.name}`}
+              aria-expanded={isArgsVisible(utility.key)}
+            >
+              <span className="text-[9px] font-bold tracking-tight text-(--text-subtle) uppercase opacity-60 transition-opacity group-hover:opacity-80">
                 Custom Args
               </span>
-              <Toggle
-                checked={isArgsVisible(utility.key)}
-                onChange={() => toggleArgs(utility.key)}
-                aria-label={`Toggle custom arguments for ${utility.name}`}
+              <ChevronDownIcon
+                width={12}
+                height={12}
+                className={`shrink-0 text-(--text-muted) transition-transform ${isArgsVisible(utility.key) ? 'rotate-180' : ''}`}
               />
-            </div>
+            </button>
           </div>
 
           <div className="flex items-center gap-4">

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -41,8 +41,15 @@ export function AppsSection() {
 
   const [showArgsMap, setShowArgsMap] = useState<Record<string, boolean>>({})
 
+  const isArgsVisible = (key: string) => {
+    return showArgsMap[key] !== undefined ? showArgsMap[key] : !!appArgs[key]
+  }
+
   const toggleArgs = (key: string) => {
-    setShowArgsMap((prev) => ({ ...prev, [key]: !prev[key] }))
+    setShowArgsMap((prev) => ({
+      ...prev,
+      [key]: prev[key] !== undefined ? !prev[key] : !appArgs[key]
+    }))
   }
 
   return (
@@ -90,7 +97,7 @@ export function AppsSection() {
                 Custom Args
               </span>
               <Toggle
-                checked={!!showArgsMap[utility.key] || !!appArgs[utility.key]}
+                checked={isArgsVisible(utility.key)}
                 onChange={() => toggleArgs(utility.key)}
                 aria-label={`Toggle custom arguments for ${utility.name}`}
               />
@@ -157,7 +164,7 @@ export function AppsSection() {
             </button>
           </div>
 
-          {(showArgsMap[utility.key] || appArgs[utility.key]) && (
+          {isArgsVisible(utility.key) && (
             <input
               type="text"
               value={appArgs[utility.key] || ''}


### PR DESCRIPTION
## Summary
- Custom launch arguments (previously only for custom slots) now work for all built-in utilities (SimHub, CrewChief, etc.)
- Args input is hidden by default and revealed via chevron expand — consistent with other expand/collapse patterns in the UI
- Config export/import now correctly preserves args for built-in utilities (was silently dropping them)
- `getAppArgs` in spawn.ts unified to look up args by path across all entries, not just custom slots

## Known limitation
Arg resolution by executable path can mis-match when two utilities share the same `.exe` — tracked as #357 for refactor in 0.9.7.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)