### PR TITLE
feat: dynamic context menu labels for utility icon dismissal

### DIFF
--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -8,10 +8,13 @@ interface ShowAppContextMenuOptions {
 }
 
 // Strip the `.exe` suffix so context-menu labels read naturally (e.g. "Dismiss
-// OTT Warning" instead of "Dismiss OTT.exe Warning").
+// OTT Warning" instead of "Dismiss OTT.exe Warning"). Electron treats `&` in
+// menu labels as a mnemonic prefix on Windows, so we double-escape it to
+// preserve the original character in app names like "AT&T".
 function formatAppDisplayName(appPath: string, providedName?: string): string {
   const rawName = providedName?.trim() || path.basename(appPath)
-  return rawName.replace(/\.exe$/i, '') || rawName
+  const stripped = rawName.replace(/\.exe$/i, '') || rawName
+  return stripped.replace(/&/g, '&&')
 }
 
 export function buildDismissLabel(

--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -1,25 +1,54 @@
 import { BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain } from 'electron'
+import path from 'path'
 import { dismissAppIcon, publishRunningApps } from '../processes'
 
+interface ShowAppContextMenuOptions {
+  tracked?: boolean
+  name?: string
+}
+
+// Strip the `.exe` suffix so context-menu labels read naturally (e.g. "Dismiss
+// OTT Warning" instead of "Dismiss OTT.exe Warning").
+function formatAppDisplayName(appPath: string, providedName?: string): string {
+  const rawName = providedName?.trim() || path.basename(appPath)
+  return rawName.replace(/\.exe$/i, '') || rawName
+}
+
+export function buildDismissLabel(
+  appPath: string,
+  options: ShowAppContextMenuOptions = {}
+): string {
+  const displayName = formatAppDisplayName(appPath, options.name)
+  // Tracked utilities keep their icon visible after the warning clears, so
+  // labeling the action "Dismiss Icon" is misleading (see #363). Use
+  // "Dismiss Warning" for tracked apps and "Dismiss Icon" only for untracked
+  // mismatches where the icon truly disappears.
+  const action = options.tracked ? 'Dismiss Warning' : 'Dismiss Icon'
+  return displayName ? `${action} for ${displayName}` : action
+}
+
 export function registerContextMenuHandlers() {
-  ipcMain.handle('show-app-context-menu', (event, appPath: string, gameKey: string) => {
-    const template: MenuItemConstructorOptions[] = [
-      {
-        label: 'Dismiss Icon',
-        click: () => {
-          dismissAppIcon(appPath, gameKey)
-          publishRunningApps('scan').catch((err) => {
-            console.error('Failed to publish running apps after dismissing icon', err)
-          })
+  ipcMain.handle(
+    'show-app-context-menu',
+    (event, appPath: string, gameKey: string, options?: ShowAppContextMenuOptions) => {
+      const template: MenuItemConstructorOptions[] = [
+        {
+          label: buildDismissLabel(appPath, options),
+          click: () => {
+            dismissAppIcon(appPath, gameKey)
+            publishRunningApps('scan').catch((err) => {
+              console.error('Failed to publish running apps after dismissing icon', err)
+            })
+          }
         }
+      ]
+
+      const menu = Menu.buildFromTemplate(template)
+      const window = BrowserWindow.fromWebContents(event.sender)
+
+      if (window) {
+        menu.popup({ window })
       }
-    ]
-
-    const menu = Menu.buildFromTemplate(template)
-    const window = BrowserWindow.fromWebContents(event.sender)
-
-    if (window) {
-      menu.popup({ window })
     }
-  })
+  )
 }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -186,5 +186,9 @@ export interface ElectronAPI {
   getAssetData: (filename: string) => Promise<string | null>
   getFileIcon: (filePath: string) => Promise<string | null>
   getVersion: () => Promise<string>
-  showAppContextMenu: (appPath: string, gameKey: string) => Promise<void>
+  showAppContextMenu: (
+    appPath: string,
+    gameKey: string,
+    options?: { tracked?: boolean; name?: string }
+  ) => Promise<void>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -110,8 +110,11 @@ const electronAPI: ElectronAPI = {
   getAssetData: (filename: string) => ipcRenderer.invoke('get-asset-data', filename),
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
   getVersion: () => ipcRenderer.invoke('get-version'),
-  showAppContextMenu: (appPath: string, gameKey: string) =>
-    ipcRenderer.invoke('show-app-context-menu', appPath, gameKey)
+  showAppContextMenu: (
+    appPath: string,
+    gameKey: string,
+    options?: { tracked?: boolean; name?: string }
+  ) => ipcRenderer.invoke('show-app-context-menu', appPath, gameKey, options)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -130,7 +130,8 @@ export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'setting
             path: a.path,
             gameKey: a.gameKey,
             warning: a.warning,
-            elevated: a.elevated
+            elevated: a.elevated,
+            tracked: a.tracked
           }))
 
           return (

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -65,7 +65,10 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
             onContextMenu={(e) => {
               if (app.warning) {
                 e.preventDefault()
-                showAppContextMenu(app.path, app.gameKey)
+                showAppContextMenu(app.path, app.gameKey, {
+                  tracked: app.tracked,
+                  name: app.name
+                })
               }
             }}
           >

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -8,6 +8,7 @@ export interface RunningAppIcon {
   gameKey: string
   warning?: string
   elevated?: boolean
+  tracked?: boolean
 }
 
 interface RunningAppsStripProps {
@@ -42,7 +43,10 @@ export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningA
               onContextMenu={(e) => {
                 if (app.warning) {
                   e.preventDefault()
-                  showAppContextMenu(app.path, app.gameKey)
+                  showAppContextMenu(app.path, app.gameKey, {
+                    tracked: app.tracked,
+                    name: app.name
+                  })
                 }
               }}
             />

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -13,6 +13,7 @@ export type RunningApp = {
   gameKey: string
   warning?: string
   elevated?: boolean
+  tracked?: boolean
 }
 
 export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | 'config' | 'scan'

--- a/tests/main/contextMenuLabel.test.ts
+++ b/tests/main/contextMenuLabel.test.ts
@@ -45,4 +45,13 @@ describe('buildDismissLabel', () => {
   test('drops the display segment when name resolution yields an empty string', () => {
     expect(buildDismissLabel('', { name: '' })).toBe('Dismiss Icon')
   })
+
+  test('escapes ampersands so Electron does not treat them as mnemonics', () => {
+    expect(buildDismissLabel('C:/games/sim/AT&T.exe', { tracked: false })).toBe(
+      'Dismiss Icon for AT&&T'
+    )
+    expect(buildDismissLabel('C:/games/sim/utility.exe', { tracked: true, name: 'Foo & Bar' })).toBe(
+      'Dismiss Warning for Foo && Bar'
+    )
+  })
 })

--- a/tests/main/contextMenuLabel.test.ts
+++ b/tests/main/contextMenuLabel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test, vi } from 'vitest'
+
+// The module under test imports from '../processes', which transitively loads
+// Electron. Stub both before importing so the suite runs in a plain Node env.
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn() },
+  ipcMain: { handle: vi.fn() }
+}))
+
+vi.mock('../../src/main/processes', () => ({
+  dismissAppIcon: vi.fn(),
+  publishRunningApps: vi.fn(() => Promise.resolve())
+}))
+
+import { buildDismissLabel } from '../../src/main/ipc/context-menu'
+
+describe('buildDismissLabel', () => {
+  test('untracked mismatch uses "Dismiss Icon"', () => {
+    expect(
+      buildDismissLabel('C:/games/sim/utility.exe', { tracked: false, name: 'utility.exe' })
+    ).toBe('Dismiss Icon for utility')
+  })
+
+  test('tracked utility uses "Dismiss Warning"', () => {
+    expect(buildDismissLabel('C:/games/sim/OTT.exe', { tracked: true, name: 'OTT.exe' })).toBe(
+      'Dismiss Warning for OTT'
+    )
+  })
+
+  test('falls back to the basename when name is omitted', () => {
+    expect(buildDismissLabel('C:/games/sim/SimAppPro.exe')).toBe('Dismiss Icon for SimAppPro')
+  })
+
+  test('preserves names that have no .exe suffix', () => {
+    expect(buildDismissLabel('C:/games/sim/launcher', { tracked: true, name: 'launcher' })).toBe(
+      'Dismiss Warning for launcher'
+    )
+  })
+
+  test('treats undefined tracked as untracked', () => {
+    expect(buildDismissLabel('C:/games/sim/foo.exe')).toBe('Dismiss Icon for foo')
+  })
+
+  test('drops the display segment when name resolution yields an empty string', () => {
+    expect(buildDismissLabel('', { name: '' })).toBe('Dismiss Icon')
+  })
+})

