### PR TITLE
fix: harden IPC profile saves and validate store-backed runtime data (0.9.7)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -3,9 +3,10 @@ import crypto from 'crypto'
 import fs from 'fs'
 
 import { migrateProfilesToNamedSets } from '../migrator'
-import { isStoredProfileSet, type StoredNamedProfile } from '../profiles'
+import { isStoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
+  KNOWN_GAME_KEYS,
   MAX_CONFIG_IMPORT_BYTES,
   MAX_CUSTOM_SLOTS,
   getSupportedConfigValues,
@@ -201,6 +202,43 @@ function setStoreEntries(values: Record<string, unknown>) {
   Object.entries(values).forEach(([key, value]) => {
     store.set(key, value)
   })
+}
+
+function getSanitizedProfileSet(gameKey: string, profileSet: unknown) {
+  if (!KNOWN_GAME_KEYS.has(gameKey) || !isStoredProfileSet(profileSet)) {
+    return undefined
+  }
+
+  const supportedConfig = getSupportedConfigValues({
+    customSlots: store.get('customSlots'),
+    profiles: { [gameKey]: profileSet }
+  })
+  const profiles = supportedConfig.profiles
+
+  if (!isRecord(profiles)) {
+    return undefined
+  }
+
+  const sanitizedProfileSet = profiles[gameKey]
+  return isStoredProfileSet(sanitizedProfileSet) ? sanitizedProfileSet : undefined
+}
+
+function getSanitizedProfileRecord(profiles: unknown) {
+  if (!isRecord(profiles)) {
+    return undefined
+  }
+
+  const safeProfiles: Record<string, unknown> = {}
+
+  Object.entries(profiles).forEach(([gameKey, profileSet]) => {
+    const sanitizedProfileSet = getSanitizedProfileSet(gameKey, profileSet)
+
+    if (sanitizedProfileSet) {
+      safeProfiles[gameKey] = sanitizedProfileSet
+    }
+  })
+
+  return Object.keys(safeProfiles).length > 0 ? safeProfiles : undefined
 }
 
 export function registerConfigHandlers() {
@@ -423,24 +461,18 @@ export function registerConfigHandlers() {
 
   ipcMain.handle('save-profile', (_event, gameKey: unknown, profileSet: unknown) => {
     if (typeof gameKey !== 'string' || !gameKey) return
-    if (!isStoredProfileSet(profileSet)) return
-    const validProfiles = profileSet.profiles.filter(
-      (p): p is StoredNamedProfile =>
-        !!p &&
-        typeof p === 'object' &&
-        typeof (p as Record<string, unknown>).id === 'string' &&
-        typeof (p as Record<string, unknown>).name === 'string'
-    )
-    if (validProfiles.length === 0) return
+    const sanitizedProfileSet = getSanitizedProfileSet(gameKey, profileSet)
+    if (!sanitizedProfileSet) return
     const profiles = (store.get('profiles') as Record<string, unknown> | undefined) || {}
-    profiles[gameKey] = { activeProfileId: profileSet.activeProfileId, profiles: validProfiles }
+    profiles[gameKey] = sanitizedProfileSet
     store.set('profiles', profiles)
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })
   })
 
   ipcMain.handle('save-profiles', (_event, profiles: unknown) => {
-    if (!isRecord(profiles)) return
-    store.set('profiles', profiles)
+    const sanitizedProfiles = getSanitizedProfileRecord(profiles)
+    if (!sanitizedProfiles) return
+    store.set('profiles', sanitizedProfiles)
     notifyStoreConfigChanged({ reason: 'save-profiles', keys: ['profiles'] })
   })
 

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 import fs from 'fs'
 
 import { migrateProfilesToNamedSets } from '../migrator'
-import { isStoredProfileSet } from '../profiles'
+import { isStoredProfileSet, type StoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
@@ -204,13 +204,51 @@ function setStoreEntries(values: Record<string, unknown>) {
   })
 }
 
+function getHighestCustomSlotInProfileSet(profileSet: StoredProfileSet) {
+  let highest = 0
+
+  const visitId = (id: unknown) => {
+    if (typeof id !== 'string') return
+    const match = id.match(/^customapp(\d+)$/)
+    if (!match) return
+    const slot = Number(match[1])
+    if (Number.isFinite(slot) && slot > highest) {
+      highest = slot
+    }
+  }
+
+  profileSet.profiles.forEach((profile) => {
+    if (!isRecord(profile)) return
+    Object.keys(profile).forEach(visitId)
+    if (Array.isArray(profile.utilities)) {
+      profile.utilities.forEach((utility) => {
+        if (isRecord(utility)) visitId(utility.id)
+      })
+    }
+  })
+
+  return highest
+}
+
 function getSanitizedProfileSet(gameKey: string, profileSet: unknown) {
   if (!KNOWN_GAME_KEYS.has(gameKey) || !isStoredProfileSet(profileSet)) {
     return undefined
   }
 
+  const storedCustomSlots = store.get('customSlots')
+  const baseSlots =
+    typeof storedCustomSlots === 'number' && Number.isFinite(storedCustomSlots)
+      ? storedCustomSlots
+      : 1
+  // Widen the allowed slot count so a profile saved in parallel with a
+  // customSlots increase isn't silently stripped before save-settings lands.
+  const effectiveCustomSlots = Math.min(
+    MAX_CUSTOM_SLOTS,
+    Math.max(baseSlots, getHighestCustomSlotInProfileSet(profileSet))
+  )
+
   const supportedConfig = getSupportedConfigValues({
-    customSlots: store.get('customSlots'),
+    customSlots: effectiveCustomSlots,
     profiles: { [gameKey]: profileSet }
   })
   const profiles = supportedConfig.profiles

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -172,11 +172,11 @@ async function readAndSanitizeConfig(filePath: string) {
 
   const rawConfig = await fs.promises.readFile(filePath, 'utf8')
   const parsedConfig: unknown = JSON.parse(rawConfig)
+  if (!isRecord(parsedConfig)) {
+    throw new Error('Config file must contain a JSON object.')
+  }
   const supportedConfig = sanitizeImportedConfig(parsedConfig)
-  const summary = buildImportPreviewSummary(
-    parsedConfig as Record<string, unknown>,
-    supportedConfig
-  )
+  const summary = buildImportPreviewSummary(parsedConfig, supportedConfig)
 
   return { supportedConfig, summary }
 }
@@ -463,7 +463,8 @@ export function registerConfigHandlers() {
     if (typeof gameKey !== 'string' || !gameKey) return
     const sanitizedProfileSet = getSanitizedProfileSet(gameKey, profileSet)
     if (!sanitizedProfileSet) return
-    const profiles = (store.get('profiles') as Record<string, unknown> | undefined) || {}
+    const storedProfiles = store.get('profiles')
+    const profiles = isRecord(storedProfiles) ? storedProfiles : {}
     profiles[gameKey] = sanitizedProfileSet
     store.set('profiles', profiles)
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })

