### PR TITLE
fix: harden save-settings, set-login-item, and browse-path IPC (0.9.7)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -13,6 +13,7 @@ import {
   getStoredZoomFactor,
   requireSafeZoomFactor,
   sanitizeImportedConfig,
+  sanitizeSettingsPatch,
   store
 } from '../store'
 import { isRecord } from '../utils'
@@ -409,7 +410,8 @@ export function registerConfigHandlers() {
     return app.getVersion()
   })
 
-  ipcMain.handle('set-login-item', (_event, openAtLogin: boolean) => {
+  ipcMain.handle('set-login-item', (_event, openAtLogin: unknown) => {
+    if (typeof openAtLogin !== 'boolean') return
     app.setLoginItemSettings({ openAtLogin })
   })
 
@@ -441,51 +443,7 @@ export function registerConfigHandlers() {
 
   ipcMain.handle('save-settings', (_event, patch: unknown) => {
     if (!isRecord(patch)) return
-    const OBJECT_KEYS = new Set(['appPaths', 'gamePaths', 'appNames', 'appArgs'])
-    const BOOLEAN_KEYS = new Set([
-      'accentBgTint',
-      'focusActiveTitle',
-      'startMinimized',
-      'minimizeToTray',
-      'autoCheckUpdates',
-      'startWithWindows'
-    ])
-    const STRING_KEYS = new Set(['accentPreset', 'accentCustom'])
-    const THEME_MODES = new Set(['light', 'dark', 'system'])
-    const WRITABLE_KEYS = new Set([
-      ...OBJECT_KEYS,
-      ...BOOLEAN_KEYS,
-      ...STRING_KEYS,
-      'themeMode',
-      'customSlots',
-      'launchDelayMs',
-      'zoomFactor'
-    ])
-
-    const safe: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(patch)) {
-      if (!WRITABLE_KEYS.has(key)) continue
-      if (OBJECT_KEYS.has(key) && isRecord(value)) {
-        safe[key] = value
-      } else if (BOOLEAN_KEYS.has(key) && typeof value === 'boolean') {
-        safe[key] = value
-      } else if (STRING_KEYS.has(key) && typeof value === 'string') {
-        safe[key] = value
-      } else if (key === 'themeMode' && typeof value === 'string' && THEME_MODES.has(value)) {
-        safe.themeMode = value
-      } else if (
-        key === 'customSlots' &&
-        typeof value === 'number' &&
-        Number.isFinite(value) &&
-        value >= 1
-      ) {
-        safe[key] = Math.min(Math.floor(value), MAX_CUSTOM_SLOTS)
-      } else if (key === 'launchDelayMs' && typeof value === 'number' && Number.isFinite(value)) {
-        safe[key] = Math.min(Math.max(Math.round(value), 0), 5000)
-      } else if (key === 'zoomFactor' && typeof value === 'number' && Number.isFinite(value)) {
-        safe[key] = requireSafeZoomFactor(value)
-      }
-    }
+    const safe = sanitizeSettingsPatch(patch)
     const changedKeys = Object.keys(safe)
     if (changedKeys.length > 0) {
       setStoreEntries(safe)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -597,3 +597,37 @@ export function getSupportedConfigValues(config: Record<string, unknown>) {
 
   return supportedConfig
 }
+
+export function sanitizeSettingsPatch(patch: Record<string, unknown>) {
+  const currentCustomSlots = getSafeCustomSlots(store.get('customSlots'))
+  const patchCustomSlots = getSafeCustomSlots(patch.customSlots)
+  const config: Record<string, unknown> = {
+    customSlots: patchCustomSlots ?? currentCustomSlots ?? 1
+  }
+
+  EXPECTED_CONFIG_KEYS.forEach((key) => {
+    if (
+      key !== 'profiles' &&
+      key !== 'windowBounds' &&
+      key !== 'profileUtilityOrderMigrated' &&
+      key !== 'profileSetsMigrated' &&
+      key !== 'migrated' &&
+      Object.prototype.hasOwnProperty.call(patch, key)
+    ) {
+      config[key] = patch[key]
+    }
+  })
+
+  const supportedConfig = getSupportedConfigValues(config)
+  delete supportedConfig.profiles
+  delete supportedConfig.windowBounds
+  delete supportedConfig.profileUtilityOrderMigrated
+  delete supportedConfig.profileSetsMigrated
+  delete supportedConfig.migrated
+
+  if (!Object.prototype.hasOwnProperty.call(patch, 'customSlots')) {
+    delete supportedConfig.customSlots
+  }
+
+  return supportedConfig
+}

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -177,7 +177,8 @@ export function registerWindowHandlers() {
    * Opens a file dialog to select an executable file and sends the path back.
    * @param inputId The ID of the input field in the Renderer to update.
    */
-  ipcMain.handle('browse-path', async (_event, inputId) => {
+  ipcMain.handle('browse-path', async (_event, inputId: unknown) => {
+    const safeInputId = typeof inputId === 'string' ? inputId : ''
     try {
       const options: OpenDialogOptions = {
         title: 'Select Executable File (.exe)',
@@ -189,12 +190,12 @@ export function registerWindowHandlers() {
           ? await dialog.showOpenDialog(mainWindow, options)
           : await dialog.showOpenDialog(options)
       if (!result.canceled && result.filePaths.length > 0) {
-        return { filePath: result.filePaths[0], inputId }
+        return { filePath: result.filePaths[0], inputId: safeInputId }
       }
-      return { filePath: null, inputId }
+      return { filePath: null, inputId: safeInputId }
     } catch (err) {
       console.error('Dialog error:', err)
-      return { filePath: null, inputId }
+      return { filePath: null, inputId: safeInputId }
     }
   })
 

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -39,6 +39,7 @@ async function loadConfigModule() {
       if (!c || typeof c !== 'object' || Object.keys(c).length === 0) return { imported: true }
       return c
     }),
+    sanitizeSettingsPatch: vi.fn((patch) => patch),
     store: { store: {}, get: vi.fn(), set: vi.fn(), clear: vi.fn() }
   }
   vi.doMock('/src/main/store.ts', () => storeModuleMock)
@@ -243,6 +244,37 @@ test('save-profiles stores only sanitized known profile sets', async () => {
     customSlots: 1,
     profiles: { ac: rawProfileSet }
   })
+})
+
+test('save-settings stores sanitized patch values only', async () => {
+  await loadConfigModule()
+  const storeModule = await import('../../src/main/store')
+
+  vi.mocked(storeModule.sanitizeSettingsPatch).mockReturnValue({
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    appArgs: { customapp1: '--safe' }
+  })
+
+  await invokeConfigHandler('save-settings', {}, { appPaths: { simhub: 'C:/Tools/SimHub.exe' } })
+
+  expect(storeModule.sanitizeSettingsPatch).toHaveBeenCalledWith({
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+  expect(storeModule.store.set).toHaveBeenCalledWith('appPaths', {
+    simhub: 'C:/Tools/SimHub.exe'
+  })
+  expect(storeModule.store.set).toHaveBeenCalledWith('appArgs', { customapp1: '--safe' })
+})
+
+test('set-login-item ignores non-boolean runtime values', async () => {
+  await loadConfigModule()
+  const { app } = await import('electron')
+
+  await invokeConfigHandler('set-login-item', {}, 'true')
+  expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+
+  await invokeConfigHandler('set-login-item', {}, true)
+  expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true })
 })
 
 test('save-profile widens customSlots when profile references a slot beyond the stored count', async () => {

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -20,6 +20,7 @@ async function loadStoreModule() {
     getStoredBoolean: storeModule.getStoredBoolean,
     getStoredStringRecord: storeModule.getStoredStringRecord,
     MAX_CUSTOM_SLOTS: storeModule.MAX_CUSTOM_SLOTS,
+    sanitizeSettingsPatch: storeModule.sanitizeSettingsPatch,
     sanitizeImportedConfig: storeModule.sanitizeImportedConfig,
     store: storeModule.store
   }
@@ -104,6 +105,42 @@ test('sanitizeImportedConfig filters path, name, args, and prototype pollution k
     appPaths: { simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' },
     appNames: { simhub: 'SimHub', customapp2: 'Overlay' },
     appArgs: { customapp2: '--safe', simhub: '--not-allowed' }
+  })
+})
+
+test('sanitizeSettingsPatch filters object settings like config import', async () => {
+  const { sanitizeSettingsPatch, store } = await loadStoreModule()
+  store.set('customSlots', 2)
+
+  expect(
+    sanitizeSettingsPatch({
+      gamePaths: {
+        iracing: ' C:/Games/iRacing/iRacingSim64DX11.exe ',
+        unknown: 'C:/Games/Unknown.exe',
+        acc: 'C:/Games/ACC/readme.txt',
+        __proto__: 'C:/Games/Polluted.exe'
+      },
+      appPaths: {
+        simhub: 'C:/Tools/SimHub.exe',
+        customapp2: 'C:/Tools/Overlay.exe',
+        customapp3: 'C:/Tools/OutOfRange.exe'
+      },
+      appNames: {
+        simhub: ' SimHub ',
+        customapp2: 'Overlay',
+        customapp3: 'Hidden'
+      },
+      appArgs: {
+        customapp2: ' --safe ',
+        customapp3: '--out-of-range',
+        constructor: '--polluted'
+      }
+    })
+  ).toEqual({
+    gamePaths: { iracing: 'C:/Games/iRacing/iRacingSim64DX11.exe' },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' },
+    appNames: { simhub: 'SimHub', customapp2: 'Overlay' },
+    appArgs: { customapp2: '--safe' }
   })
 })
 

--- a/tests/main/window.test.ts
+++ b/tests/main/window.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+type MockIpcHandler = (...args: unknown[]) => unknown | Promise<unknown>
+
+async function invokeWindowHandler(channel: string, ...args: unknown[]) {
+  const { __ipcHandlers } = await import('electron')
+  return (await (__ipcHandlers as Record<string, MockIpcHandler>)[channel](...args)) as {
+    filePath: string | null
+    inputId: string
+  }
+}
+
+async function loadWindowModule() {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  vi.doMock('../../src/main/store', () => ({
+    getStoredBoolean: vi.fn(),
+    getStoredZoomFactor: vi.fn()
+  }))
+  vi.doMock('electron-updater', () => ({
+    autoUpdater: {
+      autoDownload: false,
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      on: vi.fn(),
+      quitAndInstall: vi.fn()
+    }
+  }))
+
+  const mod = await import('../../src/main/window')
+  mod.registerWindowHandlers()
+  return mod
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('browse-path echoes only string input ids', async () => {
+  await loadWindowModule()
+  const { dialog } = await import('electron')
+
+  vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+    canceled: false,
+    filePaths: ['C:/Tools/SimHub.exe']
+  })
+
+  await expect(invokeWindowHandler('browse-path', {}, { id: 'appPaths.simhub' })).resolves.toEqual({
+    filePath: 'C:/Tools/SimHub.exe',
+    inputId: ''
+  })
+
+  await expect(invokeWindowHandler('browse-path', {}, 'appPaths.simhub')).resolves.toEqual({
+    filePath: 'C:/Tools/SimHub.exe',
+    inputId: 'appPaths.simhub'
+  })
+})


### PR DESCRIPTION
## Summary

Hardens four IPC handlers per the 0.9.7 security audit:

- **save-settings** now sanitizes through a new `sanitizeSettingsPatch` helper that reuses the existing config-import path. `appPaths`, `gamePaths`, `appNames`, and `appArgs` get the same prototype-pollution guard, key allow-list, and value validation as imported configs.
- **set-login-item** rejects non-boolean runtime values.
- **browse-path** only echoes string `inputId` back to the renderer; otherwise returns `''`.

Net code reduction in `config.ts` (~50 inline validation lines replaced by one helper call).

Closes #332
Closes #333
Closes #334
Closes #336

## Test plan

- [x] `npm test -- tests/main/store.test.ts tests/main/configImportPreview.test.ts tests/main/window.test.ts` — 18/18 pass
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run format:check` — pass
- [ ] CI build passes

## Notes

Subtle behavior tightenings (all in the safer direction, consistent with config import):
- Invalid `zoomFactor` → resets to default instead of being silently dropped
- Invalid `customSlots` (negative/NaN) → clamped to 1 instead of dropped
- Invalid `accentCustom` (non-hex) → rejected instead of accepted
- `appPaths.customappN` where N > customSlots → stripped instead of stored as orphaned data