### PR TITLE
fix: refresh utility icon in Settings immediately after Browse

### DIFF
--- a/src/main/ipc/icons.ts
+++ b/src/main/ipc/icons.ts
@@ -7,6 +7,28 @@ import { getStoredStringRecord } from '../store'
 let genericIconFingerprint: string | null | undefined
 let genericIconFingerprintPromise: Promise<string | null> | null = null
 
+const RECENTLY_BROWSED_PATH_LIMIT = 32
+const recentlyBrowsedPaths = new Set<string>()
+
+/**
+ * Marks a file path as having been selected by the user via the OS file
+ * dialog. This grants `get-file-icon` permission to read its icon before the
+ * path has been persisted to the store, so freshly picked executables show
+ * their icon immediately in Settings rather than only after an app restart.
+ */
+export function markRecentlyBrowsedPath(filePath: string) {
+  if (typeof filePath !== 'string' || !filePath) return
+  if (recentlyBrowsedPaths.has(filePath)) {
+    recentlyBrowsedPaths.delete(filePath)
+  }
+  recentlyBrowsedPaths.add(filePath)
+  while (recentlyBrowsedPaths.size > RECENTLY_BROWSED_PATH_LIMIT) {
+    const oldest = recentlyBrowsedPaths.values().next().value
+    if (oldest === undefined) break
+    recentlyBrowsedPaths.delete(oldest)
+  }
+}
+
 async function computeGenericIconFingerprint() {
   if (process.platform !== 'win32') {
     return null
@@ -86,7 +108,7 @@ export function registerIconHandlers() {
       ...Object.values(getStoredStringRecord('gamePaths')),
       ...Object.values(getStoredStringRecord('appPaths'))
     ]
-    if (!storedPaths.includes(filePath)) return null
+    if (!storedPaths.includes(filePath) && !recentlyBrowsedPaths.has(filePath)) return null
 
     try {
       const icon = await app.getFileIcon(filePath, { size: 'normal' })

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, screen, type OpenDialogOptions } f
 import path from 'path'
 
 import { getIsQuitting, setIsQuitting } from './app-state'
+import { markRecentlyBrowsedPath } from './ipc/icons'
 import { getStoredBoolean, getStoredZoomFactor, isWindowBounds, store } from './store'
 import { checkForUpdates, registerUpdaterEvents } from './updater'
 import { clamp } from './utils'
@@ -190,7 +191,9 @@ export function registerWindowHandlers() {
           ? await dialog.showOpenDialog(mainWindow, options)
           : await dialog.showOpenDialog(options)
       if (!result.canceled && result.filePaths.length > 0) {
-        return { filePath: result.filePaths[0], inputId: safeInputId }
+        const filePath = result.filePaths[0]
+        markRecentlyBrowsedPath(filePath)
+        return { filePath, inputId: safeInputId }
       }
       return { filePath: null, inputId: safeInputId }
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #386 — after picking a utility executable in Settings, the row stayed on the "T" fallback initial until the app was restarted. The cause is in the main process: `get-file-icon` only accepts paths already persisted in the store, so the icon fetch in `handleBrowse` returned `null` for a freshly picked (but unsaved) executable, leaving `appIcons` empty for that slot.

## Fix

- Track the most recently picked paths (LRU set, capped at 32) in `src/main/ipc/icons.ts` via a new `markRecentlyBrowsedPath` helper.
- `browse-path` (in `src/main/window.ts`) now marks every path it returns. The OS dialog is explicit user consent for that specific file, so this preserves the original intent of the security check (no arbitrary probing) while letting the legitimately picked executable through to `app.getFileIcon`.
- `get-file-icon` allows a path if it is either stored or recently browsed.

The renderer side (`handleBrowse` → `setAppIcons` → row consumes `appIcons[utility.key]`) was already correct; with the main-process check relaxed, the icon now resolves and flows into the row state on first pick.

bot: no codex

## Test plan

- [x] `npm run typecheck`
- [x] `npm run format:check` (only pre-existing warning in an unrelated worktree)
- [x] `npx eslint src/main/ipc/icons.ts src/main/window.ts`
- [x] `npm test` (the two `migrator.test.ts` failures are pre-existing on `main`)
- [x] `npm run build`
- [x] Manual: Settings → Add slot → Browse → pick `.exe`. Icon should appear in the row immediately, before clicking Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)