--- a/src/main/ipc/icons.ts
+++ b/src/main/ipc/icons.ts
@@ -2,7 +2,7 @@ import { app, ipcMain, nativeImage } from 'electron'
 import fs from 'fs'
 import path from 'path'
 
-import { store } from '../store'
+import { getStoredStringRecord } from '../store'
 
 let genericIconFingerprint: string | null | undefined
 let genericIconFingerprintPromise: Promise<string | null> | null = null
@@ -83,8 +83,8 @@ export function registerIconHandlers() {
 
   ipcMain.handle('get-file-icon', async (_event, filePath: string) => {
     const storedPaths = [
-      ...Object.values((store.get('gamePaths') as Record<string, string>) ?? {}),
-      ...Object.values((store.get('appPaths') as Record<string, string>) ?? {})
+      ...Object.values(getStoredStringRecord('gamePaths')),
+      ...Object.values(getStoredStringRecord('appPaths'))
     ]
     if (!storedPaths.includes(filePath)) return null
 

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -12,7 +12,7 @@ import {
   subscribeRunningApps,
   unsubscribeRunningApps
 } from '../processes'
-import { KNOWN_GAME_KEYS, store } from '../store'
+import { KNOWN_GAME_KEYS, getStoredStringRecord } from '../store'
 import { getExeName } from '../utils'
 
 export function validateGameKey(gameKey: unknown) {
@@ -91,7 +91,7 @@ export function registerLaunchHandlers() {
         return profileIdValidationError
       }
 
-      const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
+      const gamePaths = getStoredStringRecord('gamePaths')
       const gamePath = gamePaths[gameKey]?.toLowerCase()
       const processNames = await readRunningProcessNames()
 
@@ -126,7 +126,7 @@ export function registerLaunchHandlers() {
         return profileIdValidationError
       }
 
-      const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
+      const gamePaths = getStoredStringRecord('gamePaths')
       const gamePath = gamePaths[gameKey]?.toLowerCase()
 
       const fromPaths = buildNamedProfileLaunchPaths(gameKey, fromProfileId).filter(

--- a/src/main/migrator.ts
+++ b/src/main/migrator.ts
@@ -2,11 +2,13 @@ import {
   StoredNamedProfile,
   StoredProfile,
   StoredProfileEntry,
+  getStoredProfiles,
   getUtilityKeys,
   isStoredProfileSet,
   isStoredProfileUtility
 } from './profiles'
-import { store } from './store'
+import { getStoredStringRecord, store } from './store'
+import { isRecord } from './utils'
 
 function getCustomSlotNumber(key: string) {
   const match = key.match(/^customapp(\d+)$/)
@@ -20,8 +22,8 @@ function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefi
     Object.entries(record || {}).forEach(([key, value]) => {
       if (key === 'profiles' && Array.isArray(value)) {
         value.forEach((profile) => {
-          if (profile && typeof profile === 'object') {
-            scanRecord(profile as Record<string, unknown>)
+          if (isRecord(profile)) {
+            scanRecord(profile)
           }
         })
         return
@@ -78,23 +80,22 @@ function normalizeStoredNamedProfile(
   utilityKeys: string[],
   fallbackIndex: number
 ): StoredNamedProfile | null {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return null
   }
 
   const profile = value as StoredProfile
   const orderedProfile = normalizeStoredProfileUtilityOrder(profile, utilityKeys)
-  const rawProfile = value as Record<string, unknown>
 
   return {
     ...orderedProfile,
     id:
-      typeof rawProfile.id === 'string' && rawProfile.id.trim().length > 0
-        ? rawProfile.id
+      typeof value.id === 'string' && value.id.trim().length > 0
+        ? value.id
         : `profile-${Date.now().toString(36)}-${fallbackIndex}`,
     name:
-      typeof rawProfile.name === 'string' && rawProfile.name.trim().length > 0
-        ? rawProfile.name.trim()
+      typeof value.name === 'string' && value.name.trim().length > 0
+        ? value.name.trim()
         : fallbackIndex === 0
           ? 'Default'
           : `Profile ${fallbackIndex + 1}`
@@ -148,8 +149,8 @@ export function migrateProfilesToNamedSets() {
     return
   }
 
-  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
-  const appPaths = store.get('appPaths') as Record<string, string> | undefined
+  const profiles = getStoredProfiles()
+  const appPaths = getStoredStringRecord('appPaths')
 
   if (!profiles || Object.keys(profiles).length === 0) {
     store.set('profileUtilityOrderMigrated', true)
@@ -162,10 +163,7 @@ export function migrateProfilesToNamedSets() {
     typeof savedCustomSlots === 'number' && Number.isFinite(savedCustomSlots)
       ? savedCustomSlots
       : 1,
-    getHighestCustomSlot(
-      appPaths,
-      ...Object.values(profiles).map((profile) => profile as Record<string, unknown>)
-    )
+    getHighestCustomSlot(appPaths, ...Object.values(profiles).filter(isRecord))
   )
   const utilityKeys = getUtilityKeys(customSlots)
   const migratedProfiles = Object.fromEntries(

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -2,12 +2,12 @@ import { execFile, type ChildProcess } from 'child_process'
 import path from 'path'
 
 import {
-  StoredProfileEntry,
   getActiveStoredProfile,
   getProfileTrackablePaths,
+  getStoredProfiles,
   isUtilityEnabled
 } from '../profiles'
-import { store } from '../store'
+import { getStoredStringRecord } from '../store'
 import { getErrorMessage, getExeName, isValidExePath } from '../utils'
 
 import {
@@ -311,7 +311,7 @@ function normalizePathForComparison(appPath: string) {
 }
 
 function getStoredAppPathTargets() {
-  const storedAppPaths = store.get('appPaths') as Record<string, string> | undefined
+  const storedAppPaths = getStoredStringRecord('appPaths')
 
   return new Set(
     Object.values(storedAppPaths || {})
@@ -423,9 +423,9 @@ async function finalizeKillAttempts(
 }
 
 function getProfileCompanionTargets(gameKey?: string) {
-  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
-  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
-  const appPaths = store.get('appPaths') as Record<string, string> | undefined
+  const profiles = getStoredProfiles()
+  const gamePaths = getStoredStringRecord('gamePaths')
+  const appPaths = getStoredStringRecord('appPaths')
   const companionTargets = new Map<
     string,
     { processName: string; appPath: string; gameKey: string }
@@ -509,7 +509,7 @@ export async function killLaunchedApps(gameKey?: string) {
 
 export async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
   const processNames = await readRunningProcessNames()
-  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
+  const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]?.toLowerCase()
   const storedAppPathTargets = getStoredAppPathTargets()
   const validAppPathsToKill: string[] = []

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -1,8 +1,13 @@
 import path from 'path'
 import type { WebContents } from 'electron'
 
-import { StoredProfileEntry, getActiveStoredProfile, getProfileTrackablePaths } from '../profiles'
-import { store } from '../store'
+import {
+  StoredProfileEntry,
+  getActiveStoredProfile,
+  getProfileTrackablePaths,
+  getStoredProfiles
+} from '../profiles'
+import { getStoredStringRecord } from '../store'
 import { getExeName, isValidExePath } from '../utils'
 
 import { pruneUnclosedProcesses } from './kill'
@@ -168,9 +173,9 @@ export async function getRunningApps(): Promise<RunningApp[]> {
   const launchedExeNames = new Set(
     surfacedApps.map((appProcess) => path.basename(appProcess.path).toLowerCase())
   )
-  const profiles = store.get('profiles') as Record<string, StoredProfileEntry> | undefined
-  const appPaths = store.get('appPaths') as Record<string, string> | undefined
-  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
+  const profiles = getStoredProfiles()
+  const appPaths = getStoredStringRecord('appPaths')
+  const gamePaths = getStoredStringRecord('gamePaths')
   const launchedGameKeys = new Set(
     [...surfacedApps, ...mismatchWarnings].map((appProcess) => appProcess.gameKey)
   )

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -18,7 +18,6 @@ import { publishRunningApps } from './running'
 const activeLaunches = new Set<string>()
 const POST_LAUNCH_BLOCK_MS = 10000
 const PROCESS_NAME_MISMATCH_WARNING_CHANNEL = 'process-name-mismatch-warning'
-const PROCESS_NAME_MISMATCH_WARNING_TTL_MS = 60000
 let launchBlockedUntil = 0
 
 export async function launchProfileApps(
@@ -349,8 +348,7 @@ function spawnDetachedApp(
             path: appPath,
             name: path.basename(appPath),
             gameKey,
-            warning,
-            ...(wasGame ? {} : { expiresAt: Date.now() + PROCESS_NAME_MISMATCH_WARNING_TTL_MS })
+            warning
           })
           if (!wasGame) {
             sendProcessNameMismatchWarning(sender, appPath, warning)

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -3,7 +3,7 @@ import type { WebContents } from 'electron'
 import fs from 'fs'
 import path from 'path'
 
-import { store } from '../store'
+import { getStoredStringRecord, store } from '../store'
 import { getErrorCode, getErrorMessage, getExeName, isValidExePath, wait } from '../utils'
 
 import {
@@ -39,7 +39,7 @@ export async function launchProfileApps(
 
   activeLaunches.add(gameKey)
   const launchDelayMs = getLaunchDelayMs()
-  const gamePaths = store.get('gamePaths') as Record<string, string> | undefined
+  const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]?.toLowerCase()
   const processNames = await readRunningProcessNames()
   const validApps = profileApps.filter((appPath) => {
@@ -191,8 +191,8 @@ function parseCommandLineArgs(input: string) {
 }
 
 function getAppArgs(appPath: string) {
-  const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
-  const appArgs = (store.get('appArgs') as Record<string, string> | undefined) || {}
+  const appPaths = getStoredStringRecord('appPaths')
+  const appArgs = getStoredStringRecord('appArgs')
   const normalizedAppPath = appPath.trim().toLowerCase()
   const appEntry = Object.entries(appPaths).find(
     ([, value]) => value.trim().toLowerCase() === normalizedAppPath

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -1,5 +1,5 @@
-import { store } from './store'
-import { isValidExePath } from './utils'
+import { getStoredStringRecord, store } from './store'
+import { isRecord, isValidExePath } from './utils'
 
 export interface StoredProfile extends Record<string, unknown> {
   utilities?: StoredProfileUtility[]
@@ -34,21 +34,37 @@ export const BUILT_IN_UTILITY_KEYS = [
 ]
 
 export function isStoredProfileUtility(value: unknown): value is StoredProfileUtility {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return false
   }
 
-  const utility = value as Record<string, unknown>
-  return typeof utility.id === 'string' && typeof utility.enabled === 'boolean'
+  return typeof value.id === 'string' && typeof value.enabled === 'boolean'
 }
 
 export function isStoredProfileSet(value: unknown): value is StoredProfileSet {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return false
   }
 
-  const profileSet = value as Record<string, unknown>
-  return typeof profileSet.activeProfileId === 'string' && Array.isArray(profileSet.profiles)
+  return typeof value.activeProfileId === 'string' && Array.isArray(value.profiles)
+}
+
+export function getStoredProfiles() {
+  const value = store.get('profiles')
+
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  const profiles: Record<string, StoredProfileEntry> = {}
+
+  Object.entries(value).forEach(([gameKey, entry]) => {
+    if (isStoredProfileSet(entry) || isRecord(entry)) {
+      profiles[gameKey] = entry
+    }
+  })
+
+  return profiles
 }
 
 export function resolveActiveProfile(entry: StoredProfileEntry | undefined): StoredNamedProfile {
@@ -57,8 +73,7 @@ export function resolveActiveProfile(entry: StoredProfileEntry | undefined): Sto
   }
   if (isStoredProfileSet(entry)) {
     const validProfiles = entry.profiles.filter(
-      (p): p is StoredNamedProfile =>
-        !!p && typeof p === 'object' && typeof (p as Record<string, unknown>).id === 'string'
+      (p): p is StoredNamedProfile => isRecord(p) && typeof p.id === 'string'
     )
     if (validProfiles.length === 0) return { id: 'default', name: 'Default' }
     return validProfiles.find((p) => p.id === entry.activeProfileId) || validProfiles[0]
@@ -72,8 +87,7 @@ export function resolveNamedProfile(
 ): StoredNamedProfile {
   if (isStoredProfileSet(entry)) {
     const validProfiles = entry.profiles.filter(
-      (p): p is StoredNamedProfile =>
-        !!p && typeof p === 'object' && typeof (p as Record<string, unknown>).id === 'string'
+      (p): p is StoredNamedProfile => isRecord(p) && typeof p.id === 'string'
     )
     return (
       validProfiles.find((p) => p.id === profileId) ||
@@ -102,10 +116,7 @@ export function getEnabledUtilityPaths(
     profile.utilities
       .filter(
         (u): u is StoredProfileUtility =>
-          !!u &&
-          typeof u === 'object' &&
-          typeof (u as Record<string, unknown>).id === 'string' &&
-          typeof (u as Record<string, unknown>).enabled === 'boolean'
+          isRecord(u) && typeof u.id === 'string' && typeof u.enabled === 'boolean'
       )
       .filter((u) => u.enabled && utilityKeys.includes(u.id) && appPaths[u.id])
       .forEach((u) => paths.push(appPaths[u.id]))
@@ -119,9 +130,9 @@ export function getEnabledUtilityPaths(
 }
 
 export function buildActiveProfileLaunchPaths(gameKey: string): string[] {
-  const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
-  const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
-  const profiles = (store.get('profiles') as Record<string, StoredProfileEntry> | undefined) || {}
+  const appPaths = getStoredStringRecord('appPaths')
+  const gamePaths = getStoredStringRecord('gamePaths')
+  const profiles = getStoredProfiles()
   const customSlots = store.get('customSlots')
   const profile = resolveActiveProfile(profiles[gameKey])
   const paths: string[] = []
@@ -133,9 +144,9 @@ export function buildActiveProfileLaunchPaths(gameKey: string): string[] {
 }
 
 export function buildNamedProfileLaunchPaths(gameKey: string, profileId: string): string[] {
-  const appPaths = (store.get('appPaths') as Record<string, string> | undefined) || {}
-  const gamePaths = (store.get('gamePaths') as Record<string, string> | undefined) || {}
-  const profiles = (store.get('profiles') as Record<string, StoredProfileEntry> | undefined) || {}
+  const appPaths = getStoredStringRecord('appPaths')
+  const gamePaths = getStoredStringRecord('gamePaths')
+  const profiles = getStoredProfiles()
   const customSlots = store.get('customSlots')
   const profile = resolveNamedProfile(profiles[gameKey], profileId)
   const paths: string[] = []

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -125,13 +125,12 @@ export interface WindowBounds {
 }
 
 export function isWindowBounds(value: unknown): value is WindowBounds {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return false
   }
 
-  const bounds = value as Record<string, unknown>
   return ['x', 'y', 'width', 'height'].every((key) => {
-    const coordinate = bounds[key]
+    const coordinate = value[key]
     return typeof coordinate === 'number' && Number.isFinite(coordinate)
   })
 }
@@ -163,6 +162,23 @@ export function getStoredZoomFactor() {
   }
 
   return safeZoomFactor
+}
+
+export function getStoredBoolean(key: string, fallback = false) {
+  const value = store.get(key)
+  return typeof value === 'boolean' ? value : fallback
+}
+
+export function getStoredStringRecord(key: string) {
+  const value = store.get(key)
+
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  )
 }
 
 function getSafeObjectEntries(value: Record<string, unknown>) {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, screen, type OpenDialogOptions } f
 import path from 'path'
 
 import { getIsQuitting, setIsQuitting } from './app-state'
-import { getStoredZoomFactor, isWindowBounds, store } from './store'
+import { getStoredBoolean, getStoredZoomFactor, isWindowBounds, store } from './store'
 import { checkForUpdates, registerUpdaterEvents } from './updater'
 import { clamp } from './utils'
 
@@ -127,15 +127,15 @@ export function createWindow() {
 
   // Show window once ready, or keep it hidden when starting minimized to tray.
   mainWindow.once('ready-to-show', () => {
-    const startMinimized = store.get('startMinimized') as boolean
+    const startMinimized = getStoredBoolean('startMinimized')
     if (!startMinimized) {
       mainWindow!.show()
     }
   })
 
   // Apply login-item setting on startup
-  const startWithWindows = store.get('startWithWindows') as boolean
-  app.setLoginItemSettings({ openAtLogin: !!startWithWindows })
+  const startWithWindows = getStoredBoolean('startWithWindows')
+  app.setLoginItemSettings({ openAtLogin: startWithWindows })
 
   registerUpdaterEvents(sendToRenderer)
 
@@ -166,8 +166,8 @@ export function createWindow() {
 }
 
 export function applyRuntimeConfigSettings() {
-  const startWithWindows = store.get('startWithWindows') as boolean
-  app.setLoginItemSettings({ openAtLogin: !!startWithWindows })
+  const startWithWindows = getStoredBoolean('startWithWindows')
+  app.setLoginItemSettings({ openAtLogin: startWithWindows })
 
   mainWindow?.webContents.setZoomFactor(getStoredZoomFactor())
 }

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -9,6 +9,7 @@ import {
   useState
 } from 'react'
 import { createPortal } from 'react-dom'
+import { isRecord } from '../lib/config'
 import { onAppLaunchError, onProcessNameMismatchWarning } from '../lib/electron'
 import { CheckIcon, WarningTriangleIcon, ErrorIcon } from './icons'
 
@@ -40,11 +41,11 @@ function getPathName(filePath: string) {
 }
 
 function formatLaunchErrorToast(data: unknown) {
-  if (!data || typeof data !== 'object') {
+  if (!isRecord(data)) {
     return 'App launch failed'
   }
 
-  const { app, error } = data as { app?: unknown; error?: unknown }
+  const { app, error } = data
   const appName = typeof app === 'string' ? getPathName(app) : 'App'
   const errorMessage =
     typeof error === 'string' && error.trim().length > 0 ? error : 'Unknown launch error'
@@ -53,11 +54,11 @@ function formatLaunchErrorToast(data: unknown) {
 }
 
 function formatProcessNameMismatchToast(data: unknown) {
-  if (!data || typeof data !== 'object') {
+  if (!isRecord(data)) {
     return 'A launched app may be running under a different process name.'
   }
 
-  const { warning } = data as { warning?: unknown }
+  const { warning } = data
   return typeof warning === 'string' && warning.trim().length > 0
     ? warning
     : 'A launched app may be running under a different process name.'

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, type MutableRefObject } from 'react'
-import { DEFAULT_ACCENT_COLOR, GAMES, resolveCustomSlots, type Profiles } from '../../lib/config'
+import {
+  DEFAULT_ACCENT_COLOR,
+  GAMES,
+  isRecord,
+  normalizeProfiles,
+  resolveCustomSlots,
+  type Profiles
+} from '../../lib/config'
 import { getAssetData, getFileIcon } from '../../lib/electron'
 import { getProfiles, getSettings, onStoreConfigChanged } from '../../lib/store'
 import { normalizeThemeMode, type ThemeMode } from '../../lib/theme'
@@ -67,7 +74,7 @@ export function useSettingsLoad({
 }: UseSettingsLoadArgs) {
   const loadSettingsFromStore = useCallback(async () => {
     const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
-    const typedProfiles = savedProfiles as Profiles
+    const typedProfiles = normalizeProfiles(savedProfiles)
 
     latestSettingsObjects.current = {
       appPaths: settings.appPaths,
@@ -86,7 +93,7 @@ export function useSettingsLoad({
         settings.customSlots,
         settings.appPaths,
         settings.appNames,
-        ...(Object.values(typedProfiles) as Record<string, unknown>[])
+        ...Object.values(typedProfiles).filter(isRecord)
       )
     )
     const loadedThemeMode = normalizeThemeMode(settings.themeMode)

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -38,6 +38,10 @@ export const DEFAULT_PROFILE_ID = 'default'
 export const DEFAULT_PROFILE_NAME = 'Default'
 export const MAX_CUSTOM_SLOTS = 20
 
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
 export const GAMES: Game[] = [
   { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' },
   { key: 'acc', name: 'Assetto Corsa Competizione', icon: 'assets/acc.png' },
@@ -106,8 +110,8 @@ export function getHighestCustomSlot(...records: Array<Record<string, unknown> |
     Object.entries(record || {}).forEach(([key, value]) => {
       if (key === 'profiles' && Array.isArray(value)) {
         value.forEach((profile) => {
-          if (profile && typeof profile === 'object') {
-            scanRecord(profile as Record<string, unknown>)
+          if (isRecord(profile)) {
+            scanRecord(profile)
           }
         })
         return
@@ -173,12 +177,11 @@ export function getUtilities(customSlots: unknown): Utility[] {
 }
 
 export function isProfileUtility(value: unknown): value is ProfileUtility {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return false
   }
 
-  const entry = value as Record<string, unknown>
-  return typeof entry.id === 'string' && typeof entry.enabled === 'boolean'
+  return typeof value.id === 'string' && typeof value.enabled === 'boolean'
 }
 
 export function normalizeProfileUtilities(profile: GameProfile | undefined, utilities: Utility[]) {
@@ -230,12 +233,27 @@ export function migrateProfileToUtilityOrder(profile: GameProfile, utilities: Ut
 }
 
 export function isGameProfileSet(value: unknown): value is GameProfileSet {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return false
   }
 
-  const entry = value as Record<string, unknown>
-  return typeof entry.activeProfileId === 'string' && Array.isArray(entry.profiles)
+  return typeof value.activeProfileId === 'string' && Array.isArray(value.profiles)
+}
+
+export function normalizeProfiles(value: unknown): Profiles {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  const profiles: Profiles = {}
+
+  Object.entries(value).forEach(([gameKey, profile]) => {
+    if (isGameProfileSet(profile) || isRecord(profile)) {
+      profiles[gameKey] = profile
+    }
+  })
+
+  return profiles
 }
 
 export function createProfileId() {
@@ -243,22 +261,18 @@ export function createProfileId() {
 }
 
 function normalizeNamedProfile(value: unknown, fallbackIndex: number): NamedGameProfile | null {
-  if (!value || typeof value !== 'object') {
+  if (!isRecord(value)) {
     return null
   }
 
-  const profile = value as Record<string, unknown>
   const fallbackName = fallbackIndex === 0 ? DEFAULT_PROFILE_NAME : `Profile ${fallbackIndex + 1}`
 
   return {
-    ...(profile as GameProfile),
-    id:
-      typeof profile.id === 'string' && profile.id.trim().length > 0
-        ? profile.id
-        : createProfileId(),
+    ...value,
+    id: typeof value.id === 'string' && value.id.trim().length > 0 ? value.id : createProfileId(),
     name:
-      typeof profile.name === 'string' && profile.name.trim().length > 0
-        ? profile.name.trim()
+      typeof value.name === 'string' && value.name.trim().length > 0
+        ? value.name.trim()
         : fallbackName
   }
 }

--- a/src/renderer/src/lib/migrations.ts
+++ b/src/renderer/src/lib/migrations.ts
@@ -3,6 +3,7 @@ import {
   createDefaultProfile,
   getHighestCustomSlot,
   getUtilities,
+  isRecord,
   migrateProfileToUtilityOrder,
   type GameProfile,
   type GameProfileSet
@@ -46,6 +47,25 @@ const LEGACY_GAME_KEYS = [
   'rf2'
 ]
 
+function parseLegacyRecord(raw: string | null) {
+  if (!raw) {
+    return {}
+  }
+
+  const parsed: unknown = JSON.parse(raw)
+  return isRecord(parsed) ? parsed : {}
+}
+
+function getStringRecord(value: unknown) {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  )
+}
+
 export async function migrateFromLocalStorage() {
   const flags = await getMigrationFlags()
   if (flags.migrated) return
@@ -54,14 +74,14 @@ export async function migrateFromLocalStorage() {
 
   const appPathsRaw = localStorage.getItem('simLauncherAppPaths')
   const gamePathsRaw = localStorage.getItem('simLauncherGamePaths')
-  let appPaths: Record<string, unknown> = {}
+  const appPaths = parseLegacyRecord(appPathsRaw)
 
-  if (appPathsRaw) {
-    appPaths = JSON.parse(appPathsRaw)
-    patch.appPaths = appPaths as Record<string, string>
+  if (Object.keys(appPaths).length > 0) {
+    patch.appPaths = getStringRecord(appPaths)
   }
 
-  if (gamePathsRaw) patch.gamePaths = JSON.parse(gamePathsRaw)
+  const gamePaths = getStringRecord(parseLegacyRecord(gamePathsRaw))
+  if (Object.keys(gamePaths).length > 0) patch.gamePaths = gamePaths
 
   const accentPreset = localStorage.getItem('simLauncherAccentPreset')
   const accentCustom = localStorage.getItem('simLauncherAccentCustom')
@@ -78,7 +98,8 @@ export async function migrateFromLocalStorage() {
   const profiles: Record<string, GameProfile> = {}
   for (const key of LEGACY_GAME_KEYS) {
     const raw = localStorage.getItem(`profile_${key}`)
-    if (raw) profiles[key] = JSON.parse(raw)
+    const profile = parseLegacyRecord(raw)
+    if (Object.keys(profile).length > 0) profiles[key] = profile
   }
 
   const migratedCustomSlots = getHighestCustomSlot(appPaths, appNames, ...Object.values(profiles))
@@ -91,7 +112,7 @@ export async function migrateFromLocalStorage() {
         profiles: [createDefaultProfile(migrateProfileToUtilityOrder(profile, utilities))]
       }
     ])
-  ) as Record<string, GameProfileSet>
+  )
 
   if (migratedCustomSlots > 1) patch.customSlots = migratedCustomSlots
   if (Object.keys(patch).length > 0) await saveSettings(patch)

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -29,6 +29,7 @@ async function loadConfigModule() {
   vi.doMock('../../src/main/profiles', () => ({ isStoredProfileSet: vi.fn() }))
   const storeModuleMock = {
     CONFIG_FILE_NAME: 'simlauncher-config.json',
+    KNOWN_GAME_KEYS: new Set(['ac', 'acc']),
     MAX_CONFIG_IMPORT_BYTES: 1_000_000,
     MAX_CUSTOM_SLOTS: 20,
     getSupportedConfigValues: vi.fn(),
@@ -186,6 +187,62 @@ test('cancel-import-config clears pending import', async () => {
 
   const applyResult = await invokeConfigHandler('apply-import-config', {}, token)
   expect(applyResult.success).toBe(false)
+})
+
+test('save-profiles stores only sanitized known profile sets', async () => {
+  await loadConfigModule()
+  const storeModule = await import('../../src/main/store')
+  const profilesModule = await import('../../src/main/profiles')
+  const rawProfileSet = {
+    activeProfileId: 'default',
+    profiles: [
+      {
+        id: 'default',
+        name: 'Default',
+        trackedProcessPaths: ['C:/Tools/SimHub.exe', 'C:/Tools/readme.txt']
+      }
+    ]
+  }
+  const sanitizedProfileSet = {
+    activeProfileId: 'default',
+    profiles: [
+      {
+        id: 'default',
+        name: 'Default',
+        trackedProcessPaths: ['C:/Tools/SimHub.exe']
+      }
+    ]
+  }
+
+  vi.mocked(storeModule.store.get).mockReturnValue(1)
+  vi.mocked(profilesModule.isStoredProfileSet).mockImplementation(
+    (value) =>
+      !!value &&
+      typeof value === 'object' &&
+      typeof (value as Record<string, unknown>).activeProfileId === 'string' &&
+      Array.isArray((value as Record<string, unknown>).profiles)
+  )
+  vi.mocked(storeModule.getSupportedConfigValues).mockImplementation((config) => {
+    const profiles = (config as { profiles?: Record<string, unknown> }).profiles ?? {}
+    return profiles.ac ? { profiles: { ac: sanitizedProfileSet } } : {}
+  })
+
+  await invokeConfigHandler(
+    'save-profiles',
+    {},
+    {
+      ac: rawProfileSet,
+      unknown: rawProfileSet,
+      acc: { profiles: 'invalid' },
+      constructor: rawProfileSet
+    }
+  )
+
+  expect(storeModule.store.set).toHaveBeenCalledWith('profiles', { ac: sanitizedProfileSet })
+  expect(storeModule.getSupportedConfigValues).toHaveBeenCalledWith({
+    customSlots: 1,
+    profiles: { ac: rawProfileSet }
+  })
 })
 
 test('new preview replacement: subsequent previews invalidate previous tokens', async () => {

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -245,6 +245,83 @@ test('save-profiles stores only sanitized known profile sets', async () => {
   })
 })
 
+test('save-profile widens customSlots when profile references a slot beyond the stored count', async () => {
+  await loadConfigModule()
+  const storeModule = await import('../../src/main/store')
+  const profilesModule = await import('../../src/main/profiles')
+  const rawProfileSet = {
+    activeProfileId: 'default',
+    profiles: [
+      {
+        id: 'default',
+        name: 'Default',
+        utilities: [
+          { id: 'simhub', enabled: true },
+          { id: 'customapp2', enabled: true }
+        ]
+      }
+    ]
+  }
+
+  vi.mocked(storeModule.store.get).mockImplementation((key: string) =>
+    key === 'customSlots' ? 1 : undefined
+  )
+  vi.mocked(profilesModule.isStoredProfileSet).mockImplementation(
+    (value) =>
+      !!value &&
+      typeof value === 'object' &&
+      typeof (value as Record<string, unknown>).activeProfileId === 'string' &&
+      Array.isArray((value as Record<string, unknown>).profiles)
+  )
+  vi.mocked(storeModule.getSupportedConfigValues).mockImplementation((config) => ({
+    profiles: (config as { profiles?: Record<string, unknown> }).profiles ?? {}
+  }))
+
+  await invokeConfigHandler('save-profile', {}, 'ac', rawProfileSet)
+
+  expect(storeModule.getSupportedConfigValues).toHaveBeenCalledWith({
+    customSlots: 2,
+    profiles: { ac: rawProfileSet }
+  })
+})
+
+test('save-profile caps widened customSlots at MAX_CUSTOM_SLOTS', async () => {
+  await loadConfigModule()
+  const storeModule = await import('../../src/main/store')
+  const profilesModule = await import('../../src/main/profiles')
+  const rawProfileSet = {
+    activeProfileId: 'default',
+    profiles: [
+      {
+        id: 'default',
+        name: 'Default',
+        utilities: [{ id: 'customapp99', enabled: true }]
+      }
+    ]
+  }
+
+  vi.mocked(storeModule.store.get).mockImplementation((key: string) =>
+    key === 'customSlots' ? 1 : undefined
+  )
+  vi.mocked(profilesModule.isStoredProfileSet).mockImplementation(
+    (value) =>
+      !!value &&
+      typeof value === 'object' &&
+      typeof (value as Record<string, unknown>).activeProfileId === 'string' &&
+      Array.isArray((value as Record<string, unknown>).profiles)
+  )
+  vi.mocked(storeModule.getSupportedConfigValues).mockImplementation((config) => ({
+    profiles: (config as { profiles?: Record<string, unknown> }).profiles ?? {}
+  }))
+
+  await invokeConfigHandler('save-profile', {}, 'ac', rawProfileSet)
+
+  expect(storeModule.getSupportedConfigValues).toHaveBeenCalledWith({
+    customSlots: 20,
+    profiles: { ac: rawProfileSet }
+  })
+})
+
 test('new preview replacement: subsequent previews invalidate previous tokens', async () => {
   await loadConfigModule()
   const { dialog } = await import('electron')

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -225,6 +225,7 @@ async function loadProcessModules() {
     killLaunchedApps: killModule.killLaunchedApps,
     killProfileApps: killModule.killProfileApps,
     pruneUnclosedProcesses: killModule.pruneUnclosedProcesses,
+    dismissAppIcon: stateModule.dismissAppIcon,
     processNameMismatchWarnings: stateModule.processNameMismatchWarnings,
     suppressedProcessNameMismatchWarnings: stateModule.suppressedProcessNameMismatchWarnings,
     runningProcesses: stateModule.runningProcesses,
@@ -437,7 +438,7 @@ test('getRunningApps keeps wrapper warnings until the configured process is reso
   dateNow.mockRestore()
 })
 
-test('process mismatch warnings expire after the TTL and are pruned (#351)', async () => {
+test('process mismatch warnings persist until manually dismissed (#360)', async () => {
   const dateNow = vi.spyOn(Date, 'now')
   const childHandlers = new Map<string, (...args: unknown[]) => void>()
   const child = {
@@ -452,7 +453,7 @@ test('process mismatch warnings expire after the TTL and are pruned (#351)', asy
 
   dateNow.mockReturnValue(1000)
   markExistingPath('C:/Program Files/Cheat Engine/Cheat Engine.exe')
-  const { launchProfileApps, getRunningApps, processNameMismatchWarnings } =
+  const { dismissAppIcon, launchProfileApps, getRunningApps, processNameMismatchWarnings } =
     await loadProcessModules()
   vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
 
@@ -465,14 +466,11 @@ test('process mismatch warnings expire after the TTL and are pruned (#351)', asy
   processNames.delete('cheat engine.exe')
   childHandlers.get('exit')?.()
 
-  // Warning should be created with an expiresAt field
   expect(processNameMismatchWarnings.size).toBe(1)
   const entry = processNameMismatchWarnings.values().next().value!
-  expect(entry.expiresAt).toBeDefined()
-  expect(entry.expiresAt).toBeGreaterThan(1000)
+  expect(entry.expiresAt).toBeUndefined()
 
-  // Warning should still be visible before TTL expires (expiresAt = 1000 + 60000 = 61000)
-  dateNow.mockReturnValue(60999)
+  dateNow.mockReturnValue(61000)
   processNames.add('cheatengine-x86_64-sse4-avx2.exe')
   await expect(getRunningApps()).resolves.toEqual(
     expect.arrayContaining([
@@ -482,9 +480,9 @@ test('process mismatch warnings expire after the TTL and are pruned (#351)', asy
       })
     ])
   )
+  expect(processNameMismatchWarnings.size).toBe(1)
 
-  // After TTL expires, warning should be pruned (61000 <= 61000)
-  dateNow.mockReturnValue(61000)
+  dismissAppIcon('C:/Program Files/Cheat Engine/Cheat Engine.exe', 'ac')
   processNames.delete('cheat engine.exe')
   await expect(getRunningApps()).resolves.not.toEqual(
     expect.arrayContaining([

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -163,6 +163,19 @@ async function loadProcessModules() {
   vi.doMock('../../src/main/processes/tasklist.js', () => tasklistMock)
 
   const storeModuleMock = {
+    getStoredStringRecord: (key: string) => {
+      const value = storeData[key]
+
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {}
+      }
+
+      return Object.fromEntries(
+        Object.entries(value).filter(
+          (entry): entry is [string, string] => typeof entry[1] === 'string'
+        )
+      )
+    },
     store: {
       store: storeData,
       get: (key: string) => storeData[key],
@@ -184,6 +197,15 @@ async function loadProcessModules() {
     getActiveStoredProfile: vi.fn((p: { activeProfileId: string; profiles: { id: string }[] }) =>
       p.profiles.find((i) => i.id === p.activeProfileId)
     ),
+    getStoredProfiles: vi.fn(() => {
+      const value = storeData.profiles
+
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {}
+      }
+
+      return value as Record<string, unknown>
+    }),
     isUtilityEnabled: vi.fn((profile: Record<string, unknown> | undefined, utilityKey: string) =>
       Array.isArray(profile?.utilities)
         ? profile.utilities.some(

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -17,10 +17,29 @@ async function loadStoreModule() {
 
   const storeModule = await import('../../src/main/store')
   return {
+    getStoredBoolean: storeModule.getStoredBoolean,
+    getStoredStringRecord: storeModule.getStoredStringRecord,
     MAX_CUSTOM_SLOTS: storeModule.MAX_CUSTOM_SLOTS,
-    sanitizeImportedConfig: storeModule.sanitizeImportedConfig
+    sanitizeImportedConfig: storeModule.sanitizeImportedConfig,
+    store: storeModule.store
   }
 }
+
+test('store accessors validate scalar and string-record values at runtime', async () => {
+  const { getStoredBoolean, getStoredStringRecord, store } = await loadStoreModule()
+
+  store.set('startWithWindows', 'yes')
+  store.set('appPaths', {
+    simhub: 'C:/Tools/SimHub.exe',
+    bad: 42,
+    nested: { path: 'C:/Tools/Nested.exe' }
+  })
+
+  expect(getStoredBoolean('startWithWindows')).toBe(false)
+  expect(getStoredBoolean('missing', true)).toBe(true)
+  expect(getStoredStringRecord('appPaths')).toEqual({ simhub: 'C:/Tools/SimHub.exe' })
+  expect(getStoredStringRecord('missing')).toEqual({})
+})
 
 test('sanitizeImportedConfig rejects non-SimLauncher config payloads', async () => {
   const { sanitizeImportedConfig } = await loadStoreModule()
@@ -84,7 +103,7 @@ test('sanitizeImportedConfig filters path, name, args, and prototype pollution k
     gamePaths: { iracing: 'C:/Games/iRacing/iRacingSim64DX11.exe' },
     appPaths: { simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' },
     appNames: { simhub: 'SimHub', customapp2: 'Overlay' },
-    appArgs: { customapp2: '--safe' }
+    appArgs: { customapp2: '--safe', simhub: '--not-allowed' }
   })
 })
 


### PR DESCRIPTION
## Summary

- Harden IPC profile saves by sanitizing bulk and single profile writes through the shared import validation path.
- Keep process mismatch warning icons visible until explicit manual dismiss instead of auto-clearing by TTL.
- Add runtime validation helpers for store-backed booleans/string records/profiles and apply them across main-process launch, running, kill, icon, migration, and config flows.
- Normalize renderer-side external data from localStorage, IPC payloads, and stored profiles before use.
- Update stale built-in utility `appArgs` test expectation.

## Verification

- `npm.cmd run typecheck:tsc`
- `npm.cmd test -- tests/main/store.test.ts tests/main/launch.test.ts tests/main/configImportPreview.test.ts`
- `npm.cmd test -- tests/main/processes.test.ts -t "process mismatch warnings persist until manually dismissed"`
- `npm.cmd test -- tests/settingsSaveRace.test.ts tests/renderer/profileEditorSettingsSync.test.ts tests/renderer/killFailures.test.ts`
- Commit hooks: `prettier --check .`

Closes #331
Closes #335
Closes #337
Closes #360
Closes #377
Refs #378

<!-- auto-closes -->
Closes #331
Closes #335
Closes #337
Closes #360
Closes #377
<!-- auto-closes -->