### PR TITLE
feat: right-click context menu to dismiss utility icons (#328)

### DIFF
--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -2,12 +2,12 @@ import { BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain } from 'electr
 import { dismissAppIcon, publishRunningApps } from '../processes'
 
 export function registerContextMenuHandlers() {
-  ipcMain.handle('show-app-context-menu', (event, appPath: string) => {
+  ipcMain.handle('show-app-context-menu', (event, appPath: string, gameKey: string) => {
     const template: MenuItemConstructorOptions[] = [
       {
         label: 'Dismiss Icon',
         click: () => {
-          dismissAppIcon(appPath)
+          dismissAppIcon(appPath, gameKey)
           publishRunningApps('scan').catch((err) => {
             console.error('Failed to publish running apps after dismissing icon', err)
           })

--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -1,0 +1,25 @@
+import { BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain } from 'electron'
+import { dismissAppIcon, publishRunningApps } from '../processes'
+
+export function registerContextMenuHandlers() {
+  ipcMain.handle('show-app-context-menu', (event, appPath: string) => {
+    const template: MenuItemConstructorOptions[] = [
+      {
+        label: 'Dismiss Icon',
+        click: () => {
+          dismissAppIcon(appPath)
+          publishRunningApps('scan').catch((err) => {
+            console.error('Failed to publish running apps after dismissing icon', err)
+          })
+        }
+      }
+    ]
+
+    const menu = Menu.buildFromTemplate(template)
+    const window = BrowserWindow.fromWebContents(event.sender)
+
+    if (window) {
+      menu.popup({ window })
+    }
+  })
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,6 +1,7 @@
 import { registerUpdaterHandlers } from '../updater'
 import { registerWindowHandlers, sendToRenderer } from '../window'
 import { registerConfigHandlers } from './config'
+import { registerContextMenuHandlers } from './context-menu'
 import { registerIconHandlers } from './icons'
 import { registerLaunchHandlers } from './launch'
 
@@ -8,6 +9,7 @@ export function registerHandlers() {
   registerConfigHandlers()
   registerLaunchHandlers()
   registerIconHandlers()
+  registerContextMenuHandlers()
   registerWindowHandlers()
   registerUpdaterHandlers(sendToRenderer)
 }

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -5,6 +5,7 @@ export {
   subscribeRunningApps,
   unsubscribeRunningApps
 } from './processes/running'
+export { dismissAppIcon } from './processes/state'
 export { launchProfileApps, isRunningExePath } from './processes/spawn'
 export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -14,7 +14,8 @@ import {
   processNameMismatchWarnings,
   runningProcesses,
   suppressProcessNameMismatchWarning,
-  unclosedProcesses
+  unclosedProcesses,
+  getUnclosedProcessKey
 } from './state'
 import { publishRunningApps } from './running'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
@@ -151,33 +152,6 @@ function findProcessIdsByExecutablePath(processName: string, appPath: string) {
   })
 }
 
-function processExistsByName(processName: string) {
-  return new Promise<boolean>((resolve) => {
-    const script = [
-      `$name = '${escapeWmiString(processName)}'`,
-      'Get-CimInstance Win32_Process -Filter "Name = \'$name\'" |',
-      '  Select-Object -First 1 -ExpandProperty ProcessId |',
-      '  ConvertTo-Json -Compress'
-    ].join('\n')
-
-    execFile(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
-      { windowsHide: true },
-      (error, stdout, stderr) => {
-        if (error) {
-          const detail = stderr.trim() || stdout.trim() || error.message
-          console.error(`Failed to check process existence for ${processName}: ${detail}`)
-          resolve(false)
-          return
-        }
-
-        resolve(parseProcessIds(stdout).length > 0)
-      }
-    )
-  })
-}
-
 async function killProcessTree(
   child: ChildProcess,
   appPath: string,
@@ -288,10 +262,6 @@ async function killProcessByImageName(
     notFound: result.notFound,
     staleTask: result.staleTask
   }
-}
-
-function getUnclosedProcessKey(gameKey: string | undefined, appPath: string, processName: string) {
-  return `${gameKey || 'unknown'}:${(appPath || processName).toLowerCase()}`
 }
 
 function clearUnclosedProcess(

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -37,3 +37,9 @@ export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()) {
     }
   })
 }
+
+export function dismissAppIcon(appPath: string) {
+  const normalizedPath = appPath.toLowerCase()
+  processNameMismatchWarnings.delete(normalizedPath)
+  unclosedProcesses.delete(normalizedPath)
+}

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -38,8 +38,16 @@ export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()) {
   })
 }
 
-export function dismissAppIcon(appPath: string) {
+export function getUnclosedProcessKey(
+  gameKey: string | undefined,
+  appPath: string,
+  processName: string
+) {
+  return `${gameKey || 'unknown'}:${(appPath || processName).toLowerCase()}`
+}
+
+export function dismissAppIcon(appPath: string, gameKey?: string) {
   const normalizedPath = appPath.toLowerCase()
   processNameMismatchWarnings.delete(normalizedPath)
-  unclosedProcesses.delete(normalizedPath)
+  unclosedProcesses.delete(getUnclosedProcessKey(gameKey, appPath, getExeName(appPath)))
 }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -182,4 +182,5 @@ export interface ElectronAPI {
   getAssetData: (filename: string) => Promise<string | null>
   getFileIcon: (filePath: string) => Promise<string | null>
   getVersion: () => Promise<string>
+  showAppContextMenu: (appPath: string) => Promise<void>
 }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -182,5 +182,5 @@ export interface ElectronAPI {
   getAssetData: (filename: string) => Promise<string | null>
   getFileIcon: (filePath: string) => Promise<string | null>
   getVersion: () => Promise<string>
-  showAppContextMenu: (appPath: string) => Promise<void>
+  showAppContextMenu: (appPath: string, gameKey: string) => Promise<void>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -101,7 +101,8 @@ const electronAPI: ElectronAPI = {
   getAssetData: (filename: string) => ipcRenderer.invoke('get-asset-data', filename),
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
   getVersion: () => ipcRenderer.invoke('get-version'),
-  showAppContextMenu: (appPath: string) => ipcRenderer.invoke('show-app-context-menu', appPath)
+  showAppContextMenu: (appPath: string, gameKey: string) =>
+    ipcRenderer.invoke('show-app-context-menu', appPath, gameKey)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -100,7 +100,8 @@ const electronAPI: ElectronAPI = {
   cancelImportConfig: (token: string) => ipcRenderer.invoke('cancel-import-config', token),
   getAssetData: (filename: string) => ipcRenderer.invoke('get-asset-data', filename),
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
-  getVersion: () => ipcRenderer.invoke('get-version')
+  getVersion: () => ipcRenderer.invoke('get-version'),
+  showAppContextMenu: (appPath: string) => ipcRenderer.invoke('show-app-context-menu', appPath)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -127,6 +127,7 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
           const runningAppIcons = appsForGame.map((a) => ({
             icon: appIconCache[normalizePath(a.path)] ?? null,
             name: a.name,
+            path: a.path,
             warning: a.warning,
             elevated: a.elevated
           }))

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -128,6 +128,7 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
             icon: appIconCache[normalizePath(a.path)] ?? null,
             name: a.name,
             path: a.path,
+            gameKey: a.gameKey,
             warning: a.warning,
             elevated: a.elevated
           }))

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -5,6 +5,7 @@ export interface RunningAppIcon {
   icon: string | null
   name: string
   path: string
+  gameKey: string
   warning?: string
   elevated?: boolean
 }
@@ -40,7 +41,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
               }
               onContextMenu={(e) => {
                 e.preventDefault()
-                showAppContextMenu(app.path)
+                showAppContextMenu(app.path, app.gameKey)
               }}
             />
           )
@@ -57,7 +58,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
             title={app.warning || app.name}
             onContextMenu={(e) => {
               e.preventDefault()
-              showAppContextMenu(app.path)
+              showAppContextMenu(app.path, app.gameKey)
             }}
           >
             {app.name

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { showAppContextMenu } from '../../lib/electron'
 
 export interface RunningAppIcon {
   icon: string | null
@@ -39,7 +40,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
               }
               onContextMenu={(e) => {
                 e.preventDefault()
-                window.electronAPI.showAppContextMenu(app.path)
+                showAppContextMenu(app.path)
               }}
             />
           )
@@ -56,7 +57,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
             title={app.warning || app.name}
             onContextMenu={(e) => {
               e.preventDefault()
-              window.electronAPI.showAppContextMenu(app.path)
+              showAppContextMenu(app.path)
             }}
           >
             {app.name

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -52,7 +52,7 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
         return (
           <div
             key={i}
-            className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
+            className={`fallback-initial-icon select-none h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
             title={app.warning || app.name}
             onContextMenu={(e) => {
               e.preventDefault()

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -40,8 +40,10 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
                 setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
               }
               onContextMenu={(e) => {
-                e.preventDefault()
-                showAppContextMenu(app.path, app.gameKey)
+                if (app.warning) {
+                  e.preventDefault()
+                  showAppContextMenu(app.path, app.gameKey)
+                }
               }}
             />
           )
@@ -57,8 +59,10 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
             className={`fallback-initial-icon select-none h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
             title={app.warning || app.name}
             onContextMenu={(e) => {
-              e.preventDefault()
-              showAppContextMenu(app.path, app.gameKey)
+              if (app.warning) {
+                e.preventDefault()
+                showAppContextMenu(app.path, app.gameKey)
+              }
             }}
           >
             {app.name

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 export interface RunningAppIcon {
   icon: string | null
   name: string
+  path: string
   warning?: string
   elevated?: boolean
 }
@@ -36,6 +37,10 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
               onError={() =>
                 setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
               }
+              onContextMenu={(e) => {
+                e.preventDefault()
+                window.electronAPI.showAppContextMenu(app.path)
+              }}
             />
           )
         }
@@ -49,6 +54,10 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
             key={i}
             className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
             title={app.warning || app.name}
+            onContextMenu={(e) => {
+              e.preventDefault()
+              window.electronAPI.showAppContextMenu(app.path)
+            }}
           >
             {app.name
               .replace(/\.exe$/i, '')

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -120,7 +120,7 @@ export function AppsSection() {
               />
             ) : (
               <div
-                className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
+                className="fallback-initial-icon select-none flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
                 title={`${appNames[utility.key] || utility.name} icon fallback`}
               >
                 {getInitials(appNames[utility.key] || utility.name)}

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -27,3 +27,4 @@ export const setZoom = window.electronAPI.setZoom
 export const getAssetData = window.electronAPI.getAssetData
 export const getFileIcon = window.electronAPI.getFileIcon
 export const getVersion = () => window.electronAPI.getVersion()
+export const showAppContextMenu = window.electronAPI.showAppContextMenu


### PR DESCRIPTION
## Summary
- Adds right-click context menu on running utility icons in the overlay strip
- Single action: **Dismiss Icon** — removes the icon immediately (clears from both `processNameMismatchWarnings` and `unclosedProcesses`)
- All IPC wired through `electron.ts` (consistent with project pattern)
- Fallback placeholder icons (letter initials) are now non-selectable (`select-none`) in both `RunningAppsStrip` and `AppsSection`

Closes #328
Refs #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)