--- a/tests/main/contextMenuLabel.test.ts
+++ b/tests/main/contextMenuLabel.test.ts
@@ -50,8 +50,8 @@ describe('buildDismissLabel', () => {
     expect(buildDismissLabel('C:/games/sim/AT&T.exe', { tracked: false })).toBe(
       'Dismiss Icon for AT&&T'
     )
-    expect(buildDismissLabel('C:/games/sim/utility.exe', { tracked: true, name: 'Foo & Bar' })).toBe(
-      'Dismiss Warning for Foo && Bar'
-    )
+    expect(
+      buildDismissLabel('C:/games/sim/utility.exe', { tracked: true, name: 'Foo & Bar' })
+    ).toBe('Dismiss Warning for Foo && Bar')
   })
 })


### PR DESCRIPTION
## Summary
- Pick the dismiss verb based on whether the app is `tracked`: "Dismiss Warning" for tracked utilities whose icon remains after the warning clears (e.g. OTT), "Dismiss Icon" for untracked mismatches where the icon disappears entirely.
- Surface the specific app name in the label (`Dismiss Warning for OTT`) so the action's target is unambiguous.
- Thread `tracked` + `name` from `getRunningApps` through the `RunningAppIcon` prop into the `show-app-context-menu` IPC.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npx eslint` on changed files
- [x] `npm test` (new `tests/main/contextMenuLabel.test.ts` + 132 of 138 prior tests; the 6 pre-existing failures are unrelated and already fail on `main`)
- [x] `npm run build`
- [x] Manual: right-click a tracked utility (OTT) with a visible mismatch warning and verify the label reads "Dismiss Warning for OTT"
- [x] Manual: right-click an untracked mismatch warning and verify the label reads "Dismiss Icon for <name>"

Closes #363

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- auto-closes -->
Closes #363
<!-- auto-closes -->