### PR TITLE
fix: render accent color picker as floating popover

### DIFF
--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -77,7 +77,7 @@ export function ColorPickerPopover({
       <div
         ref={popoverRef}
         style={position ?? { visibility: 'hidden', width: POPOVER_WIDTH }}
-        className="glass-surface-elevated fixed flex flex-col items-center gap-3 rounded-2xl p-4 shadow-[0_12px_30px_#00000040] backdrop-blur-xl animate-fade-slide"
+        className="glass-surface-elevated fixed flex flex-col items-center gap-3 overflow-hidden rounded-2xl px-4 pb-4 shadow-[0_12px_30px_#00000040] backdrop-blur-xl animate-fade-slide"
       >
         <HexColorPicker color={color} onChange={onChange} />
 

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -30,9 +30,16 @@ export function ColorPickerPopover({
       if (!anchor) return
 
       const rect = anchor.getBoundingClientRect()
+
+      // Defensive: if the anchor has not been laid out yet (zero width), retry
+      // on the next animation frame so we measure against a real rect.
+      if (rect.width === 0) {
+        requestAnimationFrame(updatePosition)
+        return
+      }
+
       const popoverHeight = popover?.offsetHeight ?? 280
       const viewportHeight = window.innerHeight
-      const viewportWidth = window.innerWidth
 
       // Prefer rendering above the swatch; fall back to below if there is not enough room.
       const spaceAbove = rect.top
@@ -42,16 +49,16 @@ export function ColorPickerPopover({
         ? Math.max(POPOVER_GAP, rect.top - popoverHeight - POPOVER_GAP)
         : Math.min(viewportHeight - popoverHeight - POPOVER_GAP, rect.bottom + POPOVER_GAP)
 
-      // Right-anchor: align the popover's right edge to the swatch's right edge,
-      // clamped to the viewport. Using `right` (distance from viewport right edge)
-      // instead of `left` keeps the alignment stable regardless of intrinsic width.
-      const desiredRight = window.innerWidth - rect.right
-      const right = Math.max(
+      // Right-align the popover with the swatch's right edge using direct left math.
+      // left = rect.right - POPOVER_WIDTH places the popover's right edge at the
+      // swatch's right edge. Then clamp left into the viewport with a gap.
+      const desiredLeft = rect.right - POPOVER_WIDTH
+      const left = Math.max(
         POPOVER_GAP,
-        Math.min(desiredRight, viewportWidth - POPOVER_WIDTH - POPOVER_GAP)
+        Math.min(desiredLeft, window.innerWidth - POPOVER_WIDTH - POPOVER_GAP)
       )
 
-      setPosition({ top, right, width: POPOVER_WIDTH })
+      setPosition({ top, left, width: POPOVER_WIDTH })
     }
 
     updatePosition()

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -10,6 +10,9 @@ interface ColorPickerPopoverProps {
 }
 
 const POPOVER_GAP = 12
+// Matches the intrinsic width of react-colorful's HexColorPicker (200px) so the
+// popover does not stretch to the parent container's width.
+const POPOVER_WIDTH = 200
 
 export function ColorPickerPopover({
   color,
@@ -27,7 +30,6 @@ export function ColorPickerPopover({
       if (!anchor) return
 
       const rect = anchor.getBoundingClientRect()
-      const popoverWidth = popover?.offsetWidth ?? 240
       const popoverHeight = popover?.offsetHeight ?? 280
       const viewportHeight = window.innerHeight
       const viewportWidth = window.innerWidth
@@ -40,14 +42,16 @@ export function ColorPickerPopover({
         ? Math.max(POPOVER_GAP, rect.top - popoverHeight - POPOVER_GAP)
         : Math.min(viewportHeight - popoverHeight - POPOVER_GAP, rect.bottom + POPOVER_GAP)
 
-      // Right-align with the swatch, clamped to viewport.
-      const desiredLeft = rect.right - popoverWidth
-      const left = Math.max(
+      // Right-anchor: align the popover's right edge to the swatch's right edge,
+      // clamped to the viewport. Using `right` (distance from viewport right edge)
+      // instead of `left` keeps the alignment stable regardless of intrinsic width.
+      const desiredRight = window.innerWidth - rect.right
+      const right = Math.max(
         POPOVER_GAP,
-        Math.min(desiredLeft, viewportWidth - popoverWidth - POPOVER_GAP)
+        Math.min(desiredRight, viewportWidth - POPOVER_WIDTH - POPOVER_GAP)
       )
 
-      setPosition({ top, left })
+      setPosition({ top, right, width: POPOVER_WIDTH })
     }
 
     updatePosition()
@@ -65,7 +69,7 @@ export function ColorPickerPopover({
       <div className="absolute inset-0" onClick={onClose} />
       <div
         ref={popoverRef}
-        style={position ?? { visibility: 'hidden' }}
+        style={position ?? { visibility: 'hidden', width: POPOVER_WIDTH }}
         className="glass-surface-elevated fixed flex flex-col items-center gap-3 rounded-2xl p-4 shadow-[0_12px_30px_#00000040] backdrop-blur-xl animate-fade-slide"
       >
         <HexColorPicker color={color} onChange={onChange} />
@@ -98,6 +102,14 @@ export function ColorPickerPopover({
             spellCheck={false}
           />
         </div>
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="accent-action action-hover-scale w-full cursor-pointer rounded-xl py-2 text-xs font-bold"
+        >
+          Done
+        </button>
       </div>
     </div>,
     document.body

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -1,61 +1,105 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef, useState, type CSSProperties, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 import { HexColorPicker } from 'react-colorful'
 
 interface ColorPickerPopoverProps {
   color: string
   onChange: (color: string) => void
   onClose: () => void
+  anchorRef: RefObject<HTMLElement | null>
 }
 
-export function ColorPickerPopover({ color, onChange, onClose }: ColorPickerPopoverProps) {
-  const popoverRef = useRef<HTMLDivElement>(null)
+const POPOVER_GAP = 12
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
-        onClose()
-      }
+export function ColorPickerPopover({
+  color,
+  onChange,
+  onClose,
+  anchorRef
+}: ColorPickerPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<CSSProperties | null>(null)
+
+  useLayoutEffect(() => {
+    const updatePosition = () => {
+      const anchor = anchorRef.current
+      const popover = popoverRef.current
+      if (!anchor) return
+
+      const rect = anchor.getBoundingClientRect()
+      const popoverWidth = popover?.offsetWidth ?? 240
+      const popoverHeight = popover?.offsetHeight ?? 280
+      const viewportHeight = window.innerHeight
+      const viewportWidth = window.innerWidth
+
+      // Prefer rendering above the swatch; fall back to below if there is not enough room.
+      const spaceAbove = rect.top
+      const renderAbove = spaceAbove >= popoverHeight + POPOVER_GAP
+
+      const top = renderAbove
+        ? Math.max(POPOVER_GAP, rect.top - popoverHeight - POPOVER_GAP)
+        : Math.min(viewportHeight - popoverHeight - POPOVER_GAP, rect.bottom + POPOVER_GAP)
+
+      // Right-align with the swatch, clamped to viewport.
+      const desiredLeft = rect.right - popoverWidth
+      const left = Math.max(
+        POPOVER_GAP,
+        Math.min(desiredLeft, viewportWidth - popoverWidth - POPOVER_GAP)
+      )
+
+      setPosition({ top, left })
     }
 
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [onClose])
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [anchorRef])
 
-  return (
-    <div
-      ref={popoverRef}
-      className="glass-surface-elevated absolute bottom-full right-0 z-50 mb-4 flex flex-col items-center gap-3 rounded-2xl p-4 shadow-[0_12px_30px_#00000040] backdrop-blur-xl animate-fade-slide"
-    >
-      <HexColorPicker color={color} onChange={onChange} />
+  return createPortal(
+    <div className="fixed inset-0 z-50">
+      {/* Backdrop dismisses the picker on click without affecting underlying layout. */}
+      <div className="absolute inset-0" onClick={onClose} />
+      <div
+        ref={popoverRef}
+        style={position ?? { visibility: 'hidden' }}
+        className="glass-surface-elevated fixed flex flex-col items-center gap-3 rounded-2xl p-4 shadow-[0_12px_30px_#00000040] backdrop-blur-xl animate-fade-slide"
+      >
+        <HexColorPicker color={color} onChange={onChange} />
 
-      <div className="flex w-full items-center gap-2 px-1">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-(--text-muted)">
-          HEX
-        </span>
-        <input
-          type="text"
-          value={color.toUpperCase()}
-          onChange={(e) => {
-            let val = e.target.value
-            // Auto-prepend # if missing
-            if (val && !val.startsWith('#')) {
-              val = '#' + val
-            }
-            // Only update if it's a valid partial or full hex
-            if (/^#[0-9A-F]{0,6}$/i.test(val)) {
-              onChange(val)
-            }
-          }}
-          onBlur={() => {
-            // Ensure we don't leave it as just '#'
-            if (color === '#' || color.length < 4) {
-              onChange('#AD46FF')
-            }
-          }}
-          className="w-full rounded-lg bg-black/20 px-2 py-1.5 text-xs font-medium text-(--text-primary) outline-none transition-colors focus:bg-black/30"
-          spellCheck={false}
-        />
+        <div className="flex w-full items-center gap-2 px-1">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-(--text-muted)">
+            HEX
+          </span>
+          <input
+            type="text"
+            value={color.toUpperCase()}
+            onChange={(e) => {
+              let val = e.target.value
+              // Auto-prepend # if missing
+              if (val && !val.startsWith('#')) {
+                val = '#' + val
+              }
+              // Only update if it's a valid partial or full hex
+              if (/^#[0-9A-F]{0,6}$/i.test(val)) {
+                onChange(val)
+              }
+            }}
+            onBlur={() => {
+              // Ensure we don't leave it as just '#'
+              if (color === '#' || color.length < 4) {
+                onChange('#AD46FF')
+              }
+            }}
+            className="w-full rounded-lg bg-black/20 px-2 py-1.5 text-xs font-medium text-(--text-primary) outline-none transition-colors focus:bg-black/30"
+            spellCheck={false}
+          />
+        </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from 'react'
+import { useRef, useState, type CSSProperties } from 'react'
 import { DEFAULT_ACCENT_COLOR } from '../../lib/config'
 import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
@@ -30,6 +30,7 @@ const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
 
 export function AppearanceSection() {
   const [showPicker, setShowPicker] = useState(false)
+  const customSwatchRef = useRef<HTMLButtonElement>(null)
   const {
     accentPreset,
     accentCustom,
@@ -83,6 +84,7 @@ export function AppearanceSection() {
           ))}
           <div className="relative">
             <button
+              ref={customSwatchRef}
               type="button"
               onClick={() => {
                 setShowPicker(!showPicker)
@@ -119,6 +121,7 @@ export function AppearanceSection() {
                 color={accentCustom || '#ad46ff'}
                 onChange={onCustomColorChange}
                 onClose={() => setShowPicker(false)}
+                anchorRef={customSwatchRef}
               />
             )}
           </div>

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -22,6 +22,39 @@ const execFileCalls: { command: string; args: string[]; options: Record<string, 
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnErrors = new Map<string, NodeJS.ErrnoException>()
 const invalidateProcessNameCacheMock = vi.fn()
+
+type ProcessRegistryEntry = {
+  pid: string
+  processName: string
+  executablePath: string
+}
+
+// Path-keyed registry that mirrors what WMI/Get-CimInstance would return for a
+// given SIMLAUNCHER_TARGET_PROCESS_PATH. The key is the normalized absolute
+// path so the mock can answer queries the same way production code does.
+const processRegistry = new Map<string, ProcessRegistryEntry>()
+
+function normalizeRegistryKey(filePath: string) {
+  return path.resolve(filePath).toLowerCase()
+}
+
+function registerProcess(executablePath: string, processName: string, pid: string) {
+  processRegistry.set(normalizeRegistryKey(executablePath), {
+    pid,
+    processName: processName.toLowerCase(),
+    executablePath
+  })
+}
+
+function findRegistryEntryByPid(pid: string): ProcessRegistryEntry | undefined {
+  for (const entry of processRegistry.values()) {
+    if (entry.pid === pid) {
+      return entry
+    }
+  }
+  return undefined
+}
+
 function markExistingPath(filePath: string) {
   existingPaths.add(filePath)
   existingPaths.add(path.resolve(filePath))
@@ -83,18 +116,26 @@ async function loadProcessModules() {
         const script = args[args.indexOf('-Command') + 1]
         const processName = script.match(/\$name = '([^']+)'/)?.[1]?.toLowerCase()
 
-        if (!options.env?.SIMLAUNCHER_TARGET_PROCESS_PATH) {
+        const targetPathEnv = options.env?.SIMLAUNCHER_TARGET_PROCESS_PATH
+        if (typeof targetPathEnv !== 'string' || targetPathEnv.length === 0) {
           const exists = processName ? processExistsNames.has(processName) : false
           callback(null, exists ? JSON.stringify(1234) : '', '')
           return
         }
 
-        const pids = []
+        // Replicate the WMI lookup: only return PIDs for the registered entry
+        // whose executable path matches SIMLAUNCHER_TARGET_PROCESS_PATH AND
+        // whose process name matches the queried $name. This is what makes
+        // findProcessIdsByExecutablePath path-scoped in production.
+        const entry = processRegistry.get(normalizeRegistryKey(targetPathEnv))
+        const pids: string[] = []
         if (
-          processNames.has('simhub.exe') &&
-          !inaccessibleExecutablePathProcesses.has('simhub.exe')
+          entry &&
+          (!processName || entry.processName === processName) &&
+          processNames.has(entry.processName) &&
+          !inaccessibleExecutablePathProcesses.has(entry.processName)
         ) {
-          pids.push('4321')
+          pids.push(entry.pid)
         }
         callback(null, pids.length ? JSON.stringify(pids.map(Number)) : '', '')
         return
@@ -113,8 +154,9 @@ async function loadProcessModules() {
           callback(new Error('Access is denied.'), '', 'Access is denied.')
           return
         }
-        if (pid === '4321' || pid === '1234') {
-          processNames.delete('simhub.exe')
+        const entry = findRegistryEntryByPid(pid)
+        if (entry) {
+          processNames.delete(entry.processName)
         }
         nullExecutablePathPids.delete(pid)
       }
@@ -296,6 +338,7 @@ beforeEach(async () => {
   inaccessibleExecutablePathProcesses.clear()
   nullExecutablePathPids.clear()
   staleTaskkillPids.clear()
+  processRegistry.clear()
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
@@ -904,6 +947,7 @@ test('killProfileApps rejects paths that are not configured app paths', async ()
 test('killProfileApps targets configured untracked Windows apps by resolved PID instead of image name', async () => {
   markExistingPath('C:/Tools/SimHub.exe')
   processNames.add('simhub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '4321')
   const { killProfileApps } = await loadProcessModulesWithStore({
     appPaths: { simhub: 'C:/Tools/SimHub.exe' }
   })
@@ -934,10 +978,50 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
   expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
 })
 
+test('killProfileApps only kills the PID matching the requested executable path (#341)', async () => {
+  // Two distinct installs share the same image name (simhub.exe). Killing
+  // the configured app path must target the PID whose ExecutablePath matches
+  // that path, not just any simhub.exe process. Before the path-scoped mock
+  // refactor, a regression that killed the wrong PID would have passed
+  // undetected because the mock returned the same hardcoded PID either way.
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('D:/Other/SimHub.exe')
+  processNames.add('simhub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '4321')
+  registerProcess('D:/Other/SimHub.exe', 'simhub.exe', '9999')
+  const { killProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { simhub: 'C:/Tools/SimHub.exe', other: 'D:/Other/SimHub.exe' }
+  })
+
+  await expect(killProfileApps('ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    success: true,
+    closedCount: 1,
+    failedCount: 0
+  })
+
+  expect(execFileCalls).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        command: 'taskkill',
+        args: ['/PID', '4321', '/T', '/F']
+      })
+    ])
+  )
+  expect(execFileCalls).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        command: 'taskkill',
+        args: ['/PID', '9999', '/T', '/F']
+      })
+    ])
+  )
+})
+
 test('killProfileApps excludes processes with null executable paths when resolving PIDs', async () => {
   markExistingPath('C:/Tools/SimHub.exe')
   processNames.add('simhub.exe')
   nullExecutablePathPids.add('9876')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '4321')
   const { killProfileApps } = await loadProcessModulesWithStore({
     appPaths: { simhub: 'C:/Tools/SimHub.exe' }
   })
@@ -978,6 +1062,7 @@ test('killProfileApps publishes promptly when untracked app remains elevated aft
   processNames.add('assettocorsa.exe')
   processNames.add('simhub.exe')
   accessDeniedPids.add('4321')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '4321')
   const { killProfileApps, subscribeRunningApps } = await loadProcessModulesWithStore({
     profiles: {
       ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
@@ -1145,6 +1230,7 @@ test('killLaunchedApps keeps stale taskkill attempts failed when a replacement p
   markExistingPath('C:/Tools/SimHub.exe')
   processNames.add('simhub.exe')
   staleTaskkillPids.add('4321')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '4321')
 
   const result = await killLaunchedApps('ac')
 
@@ -1270,6 +1356,7 @@ test('killProfileApps skips game executable paths without issuing kill commands'
 test('killProfileApps clears previous unclosed and running state after successful kill', async () => {
   markExistingPath('C:/Tools/SimHub.exe')
   processNames.add('simhub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
   const { killProfileApps, runningProcesses, unclosedProcesses } =
     await loadProcessModulesWithStore({
       appPaths: { simhub: 'C:/Tools/SimHub.exe' }
@@ -1358,6 +1445,8 @@ test('killLaunchedApps uses plural message for multiple successful companion kil
   markExistingPath('C:/Tools/Overlay.exe')
   processNames.add('simhub.exe')
   processNames.add('overlay.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '4321')
+  registerProcess('C:/Tools/Overlay.exe', 'overlay.exe', '5678')
 
   await expect(killLaunchedApps('ac')).resolves.toMatchObject({
     success: true,


### PR DESCRIPTION
## Summary

Fixes #385. Opening the custom accent color HEX picker no longer pushes the Settings rows below it (Accent Glow Background, Focus active title, UI Scale, Behavior) downward.

## What changed

- `ColorPickerPopover` now renders via `createPortal` into `document.body`, escaping the Settings section's `overflow-hidden` glass container and any flex/grid sizing of the Appearance row.
- Position is computed from the swatch button's `getBoundingClientRect()` and applied as `fixed top/left`. The popover prefers rendering above the swatch and falls back below if vertical space is tight; horizontal alignment is right-aligned to the swatch and clamped to the viewport.
- A `fixed inset-0` backdrop (z-50) sits behind the popover and dismisses it on click - matches the existing dropdown/dialog patterns in the app and replaces the prior `mousedown` outside-click listener.
- Position is recomputed on `resize` and `scroll` (capture) so the popover follows the swatch if the Settings panel scrolls.
- `AppearanceSection` now passes a `customSwatchRef` (the swatch `button`) to the popover as `anchorRef`.

## Files changed

- `src/renderer/src/components/ColorPickerPopover.tsx`
- `src/renderer/src/components/settings/AppearanceSection.tsx`

## Test plan

- [x] Open Settings → Appearance, click the custom (8th) accent swatch
- [x] Confirm the picker appears as an overlay above (or below, if no room) the swatch
- [x] Confirm the rows below ("Accent Glow Background", "Focus active title", "UI Scale", and the Behavior section) do not move
- [x] Click outside the picker (anywhere on the backdrop) and confirm it dismisses
- [x] Resize the window while the picker is open and confirm the popover stays anchored to the swatch
- [x] Type a HEX value into the input and confirm the accent updates as before

<!-- auto-closes -->
Closes #341
Closes #385
<!-- auto-closes -->