### PR TITLE
fix: suppress misleading kill-failed toast when launched exe is gone (#390)

### DIFF
--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -63,7 +63,7 @@ export function registerLaunchHandlers() {
       return { success: false, error: 'No executable paths configured for this profile.' }
     }
 
-    const processNames = await readRunningProcessNames()
+    const { processNames } = await readRunningProcessNames()
     const missingPaths = allPaths.filter((p) => !isRunningExePath(processNames, p))
 
     if (missingPaths.length === 0) {
@@ -93,7 +93,7 @@ export function registerLaunchHandlers() {
 
       const gamePaths = getStoredStringRecord('gamePaths')
       const gamePath = gamePaths[gameKey]?.toLowerCase()
-      const processNames = await readRunningProcessNames()
+      const { processNames } = await readRunningProcessNames()
 
       const utilityPaths = (profileId: string) =>
         new Set(
@@ -136,7 +136,7 @@ export function registerLaunchHandlers() {
         (p) => !gamePath || p.toLowerCase() !== gamePath
       )
       const toPathSet = new Set(toPaths.map((p) => p.toLowerCase()))
-      const processNamesBeforeSwitch = await readRunningProcessNames()
+      const { processNames: processNamesBeforeSwitch } = await readRunningProcessNames()
 
       const pathsToStop = fromPaths.filter(
         (p) => !toPathSet.has(p.toLowerCase()) && processNamesBeforeSwitch.has(getExeName(p))
@@ -147,7 +147,7 @@ export function registerLaunchHandlers() {
         killResult = await killProfileApps(gameKey, pathsToStop)
       }
 
-      const processNamesAfterStop = await readRunningProcessNames()
+      const { processNames: processNamesAfterStop } = await readRunningProcessNames()
       const pathsToStart = toPaths.filter((p) => !processNamesAfterStop.has(getExeName(p)))
 
       if (pathsToStart.length === 0) {

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -350,6 +350,15 @@ async function finalizeKillAttempts(
   const processNamesAfterKill = await readRunningProcessNames()
   const finalizedAttempts = await Promise.all(
     attempts.map(async (attempt) => {
+      // Treat the launched exe's absence from the post-kill tasklist as the
+      // authoritative success signal. This covers apps whose actual running
+      // process has a different name than the launched exe (e.g. Perplexity
+      // and similar Electron wrappers, see #390): the kill effectively
+      // succeeded if the image we asked Windows to terminate is gone, even
+      // when taskkill reported access-denied/not-found or WMI returns a
+      // stale PID on the post-kill recheck.
+      const imageGoneFromTasklist = !processNamesAfterKill.has(attempt.processName)
+
       let stillRunning: boolean
       let isElevatedInconclusive = false
       if (isFullExePath(attempt.appPath)) {
@@ -358,28 +367,33 @@ async function finalizeKillAttempts(
           attempt.appPath
         )
         isElevatedInconclusive =
+          !imageGoneFromTasklist &&
           attempt.notFound === true &&
           attempt.staleTask !== true &&
           processNamesAfterKill.has(attempt.processName)
         stillRunning =
-          processIds.length > 0 ||
-          isElevatedInconclusive ||
-          (attempt.accessDenied === true &&
-            !attempt.notFound &&
-            processNamesAfterKill.has(attempt.processName))
+          !imageGoneFromTasklist &&
+          (processIds.length > 0 ||
+            isElevatedInconclusive ||
+            (attempt.accessDenied === true &&
+              !attempt.notFound &&
+              processNamesAfterKill.has(attempt.processName)))
       } else {
         stillRunning = processNamesAfterKill.has(attempt.processName)
       }
       return {
         ...attempt,
         stillRunning,
+        imageGoneFromTasklist,
         accessDenied: attempt.accessDenied || isElevatedInconclusive
       }
     })
   )
 
   finalizedAttempts.forEach((attempt) => {
-    const failedToClose = attempt.stillRunning || (!attempt.success && !attempt.notFound)
+    const failedToClose =
+      attempt.stillRunning ||
+      (!attempt.success && !attempt.notFound && !attempt.imageGoneFromTasklist)
 
     if (failedToClose) {
       registerUnclosedProcess(attempt)
@@ -398,7 +412,9 @@ async function finalizeKillAttempts(
   })
 
   const failedAttempts = finalizedAttempts.filter(
-    (attempt) => attempt.stillRunning || (!attempt.success && !attempt.notFound)
+    (attempt) =>
+      attempt.stillRunning ||
+      (!attempt.success && !attempt.notFound && !attempt.imageGoneFromTasklist)
   )
   const closedCount = finalizedAttempts.length - failedAttempts.length
   const failures: KillFailure[] = failedAttempts.map((attempt) => {

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -347,7 +347,8 @@ async function finalizeKillAttempts(
   }
 
   invalidateProcessNameCache()
-  const processNamesAfterKill = await readRunningProcessNames()
+  const { processNames: processNamesAfterKill, succeeded: tasklistReadSucceeded } =
+    await readRunningProcessNames()
   const finalizedAttempts = await Promise.all(
     attempts.map(async (attempt) => {
       // Treat the launched exe's absence from the post-kill tasklist as the
@@ -357,7 +358,12 @@ async function finalizeKillAttempts(
       // succeeded if the image we asked Windows to terminate is gone, even
       // when taskkill reported access-denied/not-found or WMI returns a
       // stale PID on the post-kill recheck.
-      const imageGoneFromTasklist = !processNamesAfterKill.has(attempt.processName)
+      //
+      // Gate this override on tasklistReadSucceeded so a transient tasklist
+      // command failure (which yields an empty Set) doesn't silently turn
+      // real taskkill failures into false successes (see #399).
+      const imageGoneFromTasklist =
+        tasklistReadSucceeded && !processNamesAfterKill.has(attempt.processName)
 
       let stillRunning: boolean
       let isElevatedInconclusive = false
@@ -488,7 +494,7 @@ function getProfileCompanionTargets(gameKey?: string) {
 }
 
 export async function killLaunchedApps(gameKey?: string) {
-  const processNames = await readRunningProcessNames()
+  const { processNames } = await readRunningProcessNames()
   const companionTargets = getProfileCompanionTargets(gameKey)
   const killTasks: Promise<KillAttemptResult>[] = []
 
@@ -524,7 +530,7 @@ export async function killLaunchedApps(gameKey?: string) {
 }
 
 export async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
-  const processNames = await readRunningProcessNames()
+  const { processNames } = await readRunningProcessNames()
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]?.toLowerCase()
   const storedAppPathTargets = getStoredAppPathTargets()

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -133,9 +133,14 @@ async function getTrackedRunningApps(
 }
 
 export async function getRunningApps(): Promise<RunningApp[]> {
-  const processNames = await readRunningProcessNames()
-  pruneStoppedRunningProcesses(processNames)
-  pruneUnclosedProcesses(processNames)
+  const { processNames, succeeded: tasklistReadSucceeded } = await readRunningProcessNames()
+  // When the tasklist read failed, processNames is an empty Set with no
+  // signal value — skip pruning so we don't silently clear running/unclosed
+  // state based on bogus "everything is gone" data (see #399).
+  if (tasklistReadSucceeded) {
+    pruneStoppedRunningProcesses(processNames)
+    pruneUnclosedProcesses(processNames)
+  }
   pruneExpiredProcessNameMismatchWarnings()
 
   const launchedApps = Array.from(runningProcesses.entries()).map(([appPath, appProcess]) => ({

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -41,7 +41,7 @@ export async function launchProfileApps(
   const launchDelayMs = getLaunchDelayMs()
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]?.toLowerCase()
-  const processNames = await readRunningProcessNames()
+  const { processNames } = await readRunningProcessNames()
   const validApps = profileApps.filter((appPath) => {
     if (!isValidExePath(appPath)) {
       console.error(`Skipping invalid path: ${appPath}`)

--- a/src/main/processes/tasklist.ts
+++ b/src/main/processes/tasklist.ts
@@ -2,16 +2,21 @@ import { execFile } from 'child_process'
 
 const CACHE_TTL_MS = 500
 
-let cachedResult: Set<string> | undefined
-let cachedAt = 0
-let inflight: Promise<Set<string>> | undefined
+export interface RunningProcessNamesResult {
+  processNames: Set<string>
+  succeeded: boolean
+}
 
-function spawnTasklist(): Promise<Set<string>> {
-  return new Promise<Set<string>>((resolve) => {
+let cachedResult: RunningProcessNamesResult | undefined
+let cachedAt = 0
+let inflight: Promise<RunningProcessNamesResult> | undefined
+
+function spawnTasklist(): Promise<RunningProcessNamesResult> {
+  return new Promise<RunningProcessNamesResult>((resolve) => {
     execFile('tasklist', ['/fo', 'csv', '/nh'], { windowsHide: true }, (error, stdout) => {
       if (error) {
         console.error('Failed to read running processes:', error)
-        resolve(new Set())
+        resolve({ processNames: new Set(), succeeded: false })
         return
       }
 
@@ -22,12 +27,12 @@ function spawnTasklist(): Promise<Set<string>> {
           names.add(match[1].toLowerCase())
         }
       })
-      resolve(names)
+      resolve({ processNames: names, succeeded: true })
     })
   })
 }
 
-export function readRunningProcessNames(): Promise<Set<string>> {
+export function readRunningProcessNames(): Promise<RunningProcessNamesResult> {
   if (cachedResult && Date.now() - cachedAt < CACHE_TTL_MS) {
     return Promise.resolve(cachedResult)
   }
@@ -37,10 +42,15 @@ export function readRunningProcessNames(): Promise<Set<string>> {
   }
 
   inflight = spawnTasklist()
-    .then((names) => {
-      cachedResult = names
-      cachedAt = Date.now()
-      return names
+    .then((result) => {
+      // Only cache successful reads so a transient tasklist failure doesn't
+      // poison subsequent calls for the full TTL window and so callers can
+      // distinguish "process is gone" from "we don't know".
+      if (result.succeeded) {
+        cachedResult = result
+        cachedAt = Date.now()
+      }
+      return result
     })
     .finally(() => {
       inflight = undefined

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -30,6 +30,11 @@ const processNamesGoneAfterWmiLookup = new Set<string>()
 // predicate `processNamesAfterKill.has(processName)` must stay true so the
 // staleTask branch is the only thing keeping isElevatedInconclusive false.
 const processNamesGoneAfterKill = new Set<string>()
+// "taskkill /PID reports access-denied, but the image is gone from tasklist
+// afterwards" — used to model #390 where the launched exe's actual running
+// process has a different name, so the wrapper's PID kill fails but the app
+// effectively exits anyway (and the verification must treat that as success).
+const pidsAccessDeniedButImageGone = new Set<string>()
 const wmiLookupCounts = new Map<string, number>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
@@ -182,6 +187,12 @@ async function loadProcessModules() {
           return
         }
         if (accessDeniedPids.has(pid)) {
+          if (pidsAccessDeniedButImageGone.has(pid)) {
+            const entry = findRegistryEntryByPid(pid)
+            if (entry) {
+              processNames.delete(entry.processName)
+            }
+          }
           callback(new Error('Access is denied.'), '', 'Access is denied.')
           return
         }
@@ -371,6 +382,7 @@ beforeEach(async () => {
   staleTaskkillPids.clear()
   processNamesGoneAfterWmiLookup.clear()
   processNamesGoneAfterKill.clear()
+  pidsAccessDeniedButImageGone.clear()
   wmiLookupCounts.clear()
   processRegistry.clear()
   execFileCalls.length = 0
@@ -2013,4 +2025,46 @@ test('pruneUnclosedProcesses removes entries whose image is no longer active (#3
   expect(unclosedProcesses.has('ac:c:/tools/active.exe')).toBe(true)
   expect(unclosedProcesses.has('ac:c:/tools/inactive.exe')).toBe(false)
   expect(unclosedProcesses.has('ac:c:/tools/also-inactive.exe')).toBe(false)
+})
+
+test('kill is reported successful when the launched exe is gone from tasklist even if taskkill complained (#390)', async () => {
+  // Reproduces the Perplexity scenario from #390: the launched exe (a wrapper
+  // / Electron stub) spawns the real app under a different process name and
+  // exits. When the user closes the profile, taskkill against the tracked
+  // PID may fail (access-denied / no-running-instance) because the wrapper
+  // PID is already stale, BUT the launched image is gone from tasklist on
+  // the post-kill recheck — the kill effectively succeeded. The finalize
+  // logic must treat this as success and NOT emit a "couldn't be closed"
+  // toast / unclosed entry.
+  markExistingPath('C:/Users/test/AppData/Local/Programs/Perplexity/Perplexity.exe')
+  processNames.add('perplexity.exe')
+  registerProcess(
+    'C:/Users/test/AppData/Local/Programs/Perplexity/Perplexity.exe',
+    'perplexity.exe',
+    '9876'
+  )
+  // taskkill /PID 9876 will report access-denied, but the image disappears
+  // from tasklist anyway (the wrapper exited / the OS finished tearing down
+  // the tree).
+  accessDeniedPids.add('9876')
+  pidsAccessDeniedButImageGone.add('9876')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: {
+      perplexity: 'C:/Users/test/AppData/Local/Programs/Perplexity/Perplexity.exe'
+    }
+  })
+
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({
+    success: true,
+    closedCount: 1,
+    failedCount: 0,
+    failures: []
+  })
+  expect(
+    unclosedProcesses.has('ac:c:/users/test/appdata/local/programs/perplexity/perplexity.exe')
+  ).toBe(false)
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -35,6 +35,17 @@ const processNamesGoneAfterKill = new Set<string>()
 // process has a different name, so the wrapper's PID kill fails but the app
 // effectively exits anyway (and the verification must treat that as success).
 const pidsAccessDeniedButImageGone = new Set<string>()
+// Mutable flag that flips the mocked readRunningProcessNames into the "tasklist
+// command failed" branch (succeeded: false, empty Set). Used to verify that
+// kill verification doesn't treat an empty Set as evidence-of-exit when the
+// read itself was invalid (see #399).
+let tasklistReadShouldFail = false
+// When >0, the mocked readRunningProcessNames returns a successful response
+// for the first N calls, then starts failing. Lets a single test simulate a
+// transient tasklist failure on the post-kill recheck only — without breaking
+// the pre-kill scan that decides which processes to attempt to kill.
+let tasklistReadFailAfterCalls = 0
+let tasklistReadCallCount = 0
 const wmiLookupCounts = new Map<string, number>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
@@ -238,7 +249,21 @@ async function loadProcessModules() {
 
   const tasklistMock = {
     invalidateProcessNameCache: invalidateProcessNameCacheMock,
-    readRunningProcessNames: vi.fn(() => Promise.resolve(new Set(processNames)))
+    readRunningProcessNames: vi.fn(() => {
+      tasklistReadCallCount += 1
+      const shouldFailNow =
+        tasklistReadShouldFail ||
+        (tasklistReadFailAfterCalls > 0 && tasklistReadCallCount > tasklistReadFailAfterCalls)
+      // Production's readRunningProcessNames swallows tasklist execution
+      // errors and resolves with an empty Set + succeeded: false. Modelling
+      // the empty-Set here is what lets the regression test distinguish
+      // "image is gone" from "we don't know" (see #399).
+      return Promise.resolve(
+        shouldFailNow
+          ? { processNames: new Set<string>(), succeeded: false }
+          : { processNames: new Set(processNames), succeeded: true }
+      )
+    })
   }
   vi.doMock('./tasklist', () => tasklistMock)
   vi.doMock('/src/main/processes/tasklist.ts', () => tasklistMock)
@@ -383,6 +408,9 @@ beforeEach(async () => {
   processNamesGoneAfterWmiLookup.clear()
   processNamesGoneAfterKill.clear()
   pidsAccessDeniedButImageGone.clear()
+  tasklistReadShouldFail = false
+  tasklistReadFailAfterCalls = 0
+  tasklistReadCallCount = 0
   wmiLookupCounts.clear()
   processRegistry.clear()
   execFileCalls.length = 0
@@ -2067,4 +2095,49 @@ test('kill is reported successful when the launched exe is gone from tasklist ev
   expect(
     unclosedProcesses.has('ac:c:/users/test/appdata/local/programs/perplexity/perplexity.exe')
   ).toBe(false)
+})
+
+test('kill is NOT reported successful when taskkill failed and the post-kill tasklist read itself failed (#399)', async () => {
+  // Codex review noted that gating success on `!processNamesAfterKill.has(...)`
+  // alone collapses two very different states into one when the post-kill
+  // tasklist command itself fails: production's readRunningProcessNames
+  // swallows the error and returns an empty Set, which would make the
+  // imageGoneFromTasklist override misfire and turn a real taskkill failure
+  // into a false success. The fix propagates a `succeeded` flag so the
+  // override only applies when the read actually confirmed the image is gone.
+  markExistingPath('C:/tools/access-denied-app.exe')
+  processNames.add('access-denied-app.exe')
+  registerProcess('C:/tools/access-denied-app.exe', 'access-denied-app.exe', '5555')
+  // taskkill /PID 5555 reports access-denied AND leaves the image in
+  // tasklist — i.e. nothing was actually terminated.
+  accessDeniedPids.add('5555')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: {
+      accessdenied: 'C:/tools/access-denied-app.exe'
+    }
+  })
+
+  // Let the PRE-kill scan succeed so a kill attempt is actually dispatched,
+  // then make the POST-kill recheck fail. With the buggy code, the empty Set
+  // from the failed recheck satisfied `!processNamesAfterKill.has(...)` and
+  // turned the access-denied failure into success: true / closedCount: 1.
+  tasklistReadFailAfterCalls = 1
+
+  const result = await killLaunchedApps('ac')
+
+  expect(result.success).toBe(false)
+  expect(result.failedCount).toBe(1)
+  expect(result.closedCount).toBe(0)
+  expect(result.failures).toHaveLength(1)
+  expect(result.failures[0]).toMatchObject({
+    appName: 'access-denied-app.exe',
+    reason: 'access_denied'
+  })
+  // The unclosed-process entry must be registered so the UI surfaces the
+  // failure rather than silently clearing it.
+  expect(unclosedProcesses.has('ac:c:/tools/access-denied-app.exe')).toBe(true)
 })

--- a/tests/main/tasklist.test.ts
+++ b/tests/main/tasklist.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 let tasklistCallCount = 0
 let tasklistOutput =
   '"SimHub.exe","1234","Console","1","50,000 K"\r\n"CrewChief.exe","5678","Console","1","30,000 K"'
+let tasklistError: Error | null = null
 
 async function loadTasklistModule() {
   vi.resetModules()
@@ -10,7 +11,7 @@ async function loadTasklistModule() {
   vi.doMock('child_process', () => ({
     execFile: vi.fn((_command, _args, _options, callback) => {
       tasklistCallCount += 1
-      callback(null, tasklistOutput, '')
+      callback(tasklistError, tasklistError ? '' : tasklistOutput, '')
     })
   }))
 
@@ -21,6 +22,7 @@ beforeEach(() => {
   tasklistCallCount = 0
   tasklistOutput =
     '"SimHub.exe","1234","Console","1","50,000 K"\r\n"CrewChief.exe","5678","Console","1","30,000 K"'
+  tasklistError = null
 })
 
 afterEach(() => {
@@ -30,11 +32,12 @@ afterEach(() => {
 test('readRunningProcessNames parses tasklist CSV output into lowercase process names', async () => {
   const { readRunningProcessNames } = await loadTasklistModule()
 
-  const names = await readRunningProcessNames()
+  const result = await readRunningProcessNames()
 
-  expect(names).toBeInstanceOf(Set)
-  expect(names.has('simhub.exe')).toBe(true)
-  expect(names.has('crewchief.exe')).toBe(true)
+  expect(result.succeeded).toBe(true)
+  expect(result.processNames).toBeInstanceOf(Set)
+  expect(result.processNames.has('simhub.exe')).toBe(true)
+  expect(result.processNames.has('crewchief.exe')).toBe(true)
   expect(tasklistCallCount).toBe(1)
 })
 
@@ -83,13 +86,47 @@ test('invalidateProcessNameCache forces a fresh read on next call', async () => 
 
   const first = await readRunningProcessNames()
   expect(tasklistCallCount).toBe(1)
-  expect(first.has('simhub.exe')).toBe(true)
+  expect(first.processNames.has('simhub.exe')).toBe(true)
 
   tasklistOutput = '"NewApp.exe","9999","Console","1","10,000 K"'
   invalidateProcessNameCache()
 
   const second = await readRunningProcessNames()
   expect(tasklistCallCount).toBe(2)
-  expect(second.has('newapp.exe')).toBe(true)
-  expect(second.has('simhub.exe')).toBe(false)
+  expect(second.processNames.has('newapp.exe')).toBe(true)
+  expect(second.processNames.has('simhub.exe')).toBe(false)
+})
+
+test('tasklist execution failure resolves with succeeded: false and an empty Set', async () => {
+  tasklistError = new Error('tasklist command not found')
+  const { readRunningProcessNames } = await loadTasklistModule()
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  const result = await readRunningProcessNames()
+
+  expect(result.succeeded).toBe(false)
+  expect(result.processNames).toBeInstanceOf(Set)
+  expect(result.processNames.size).toBe(0)
+  expect(consoleErrorSpy).toHaveBeenCalled()
+  consoleErrorSpy.mockRestore()
+})
+
+test('failed reads are not cached so the next call retries the tasklist command', async () => {
+  tasklistError = new Error('transient tasklist failure')
+  const { readRunningProcessNames } = await loadTasklistModule()
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  const first = await readRunningProcessNames()
+  expect(first.succeeded).toBe(false)
+  expect(tasklistCallCount).toBe(1)
+
+  // Recover from the failure and verify the next call actually spawns
+  // tasklist again (no poisoned-cache reuse of the failed result).
+  tasklistError = null
+  const second = await readRunningProcessNames()
+
+  expect(tasklistCallCount).toBe(2)
+  expect(second.succeeded).toBe(true)
+  expect(second.processNames.has('simhub.exe')).toBe(true)
+  consoleErrorSpy.mockRestore()
 })


### PR DESCRIPTION
## Summary
- Closes #390. When closing a profile that contains an app whose actual running process name differs from the launched `.exe` (e.g. Perplexity / Electron wrappers), the kill verification could falsely emit a "couldn't be closed" toast even though the app had in fact exited.
- Root cause: `finalizeKillAttempts` only treated the kill as successful when `taskkill` returned cleanly AND the post-kill WMI / image-in-tasklist signals lined up. For wrapper-style apps, taskkill against the stale wrapper PID often returns access-denied / no-running-instance while the launched image is already gone from tasklist on the recheck — currently this still registers an unclosed entry.
- Fix: treat the launched exe's absence from the post-kill tasklist as the authoritative success signal. Short-circuit `stillRunning` to false and ignore the `!success && !notFound` failure condition when the image is gone. The existing elevated-process / WMI verification logic is preserved for the case where the image really is still in tasklist.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npx eslint src/main/processes/kill.ts tests/main/processes.test.ts`
- [x] `npm test -- tests/main/processes.test.ts` (51/51 passing, including new regression test)
- [x] `npm run build`
- [x] Manual smoke: launch a profile with Perplexity, click close — confirm no "couldn't be closed" toast and running apps list updates.

skip-codex-review

<!-- auto-closes -->
Closes #390
<!-- auto-closes -->