### PR TITLE
fix: explain lost tracking after wrapper exit (#402)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -364,7 +364,7 @@ function spawnDetachedApp(
         const wasClosedBySimLauncher = consumeProcessNameMismatchWarningSuppression(appPath)
 
         if (exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
-          const warning = `${path.basename(appPath)} exited shortly after launch. If it starts another process with a different name, add that executable under tracked processes to prevent duplicate launches.`
+          const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add that executable to this slot under tracked processes. Right-click the icon to dismiss this warning.`
 
           processNameMismatchWarnings.set(appPath.toLowerCase(), {
             path: appPath,

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -458,7 +458,7 @@ test('getRunningApps surfaces a warning when a launched wrapper exits before its
         path: 'C:/Program Files/Cheat Engine/Cheat Engine.exe',
         name: 'Cheat Engine.exe',
         gameKey: 'ac',
-        warning: expect.stringContaining('starts another process with a different name')
+        warning: expect.stringContaining('SimLauncher can no longer detect when you close it')
       })
     ])
   )
@@ -549,7 +549,7 @@ test('getRunningApps keeps wrapper warnings until the configured process is reso
     'process-name-mismatch-warning',
     expect.objectContaining({
       app: 'C:/Program Files/Cheat Engine/Cheat Engine.exe',
-      warning: expect.stringContaining('starts another process with a different name')
+      warning: expect.stringContaining('SimLauncher can no longer detect when you close it')
     })
   )
   dateNow.mockReturnValue(30000)
@@ -557,7 +557,7 @@ test('getRunningApps keeps wrapper warnings until the configured process is reso
     expect.arrayContaining([
       expect.objectContaining({
         path: 'C:/Program Files/Cheat Engine/Cheat Engine.exe',
-        warning: expect.stringContaining('starts another process with a different name')
+        warning: expect.stringContaining('SimLauncher can no longer detect when you close it')
       })
     ])
   )
@@ -634,6 +634,52 @@ test('process mismatch warnings persist until manually dismissed (#360)', async 
   expect(processNameMismatchWarnings.size).toBe(0)
 
   dateNow.mockRestore()
+})
+
+test('wrapper exit warning tells the user tracking is lost and how to fix it (#402)', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  markExistingPath('C:/Tools/Perplexity.exe')
+  const { launchProfileApps, processNameMismatchWarnings } = await loadProcessModules()
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/Perplexity.exe'])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  // Simulate the wrapper exiting immediately after spawning a differently-named
+  // child process. The launched image disappears from tasklist while another
+  // PID continues running under a different name.
+  processNames.delete('perplexity.exe')
+  processNames.add('perplexity-helper.exe')
+  childHandlers.get('exit')?.()
+
+  const mismatchCall = sender.send.mock.calls.find(
+    ([channel]) => channel === 'process-name-mismatch-warning'
+  )
+  expect(mismatchCall).toBeDefined()
+  const payload = mismatchCall?.[1] as { app: string; warning: string }
+  expect(payload.app).toBe('C:/Tools/Perplexity.exe')
+  // Wording must (a) name the exited wrapper, (b) state SimLauncher loses
+  // tracking, (c) point the user at Task Manager + tracked processes to fix.
+  expect(payload.warning).toContain('Perplexity.exe')
+  expect(payload.warning).toMatch(/no longer detect when you close it/i)
+  expect(payload.warning).toMatch(/task manager/i)
+  expect(payload.warning).toMatch(/tracked processes/i)
+
+  // Persistent strip warning carries the same actionable copy so the user
+  // doesn't only see it during the 5s toast window.
+  const stripWarning = processNameMismatchWarnings.values().next().value
+  expect(stripWarning?.warning).toBe(payload.warning)
 })
 
 test('killLaunchedApps does not create a wrapper warning for user-initiated closes', async () => {


### PR DESCRIPTION
Closes #402.

## Diagnosis

Pre-existing wrapper-exe limitation, **not a regression** between 0.9.6 and 0.9.7. The wrapper-warning infrastructure (`spawn.ts` early-exit handler + `processNameMismatchWarnings` map + strip ring) was added across the #314 batch and has always keyed tracking on the launched exe's image name. When a wrapper-style app (Perplexity, Discord, Spotify, Electron stubs) spawns a child under a different name and then exits the wrapper PID, tasklist no longer surfaces it. SimLauncher then has no way to notice the user manually closing the actual child, so the icon stays in the running-apps strip until the next launch cycle.

A full structural fix would require either PID-parent tracking + child adoption or a user-configurable additional-tracked-process-name field on the slot. Both are larger than the issue's scope guidance.

## Approach (scoped per issue guidance)

This PR takes the issue's "At minimum" option: improve the warning UX so the user understands what happened and what to do, without changing the tracking model. Specifically the early-exit warning now:

- names the wrapper exe that exited
- explicitly states **SimLauncher can no longer detect when you close it**
- tells the user to find the child name in **Task Manager** and add it under **tracked processes** for the slot
- mentions the right-click dismiss affordance on the persistent strip icon (covers the #360 persistence path)

The same string is sent on both the toast IPC and stored in the persistent `processNameMismatchWarnings` entry, so the user sees consistent guidance whether they catch the 5s toast or only the strip-icon hover tooltip.

## Files changed

- `src/main/processes/spawn.ts` — warning copy
- `tests/main/processes.test.ts` — updated 3 existing wording assertions + added 1 regression test (#402)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run format:check` clean
- [x] `npx eslint` clean on changed files
- [x] `tests/main/processes.test.ts` — 54/54 pass including new `wrapper exit warning tells the user tracking is lost and how to fix it (#402)`
- [x] `npm run build` passes
- [x] Manual: launch a Perplexity profile and verify the new toast/strip-warning copy reads correctly
- [x] Manual: right-click the warning strip icon and confirm Dismiss Icon still works

## Pre-existing test failure (not caused by this PR)

`tests/main/migrator.test.ts` has 2 failing tests on `main` due to the store mock missing `getStoredStringRecord` (introduced by #379). Out of scope here.

## Follow-up

The structural fix (PID-parent child adoption, or per-slot configurable extra tracked-process names) should be a separate issue. The improved copy guides the user toward the existing tracked-processes mechanism in the meantime.