### PR TITLE
fix: add getStoredStringRecord to migrator test mock

### DIFF
--- a/tests/main/migrator.test.ts
+++ b/tests/main/migrator.test.ts
@@ -16,6 +16,17 @@ async function loadMigratorModule() {
       set(key: string, value: unknown) {
         storeData[key] = value
       }
+    },
+    getStoredStringRecord(key: string) {
+      const value = storeData[key]
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {}
+      }
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).filter(
+          (entry): entry is [string, string] => typeof entry[1] === 'string'
+        )
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes the 2 long-standing failing tests in `tests/main/migrator.test.ts` that were caused by a mock module missing the `getStoredStringRecord` export added to production in #379.

## Test plan
- [x] `npm test -- tests/main/migrator.test.ts` — 2/2 pass
- [x] `npm run typecheck`, `lint`, `format:check`, `build` all green

Closes #407

<!-- auto-closes -->
Closes #407
<!-- auto-closes -->