### PR TITLE
fix: upgrade fast-uri to 3.1.2 (GHSA-v39h-62p7-jpjc)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5018,9 +5018,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
-      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Upgrades `fast-uri` from 3.1.1 → 3.1.2 via `npm audit fix`
- Patches high severity vuln GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters)
- Unblocks re-run of v0.9.6 release CI which was failing on `npm audit --omit=dev`

Closes #365

<!-- auto-closes -->
Closes #365
<!-- auto-closes -->