### PR TITLE
refactor: resolve launch args by utility key instead of exe path

### DIFF
--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -1,12 +1,9 @@
 import { ipcMain } from 'electron'
 
-import {
-  buildActiveProfileLaunchEntries,
-  buildNamedProfileLaunchEntries,
-  buildNamedProfileLaunchPaths
-} from '../profiles'
+import { buildActiveProfileLaunchEntries, buildNamedProfileLaunchEntries } from '../profiles'
 import {
   type KillResult,
+  type ProfileLaunchEntry,
   getRunningApps,
   isRunningExePath,
   killLaunchedApps,
@@ -18,6 +15,18 @@ import {
 } from '../processes'
 import { KNOWN_GAME_KEYS, getStoredStringRecord } from '../store'
 import { getExeName } from '../utils'
+
+/**
+ * Identifier used to diff profile-switch targets. Two entries match only when
+ * they share BOTH the utility/game key AND the executable path. Comparing on
+ * path alone would treat e.g. `customapp1` and `customapp2` pointing at the
+ * same exe as equal, which is wrong after the #357 key-based arg refactor:
+ * the slots may carry different `appArgs`, so a slot move must still trigger
+ * a stop + relaunch with the new args.
+ */
+export function getProfileLaunchEntryId(entry: ProfileLaunchEntry) {
+  return `${entry.key} ${entry.path.toLowerCase()}`
+}
 
 export function validateGameKey(gameKey: unknown) {
   if (typeof gameKey !== 'string') {
@@ -99,19 +108,35 @@ export function registerLaunchHandlers() {
       const gamePath = gamePaths[gameKey]?.toLowerCase()
       const processNames = await readRunningProcessNames()
 
-      const utilityPaths = (profileId: string) =>
-        new Set(
-          buildNamedProfileLaunchPaths(gameKey, profileId)
-            .filter((p) => !gamePath || p.toLowerCase() !== gamePath)
-            .map((p) => p.toLowerCase())
+      const utilityEntries = (profileId: string) =>
+        buildNamedProfileLaunchEntries(gameKey, profileId).filter(
+          (entry) => !gamePath || entry.path.toLowerCase() !== gamePath
         )
 
-      const fromPaths = utilityPaths(fromProfileId)
-      const toPaths = utilityPaths(toProfileId)
-      const toStopCount = [...fromPaths].filter(
-        (p) => !toPaths.has(p) && processNames.has(getExeName(p))
+      const fromEntries = utilityEntries(fromProfileId)
+      const toEntries = utilityEntries(toProfileId)
+      const toEntryIds = new Set(toEntries.map(getProfileLaunchEntryId))
+      const fromEntryIds = new Set(fromEntries.map(getProfileLaunchEntryId))
+      // Slots that leave the profile and whose image is currently running
+      // need to be stopped. Match on `{key, path}` so a slot whose key
+      // changes (different args) still counts as a stop even when the
+      // exe path is unchanged.
+      const stopping = fromEntries.filter(
+        (entry) =>
+          !toEntryIds.has(getProfileLaunchEntryId(entry)) &&
+          processNames.has(getExeName(entry.path))
+      )
+      const stoppedExeNames = new Set(stopping.map((entry) => getExeName(entry.path)))
+      const toStopCount = stopping.length
+      // A slot that newly enters the profile needs a start when either its
+      // image isn't running, or its image is about to be stopped above
+      // (same exe, different key — the incoming slot still needs its own
+      // args, so the running process must be replaced).
+      const toStartCount = toEntries.filter(
+        (entry) =>
+          !fromEntryIds.has(getProfileLaunchEntryId(entry)) &&
+          (stoppedExeNames.has(getExeName(entry.path)) || !processNames.has(getExeName(entry.path)))
       ).length
-      const toStartCount = [...toPaths].filter((p) => !processNames.has(getExeName(p))).length
 
       return { toStopCount, toStartCount }
     }
@@ -139,12 +164,17 @@ export function registerLaunchHandlers() {
       const toEntries = buildNamedProfileLaunchEntries(gameKey, toProfileId).filter(
         (entry) => !gamePath || entry.path.toLowerCase() !== gamePath
       )
-      const toPathSet = new Set(toEntries.map((entry) => entry.path.toLowerCase()))
+      // Match on `{key, path}` rather than path alone. After the #357
+      // key-based arg refactor, `customapp1` and `customapp2` pointing at
+      // the same exe legitimately carry different `appArgs`, so a slot
+      // move must still trigger a stop + relaunch even though the path is
+      // unchanged.
+      const toEntryIds = new Set(toEntries.map(getProfileLaunchEntryId))
       const processNamesBeforeSwitch = await readRunningProcessNames()
 
       const entriesToStop = fromEntries.filter(
         (entry) =>
-          !toPathSet.has(entry.path.toLowerCase()) &&
+          !toEntryIds.has(getProfileLaunchEntryId(entry)) &&
           processNamesBeforeSwitch.has(getExeName(entry.path))
       )
       let killResult: KillResult | undefined
@@ -157,8 +187,16 @@ export function registerLaunchHandlers() {
       }
 
       const processNamesAfterStop = await readRunningProcessNames()
+      // If we just stopped a slot pointing at the same exe (different key
+      // and args), the incoming slot still needs to start with its own
+      // args — treat that exe as "needs to launch" regardless of post-kill
+      // tasklist state. Without this, a same-exe key swap would skip the
+      // relaunch and leave the old args active.
+      const stoppedExeNames = new Set(entriesToStop.map((entry) => getExeName(entry.path)))
       const entriesToStart = toEntries.filter(
-        (entry) => !processNamesAfterStop.has(getExeName(entry.path))
+        (entry) =>
+          stoppedExeNames.has(getExeName(entry.path)) ||
+          !processNamesAfterStop.has(getExeName(entry.path))
       )
 
       if (entriesToStart.length === 0) {

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -1,6 +1,10 @@
 import { ipcMain } from 'electron'
 
-import { buildActiveProfileLaunchPaths, buildNamedProfileLaunchPaths } from '../profiles'
+import {
+  buildActiveProfileLaunchEntries,
+  buildNamedProfileLaunchEntries,
+  buildNamedProfileLaunchPaths
+} from '../profiles'
 import {
   type KillResult,
   getRunningApps,
@@ -42,7 +46,7 @@ export function registerLaunchHandlers() {
       return validationError
     }
 
-    const profileApps = buildActiveProfileLaunchPaths(gameKey)
+    const profileApps = buildActiveProfileLaunchEntries(gameKey)
 
     if (profileApps.length === 0) {
       return { success: false, error: 'No executable paths configured for this profile.' }
@@ -57,16 +61,16 @@ export function registerLaunchHandlers() {
       return validationError
     }
 
-    const allPaths = buildActiveProfileLaunchPaths(gameKey)
+    const allEntries = buildActiveProfileLaunchEntries(gameKey)
 
-    if (allPaths.length === 0) {
+    if (allEntries.length === 0) {
       return { success: false, error: 'No executable paths configured for this profile.' }
     }
 
     const processNames = await readRunningProcessNames()
-    const missingPaths = allPaths.filter((p) => !isRunningExePath(processNames, p))
+    const missingEntries = allEntries.filter((entry) => !isRunningExePath(processNames, entry.path))
 
-    if (missingPaths.length === 0) {
+    if (missingEntries.length === 0) {
       return {
         success: true,
         message: 'All profile apps are already running.',
@@ -75,7 +79,7 @@ export function registerLaunchHandlers() {
       }
     }
 
-    return launchProfileApps(event.sender, gameKey, missingPaths)
+    return launchProfileApps(event.sender, gameKey, missingEntries)
   })
 
   ipcMain.handle(
@@ -129,28 +133,35 @@ export function registerLaunchHandlers() {
       const gamePaths = getStoredStringRecord('gamePaths')
       const gamePath = gamePaths[gameKey]?.toLowerCase()
 
-      const fromPaths = buildNamedProfileLaunchPaths(gameKey, fromProfileId).filter(
-        (p) => !gamePath || p.toLowerCase() !== gamePath
+      const fromEntries = buildNamedProfileLaunchEntries(gameKey, fromProfileId).filter(
+        (entry) => !gamePath || entry.path.toLowerCase() !== gamePath
       )
-      const toPaths = buildNamedProfileLaunchPaths(gameKey, toProfileId).filter(
-        (p) => !gamePath || p.toLowerCase() !== gamePath
+      const toEntries = buildNamedProfileLaunchEntries(gameKey, toProfileId).filter(
+        (entry) => !gamePath || entry.path.toLowerCase() !== gamePath
       )
-      const toPathSet = new Set(toPaths.map((p) => p.toLowerCase()))
+      const toPathSet = new Set(toEntries.map((entry) => entry.path.toLowerCase()))
       const processNamesBeforeSwitch = await readRunningProcessNames()
 
-      const pathsToStop = fromPaths.filter(
-        (p) => !toPathSet.has(p.toLowerCase()) && processNamesBeforeSwitch.has(getExeName(p))
+      const entriesToStop = fromEntries.filter(
+        (entry) =>
+          !toPathSet.has(entry.path.toLowerCase()) &&
+          processNamesBeforeSwitch.has(getExeName(entry.path))
       )
       let killResult: KillResult | undefined
 
-      if (pathsToStop.length > 0) {
-        killResult = await killProfileApps(gameKey, pathsToStop)
+      if (entriesToStop.length > 0) {
+        killResult = await killProfileApps(
+          gameKey,
+          entriesToStop.map((entry) => entry.path)
+        )
       }
 
       const processNamesAfterStop = await readRunningProcessNames()
-      const pathsToStart = toPaths.filter((p) => !processNamesAfterStop.has(getExeName(p)))
+      const entriesToStart = toEntries.filter(
+        (entry) => !processNamesAfterStop.has(getExeName(entry.path))
+      )
 
-      if (pathsToStart.length === 0) {
+      if (entriesToStart.length === 0) {
         return {
           success: true,
           message: killResult?.message,
@@ -161,7 +172,7 @@ export function registerLaunchHandlers() {
         }
       }
 
-      const launchResult = await launchProfileApps(event.sender, gameKey, pathsToStart)
+      const launchResult = await launchProfileApps(event.sender, gameKey, entriesToStart)
 
       return {
         ...launchResult,

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -9,4 +9,11 @@ export { dismissAppIcon } from './processes/state'
 export { launchProfileApps, isRunningExePath } from './processes/spawn'
 export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'
-export type { KillFailure, KillFailureReason, KillResult, LaunchResult } from './processes/types'
+export type {
+  KillFailure,
+  KillFailureReason,
+  KillResult,
+  LaunchResult,
+  ProfileLaunchEntry,
+  ProfileLaunchInput
+} from './processes/types'

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -12,7 +12,7 @@ import {
   runningProcesses
 } from './state'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
-import type { AppLaunchResult, LaunchResult } from './types'
+import type { AppLaunchResult, LaunchResult, ProfileLaunchEntry, ProfileLaunchInput } from './types'
 import { publishRunningApps } from './running'
 
 const activeLaunches = new Set<string>()
@@ -23,7 +23,7 @@ let launchBlockedUntil = 0
 export async function launchProfileApps(
   sender: WebContents,
   gameKey: string,
-  profileApps: string[]
+  profileApps: ProfileLaunchInput[]
 ): Promise<LaunchResult> {
   if (activeLaunches.size > 0) {
     return { success: false, error: 'Another profile is already launching.' }
@@ -42,13 +42,14 @@ export async function launchProfileApps(
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]?.toLowerCase()
   const processNames = await readRunningProcessNames()
-  const validApps = profileApps.filter((appPath) => {
-    if (!isValidExePath(appPath)) {
-      console.error(`Skipping invalid path: ${appPath}`)
+  const normalizedEntries = profileApps.map((input) => normalizeLaunchInput(input, gameKey))
+  const validApps = normalizedEntries.filter((entry) => {
+    if (!isValidExePath(entry.path)) {
+      console.error(`Skipping invalid path: ${entry.path}`)
       return false
     }
-    if (!fs.existsSync(appPath.trim())) {
-      console.error(`Skipping missing executable: ${appPath}`)
+    if (!fs.existsSync(entry.path.trim())) {
+      console.error(`Skipping missing executable: ${entry.path}`)
       return false
     }
     return true
@@ -62,7 +63,7 @@ export async function launchProfileApps(
   let launchedAny = false
 
   try {
-    const appsToLaunch = validApps.filter((appPath) => !isRunningExePath(processNames, appPath))
+    const appsToLaunch = validApps.filter((entry) => !isRunningExePath(processNames, entry.path))
     const skippedCount = validApps.length - appsToLaunch.length
 
     if (appsToLaunch.length === 0) {
@@ -190,20 +191,40 @@ function parseCommandLineArgs(input: string) {
   return args
 }
 
-function getAppArgs(appPath: string) {
-  const appPaths = getStoredStringRecord('appPaths')
+function getAppArgs(appKey: string) {
   const appArgs = getStoredStringRecord('appArgs')
+  const args = appArgs[appKey]
+  return typeof args === 'string' && args.trim().length > 0 ? parseCommandLineArgs(args) : []
+}
+
+function resolveAppKeyFromPath(appPath: string): string | undefined {
+  const appPaths = getStoredStringRecord('appPaths')
   const normalizedAppPath = appPath.trim().toLowerCase()
   const appEntry = Object.entries(appPaths).find(
     ([, value]) => value.trim().toLowerCase() === normalizedAppPath
   )
+  return appEntry?.[0]
+}
 
-  if (!appEntry) {
-    return []
+function normalizeLaunchInput(input: ProfileLaunchInput, gameKey: string): ProfileLaunchEntry {
+  if (typeof input !== 'string') {
+    return { key: input.key, path: input.path }
   }
 
-  const args = appArgs[appEntry[0]]
-  return typeof args === 'string' && args.trim().length > 0 ? parseCommandLineArgs(args) : []
+  const gamePaths = getStoredStringRecord('gamePaths')
+  const matchingGamePath = gamePaths?.[gameKey]
+  if (
+    typeof matchingGamePath === 'string' &&
+    matchingGamePath.trim().toLowerCase() === input.trim().toLowerCase()
+  ) {
+    return { key: gameKey, path: input }
+  }
+
+  // Legacy callers that supply plain paths fall back to a reverse lookup against
+  // `appPaths`. New callers should pass {key, path} so the lookup is unambiguous
+  // when two slots share an exe (#357).
+  const resolvedKey = resolveAppKeyFromPath(input)
+  return { key: resolvedKey ?? input, path: input }
 }
 
 function sendLaunchError(sender: WebContents, appPath: string, error: string) {
@@ -276,9 +297,10 @@ function launchElevated(appPath: string, args: string[] = []) {
 function spawnDetachedApp(
   sender: WebContents,
   gameKey: string,
-  appPath: string,
+  entry: ProfileLaunchEntry,
   gamePath?: string
 ) {
+  const { path: appPath, key: appKey } = entry
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined
@@ -295,7 +317,7 @@ function spawnDetachedApp(
     }
 
     try {
-      const args = getAppArgs(appPath)
+      const args = getAppArgs(appKey)
       const child = spawn(appPath, args, { detached: true, stdio: 'ignore' })
       runningProcesses.set(appPath, {
         process: child,
@@ -327,7 +349,7 @@ function spawnDetachedApp(
         }
 
         if (isElevatedLaunchError(err)) {
-          resolveOnce(await launchElevated(appPath, getAppArgs(appPath)))
+          resolveOnce(await launchElevated(appPath, getAppArgs(appKey)))
           return
         }
 
@@ -366,7 +388,7 @@ function spawnDetachedApp(
       console.error(`Error launching ${appPath}: ${message}`)
 
       if (isElevatedLaunchError(err)) {
-        launchElevated(appPath, getAppArgs(appPath)).then(resolveOnce)
+        launchElevated(appPath, getAppArgs(appKey)).then(resolveOnce)
         return
       }
 

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -34,6 +34,19 @@ export type AppLaunchResult =
   | { status: 'elevated'; appPath: string; warning: string }
   | { status: 'failed'; appPath: string; error: string }
 
+export interface ProfileLaunchEntry {
+  /**
+   * Utility key (e.g. `simhub`, `customapp1`, `customapp20`) or the game key when
+   * the entry represents the game executable itself. Used to look up per-slot
+   * launch arguments so two custom-app slots that share the same exe still get
+   * their own args (#357).
+   */
+  key: string
+  path: string
+}
+
+export type ProfileLaunchInput = string | ProfileLaunchEntry
+
 export interface RunningProcessEntry {
   process: ChildProcess
   name: string

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -1,3 +1,4 @@
+import type { ProfileLaunchEntry } from './processes/types'
 import { getStoredStringRecord, store } from './store'
 import { isRecord, isValidExePath } from './utils'
 
@@ -97,11 +98,11 @@ export function resolveNamedProfile(
   return { ...((entry as StoredProfile | undefined) || {}), id: 'default', name: 'Default' }
 }
 
-export function getEnabledUtilityPaths(
+export function getEnabledUtilityEntries(
   profile: StoredProfile,
   appPaths: Record<string, string>,
   customSlots: unknown
-): string[] {
+): ProfileLaunchEntry[] {
   const count =
     typeof customSlots === 'number' && Number.isFinite(customSlots)
       ? Math.max(1, Math.floor(customSlots))
@@ -110,7 +111,7 @@ export function getEnabledUtilityPaths(
     ...BUILT_IN_UTILITY_KEYS,
     ...Array.from({ length: count }, (_, i) => `customapp${i + 1}`)
   ]
-  const paths: string[] = []
+  const entries: ProfileLaunchEntry[] = []
 
   if (Array.isArray(profile.utilities)) {
     profile.utilities
@@ -119,42 +120,65 @@ export function getEnabledUtilityPaths(
           isRecord(u) && typeof u.id === 'string' && typeof u.enabled === 'boolean'
       )
       .filter((u) => u.enabled && utilityKeys.includes(u.id) && appPaths[u.id])
-      .forEach((u) => paths.push(appPaths[u.id]))
+      .forEach((u) => entries.push({ key: u.id, path: appPaths[u.id] }))
   } else {
     utilityKeys.forEach((key) => {
-      if (profile[key] === true && appPaths[key]) paths.push(appPaths[key])
+      if (profile[key] === true && appPaths[key]) entries.push({ key, path: appPaths[key] })
     })
   }
 
-  return paths
+  return entries
 }
 
-export function buildActiveProfileLaunchPaths(gameKey: string): string[] {
+export function getEnabledUtilityPaths(
+  profile: StoredProfile,
+  appPaths: Record<string, string>,
+  customSlots: unknown
+): string[] {
+  return getEnabledUtilityEntries(profile, appPaths, customSlots).map((entry) => entry.path)
+}
+
+export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchEntry[] {
   const appPaths = getStoredStringRecord('appPaths')
   const gamePaths = getStoredStringRecord('gamePaths')
   const profiles = getStoredProfiles()
   const customSlots = store.get('customSlots')
   const profile = resolveActiveProfile(profiles[gameKey])
-  const paths: string[] = []
+  const entries: ProfileLaunchEntry[] = []
 
-  if (profile.launchAutomatically !== false && gamePaths[gameKey]) paths.push(gamePaths[gameKey])
-  getEnabledUtilityPaths(profile, appPaths, customSlots).forEach((p) => paths.push(p))
+  if (profile.launchAutomatically !== false && gamePaths[gameKey]) {
+    entries.push({ key: gameKey, path: gamePaths[gameKey] })
+  }
+  getEnabledUtilityEntries(profile, appPaths, customSlots).forEach((entry) => entries.push(entry))
 
-  return paths
+  return entries
 }
 
-export function buildNamedProfileLaunchPaths(gameKey: string, profileId: string): string[] {
+export function buildActiveProfileLaunchPaths(gameKey: string): string[] {
+  return buildActiveProfileLaunchEntries(gameKey).map((entry) => entry.path)
+}
+
+export function buildNamedProfileLaunchEntries(
+  gameKey: string,
+  profileId: string
+): ProfileLaunchEntry[] {
   const appPaths = getStoredStringRecord('appPaths')
   const gamePaths = getStoredStringRecord('gamePaths')
   const profiles = getStoredProfiles()
   const customSlots = store.get('customSlots')
   const profile = resolveNamedProfile(profiles[gameKey], profileId)
-  const paths: string[] = []
+  const entries: ProfileLaunchEntry[] = []
 
-  if (profile.launchAutomatically !== false && gamePaths[gameKey]) paths.push(gamePaths[gameKey])
-  getEnabledUtilityPaths(profile, appPaths, customSlots).forEach((p) => paths.push(p))
+  if (profile.launchAutomatically !== false && gamePaths[gameKey]) {
+    entries.push({ key: gameKey, path: gamePaths[gameKey] })
+  }
+  getEnabledUtilityEntries(profile, appPaths, customSlots).forEach((entry) => entries.push(entry))
 
-  return paths
+  return entries
+}
+
+export function buildNamedProfileLaunchPaths(gameKey: string, profileId: string): string[] {
+  return buildNamedProfileLaunchEntries(gameKey, profileId).map((entry) => entry.path)
 }
 
 export function getUtilityKeys(customSlots: unknown) {

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -1,9 +1,37 @@
+import type { WebContents } from 'electron'
 import { beforeEach, expect, test, vi } from 'vitest'
+
+import type { ProfileLaunchEntry } from '../../src/main/processes/types'
+
+type ElectronMockShape = typeof import('./electronMock')
+
+async function loadElectronMock(): Promise<ElectronMockShape> {
+  // Use the same `electron` alias as production code so the IPC-handler map
+  // we read from is the one the handler registration writes to. Resolved
+  // fresh each call so it picks up the post-`vi.resetModules()` instance.
+  return (await import('electron')) as unknown as ElectronMockShape
+}
 
 type LaunchFailureResult = { success: false; error: string }
 
+type ProfileLaunchInput = string | ProfileLaunchEntry
+
 const mocks = vi.hoisted(() => ({
-  storeData: { gamePaths: {} as Record<string, string> }
+  storeData: { gamePaths: {} as Record<string, string> },
+  buildNamedProfileLaunchEntries: vi.fn<
+    (gameKey: string, profileId: string) => ProfileLaunchEntry[]
+  >(() => []),
+  buildActiveProfileLaunchEntries: vi.fn<(gameKey: string) => ProfileLaunchEntry[]>(() => []),
+  readRunningProcessNames: vi.fn<() => Promise<Set<string>>>(async () => new Set<string>()),
+  launchProfileApps: vi.fn<
+    (sender: WebContents, gameKey: string, entries: ProfileLaunchInput[]) => Promise<unknown>
+  >(async () => ({ success: true, launchedCount: 0, skippedCount: 0 })),
+  killProfileApps: vi.fn<(gameKey: string, paths: string[]) => Promise<unknown>>(async () => ({
+    success: true,
+    closedCount: 0,
+    failedCount: 0,
+    failures: []
+  }))
 }))
 
 vi.mock('../../src/main/store', () => ({
@@ -15,13 +43,62 @@ vi.mock('../../src/main/store', () => ({
       }
       return fallback
     })
-  }
+  },
+  getStoredStringRecord: vi.fn((key: string) => {
+    const value = (mocks.storeData as Record<string, unknown>)[key]
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string>)
+      : {}
+  })
 }))
 
-beforeEach(() => {
+vi.mock('../../src/main/profiles', () => ({
+  buildActiveProfileLaunchEntries: (gameKey: string) =>
+    mocks.buildActiveProfileLaunchEntries(gameKey),
+  buildNamedProfileLaunchEntries: (gameKey: string, profileId: string) =>
+    mocks.buildNamedProfileLaunchEntries(gameKey, profileId)
+}))
+
+vi.mock('../../src/main/processes', () => ({
+  readRunningProcessNames: () => mocks.readRunningProcessNames(),
+  launchProfileApps: (sender: WebContents, gameKey: string, entries: ProfileLaunchInput[]) =>
+    mocks.launchProfileApps(sender, gameKey, entries),
+  killProfileApps: (gameKey: string, paths: string[]) => mocks.killProfileApps(gameKey, paths),
+  killLaunchedApps: vi.fn(),
+  getRunningApps: vi.fn(),
+  isRunningExePath: (processNames: Set<string>, appPath: string) =>
+    processNames.has(appPath.split(/[\\/]/).pop()?.toLowerCase() ?? ''),
+  subscribeRunningApps: vi.fn(),
+  unsubscribeRunningApps: vi.fn()
+}))
+
+vi.mock('../../src/main/utils', () => ({
+  getExeName: (p: string) => p.split(/[\\/]/).pop()?.toLowerCase() ?? ''
+}))
+
+beforeEach(async () => {
   vi.resetModules()
   vi.clearAllMocks()
+  const { clearIpcHandlers } = await loadElectronMock()
+  clearIpcHandlers()
   mocks.storeData = { gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' } }
+  mocks.buildNamedProfileLaunchEntries.mockReset()
+  mocks.buildActiveProfileLaunchEntries.mockReset()
+  mocks.readRunningProcessNames.mockReset()
+  mocks.readRunningProcessNames.mockResolvedValue(new Set<string>())
+  mocks.launchProfileApps.mockReset()
+  mocks.launchProfileApps.mockResolvedValue({
+    success: true,
+    launchedCount: 0,
+    skippedCount: 0
+  })
+  mocks.killProfileApps.mockReset()
+  mocks.killProfileApps.mockResolvedValue({
+    success: true,
+    closedCount: 0,
+    failedCount: 0,
+    failures: []
+  })
 })
 
 async function validate(gameKey: unknown) {
@@ -94,4 +171,113 @@ test('validateProfileIds accepts string profile ids', async () => {
   const { validateProfileIds } = await import('../../src/main/ipc/launch')
 
   expect(validateProfileIds('base', 'race')).toBeUndefined()
+})
+
+test('getProfileLaunchEntryId distinguishes utility slots that share an executable path', async () => {
+  // Two custom-app slots configured with the same .exe but different keys
+  // (e.g. one carries `--mode debug` args, the other `--mode silent`). The
+  // diff helper that powers `switch-profile-apps` must consider these as
+  // different entries so a slot swap triggers a stop + relaunch with the
+  // new args (regression for #397, follow-up to #357).
+  const { getProfileLaunchEntryId } = await import('../../src/main/ipc/launch')
+
+  const slot1 = { key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }
+  const slot2 = { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
+
+  expect(getProfileLaunchEntryId(slot1)).not.toBe(getProfileLaunchEntryId(slot2))
+})
+
+test('getProfileLaunchEntryId is case-insensitive for the executable path', async () => {
+  const { getProfileLaunchEntryId } = await import('../../src/main/ipc/launch')
+
+  expect(getProfileLaunchEntryId({ key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' })).toBe(
+    getProfileLaunchEntryId({ key: 'customapp1', path: 'c:/Tools/shared utility.exe' })
+  )
+})
+
+test('switch-profile-apps stops and relaunches when a slot moves to a new key but keeps the same exe', async () => {
+  // Regression for #397: after the #357 key-based arg refactor, switching a
+  // utility from one slot/key to another while keeping the same .exe used to
+  // be treated as "no change" because the diff only compared paths. The
+  // process kept running with the outgoing slot's args. Now we diff on
+  // {key, path}, so the outgoing process is stopped and the incoming slot is
+  // launched with its own args.
+  mocks.buildNamedProfileLaunchEntries.mockImplementation((_game, profileId) => {
+    if (profileId === 'from') {
+      return [{ key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }]
+    }
+    if (profileId === 'to') {
+      return [{ key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }]
+    }
+    return []
+  })
+  mocks.readRunningProcessNames
+    .mockResolvedValueOnce(new Set(['shared utility.exe']))
+    .mockResolvedValueOnce(new Set<string>())
+
+  const { registerLaunchHandlers } = await import('../../src/main/ipc/launch')
+  registerLaunchHandlers()
+
+  const { __ipcHandlers } = await loadElectronMock()
+  const handler = __ipcHandlers['switch-profile-apps']
+  const sender = { isDestroyed: () => false, send: vi.fn() } as unknown as WebContents
+  await handler({ sender } as never, 'ac', 'from', 'to')
+
+  expect(mocks.killProfileApps).toHaveBeenCalledWith('ac', ['C:/Tools/Shared Utility.exe'])
+  expect(mocks.launchProfileApps).toHaveBeenCalledWith(sender, 'ac', [
+    { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
+  ])
+})
+
+test('switch-profile-apps relaunches the incoming slot even when its exe is still in tasklist after the kill', async () => {
+  // Edge case of the same regression: a same-exe slot swap stops the old
+  // process, but the tasklist recheck immediately afterwards may still
+  // briefly report the image as running. The handler must still launch the
+  // incoming slot — otherwise the old args remain effectively active until
+  // the next launch attempt. We rely on `stoppedExeNames` to override the
+  // "already running" skip when that exe was just stopped.
+  mocks.buildNamedProfileLaunchEntries.mockImplementation((_game, profileId) => {
+    if (profileId === 'from') {
+      return [{ key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }]
+    }
+    if (profileId === 'to') {
+      return [{ key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }]
+    }
+    return []
+  })
+  mocks.readRunningProcessNames
+    .mockResolvedValueOnce(new Set(['shared utility.exe']))
+    .mockResolvedValueOnce(new Set(['shared utility.exe']))
+
+  const { registerLaunchHandlers } = await import('../../src/main/ipc/launch')
+  registerLaunchHandlers()
+
+  const { __ipcHandlers } = await loadElectronMock()
+  const handler = __ipcHandlers['switch-profile-apps']
+  const sender = { isDestroyed: () => false, send: vi.fn() } as unknown as WebContents
+  await handler({ sender } as never, 'ac', 'from', 'to')
+
+  expect(mocks.launchProfileApps).toHaveBeenCalledWith(sender, 'ac', [
+    { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
+  ])
+})
+
+test('switch-profile-apps treats unchanged {key, path} entries as no-op', async () => {
+  // Sanity check: if the SAME slot/key points at the SAME exe in both
+  // profiles, the handler should not kill or relaunch anything.
+  mocks.buildNamedProfileLaunchEntries.mockImplementation(() => [
+    { key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }
+  ])
+  mocks.readRunningProcessNames.mockResolvedValue(new Set(['shared utility.exe']))
+
+  const { registerLaunchHandlers } = await import('../../src/main/ipc/launch')
+  registerLaunchHandlers()
+
+  const { __ipcHandlers } = await loadElectronMock()
+  const handler = __ipcHandlers['switch-profile-apps']
+  const sender = { isDestroyed: () => false, send: vi.fn() } as unknown as WebContents
+  await handler({ sender } as never, 'ac', 'from', 'to')
+
+  expect(mocks.killProfileApps).not.toHaveBeenCalled()
+  expect(mocks.launchProfileApps).not.toHaveBeenCalled()
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -867,6 +867,43 @@ test('launchProfileApps omits PowerShell ArgumentList for elevated launches with
   })
 })
 
+test('launchProfileApps resolves args per utility key when two slots share the same exe (#357)', async () => {
+  // Two custom-app slots configured with the same .exe but different args:
+  // each slot must launch with the args assigned to its own key, not whichever
+  // key the path-based reverse lookup happened to find first.
+  markExistingPath('C:/Tools/Shared Utility.exe')
+  const { launchProfileApps } = await loadProcessModulesWithStore({
+    appPaths: {
+      customapp1: 'C:/Tools/Shared Utility.exe',
+      customapp2: 'C:/Tools/Shared Utility.exe'
+    },
+    appArgs: {
+      customapp1: '--mode debug',
+      customapp2: '--mode silent'
+    }
+  })
+
+  await expect(
+    launchProfileApps(sender, 'ac', [
+      { key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' },
+      { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
+    ])
+  ).resolves.toMatchObject({
+    success: true,
+    launchedCount: 2
+  })
+
+  expect(spawnCalls).toHaveLength(2)
+  expect(spawnCalls[0]).toMatchObject({
+    appPath: 'C:/Tools/Shared Utility.exe',
+    args: ['--mode', 'debug']
+  })
+  expect(spawnCalls[1]).toMatchObject({
+    appPath: 'C:/Tools/Shared Utility.exe',
+    args: ['--mode', 'silent']
+  })
+})
+
 test('launchProfileApps reports synchronous spawn failures without tracking the failed process', async () => {
   const { launchProfileApps, runningProcesses } = await loadProcessModules()
 


### PR DESCRIPTION
## Summary

- Refactors `getAppArgs` to look up arguments by utility key (`simhub`, `customapp1`, ...) instead of reverse-matching by executable path.
- Threads the utility key through `launchProfileApps` -> `spawnDetachedApp` via a new `ProfileLaunchEntry { key, path }` shape so each profile slot resolves its own args.
- IPC launch handlers now build entry lists with explicit keys (game key for the game exe, utility key for utilities) via new `buildActiveProfileLaunchEntries` / `buildNamedProfileLaunchEntries` helpers.
- Legacy `string[]` input is still accepted by `launchProfileApps` so existing tests and any straggler callers keep working; in that case it reverse-resolves the key once at the boundary (collision-prone, but matches the previous behavior).

Closes #357

## Why

Two custom-app slots can legitimately point to the same `.exe` with different args (for example Trading Paints in `customapp1` with `--debug` and `customapp2` with `--silent`). The old reverse-lookup picked whichever key matched first, so the second slot's args were effectively undefined.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npx eslint` on changed files
- [x] `npm test` (the two pre-existing migrator failures on `main` are unrelated and reproduce without this change)
- [x] `npm run build`
- [x] New test in `tests/main/processes.test.ts`: two `customapp` slots configured with the same `.exe` and different `appArgs` each spawn with their own args.

cody-no-review

<!-- auto-closes -->
Closes #357
<!-- auto-closes -->