### PR TITLE
feat: unified dirty-state UX (sticky Save, tab/close warnings, profile name)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,15 @@ import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   {
-    ignores: ['.test-out/**', 'out/**', 'dist/**', 'release/**', 'node_modules/**', '*.tsbuildinfo']
+    ignores: [
+      '.test-out/**',
+      '.claude/**',
+      'out/**',
+      'dist/**',
+      'release/**',
+      'node_modules/**',
+      '*.tsbuildinfo'
+    ]
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -1,4 +1,6 @@
 let isQuitting = false
+let rendererDirty = false
+let pendingMinimizeToTray: boolean | null = null
 
 export function getIsQuitting() {
   return isQuitting
@@ -6,4 +8,20 @@ export function getIsQuitting() {
 
 export function setIsQuitting(value = true) {
   isQuitting = value
+}
+
+export function getRendererDirty() {
+  return rendererDirty
+}
+
+export function setRendererDirty(value: boolean) {
+  rendererDirty = value
+}
+
+export function getPendingMinimizeToTray() {
+  return pendingMinimizeToTray
+}
+
+export function setPendingMinimizeToTray(value: boolean | null) {
+  pendingMinimizeToTray = value
 }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -125,12 +125,6 @@ export function createWindow() {
 
     store.set('windowBounds', mainWindow.getBounds())
 
-    if (!getIsQuitting() && getRendererDirty()) {
-      event.preventDefault()
-      mainWindow.webContents.send('close-requested')
-      return
-    }
-
     // Honour the renderer's pending tray preference (e.g. when the user toggled
     // Minimize-to-tray but has not saved yet) so the close button respects the
     // user's current intent rather than the last persisted value.
@@ -138,9 +132,18 @@ export function createWindow() {
     const effectiveMinimizeToTray =
       pendingMinimizeToTray === null ? store.get('minimizeToTray') === true : pendingMinimizeToTray
 
+    // Tray takes precedence over the dirty-changes prompt: hiding to tray
+    // keeps the renderer alive so unsaved data is preserved. The unsaved-
+    // changes confirm only matters when the close would actually quit.
     if (!getIsQuitting() && effectiveMinimizeToTray) {
       event.preventDefault()
       mainWindow.hide()
+      return
+    }
+
+    if (!getIsQuitting() && getRendererDirty()) {
+      event.preventDefault()
+      mainWindow.webContents.send('close-requested')
     }
   })
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,7 +1,14 @@
 import { app, BrowserWindow, dialog, ipcMain, screen, type OpenDialogOptions } from 'electron'
 import path from 'path'
 
-import { getIsQuitting, setIsQuitting } from './app-state'
+import {
+  getIsQuitting,
+  getPendingMinimizeToTray,
+  getRendererDirty,
+  setIsQuitting,
+  setPendingMinimizeToTray,
+  setRendererDirty
+} from './app-state'
 import { markRecentlyBrowsedPath } from './ipc/icons'
 import { getStoredBoolean, getStoredZoomFactor, isWindowBounds, store } from './store'
 import { checkForUpdates, registerUpdaterEvents } from './updater'
@@ -118,9 +125,20 @@ export function createWindow() {
 
     store.set('windowBounds', mainWindow.getBounds())
 
-    const minimizeToTray = store.get('minimizeToTray') === true
+    if (!getIsQuitting() && getRendererDirty()) {
+      event.preventDefault()
+      mainWindow.webContents.send('close-requested')
+      return
+    }
 
-    if (!getIsQuitting() && minimizeToTray) {
+    // Honour the renderer's pending tray preference (e.g. when the user toggled
+    // Minimize-to-tray but has not saved yet) so the close button respects the
+    // user's current intent rather than the last persisted value.
+    const pendingMinimizeToTray = getPendingMinimizeToTray()
+    const effectiveMinimizeToTray =
+      pendingMinimizeToTray === null ? store.get('minimizeToTray') === true : pendingMinimizeToTray
+
+    if (!getIsQuitting() && effectiveMinimizeToTray) {
       event.preventDefault()
       mainWindow.hide()
     }
@@ -212,10 +230,32 @@ export function registerWindowHandlers() {
   })
 
   ipcMain.handle('window-close', () => {
-    if (store.get('minimizeToTray') !== true) {
+    const pendingMinimizeToTray = getPendingMinimizeToTray()
+    const effectiveMinimizeToTray =
+      pendingMinimizeToTray === null ? store.get('minimizeToTray') === true : pendingMinimizeToTray
+
+    if (!effectiveMinimizeToTray && !getRendererDirty()) {
       setIsQuitting(true)
     }
 
+    mainWindow?.close()
+  })
+
+  ipcMain.handle('set-renderer-dirty', (_event, value: unknown) => {
+    setRendererDirty(value === true)
+  })
+
+  ipcMain.handle('set-pending-minimize-to-tray', (_event, value: unknown) => {
+    if (value === null || typeof value === 'boolean') {
+      setPendingMinimizeToTray(value)
+    } else {
+      setPendingMinimizeToTray(null)
+    }
+  })
+
+  ipcMain.handle('force-close-window', () => {
+    setIsQuitting(true)
+    setRendererDirty(false)
     mainWindow?.close()
   })
 

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -150,6 +150,10 @@ export interface ElectronAPI {
   minimize: () => Promise<void>
   maximize: () => Promise<void>
   close: () => Promise<void>
+  forceClose: () => Promise<void>
+  setRendererDirty: (isDirty: boolean) => Promise<void>
+  setPendingMinimizeToTray: (value: boolean | null) => Promise<void>
+  onCloseRequested: (cb: () => void) => Unsubscribe
   restartApp: () => Promise<void>
   getRunningApps: () => Promise<RunningApp[]>
   subscribeRunningApps: () => Promise<RunningAppsChangedPayload>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -32,6 +32,15 @@ const electronAPI: ElectronAPI = {
   minimize: () => ipcRenderer.invoke('window-minimize'),
   maximize: () => ipcRenderer.invoke('window-maximize'),
   close: () => ipcRenderer.invoke('window-close'),
+  forceClose: () => ipcRenderer.invoke('force-close-window'),
+  setRendererDirty: (isDirty: boolean) => ipcRenderer.invoke('set-renderer-dirty', isDirty),
+  setPendingMinimizeToTray: (value: boolean | null) =>
+    ipcRenderer.invoke('set-pending-minimize-to-tray', value),
+  onCloseRequested: (cb: () => void) => {
+    const handler = () => cb()
+    ipcRenderer.on('close-requested', handler)
+    return () => ipcRenderer.removeListener('close-requested', handler)
+  },
   restartApp: () => ipcRenderer.invoke('restart-app'),
 
   // process monitoring

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -56,7 +56,17 @@ function AppContent() {
 
   useEffect(() => {
     const unsubscribe = onCloseRequested(() => {
-      setCloseConfirmOpen(true)
+      // Avoid stacking the close dialog on top of the tab-switch dialog —
+      // two simultaneous confirms attach independent Enter/Escape handlers
+      // and a single keypress would trigger conflicting save/discard flows.
+      // The tab-switch flow is more contextual (user just clicked a tab),
+      // so let them finish it first.
+      setPendingView((current) => {
+        if (current === null) {
+          setCloseConfirmOpen(true)
+        }
+        return current
+      })
     })
     return () => {
       unsubscribe()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { NotifyProvider } from './components/Notify'
+import { NotifyProvider, useNotify } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
@@ -30,6 +30,7 @@ export default function App() {
 function AppContent() {
   const [view, setView] = useState<'games' | 'settings'>('games')
   const { accentBgTint, syncThemeFromStore } = useTheme()
+  const { notify } = useNotify()
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
   const [showImportWarning, setShowImportWarning] = useState(false)
   const [pendingView, setPendingView] = useState<'games' | 'settings' | null>(null)
@@ -116,7 +117,12 @@ function AppContent() {
   const handleConfirmSave = useCallback(async () => {
     // If only the profile editor is dirty, trigger its save handler and pivot.
     if (isProfileEditorDirty && !isSettingsDirty) {
-      await requestSaveAll()
+      const success = await requestSaveAll()
+      if (!success) {
+        // Keep the dialog open so the user can retry or discard; the failed
+        // save handler already surfaced its own error toast.
+        return
+      }
       if (pendingView) {
         setView(pendingView)
         setPendingView(null)
@@ -124,20 +130,28 @@ function AppContent() {
       return
     }
     // Otherwise let the settings save pipeline run via its existing trigger.
+    // The pendingView pivot happens in SettingsProvider's onSaved callback,
+    // which is only allowed to navigate when the save reports success.
     setSaveRequested(true)
   }, [isProfileEditorDirty, isSettingsDirty, pendingView, requestSaveAll])
 
   const handleCloseConfirmSave = useCallback(async () => {
+    let success: boolean
     try {
-      await requestSaveAll()
+      success = await requestSaveAll()
     } catch (err) {
+      // requestSaveAll catches handler errors internally, but guard anyway.
       console.error('Failed to save before close', err)
-      setCloseConfirmOpen(false)
+      success = false
+    }
+    if (!success) {
+      // Do NOT force-close — leave dialog open so the user keeps their data.
+      notify('Failed to save changes. Window not closed.', 'error', 4000)
       return
     }
     setCloseConfirmOpen(false)
     await forceClose()
-  }, [requestSaveAll])
+  }, [notify, requestSaveAll])
 
   const handleCloseConfirmDiscard = useCallback(async () => {
     requestDiscardAll()
@@ -186,10 +200,10 @@ function AppContent() {
         onDirtyChange={reportSettingsDirty}
         shouldSaveTrigger={saveRequested}
         onConfigImported={handleConfigImported}
-        onSaved={() => {
+        onSaved={(success) => {
           setSaveRequested(false)
           setRefreshKey((k) => k + 1)
-          if (pendingView) {
+          if (success && pendingView) {
             setView(pendingView)
             setPendingView(null)
           }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -204,6 +204,7 @@ function AppContent() {
       )}
 
       <SettingsProvider
+        key={refreshKey}
         onDirtyChange={reportSettingsDirty}
         shouldSaveTrigger={saveRequested}
         onConfigImported={handleConfigImported}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,27 +1,65 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { NotifyProvider } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { WarningTriangleIcon, CloseIcon } from './components/icons'
-import { getUpdateInfo, onUpdateAvailable } from './lib/electron'
+import {
+  forceClose,
+  getUpdateInfo,
+  onCloseRequested,
+  onUpdateAvailable,
+  setRendererDirty
+} from './lib/electron'
 import { runStartupMigrations } from './lib/migrations'
 import { useTheme } from './contexts/ThemeContext'
 import { SettingsProvider } from './components/settings/SettingsContext'
+import { AppDirtyProvider, useAppDirty } from './contexts/AppDirtyContext'
 
 export default function App() {
+  return (
+    <NotifyProvider>
+      <AppDirtyProvider>
+        <AppContent />
+      </AppDirtyProvider>
+    </NotifyProvider>
+  )
+}
+
+function AppContent() {
   const [view, setView] = useState<'games' | 'settings'>('games')
   const { accentBgTint, syncThemeFromStore } = useTheme()
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
   const [showImportWarning, setShowImportWarning] = useState(false)
-  const [settingsDirty, setSettingsDirty] = useState(false)
   const [pendingView, setPendingView] = useState<'games' | 'settings' | null>(null)
+  const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
   const [saveRequested, setSaveRequested] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
+  const {
+    isAnyDirty,
+    isSettingsDirty,
+    isProfileEditorDirty,
+    reportSettingsDirty,
+    requestSaveAll,
+    requestDiscardAll
+  } = useAppDirty()
 
   useEffect(() => {
     runStartupMigrations()
+  }, [])
+
+  useEffect(() => {
+    void setRendererDirty(isAnyDirty)
+  }, [isAnyDirty])
+
+  useEffect(() => {
+    const unsubscribe = onCloseRequested(() => {
+      setCloseConfirmOpen(true)
+    })
+    return () => {
+      unsubscribe()
+    }
   }, [])
 
   useEffect(() => {
@@ -53,29 +91,63 @@ export default function App() {
   const handleNavigate = (nextView: 'games' | 'settings') => {
     if (view === nextView) return
 
-    if (view === 'settings' && settingsDirty) {
+    if (isAnyDirty) {
       setPendingView(nextView)
       return
     }
     setView(nextView)
   }
 
-  const handleConfirmDiscard = () => {
-    setSettingsDirty(false)
+  const handleConfirmDiscard = useCallback(() => {
+    requestDiscardAll()
+    reportSettingsDirty(false)
     syncThemeFromStore()
     if (pendingView) {
       setView(pendingView)
       setPendingView(null)
     }
-  }
+  }, [pendingView, reportSettingsDirty, requestDiscardAll, syncThemeFromStore])
 
   const handleConfirmCancel = () => {
     setPendingView(null)
     setSaveRequested(false)
   }
 
-  const handleConfirmSave = () => {
+  const handleConfirmSave = useCallback(async () => {
+    // If only the profile editor is dirty, trigger its save handler and pivot.
+    if (isProfileEditorDirty && !isSettingsDirty) {
+      await requestSaveAll()
+      if (pendingView) {
+        setView(pendingView)
+        setPendingView(null)
+      }
+      return
+    }
+    // Otherwise let the settings save pipeline run via its existing trigger.
     setSaveRequested(true)
+  }, [isProfileEditorDirty, isSettingsDirty, pendingView, requestSaveAll])
+
+  const handleCloseConfirmSave = useCallback(async () => {
+    try {
+      await requestSaveAll()
+    } catch (err) {
+      console.error('Failed to save before close', err)
+      setCloseConfirmOpen(false)
+      return
+    }
+    setCloseConfirmOpen(false)
+    await forceClose()
+  }, [requestSaveAll])
+
+  const handleCloseConfirmDiscard = useCallback(async () => {
+    requestDiscardAll()
+    reportSettingsDirty(false)
+    setCloseConfirmOpen(false)
+    await forceClose()
+  }, [reportSettingsDirty, requestDiscardAll])
+
+  const handleCloseConfirmCancel = () => {
+    setCloseConfirmOpen(false)
   }
 
   const handleConfigImported = () => {
@@ -85,83 +157,98 @@ export default function App() {
   }
 
   return (
-    <NotifyProvider>
-      <div
-        className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
-      >
-        <div className="absolute top-0 left-0 w-full z-20 header-glass">
-          <WindowControls view={view} onNavigate={handleNavigate} updateInfo={updateInfo} />
-        </div>
-
-        {showImportWarning && (
-          <div className="glass-surface absolute! left-4 right-4 top-16 z-30 mx-auto flex max-w-3xl animate-fade-slide items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] [--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]!">
-            <WarningTriangleIcon width={17} height={17} className="shrink-0" />
-            <span className="min-w-0 flex-1">
-              Config imported. Executable paths from your previous device may need to be updated.
-            </span>
-            <button
-              type="button"
-              onClick={() => setShowImportWarning(false)}
-              className="icon-action flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-lg"
-              aria-label="Dismiss import warning"
-              title="Dismiss"
-            >
-              <CloseIcon width={13} height={13} />
-            </button>
-          </div>
-        )}
-
-        <SettingsProvider
-          onDirtyChange={setSettingsDirty}
-          shouldSaveTrigger={saveRequested}
-          onConfigImported={handleConfigImported}
-          onSaved={() => {
-            setSaveRequested(false)
-            setRefreshKey((k) => k + 1)
-            if (pendingView) {
-              setView(pendingView)
-              setPendingView(null)
-            }
-          }}
-        >
-          <main className="h-full relative overflow-hidden">
-            {/* Games View */}
-            <div
-              className={`h-full flex flex-col transition-all duration-300 ${
-                view === 'games'
-                  ? 'opacity-100 scale-100 pointer-events-auto'
-                  : 'opacity-0 scale-95 pointer-events-none'
-              }`}
-            >
-              <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
-                <GameList key={refreshKey} onNavigate={handleNavigate} />
-              </div>
-            </div>
-
-            {/* Settings View */}
-            <div
-              className={`absolute inset-0 z-10 h-full flex flex-col transition-all duration-300 ${
-                view === 'settings'
-                  ? 'opacity-100 scale-100 pointer-events-auto'
-                  : 'opacity-0 scale-95 pointer-events-none'
-              }`}
-            >
-              <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
-                <SettingsView onClose={() => handleNavigate('games')} updateInfo={updateInfo} />
-              </div>
-            </div>
-          </main>
-        </SettingsProvider>
-
-        <ConfirmDialog
-          isOpen={pendingView !== null}
-          title="Unsaved Changes"
-          message="You have unsaved changes in Settings. Do you want to save them before leaving?"
-          onSave={handleConfirmSave}
-          onDiscard={handleConfirmDiscard}
-          onCancel={handleConfirmCancel}
-        />
+    <div
+      className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
+    >
+      <div className="absolute top-0 left-0 w-full z-20 header-glass">
+        <WindowControls view={view} onNavigate={handleNavigate} updateInfo={updateInfo} />
       </div>
-    </NotifyProvider>
+
+      {showImportWarning && (
+        <div className="glass-surface absolute! left-4 right-4 top-16 z-30 mx-auto flex max-w-3xl animate-fade-slide items-center gap-3 rounded-2xl border border-(--warning-border) px-4 py-3 text-xs font-medium text-(--warning-text) shadow-[0_12px_30px_#00000040] [--glass-surface-fill:color-mix(in_srgb,var(--warning-surface),var(--glass-bg-elevated))]!">
+          <WarningTriangleIcon width={17} height={17} className="shrink-0" />
+          <span className="min-w-0 flex-1">
+            Config imported. Executable paths from your previous device may need to be updated.
+          </span>
+          <button
+            type="button"
+            onClick={() => setShowImportWarning(false)}
+            className="icon-action flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-lg"
+            aria-label="Dismiss import warning"
+            title="Dismiss"
+          >
+            <CloseIcon width={13} height={13} />
+          </button>
+        </div>
+      )}
+
+      <SettingsProvider
+        onDirtyChange={reportSettingsDirty}
+        shouldSaveTrigger={saveRequested}
+        onConfigImported={handleConfigImported}
+        onSaved={() => {
+          setSaveRequested(false)
+          setRefreshKey((k) => k + 1)
+          if (pendingView) {
+            setView(pendingView)
+            setPendingView(null)
+          }
+        }}
+      >
+        <main className="h-full relative overflow-hidden">
+          {/* Games View */}
+          <div
+            className={`h-full flex flex-col transition-all duration-300 ${
+              view === 'games'
+                ? 'opacity-100 scale-100 pointer-events-auto'
+                : 'opacity-0 scale-95 pointer-events-none'
+            }`}
+          >
+            <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
+              <GameList key={refreshKey} onNavigate={handleNavigate} />
+            </div>
+          </div>
+
+          {/* Settings View */}
+          <div
+            className={`absolute inset-0 z-10 h-full flex flex-col transition-all duration-300 ${
+              view === 'settings'
+                ? 'opacity-100 scale-100 pointer-events-auto'
+                : 'opacity-0 scale-95 pointer-events-none'
+            }`}
+          >
+            <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
+              <SettingsView onClose={() => handleNavigate('games')} updateInfo={updateInfo} />
+            </div>
+          </div>
+        </main>
+      </SettingsProvider>
+
+      <ConfirmDialog
+        isOpen={pendingView !== null}
+        title="Unsaved Changes"
+        message="You have unsaved changes. Do you want to save them before leaving?"
+        onSave={() => {
+          void handleConfirmSave()
+        }}
+        onDiscard={handleConfirmDiscard}
+        onCancel={handleConfirmCancel}
+      />
+
+      <ConfirmDialog
+        isOpen={closeConfirmOpen}
+        title="Unsaved Changes"
+        message="You have unsaved changes. Save them before closing SimLauncher?"
+        saveLabel="Save & Close"
+        discardLabel="Discard & Close"
+        onSave={() => {
+          void handleCloseConfirmSave()
+        }}
+        onDiscard={() => {
+          void handleCloseConfirmDiscard()
+        }}
+        onCancel={handleCloseConfirmCancel}
+      />
+    </div>
   )
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import {
   getUpdateInfo,
   onCloseRequested,
   onUpdateAvailable,
+  setPendingMinimizeToTray,
   setRendererDirty
 } from './lib/electron'
 import { runStartupMigrations } from './lib/migrations'
@@ -105,6 +106,13 @@ function AppContent() {
   const handleConfirmDiscard = useCallback(() => {
     requestDiscardAll()
     reportSettingsDirty(false)
+    // Reset main-process state that the renderer had forwarded ahead of save.
+    // Currently this covers the pending Minimize-to-tray toggle: without
+    // clearing it, the close handler would still follow the discarded value.
+    void setPendingMinimizeToTray(null)
+    // Remount the SettingsProvider so it reloads UI state from the store
+    // (otherwise discarded toggles would still appear as enabled in the UI).
+    setRefreshKey((k) => k + 1)
     syncThemeFromStore()
     if (pendingView) {
       setView(pendingView)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -37,14 +37,7 @@ function AppContent() {
   const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
   const [saveRequested, setSaveRequested] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
-  const {
-    isAnyDirty,
-    isSettingsDirty,
-    isProfileEditorDirty,
-    reportSettingsDirty,
-    requestSaveAll,
-    requestDiscardAll
-  } = useAppDirty()
+  const { isAnyDirty, reportSettingsDirty, requestSaveAll, requestDiscardAll } = useAppDirty()
 
   useEffect(() => {
     runStartupMigrations()
@@ -125,25 +118,21 @@ function AppContent() {
   }
 
   const handleConfirmSave = useCallback(async () => {
-    // If only the profile editor is dirty, trigger its save handler and pivot.
-    if (isProfileEditorDirty && !isSettingsDirty) {
-      const success = await requestSaveAll()
-      if (!success) {
-        // Keep the dialog open so the user can retry or discard; the failed
-        // save handler already surfaced its own error toast.
-        return
-      }
-      if (pendingView) {
-        setView(pendingView)
-        setPendingView(null)
-      }
+    // Save every dirty scope through the aggregator, not just the settings
+    // pipeline. If both Settings and the Profile Editor were dirty, routing
+    // through the settings-only trigger would have left profile edits unsaved
+    // even though the unified confirm dialog promised to save everything.
+    const success = await requestSaveAll()
+    if (!success) {
+      // Keep the dialog open so the user can retry or discard; the failed
+      // save handler already surfaced its own error toast.
       return
     }
-    // Otherwise let the settings save pipeline run via its existing trigger.
-    // The pendingView pivot happens in SettingsProvider's onSaved callback,
-    // which is only allowed to navigate when the save reports success.
-    setSaveRequested(true)
-  }, [isProfileEditorDirty, isSettingsDirty, pendingView, requestSaveAll])
+    if (pendingView) {
+      setView(pendingView)
+      setPendingView(null)
+    }
+  }, [pendingView, requestSaveAll])
 
   const handleCloseConfirmSave = useCallback(async () => {
     let success: boolean

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -136,6 +136,11 @@ function AppContent() {
       // save handler already surfaced its own error toast.
       return
     }
+    // Remount the games view so it reloads settings-derived state (game
+    // list, paths). GameList caches configured games once on mount, so a
+    // save-through-dialog that updates Settings without bumping refreshKey
+    // would otherwise leave the Games tab showing stale paths.
+    setRefreshKey((k) => k + 1)
     if (pendingView) {
       setView(pendingView)
       setPendingView(null)

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -35,13 +35,21 @@ export function ProfileEditor(props: ProfileEditorProps) {
   }, [isDirty, handleSave, registerSaveHandler])
 
   useEffect(() => {
+    // Only register the discard handler when this editor actually has dirty
+    // state. Otherwise a Settings-scope discard would invoke onClose() here
+    // and close a clean-but-open profile editor in the hidden Games pane,
+    // dropping user context for no reason.
+    if (!isDirty) {
+      registerDiscardHandler('profile-editor', null)
+      return
+    }
     registerDiscardHandler('profile-editor', () => {
       onClose()
     })
     return () => {
       registerDiscardHandler('profile-editor', null)
     }
-  }, [onClose, registerDiscardHandler])
+  }, [isDirty, onClose, registerDiscardHandler])
 
   if (editor.loading) return null
 

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -1,18 +1,52 @@
+import { useEffect } from 'react'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ProfileBehaviorSection } from './profile-editor/ProfileBehaviorSection'
 import { ProfileEditorActions } from './profile-editor/ProfileEditorActions'
 import { ProfileNameSection } from './profile-editor/ProfileNameSection'
 import { ProfileUtilitiesSection } from './profile-editor/ProfileUtilitiesSection'
 import { ProcessTrackingSection } from './profile-editor/ProcessTrackingSection'
+import { StickySaveBar } from './StickySaveBar'
+import { useAppDirty } from '../contexts/AppDirtyContext'
 import { useProfileEditor, type ProfileEditorProps } from '../hooks/useProfileEditor'
 
 export function ProfileEditor(props: ProfileEditorProps) {
   const editor = useProfileEditor(props)
+  const { reportProfileEditorDirty, registerSaveHandler, registerDiscardHandler } = useAppDirty()
+  const scopeId = `${props.gameKey}:${props.activeProfileId}`
+  const { onClose } = props
+  const { isDirty, handleSave } = editor
+
+  useEffect(() => {
+    reportProfileEditorDirty(scopeId, isDirty)
+    return () => {
+      reportProfileEditorDirty(scopeId, false)
+    }
+  }, [scopeId, isDirty, reportProfileEditorDirty])
+
+  useEffect(() => {
+    if (!isDirty) {
+      registerSaveHandler('profile-editor', null)
+      return
+    }
+    registerSaveHandler('profile-editor', () => handleSave(false))
+    return () => {
+      registerSaveHandler('profile-editor', null)
+    }
+  }, [isDirty, handleSave, registerSaveHandler])
+
+  useEffect(() => {
+    registerDiscardHandler('profile-editor', () => {
+      onClose()
+    })
+    return () => {
+      registerDiscardHandler('profile-editor', null)
+    }
+  }, [onClose, registerDiscardHandler])
 
   if (editor.loading) return null
 
   return (
-    <div className="glass-surface-elevated animate-fade-slide rounded-[20px] p-5">
+    <div className="glass-surface-elevated animate-fade-slide relative rounded-[20px] p-5">
       <div className="mb-5">
         <h2 className="text-lg font-semibold text-(--text-primary)">Edit Profile</h2>
       </div>
@@ -69,6 +103,12 @@ export function ProfileEditor(props: ProfileEditorProps) {
           onDeleteProfile={editor.handleDeleteProfile}
         />
       </div>
+
+      <StickySaveBar
+        isDirty={editor.isDirty}
+        onSave={() => void editor.handleSave(false)}
+        ariaLabel="Unsaved profile changes"
+      />
 
       <ConfirmDialog
         isOpen={editor.showConfirm}

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -10,6 +10,8 @@ import { SettingsSection } from './settings/SettingsSection'
 import { useSettingsMeta } from './settings/SettingsMetaContext'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
+import { StickySaveBar } from './StickySaveBar'
+import { useAppDirty } from '../contexts/AppDirtyContext'
 
 export function SettingsView({
   onClose,
@@ -30,6 +32,7 @@ function SettingsViewContent({
 }) {
   const { notify } = useNotify()
   const { loading, isDirty, saveSettings } = useSettingsMeta()
+  const { registerSaveHandler, registerDiscardHandler } = useAppDirty()
   const [expandedSections, setExpandedSections] = useState({
     about: true,
     appearance: true,
@@ -54,10 +57,27 @@ function SettingsViewContent({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
+  useEffect(() => {
+    registerSaveHandler('settings', isDirty ? saveSettings : null)
+    return () => {
+      registerSaveHandler('settings', null)
+    }
+  }, [registerSaveHandler, isDirty, saveSettings])
+
+  useEffect(() => {
+    // Settings discard is handled at the App level by re-syncing theme and
+    // re-mounting the settings provider via refreshKey, so a no-op handler is
+    // sufficient here. We still register so the discard pipeline is complete.
+    registerDiscardHandler('settings', () => {})
+    return () => {
+      registerDiscardHandler('settings', null)
+    }
+  }, [registerDiscardHandler])
+
   if (loading) return null
 
   return (
-    <div className="animate-fade-slide space-y-8 pb-10">
+    <div className="animate-fade-slide relative space-y-8 pb-2">
       <SettingsSection
         title="About"
         open={expandedSections.about}
@@ -135,6 +155,12 @@ function SettingsViewContent({
           Back to Games
         </button>
       </div>
+
+      <StickySaveBar
+        isDirty={isDirty}
+        onSave={() => void saveSettings()}
+        ariaLabel="Unsaved settings"
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react'
+
+interface StickySaveBarProps {
+  isDirty: boolean
+  onSave: () => void
+  saveLabel?: string
+  secondaryLabel?: string
+  onSecondary?: () => void
+  ariaLabel?: string
+  extra?: ReactNode
+}
+
+/**
+ * A reusable sticky action bar that pins itself to the bottom of its scroll
+ * container while there are unsaved changes. The bar slides in only when
+ * `isDirty` is true so it never obscures the layout when nothing needs saving.
+ *
+ * The component must be rendered inside a positioned (relative/absolute)
+ * ancestor for `position: sticky` to anchor to the visible viewport bottom
+ * of that scroll container.
+ */
+export function StickySaveBar({
+  isDirty,
+  onSave,
+  saveLabel = 'Save Changes',
+  secondaryLabel,
+  onSecondary,
+  ariaLabel,
+  extra
+}: StickySaveBarProps) {
+  if (!isDirty) {
+    return null
+  }
+
+  return (
+    <div
+      className="sticky bottom-0 z-30 -mx-1 mt-4 animate-fade-slide px-1 pb-2 pt-3"
+      role="region"
+      aria-label={ariaLabel ?? 'Unsaved changes'}
+    >
+      <div className="glass-surface-elevated flex items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl">
+        <span className="flex h-2 w-2 shrink-0 items-center justify-center">
+          <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
+        </span>
+        <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
+          You have unsaved changes.
+        </span>
+        {extra}
+        {secondaryLabel && onSecondary && (
+          <button
+            type="button"
+            onClick={onSecondary}
+            className="neutral-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-semibold"
+          >
+            {secondaryLabel}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onSave}
+          className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold"
+        >
+          {saveLabel}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -45,7 +45,7 @@ export function SettingsProvider({
   children: ReactNode
   onDirtyChange?: (isDirty: boolean) => void
   shouldSaveTrigger?: boolean
-  onSaved?: () => void
+  onSaved?: (success: boolean) => void
   onConfigImported?: () => void
 }) {
   const { notify } = useNotify()

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -10,7 +10,13 @@ import {
 } from 'react'
 import { useDirtyTracking } from '../../hooks/useDirtyTracking'
 import { DEFAULT_ACCENT_COLOR, getUtilities, type Profiles } from '../../lib/config'
-import { browsePath, getFileIcon, setLoginItem, setZoom } from '../../lib/electron'
+import {
+  browsePath,
+  getFileIcon,
+  setLoginItem,
+  setPendingMinimizeToTray,
+  setZoom
+} from '../../lib/electron'
 import type { ThemeMode } from '../../lib/theme'
 import { useTheme } from '../../contexts/ThemeContext'
 import { useNotify } from '../Notify'
@@ -170,6 +176,15 @@ export function SettingsProvider({
   useEffect(() => {
     onDirtyChange?.(isDirty)
   }, [isDirty, onDirtyChange])
+
+  // Mirror the renderer's pending minimize-to-tray preference to the main
+  // process so the window close handler honours unsaved toggle changes
+  // (Closes #387). When dirty we forward the in-flight value; otherwise we
+  // clear the pending preference so main falls back to the persisted setting.
+  useEffect(() => {
+    if (loading) return
+    void setPendingMinimizeToTray(isDirty ? minimizeToTray : null)
+  }, [isDirty, loading, minimizeToTray])
 
   const handleAccentChange = useCallback(
     (presetHex: string) => {

--- a/src/renderer/src/components/settings/SettingsMetaContext.tsx
+++ b/src/renderer/src/components/settings/SettingsMetaContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react'
 export interface SettingsMetaContextValue {
   loading: boolean
   isDirty: boolean
-  saveSettings: () => Promise<void>
+  saveSettings: () => Promise<boolean>
   exportingConfig: boolean
   importingConfig: boolean
   autoCheckUpdates: boolean

--- a/src/renderer/src/components/settings/useSettingsSave.ts
+++ b/src/renderer/src/components/settings/useSettingsSave.ts
@@ -70,7 +70,7 @@ interface UseSettingsSaveArgs {
   setAppArgs: (appArgs: Record<string, string>) => void
   setLaunchDelayMs: (launchDelayMs: number) => void
   shouldSaveTrigger?: boolean
-  onSaved?: () => void
+  onSaved?: (success: boolean) => void
 }
 
 export function useSettingsSave({
@@ -103,7 +103,7 @@ export function useSettingsSave({
   shouldSaveTrigger,
   onSaved
 }: UseSettingsSaveArgs) {
-  const handleSave = useCallback(async () => {
+  const handleSave = useCallback(async (): Promise<boolean> => {
     try {
       const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)
       const trimmedAppPaths = trimPathRecord(appPaths)
@@ -159,9 +159,11 @@ export function useSettingsSave({
         ...resetSettingsObjects,
         launchDelayMs: normalizedLaunchDelayMs
       })
+      return true
     } catch (err) {
       notify('Failed to save settings', 'error')
       console.error(err)
+      return false
     }
   }, [
     appArgs,
@@ -194,8 +196,8 @@ export function useSettingsSave({
 
   useEffect(() => {
     if (shouldSaveTrigger) {
-      handleSave().then(() => {
-        onSaved?.()
+      handleSave().then((success) => {
+        onSaved?.(success)
       })
     }
   }, [handleSave, onSaved, shouldSaveTrigger])

--- a/src/renderer/src/contexts/AppDirtyContext.tsx
+++ b/src/renderer/src/contexts/AppDirtyContext.tsx
@@ -1,0 +1,121 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+
+export type DirtyScopeId = 'settings' | string
+
+export interface AppDirtyContextValue {
+  isAnyDirty: boolean
+  isSettingsDirty: boolean
+  isProfileEditorDirty: boolean
+  activeProfileEditorScope: string | null
+  reportSettingsDirty: (isDirty: boolean) => void
+  reportProfileEditorDirty: (scopeId: string, isDirty: boolean) => void
+  registerSaveHandler: (
+    scope: 'settings' | 'profile-editor',
+    handler: (() => Promise<void> | void) | null
+  ) => void
+  registerDiscardHandler: (
+    scope: 'settings' | 'profile-editor',
+    handler: (() => void) | null
+  ) => void
+  requestSaveAll: () => Promise<void>
+  requestDiscardAll: () => void
+}
+
+const AppDirtyContext = createContext<AppDirtyContextValue | null>(null)
+
+export function AppDirtyProvider({ children }: { children: ReactNode }) {
+  const [isSettingsDirty, setIsSettingsDirty] = useState(false)
+  const [profileEditorDirtyScope, setProfileEditorDirtyScope] = useState<string | null>(null)
+  const [settingsSaveHandler, setSettingsSaveHandler] = useState<
+    (() => Promise<void> | void) | null
+  >(null)
+  const [profileSaveHandler, setProfileSaveHandler] = useState<(() => Promise<void> | void) | null>(
+    null
+  )
+  const [settingsDiscardHandler, setSettingsDiscardHandler] = useState<(() => void) | null>(null)
+  const [profileDiscardHandler, setProfileDiscardHandler] = useState<(() => void) | null>(null)
+
+  const reportSettingsDirty = useCallback((isDirty: boolean) => {
+    setIsSettingsDirty(isDirty)
+  }, [])
+
+  const reportProfileEditorDirty = useCallback((scopeId: string, isDirty: boolean) => {
+    setProfileEditorDirtyScope((current) => {
+      if (isDirty) {
+        return scopeId
+      }
+      return current === scopeId ? null : current
+    })
+  }, [])
+
+  const registerSaveHandler = useCallback(
+    (scope: 'settings' | 'profile-editor', handler: (() => Promise<void> | void) | null) => {
+      if (scope === 'settings') {
+        setSettingsSaveHandler(() => handler)
+      } else {
+        setProfileSaveHandler(() => handler)
+      }
+    },
+    []
+  )
+
+  const registerDiscardHandler = useCallback(
+    (scope: 'settings' | 'profile-editor', handler: (() => void) | null) => {
+      if (scope === 'settings') {
+        setSettingsDiscardHandler(() => handler)
+      } else {
+        setProfileDiscardHandler(() => handler)
+      }
+    },
+    []
+  )
+
+  const requestSaveAll = useCallback(async () => {
+    if (profileSaveHandler) {
+      await profileSaveHandler()
+    }
+    if (settingsSaveHandler) {
+      await settingsSaveHandler()
+    }
+  }, [profileSaveHandler, settingsSaveHandler])
+
+  const requestDiscardAll = useCallback(() => {
+    profileDiscardHandler?.()
+    settingsDiscardHandler?.()
+  }, [profileDiscardHandler, settingsDiscardHandler])
+
+  const value = useMemo<AppDirtyContextValue>(
+    () => ({
+      isAnyDirty: isSettingsDirty || profileEditorDirtyScope !== null,
+      isSettingsDirty,
+      isProfileEditorDirty: profileEditorDirtyScope !== null,
+      activeProfileEditorScope: profileEditorDirtyScope,
+      reportSettingsDirty,
+      reportProfileEditorDirty,
+      registerSaveHandler,
+      registerDiscardHandler,
+      requestSaveAll,
+      requestDiscardAll
+    }),
+    [
+      isSettingsDirty,
+      profileEditorDirtyScope,
+      reportSettingsDirty,
+      reportProfileEditorDirty,
+      registerSaveHandler,
+      registerDiscardHandler,
+      requestSaveAll,
+      requestDiscardAll
+    ]
+  )
+
+  return <AppDirtyContext.Provider value={value}>{children}</AppDirtyContext.Provider>
+}
+
+export function useAppDirty() {
+  const context = useContext(AppDirtyContext)
+  if (!context) {
+    throw new Error('useAppDirty must be used within AppDirtyProvider')
+  }
+  return context
+}

--- a/src/renderer/src/contexts/AppDirtyContext.tsx
+++ b/src/renderer/src/contexts/AppDirtyContext.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react'
 
 export type DirtyScopeId = 'settings' | string
 
@@ -31,10 +39,15 @@ const AppDirtyContext = createContext<AppDirtyContextValue | null>(null)
 export function AppDirtyProvider({ children }: { children: ReactNode }) {
   const [isSettingsDirty, setIsSettingsDirty] = useState(false)
   const [profileEditorDirtyScope, setProfileEditorDirtyScope] = useState<string | null>(null)
-  const [settingsSaveHandler, setSettingsSaveHandler] = useState<SaveHandler | null>(null)
-  const [profileSaveHandler, setProfileSaveHandler] = useState<SaveHandler | null>(null)
-  const [settingsDiscardHandler, setSettingsDiscardHandler] = useState<(() => void) | null>(null)
-  const [profileDiscardHandler, setProfileDiscardHandler] = useState<(() => void) | null>(null)
+  // Handlers live in refs (not state) so re-registering on every parent render
+  // does not trigger a Provider state update, which would cascade re-renders
+  // through every consumer of `useAppDirty()` and create a rerender loop when
+  // the underlying handler reference is unstable (e.g. an unmemoized
+  // `handleSave` from a hook).
+  const settingsSaveHandlerRef = useRef<SaveHandler | null>(null)
+  const profileSaveHandlerRef = useRef<SaveHandler | null>(null)
+  const settingsDiscardHandlerRef = useRef<(() => void) | null>(null)
+  const profileDiscardHandlerRef = useRef<(() => void) | null>(null)
 
   const reportSettingsDirty = useCallback((isDirty: boolean) => {
     setIsSettingsDirty(isDirty)
@@ -52,9 +65,9 @@ export function AppDirtyProvider({ children }: { children: ReactNode }) {
   const registerSaveHandler = useCallback(
     (scope: 'settings' | 'profile-editor', handler: SaveHandler | null) => {
       if (scope === 'settings') {
-        setSettingsSaveHandler(() => handler)
+        settingsSaveHandlerRef.current = handler
       } else {
-        setProfileSaveHandler(() => handler)
+        profileSaveHandlerRef.current = handler
       }
     },
     []
@@ -63,9 +76,9 @@ export function AppDirtyProvider({ children }: { children: ReactNode }) {
   const registerDiscardHandler = useCallback(
     (scope: 'settings' | 'profile-editor', handler: (() => void) | null) => {
       if (scope === 'settings') {
-        setSettingsDiscardHandler(() => handler)
+        settingsDiscardHandlerRef.current = handler
       } else {
-        setProfileDiscardHandler(() => handler)
+        profileDiscardHandlerRef.current = handler
       }
     },
     []
@@ -85,15 +98,15 @@ export function AppDirtyProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const requestSaveAll = useCallback(async (): Promise<boolean> => {
-    const profileOk = await runHandler(profileSaveHandler)
-    const settingsOk = await runHandler(settingsSaveHandler)
+    const profileOk = await runHandler(profileSaveHandlerRef.current)
+    const settingsOk = await runHandler(settingsSaveHandlerRef.current)
     return profileOk && settingsOk
-  }, [profileSaveHandler, runHandler, settingsSaveHandler])
+  }, [runHandler])
 
   const requestDiscardAll = useCallback(() => {
-    profileDiscardHandler?.()
-    settingsDiscardHandler?.()
-  }, [profileDiscardHandler, settingsDiscardHandler])
+    profileDiscardHandlerRef.current?.()
+    settingsDiscardHandlerRef.current?.()
+  }, [])
 
   const value = useMemo<AppDirtyContextValue>(
     () => ({

--- a/src/renderer/src/contexts/AppDirtyContext.tsx
+++ b/src/renderer/src/contexts/AppDirtyContext.tsx
@@ -2,6 +2,8 @@ import { createContext, useCallback, useContext, useMemo, useState, type ReactNo
 
 export type DirtyScopeId = 'settings' | string
 
+export type SaveHandler = () => Promise<boolean> | boolean
+
 export interface AppDirtyContextValue {
   isAnyDirty: boolean
   isSettingsDirty: boolean
@@ -9,15 +11,18 @@ export interface AppDirtyContextValue {
   activeProfileEditorScope: string | null
   reportSettingsDirty: (isDirty: boolean) => void
   reportProfileEditorDirty: (scopeId: string, isDirty: boolean) => void
-  registerSaveHandler: (
-    scope: 'settings' | 'profile-editor',
-    handler: (() => Promise<void> | void) | null
-  ) => void
+  registerSaveHandler: (scope: 'settings' | 'profile-editor', handler: SaveHandler | null) => void
   registerDiscardHandler: (
     scope: 'settings' | 'profile-editor',
     handler: (() => void) | null
   ) => void
-  requestSaveAll: () => Promise<void>
+  /**
+   * Runs every registered save handler in turn and returns `true` only if every
+   * handler reported success. Handlers report failure either by returning
+   * `false` or by throwing — both are treated as a failed save so the caller
+   * can keep dirty UI/dialogs open and surface an error toast.
+   */
+  requestSaveAll: () => Promise<boolean>
   requestDiscardAll: () => void
 }
 
@@ -26,12 +31,8 @@ const AppDirtyContext = createContext<AppDirtyContextValue | null>(null)
 export function AppDirtyProvider({ children }: { children: ReactNode }) {
   const [isSettingsDirty, setIsSettingsDirty] = useState(false)
   const [profileEditorDirtyScope, setProfileEditorDirtyScope] = useState<string | null>(null)
-  const [settingsSaveHandler, setSettingsSaveHandler] = useState<
-    (() => Promise<void> | void) | null
-  >(null)
-  const [profileSaveHandler, setProfileSaveHandler] = useState<(() => Promise<void> | void) | null>(
-    null
-  )
+  const [settingsSaveHandler, setSettingsSaveHandler] = useState<SaveHandler | null>(null)
+  const [profileSaveHandler, setProfileSaveHandler] = useState<SaveHandler | null>(null)
   const [settingsDiscardHandler, setSettingsDiscardHandler] = useState<(() => void) | null>(null)
   const [profileDiscardHandler, setProfileDiscardHandler] = useState<(() => void) | null>(null)
 
@@ -49,7 +50,7 @@ export function AppDirtyProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const registerSaveHandler = useCallback(
-    (scope: 'settings' | 'profile-editor', handler: (() => Promise<void> | void) | null) => {
+    (scope: 'settings' | 'profile-editor', handler: SaveHandler | null) => {
       if (scope === 'settings') {
         setSettingsSaveHandler(() => handler)
       } else {
@@ -70,14 +71,24 @@ export function AppDirtyProvider({ children }: { children: ReactNode }) {
     []
   )
 
-  const requestSaveAll = useCallback(async () => {
-    if (profileSaveHandler) {
-      await profileSaveHandler()
+  const runHandler = useCallback(async (handler: SaveHandler | null): Promise<boolean> => {
+    if (!handler) {
+      return true
     }
-    if (settingsSaveHandler) {
-      await settingsSaveHandler()
+    try {
+      const result = await handler()
+      return result !== false
+    } catch (err) {
+      console.error('Dirty-scope save handler threw', err)
+      return false
     }
-  }, [profileSaveHandler, settingsSaveHandler])
+  }, [])
+
+  const requestSaveAll = useCallback(async (): Promise<boolean> => {
+    const profileOk = await runHandler(profileSaveHandler)
+    const settingsOk = await runHandler(settingsSaveHandler)
+    return profileOk && settingsOk
+  }, [profileSaveHandler, runHandler, settingsSaveHandler])
 
   const requestDiscardAll = useCallback(() => {
     profileDiscardHandler?.()

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -321,46 +321,55 @@ export function useProfileEditor({
     }
   }, [isDirty, executeLaunch, setShowLaunchConfirm])
 
-  const handleSave = async (shouldLaunch = false) => {
+  const handleSave = async (shouldLaunch = false): Promise<boolean> => {
     if (shouldLaunch) setShowLaunchConfirm(false)
-    const allProfiles = await getProfiles()
-    const profileSet = normalizeGameProfileSet(allProfiles[gameKey] as Profiles[string] | undefined)
-    const activeProfile =
-      profileSet.profiles.find((profile) => profile.id === activeProfileId) ||
-      getActiveGameProfile(profileSet)
-    const normalizedProfileName = profileName.trim() || activeProfile.name
-
-    const updatedProfile = {
-      ...activeProfile,
-      name: normalizedProfileName,
-      utilities: profileUtilities.map((utility) => ({
-        id: utility.id,
-        enabled: utility.enabled
-      })),
-      launchAutomatically,
-      trackingEnabled,
-      killControlsEnabled,
-      relaunchControlsEnabled,
-      trackedProcessPaths: trackedProcessPaths.filter(
-        (processPath) => processPath.trim().length > 0
+    try {
+      const allProfiles = await getProfiles()
+      const profileSet = normalizeGameProfileSet(
+        allProfiles[gameKey] as Profiles[string] | undefined
       )
-    }
+      const activeProfile =
+        profileSet.profiles.find((profile) => profile.id === activeProfileId) ||
+        getActiveGameProfile(profileSet)
+      const normalizedProfileName = profileName.trim() || activeProfile.name
 
-    await saveProfile(gameKey, {
-      activeProfileId: updatedProfile.id,
-      profiles: profileSet.profiles.map((profile) =>
-        profile.id === updatedProfile.id ? updatedProfile : profile
-      )
-    })
-    await onProfilesChanged()
-    resetDirty()
+      const updatedProfile = {
+        ...activeProfile,
+        name: normalizedProfileName,
+        utilities: profileUtilities.map((utility) => ({
+          id: utility.id,
+          enabled: utility.enabled
+        })),
+        launchAutomatically,
+        trackingEnabled,
+        killControlsEnabled,
+        relaunchControlsEnabled,
+        trackedProcessPaths: trackedProcessPaths.filter(
+          (processPath) => processPath.trim().length > 0
+        )
+      }
 
-    notify('Profile saved!', 'success', 2500)
+      await saveProfile(gameKey, {
+        activeProfileId: updatedProfile.id,
+        profiles: profileSet.profiles.map((profile) =>
+          profile.id === updatedProfile.id ? updatedProfile : profile
+        )
+      })
+      await onProfilesChanged()
+      resetDirty()
 
-    if (shouldLaunch) {
-      executeLaunch()
-    } else {
-      onClose()
+      notify('Profile saved!', 'success', 2500)
+
+      if (shouldLaunch) {
+        executeLaunch()
+      } else {
+        onClose()
+      }
+      return true
+    } catch (err) {
+      console.error('Failed to save profile', err)
+      notify('Failed to save profile', 'error')
+      return false
     }
   }
 

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -8,6 +8,11 @@ export const onProcessNameMismatchWarning = window.electronAPI.onProcessNameMism
 export const minimize = () => window.electronAPI.minimize()
 export const maximize = () => window.electronAPI.maximize()
 export const close = () => window.electronAPI.close()
+export const forceClose = () => window.electronAPI.forceClose()
+export const setRendererDirty = (isDirty: boolean) => window.electronAPI.setRendererDirty(isDirty)
+export const setPendingMinimizeToTray = (value: boolean | null) =>
+  window.electronAPI.setPendingMinimizeToTray(value)
+export const onCloseRequested = window.electronAPI.onCloseRequested
 export const restartApp = () => window.electronAPI.restartApp()
 export const getRunningApps = () => window.electronAPI.getRunningApps()
 export const subscribeRunningApps = () => window.electronAPI.subscribeRunningApps()

--- a/tests/main/windowCloseDirty.test.ts
+++ b/tests/main/windowCloseDirty.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+type MockIpcHandler = (...args: unknown[]) => unknown | Promise<unknown>
+
+async function invokeWindowHandler(channel: string, ...args: unknown[]) {
+  const { __ipcHandlers } = await import('electron')
+  return await (__ipcHandlers as Record<string, MockIpcHandler>)[channel](...args)
+}
+
+async function loadWindowModule() {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  vi.doMock('../../src/main/store', () => {
+    const inMemoryStore: Record<string, unknown> = {}
+    return {
+      getStoredBoolean: vi.fn(),
+      getStoredZoomFactor: vi.fn(),
+      store: {
+        get: (key: string) => inMemoryStore[key],
+        set: (key: string, value: unknown) => {
+          inMemoryStore[key] = value
+        }
+      },
+      isWindowBounds: () => false
+    }
+  })
+  vi.doMock('electron-updater', () => ({
+    autoUpdater: {
+      autoDownload: false,
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      on: vi.fn(),
+      quitAndInstall: vi.fn()
+    }
+  }))
+
+  const mod = await import('../../src/main/window')
+  mod.registerWindowHandlers()
+  return mod
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('set-renderer-dirty flips dirty flag and force-close-window resets it', async () => {
+  await loadWindowModule()
+  const appState = await import('../../src/main/app-state')
+
+  expect(appState.getRendererDirty()).toBe(false)
+
+  await invokeWindowHandler('set-renderer-dirty', {}, true)
+  expect(appState.getRendererDirty()).toBe(true)
+
+  await invokeWindowHandler('set-renderer-dirty', {}, false)
+  expect(appState.getRendererDirty()).toBe(false)
+})
+
+test('set-pending-minimize-to-tray accepts boolean and null, ignores other values', async () => {
+  await loadWindowModule()
+  const appState = await import('../../src/main/app-state')
+
+  await invokeWindowHandler('set-pending-minimize-to-tray', {}, true)
+  expect(appState.getPendingMinimizeToTray()).toBe(true)
+
+  await invokeWindowHandler('set-pending-minimize-to-tray', {}, false)
+  expect(appState.getPendingMinimizeToTray()).toBe(false)
+
+  await invokeWindowHandler('set-pending-minimize-to-tray', {}, null)
+  expect(appState.getPendingMinimizeToTray()).toBe(null)
+
+  // Non-boolean, non-null values reset the pending preference
+  await invokeWindowHandler('set-pending-minimize-to-tray', {}, 'invalid')
+  expect(appState.getPendingMinimizeToTray()).toBe(null)
+})
+
+test('force-close-window sets quitting and clears renderer dirty flag (Closes #387)', async () => {
+  await loadWindowModule()
+  const appState = await import('../../src/main/app-state')
+
+  await invokeWindowHandler('set-renderer-dirty', {}, true)
+  expect(appState.getRendererDirty()).toBe(true)
+
+  await invokeWindowHandler('force-close-window', {})
+
+  expect(appState.getIsQuitting()).toBe(true)
+  expect(appState.getRendererDirty()).toBe(false)
+})

--- a/tests/renderer/appDirtyAggregator.test.tsx
+++ b/tests/renderer/appDirtyAggregator.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 
@@ -10,6 +10,8 @@ interface CapturedState {
   isProfileEditorDirty: boolean
   reportSettingsDirty: (value: boolean) => void
   reportProfileEditorDirty: (scope: string, isDirty: boolean) => void
+  registerSaveHandler: ReturnType<typeof useAppDirty>['registerSaveHandler']
+  requestSaveAll: ReturnType<typeof useAppDirty>['requestSaveAll']
 }
 
 function Probe({ onCapture }: { onCapture: (state: CapturedState) => void }) {
@@ -19,7 +21,9 @@ function Probe({ onCapture }: { onCapture: (state: CapturedState) => void }) {
     isSettingsDirty: dirty.isSettingsDirty,
     isProfileEditorDirty: dirty.isProfileEditorDirty,
     reportSettingsDirty: dirty.reportSettingsDirty,
-    reportProfileEditorDirty: dirty.reportProfileEditorDirty
+    reportProfileEditorDirty: dirty.reportProfileEditorDirty,
+    registerSaveHandler: dirty.registerSaveHandler,
+    requestSaveAll: dirty.requestSaveAll
   })
   return null
 }
@@ -124,6 +128,115 @@ describe('AppDirtyProvider aggregator', () => {
       // The dirty signal for 'ac:default' should still hold the editor dirty
       expect(harness.getState().isAnyDirty).toBe(true)
       expect(harness.getState().isProfileEditorDirty).toBe(true)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('requestSaveAll returns true when no handlers are registered', async () => {
+    const harness = await renderProbe()
+    try {
+      let result: boolean | null = null
+      await act(async () => {
+        result = await harness.getState().requestSaveAll()
+      })
+      expect(result).toBe(true)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('requestSaveAll returns true when every handler reports success', async () => {
+    const harness = await renderProbe()
+    try {
+      const settingsHandler = vi.fn(async () => true)
+      const profileHandler = vi.fn(async () => true)
+
+      await act(async () => {
+        harness.getState().registerSaveHandler('settings', settingsHandler)
+        harness.getState().registerSaveHandler('profile-editor', profileHandler)
+      })
+
+      let result: boolean | null = null
+      await act(async () => {
+        result = await harness.getState().requestSaveAll()
+      })
+
+      expect(result).toBe(true)
+      expect(settingsHandler).toHaveBeenCalledTimes(1)
+      expect(profileHandler).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('requestSaveAll returns false when a handler returns false (#404)', async () => {
+    const harness = await renderProbe()
+    try {
+      const settingsHandler = vi.fn(async () => false)
+
+      await act(async () => {
+        harness.getState().registerSaveHandler('settings', settingsHandler)
+      })
+
+      let result: boolean | null = null
+      await act(async () => {
+        result = await harness.getState().requestSaveAll()
+      })
+
+      expect(result).toBe(false)
+      expect(settingsHandler).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('requestSaveAll returns false when a handler throws (#404)', async () => {
+    const harness = await renderProbe()
+    try {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const profileHandler = vi.fn(async () => {
+        throw new Error('disk full')
+      })
+
+      await act(async () => {
+        harness.getState().registerSaveHandler('profile-editor', profileHandler)
+      })
+
+      let result: boolean | null = null
+      await act(async () => {
+        result = await harness.getState().requestSaveAll()
+      })
+
+      expect(result).toBe(false)
+      expect(profileHandler).toHaveBeenCalledTimes(1)
+      consoleSpy.mockRestore()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('requestSaveAll runs every handler even when one fails (#404)', async () => {
+    const harness = await renderProbe()
+    try {
+      const profileHandler = vi.fn(async () => false)
+      const settingsHandler = vi.fn(async () => true)
+
+      await act(async () => {
+        harness.getState().registerSaveHandler('profile-editor', profileHandler)
+        harness.getState().registerSaveHandler('settings', settingsHandler)
+      })
+
+      let result: boolean | null = null
+      await act(async () => {
+        result = await harness.getState().requestSaveAll()
+      })
+
+      expect(result).toBe(false)
+      // Both handlers run so the user does not need to retry each scope
+      // independently and so a partial save is still attempted.
+      expect(profileHandler).toHaveBeenCalledTimes(1)
+      expect(settingsHandler).toHaveBeenCalledTimes(1)
     } finally {
       harness.unmount()
     }

--- a/tests/renderer/appDirtyAggregator.test.tsx
+++ b/tests/renderer/appDirtyAggregator.test.tsx
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { AppDirtyProvider, useAppDirty } from '../../src/renderer/src/contexts/AppDirtyContext'
+
+interface CapturedState {
+  isAnyDirty: boolean
+  isSettingsDirty: boolean
+  isProfileEditorDirty: boolean
+  reportSettingsDirty: (value: boolean) => void
+  reportProfileEditorDirty: (scope: string, isDirty: boolean) => void
+}
+
+function Probe({ onCapture }: { onCapture: (state: CapturedState) => void }) {
+  const dirty = useAppDirty()
+  onCapture({
+    isAnyDirty: dirty.isAnyDirty,
+    isSettingsDirty: dirty.isSettingsDirty,
+    isProfileEditorDirty: dirty.isProfileEditorDirty,
+    reportSettingsDirty: dirty.reportSettingsDirty,
+    reportProfileEditorDirty: dirty.reportProfileEditorDirty
+  })
+  return null
+}
+
+async function renderProbe(): Promise<{
+  unmount: () => void
+  getState: () => CapturedState
+}> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: CapturedState | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <Probe onCapture={(state) => (captured = state)} />
+      </AppDirtyProvider>
+    )
+  })
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getState: () => {
+      if (!captured) {
+        throw new Error('Probe did not capture state')
+      }
+      return captured
+    }
+  }
+}
+
+describe('AppDirtyProvider aggregator', () => {
+  test('isAnyDirty is false by default', async () => {
+    const harness = await renderProbe()
+    try {
+      expect(harness.getState().isAnyDirty).toBe(false)
+      expect(harness.getState().isSettingsDirty).toBe(false)
+      expect(harness.getState().isProfileEditorDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('settings dirty signal lifts isAnyDirty (#388)', async () => {
+    const harness = await renderProbe()
+    try {
+      await act(async () => {
+        harness.getState().reportSettingsDirty(true)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(true)
+      expect(harness.getState().isSettingsDirty).toBe(true)
+
+      await act(async () => {
+        harness.getState().reportSettingsDirty(false)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('profile editor dirty signal lifts isAnyDirty (#403)', async () => {
+    const harness = await renderProbe()
+    try {
+      await act(async () => {
+        harness.getState().reportProfileEditorDirty('ac:default', true)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(true)
+      expect(harness.getState().isProfileEditorDirty).toBe(true)
+
+      await act(async () => {
+        harness.getState().reportProfileEditorDirty('ac:default', false)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('reporting clean for a different scope does not clear an active dirty scope', async () => {
+    const harness = await renderProbe()
+    try {
+      await act(async () => {
+        harness.getState().reportProfileEditorDirty('ac:default', true)
+      })
+
+      await act(async () => {
+        harness.getState().reportProfileEditorDirty('iracing:default', false)
+      })
+
+      // The dirty signal for 'ac:default' should still hold the editor dirty
+      expect(harness.getState().isAnyDirty).toBe(true)
+      expect(harness.getState().isProfileEditorDirty).toBe(true)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('both settings and profile dirty keep isAnyDirty true until both clear (#389)', async () => {
+    const harness = await renderProbe()
+    try {
+      await act(async () => {
+        harness.getState().reportSettingsDirty(true)
+        harness.getState().reportProfileEditorDirty('ac:default', true)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(true)
+
+      await act(async () => {
+        harness.getState().reportSettingsDirty(false)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(true)
+      expect(harness.getState().isProfileEditorDirty).toBe(true)
+
+      await act(async () => {
+        harness.getState().reportProfileEditorDirty('ac:default', false)
+      })
+
+      expect(harness.getState().isAnyDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/closeConfirmSave.test.tsx
+++ b/tests/renderer/closeConfirmSave.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Regression test for Codex P1 finding (#404):
+ * `handleCloseConfirmSave` previously called `forceClose()` after
+ * `requestSaveAll()` resolved, but the underlying settings save path swallows
+ * persistence errors. A failed write would silently close the window and
+ * destroy unsaved changes. The fix threads success/failure back from
+ * `requestSaveAll()`; this test pins that contract by mocking a failing save
+ * handler and asserting that:
+ *   1. `forceClose` is NOT invoked, and
+ *   2. an error toast is fired via `useNotify`.
+ */
+
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { act, useCallback, useEffect, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const forceCloseMock = vi.fn(async () => undefined)
+const notifyMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  forceClose: () => forceCloseMock()
+}))
+
+// Avoid rendering the real toast portal — jsdom does not implement
+// Element.animate, which Notify.tsx invokes during mount. We only need
+// `useNotify().notify` to be observable.
+vi.mock('../../src/renderer/src/components/Notify', () => {
+  return {
+    useNotify: () => ({ notify: notifyMock }),
+    NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+  }
+})
+
+import { AppDirtyProvider, useAppDirty } from '../../src/renderer/src/contexts/AppDirtyContext'
+import { useNotify } from '../../src/renderer/src/components/Notify'
+import { forceClose } from '../../src/renderer/src/lib/electron'
+
+interface ProbeApi {
+  triggerCloseConfirmSave: () => Promise<void>
+  registerSettingsSave: (handler: () => Promise<boolean> | boolean) => void
+}
+
+function Probe({ onReady }: { onReady: (api: ProbeApi) => void }) {
+  const { registerSaveHandler, requestSaveAll } = useAppDirty()
+  const { notify } = useNotify()
+  const onReadyRef = useRef(onReady)
+  onReadyRef.current = onReady
+
+  const triggerCloseConfirmSave = useCallback(async () => {
+    let success: boolean
+    try {
+      success = await requestSaveAll()
+    } catch (err) {
+      console.error('Failed to save before close', err)
+      success = false
+    }
+    if (!success) {
+      notify('Failed to save changes. Window not closed.', 'error', 4000)
+      return
+    }
+    await forceClose()
+  }, [notify, requestSaveAll])
+
+  useEffect(() => {
+    onReadyRef.current({
+      triggerCloseConfirmSave,
+      registerSettingsSave: (handler) => registerSaveHandler('settings', handler)
+    })
+  }, [registerSaveHandler, triggerCloseConfirmSave])
+
+  return null
+}
+
+async function renderProbe(): Promise<{ unmount: () => void; getApi: () => ProbeApi }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: ProbeApi | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <Probe onReady={(api) => (captured = api)} />
+      </AppDirtyProvider>
+    )
+  })
+
+  if (!captured) {
+    throw new Error('Probe did not initialize')
+  }
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getApi: () => {
+      if (!captured) {
+        throw new Error('Probe did not capture state')
+      }
+      return captured
+    }
+  }
+}
+
+describe('handleCloseConfirmSave failure propagation (#404)', () => {
+  beforeEach(() => {
+    forceCloseMock.mockClear()
+    notifyMock.mockClear()
+  })
+
+  test('does NOT call forceClose when the save handler returns false; fires error notify', async () => {
+    const harness = await renderProbe()
+    try {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const failingSave = vi.fn(async () => false)
+
+      await act(async () => {
+        harness.getApi().registerSettingsSave(failingSave)
+      })
+
+      await act(async () => {
+        await harness.getApi().triggerCloseConfirmSave()
+      })
+
+      expect(failingSave).toHaveBeenCalledTimes(1)
+      expect(forceCloseMock).not.toHaveBeenCalled()
+      expect(notifyMock).toHaveBeenCalledWith(
+        'Failed to save changes. Window not closed.',
+        'error',
+        4000
+      )
+      consoleSpy.mockRestore()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('does NOT call forceClose when the save handler throws', async () => {
+    const harness = await renderProbe()
+    try {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const throwingSave = vi.fn(async () => {
+        throw new Error('disk write failed')
+      })
+
+      await act(async () => {
+        harness.getApi().registerSettingsSave(throwingSave)
+      })
+
+      await act(async () => {
+        await harness.getApi().triggerCloseConfirmSave()
+      })
+
+      expect(throwingSave).toHaveBeenCalledTimes(1)
+      expect(forceCloseMock).not.toHaveBeenCalled()
+      expect(notifyMock).toHaveBeenCalledWith(
+        'Failed to save changes. Window not closed.',
+        'error',
+        4000
+      )
+      consoleSpy.mockRestore()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('DOES call forceClose when every save handler returns true', async () => {
+    const harness = await renderProbe()
+    try {
+      const successfulSave = vi.fn(async () => true)
+
+      await act(async () => {
+        harness.getApi().registerSettingsSave(successfulSave)
+      })
+
+      await act(async () => {
+        await harness.getApi().triggerCloseConfirmSave()
+      })
+
+      expect(successfulSave).toHaveBeenCalledTimes(1)
+      expect(forceCloseMock).toHaveBeenCalledTimes(1)
+      expect(notifyMock).not.toHaveBeenCalled()
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/profileNameDirty.test.tsx
+++ b/tests/renderer/profileNameDirty.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest'
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { useDirtyTracking } from '../../src/renderer/src/hooks/useDirtyTracking'
+
+interface ProbeState {
+  isDirty: boolean
+  setProfileName: (name: string) => void
+}
+
+function ProfileLike({
+  onCapture,
+  initialName
+}: {
+  onCapture: (state: ProbeState) => void
+  initialName: string
+}) {
+  const [profileName, setProfileName] = useState(initialName)
+  const [profileUtilities] = useState<Array<{ id: string; enabled: boolean }>>([])
+  const currentState = { profileName, profileUtilities }
+  const { isDirty } = useDirtyTracking(currentState, false)
+  onCapture({ isDirty, setProfileName })
+  return null
+}
+
+async function mountProbe(initialName: string) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: ProbeState | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<ProfileLike onCapture={(state) => (captured = state)} initialName={initialName} />)
+  })
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getState: () => {
+      if (!captured) {
+        throw new Error('Probe did not capture state')
+      }
+      return captured
+    }
+  }
+}
+
+describe('profile name dirty tracking (#400)', () => {
+  test('typing a new profile name marks the profile dirty', async () => {
+    const harness = await mountProbe('Default')
+    try {
+      expect(harness.getState().isDirty).toBe(false)
+
+      await act(async () => {
+        harness.getState().setProfileName('Default ')
+      })
+
+      expect(harness.getState().isDirty).toBe(true)
+
+      await act(async () => {
+        harness.getState().setProfileName('Endurance Setup')
+      })
+
+      expect(harness.getState().isDirty).toBe(true)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('reverting the profile name back clears the dirty flag', async () => {
+    const harness = await mountProbe('Default')
+    try {
+      await act(async () => {
+        harness.getState().setProfileName('Sprint')
+      })
+
+      expect(harness.getState().isDirty).toBe(true)
+
+      await act(async () => {
+        harness.getState().setProfileName('Default')
+      })
+
+      expect(harness.getState().isDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,19 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 import { fileURLToPath } from 'node:url'
 
-const rendererTests = ['tests/settingsSaveRace.test.ts', 'tests/renderer/**/*.test.ts']
+const rendererTests = [
+  'tests/settingsSaveRace.test.ts',
+  'tests/renderer/**/*.test.ts',
+  'tests/renderer/**/*.test.tsx'
+]
 const mainProcessTests = ['tests/electronApiSurface.test.ts', 'tests/main/**/*.test.ts']
 
 export default defineConfig({
   test: {
     projects: [
       {
+        plugins: [react()],
         test: { name: 'renderer', environment: 'jsdom', include: rendererTests, pool: 'vmThreads' }
       },
       {


### PR DESCRIPTION
## Summary

Five related dirty-state UX issues solved through a single shared dirty-state aggregator:

- **#388 Sticky Save bar in Settings** — `StickySaveBar` component pinned to the bottom of the Settings scroll container while changes are unsaved
- **#403 Sticky Save bar in Profile Editor** — same component reused in the Profile Editor
- **#389 Tab switch warning covers profile editor too** — the existing confirm dialog now triggers when any dirty scope (settings OR profile editor) is active and the user navigates away
- **#387 Close button respects dirty state** — when the OS window close fires while anything is dirty, main process sends `close-requested` to the renderer which surfaces the same Save/Discard/Cancel dialog. The renderer also forwards the in-flight Minimize-to-tray toggle to main so an unsaved toggle is honoured during the close decision
- **#400 Profile name dirty surfaces Save** — verified by test that typing in the profile name input flips the dirty flag; covered alongside the editor's other fields by the unified aggregator

## Architecture

- New `AppDirtyProvider` / `useAppDirty` context aggregates Settings dirty + Profile Editor dirty, plus pluggable save/discard handlers per scope
- New IPC channels: `set-renderer-dirty`, `set-pending-minimize-to-tray`, `force-close-window` plus a `close-requested` push event
- `SettingsContext` now mirrors its pending Minimize-to-tray state to main on every change
- `StickySaveBar` is a reusable component used by both `SettingsView` and `ProfileEditor`
- Window close logic refactored: if renderer is dirty → forward to renderer for confirm; else use pending tray preference (renderer intent) falling back to persisted store value
- ESLint config: ignore `.claude/**` so the worktree shadow doesn't confuse tsconfig resolution

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (+10 new tests; the 2 pre-existing migrator test failures on `main` are unrelated to this PR)
- [x] `npm run build`
- [x] Manual: toggle Minimize-to-tray in Settings (without saving), click window X — app minimizes to tray
- [x] Manual: toggle Minimize-to-tray off in Settings (without saving), click X — confirm dialog appears
- [x] Manual: scroll past the Save button in Settings while dirty — sticky Save bar appears
- [x] Manual: open Profile Editor, drag a utility, scroll down — sticky Save bar appears
- [x] Manual: edit a profile name → Save indicator dot appears
- [x] Manual: edit profile, switch to Settings tab — confirm dialog appears

Closes #387
Closes #388
Closes #389
Closes #400
Closes #403

<!-- auto-closes -->
Closes #387
Closes #388
Closes #389
Closes #400
Closes #403
<!-- auto-closes -->