### PR TITLE
refactor: extract useSettingsState from SettingsContext

### DIFF
--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -1,15 +1,6 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type Dispatch,
-  type ReactNode,
-  type SetStateAction
-} from 'react'
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { useDirtyTracking } from '../../hooks/useDirtyTracking'
-import { DEFAULT_ACCENT_COLOR, getUtilities, type Profiles } from '../../lib/config'
+import { getUtilities } from '../../lib/config'
 import {
   browsePath,
   getFileIcon,
@@ -25,15 +16,11 @@ import { AppsContext, type AppsContextValue } from './AppsContext'
 import { BehaviorContext, type BehaviorContextValue } from './BehaviorContext'
 import { GamesContext, type GamesContextValue } from './GamesContext'
 import { SettingsMetaContext, type SettingsMetaContextValue } from './SettingsMetaContext'
-import {
-  createSettingsObjectVersions,
-  type SettingsObjectField,
-  type SettingsObjectRecords
-} from './saveRace'
 import { useConfigIO } from './useConfigIO'
 import { useCustomSlots } from './useCustomSlots'
 import { useSettingsLoad } from './useSettingsLoad'
 import { useSettingsSave } from './useSettingsSave'
+import { useSettingsState } from './useSettingsState'
 
 export function SettingsProvider({
   children,
@@ -52,97 +39,61 @@ export function SettingsProvider({
   const theme = useTheme()
   const themeRef = useRef(theme)
   themeRef.current = theme
-  const [loading, setLoading] = useState(true)
 
-  const [appPaths, setAppPaths] = useState<Record<string, string>>({})
-  const [appNames, setAppNames] = useState<Record<string, string>>({})
-  const [appArgs, setAppArgs] = useState<Record<string, string>>({})
-  const [profiles, setProfiles] = useState<Profiles>({})
-  const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
-  const [customSlots, setCustomSlots] = useState(1)
-  const [accentPreset, setAccentPreset] = useState<string>(DEFAULT_ACCENT_COLOR)
-  const [accentCustom, setAccentCustom] = useState<string>('')
-  const [accentBgTint, setAccentBgTint] = useState<boolean>(false)
-  const [themeMode, setThemeMode] = useState<ThemeMode>('dark')
-  const [focusActiveTitle, setFocusActiveTitle] = useState<boolean>(true)
-  const [launchDelayMs, setLaunchDelayMs] = useState<number>(1000)
-  const [startWithWindows, setStartWithWindows] = useState<boolean>(false)
-  const [startMinimized, setStartMinimized] = useState<boolean>(false)
-  const [minimizeToTray, setMinimizeToTray] = useState<boolean>(false)
-  const [autoCheckUpdates, setAutoCheckUpdates] = useState<boolean>(true)
-  const [zoomFactor, setZoomFactor] = useState<number>(1.0)
-
-  const [isCustomColor, setIsCustomColor] = useState(false)
-  const [appIcons, setAppIcons] = useState<Record<string, string>>({})
-  const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
-  const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
-  const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
-  const latestSettingsObjects = useRef<SettingsObjectRecords>({
-    appPaths,
-    appNames,
-    appArgs,
-    gamePaths
-  })
-
-  const updateSettingsObject = useCallback(
-    (
-      field: SettingsObjectField,
-      setter: Dispatch<SetStateAction<Record<string, string>>>,
-      updater: (current: Record<string, string>) => Record<string, string>
-    ) => {
-      settingsObjectEditVersions.current[field] += 1
-      setter((current) => {
-        const next = updater(current)
-        latestSettingsObjects.current = {
-          ...latestSettingsObjects.current,
-          [field]: next
-        }
-        return next
-      })
+  const {
+    state: {
+      loading,
+      appPaths,
+      appNames,
+      appArgs,
+      profiles,
+      gamePaths,
+      customSlots,
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      focusActiveTitle,
+      launchDelayMs,
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      autoCheckUpdates,
+      zoomFactor,
+      isCustomColor,
+      appIcons,
+      gameIcons,
+      iconLoadErrors
     },
-    []
-  )
-
-  const currentSettingsState = useMemo(
-    () => ({
-      appPaths,
-      appNames,
-      appArgs,
-      profiles,
-      gamePaths,
-      customSlots,
-      accentPreset,
-      accentCustom,
-      accentBgTint,
-      themeMode,
-      focusActiveTitle,
-      launchDelayMs,
-      startWithWindows,
-      startMinimized,
-      minimizeToTray,
-      autoCheckUpdates,
-      zoomFactor
-    }),
-    [
-      appPaths,
-      appNames,
-      appArgs,
-      profiles,
-      gamePaths,
-      customSlots,
-      accentPreset,
-      accentCustom,
-      accentBgTint,
-      themeMode,
-      focusActiveTitle,
-      launchDelayMs,
-      startWithWindows,
-      startMinimized,
-      minimizeToTray,
-      autoCheckUpdates,
-      zoomFactor
-    ]
-  )
+    setters: {
+      setLoading,
+      setAppPaths,
+      setAppNames,
+      setAppArgs,
+      setProfiles,
+      setGamePaths,
+      setCustomSlots,
+      setAccentPreset,
+      setAccentCustom,
+      setAccentBgTint,
+      setThemeMode,
+      setFocusActiveTitle,
+      setLaunchDelayMs,
+      setStartWithWindows,
+      setStartMinimized,
+      setMinimizeToTray,
+      setAutoCheckUpdates,
+      setZoomFactor,
+      setIsCustomColor,
+      setAppIcons,
+      setGameIcons,
+      setIconLoadErrors
+    },
+    updateSettingsObject,
+    settingsObjectEditVersions,
+    latestSettingsObjects,
+    currentSettingsState
+  } = useSettingsState()
 
   const { isDirty, resetDirty } = useDirtyTracking(currentSettingsState, loading)
 
@@ -197,7 +148,7 @@ export function SettingsProvider({
         theme.setAccentPreset(presetHex)
       }
     },
-    [theme]
+    [theme, setAccentPreset, setIsCustomColor]
   )
 
   const handleCustomColorChange = useCallback(
@@ -205,7 +156,7 @@ export function SettingsProvider({
       setAccentCustom(hex)
       theme.setAccentCustom(hex)
     },
-    [theme]
+    [theme, setAccentCustom]
   )
 
   const handleAccentBgTintChange = useCallback(
@@ -213,7 +164,7 @@ export function SettingsProvider({
       setAccentBgTint(checked)
       theme.setAccentBgTint(checked)
     },
-    [theme]
+    [theme, setAccentBgTint]
   )
 
   const handleThemeModeChange = useCallback(
@@ -221,18 +172,24 @@ export function SettingsProvider({
       setThemeMode(mode)
       theme.setThemeMode(mode)
     },
-    [theme]
+    [theme, setThemeMode]
   )
 
-  const handleZoomFactorChange = useCallback((factor: number) => {
-    setZoomFactor(factor)
-    setZoom(factor)
-  }, [])
+  const handleZoomFactorChange = useCallback(
+    (factor: number) => {
+      setZoomFactor(factor)
+      setZoom(factor)
+    },
+    [setZoomFactor]
+  )
 
-  const handleStartWithWindowsChange = useCallback((checked: boolean) => {
-    setStartWithWindows(checked)
-    setLoginItem(checked)
-  }, [])
+  const handleStartWithWindowsChange = useCallback(
+    (checked: boolean) => {
+      setStartWithWindows(checked)
+      setLoginItem(checked)
+    },
+    [setStartWithWindows]
+  )
 
   const handleBrowse = useCallback(
     async (key: string, isGame: boolean) => {
@@ -263,14 +220,14 @@ export function SettingsProvider({
         }
       }
     },
-    [updateSettingsObject]
+    [updateSettingsObject, setGamePaths, setAppPaths, setAppIcons, setIconLoadErrors]
   )
 
   const handleGamePathChange = useCallback(
     (key: string, path: string) => {
       updateSettingsObject('gamePaths', setGamePaths, (prev) => ({ ...prev, [key]: path }))
     },
-    [updateSettingsObject]
+    [updateSettingsObject, setGamePaths]
   )
 
   const handleAppPathChange = useCallback(
@@ -284,26 +241,29 @@ export function SettingsProvider({
         })
       }
     },
-    [updateSettingsObject]
+    [updateSettingsObject, setAppPaths, setAppIcons]
   )
 
   const handleAppNameChange = useCallback(
     (key: string, name: string) => {
       updateSettingsObject('appNames', setAppNames, (prev) => ({ ...prev, [key]: name }))
     },
-    [updateSettingsObject]
+    [updateSettingsObject, setAppNames]
   )
 
   const handleAppArgsChange = useCallback(
     (key: string, args: string) => {
       updateSettingsObject('appArgs', setAppArgs, (prev) => ({ ...prev, [key]: args }))
     },
-    [updateSettingsObject]
+    [updateSettingsObject, setAppArgs]
   )
 
-  const handleIconLoadError = useCallback((key: string) => {
-    setIconLoadErrors((prev) => new Set([...prev, key]))
-  }, [])
+  const handleIconLoadError = useCallback(
+    (key: string) => {
+      setIconLoadErrors((prev) => new Set([...prev, key]))
+    },
+    [setIconLoadErrors]
+  )
 
   const { handleAddCustomSlot, handleRemoveCustomSlot, customSlotRemoveDialog } = useCustomSlots({
     appNames,
@@ -389,7 +349,8 @@ export function SettingsProvider({
       handleCustomColorChange,
       handleAccentBgTintChange,
       handleThemeModeChange,
-      handleZoomFactorChange
+      handleZoomFactorChange,
+      setFocusActiveTitle
     ]
   )
 
@@ -451,7 +412,16 @@ export function SettingsProvider({
       onMinimizeToTrayChange: setMinimizeToTray,
       onLaunchDelayMsChange: setLaunchDelayMs
     }),
-    [startWithWindows, startMinimized, minimizeToTray, launchDelayMs, handleStartWithWindowsChange]
+    [
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      launchDelayMs,
+      handleStartWithWindowsChange,
+      setStartMinimized,
+      setMinimizeToTray,
+      setLaunchDelayMs
+    ]
   )
 
   const settingsMetaValue: SettingsMetaContextValue = useMemo(
@@ -474,7 +444,8 @@ export function SettingsProvider({
       importingConfig,
       handleExportConfig,
       handleImportConfig,
-      handleSave
+      handleSave,
+      setAutoCheckUpdates
     ]
   )
 

--- a/src/renderer/src/components/settings/useSettingsState.ts
+++ b/src/renderer/src/components/settings/useSettingsState.ts
@@ -1,0 +1,243 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction
+} from 'react'
+import { DEFAULT_ACCENT_COLOR, type Profiles } from '../../lib/config'
+import type { ThemeMode } from '../../lib/theme'
+import {
+  createSettingsObjectVersions,
+  type SettingsObjectField,
+  type SettingsObjectRecords,
+  type SettingsObjectVersions
+} from './saveRace'
+
+export interface SettingsStateBundle {
+  state: {
+    loading: boolean
+    appPaths: Record<string, string>
+    appNames: Record<string, string>
+    appArgs: Record<string, string>
+    profiles: Profiles
+    gamePaths: Record<string, string>
+    customSlots: number
+    accentPreset: string
+    accentCustom: string
+    accentBgTint: boolean
+    themeMode: ThemeMode
+    focusActiveTitle: boolean
+    launchDelayMs: number
+    startWithWindows: boolean
+    startMinimized: boolean
+    minimizeToTray: boolean
+    autoCheckUpdates: boolean
+    zoomFactor: number
+    isCustomColor: boolean
+    appIcons: Record<string, string>
+    gameIcons: Record<string, string>
+    iconLoadErrors: Set<string>
+  }
+  setters: {
+    setLoading: Dispatch<SetStateAction<boolean>>
+    setAppPaths: Dispatch<SetStateAction<Record<string, string>>>
+    setAppNames: Dispatch<SetStateAction<Record<string, string>>>
+    setAppArgs: Dispatch<SetStateAction<Record<string, string>>>
+    setProfiles: Dispatch<SetStateAction<Profiles>>
+    setGamePaths: Dispatch<SetStateAction<Record<string, string>>>
+    setCustomSlots: Dispatch<SetStateAction<number>>
+    setAccentPreset: Dispatch<SetStateAction<string>>
+    setAccentCustom: Dispatch<SetStateAction<string>>
+    setAccentBgTint: Dispatch<SetStateAction<boolean>>
+    setThemeMode: Dispatch<SetStateAction<ThemeMode>>
+    setFocusActiveTitle: Dispatch<SetStateAction<boolean>>
+    setLaunchDelayMs: Dispatch<SetStateAction<number>>
+    setStartWithWindows: Dispatch<SetStateAction<boolean>>
+    setStartMinimized: Dispatch<SetStateAction<boolean>>
+    setMinimizeToTray: Dispatch<SetStateAction<boolean>>
+    setAutoCheckUpdates: Dispatch<SetStateAction<boolean>>
+    setZoomFactor: Dispatch<SetStateAction<number>>
+    setIsCustomColor: Dispatch<SetStateAction<boolean>>
+    setAppIcons: Dispatch<SetStateAction<Record<string, string>>>
+    setGameIcons: Dispatch<SetStateAction<Record<string, string>>>
+    setIconLoadErrors: Dispatch<SetStateAction<Set<string>>>
+  }
+  updateSettingsObject: (
+    field: SettingsObjectField,
+    setter: Dispatch<SetStateAction<Record<string, string>>>,
+    updater: (current: Record<string, string>) => Record<string, string>
+  ) => void
+  settingsObjectEditVersions: MutableRefObject<SettingsObjectVersions>
+  latestSettingsObjects: MutableRefObject<SettingsObjectRecords>
+  currentSettingsState: {
+    appPaths: Record<string, string>
+    appNames: Record<string, string>
+    appArgs: Record<string, string>
+    profiles: Profiles
+    gamePaths: Record<string, string>
+    customSlots: number
+    accentPreset: string
+    accentCustom: string
+    accentBgTint: boolean
+    themeMode: ThemeMode
+    focusActiveTitle: boolean
+    launchDelayMs: number
+    startWithWindows: boolean
+    startMinimized: boolean
+    minimizeToTray: boolean
+    autoCheckUpdates: boolean
+    zoomFactor: number
+  }
+}
+
+export function useSettingsState(): SettingsStateBundle {
+  const [loading, setLoading] = useState(true)
+
+  const [appPaths, setAppPaths] = useState<Record<string, string>>({})
+  const [appNames, setAppNames] = useState<Record<string, string>>({})
+  const [appArgs, setAppArgs] = useState<Record<string, string>>({})
+  const [profiles, setProfiles] = useState<Profiles>({})
+  const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
+  const [customSlots, setCustomSlots] = useState(1)
+  const [accentPreset, setAccentPreset] = useState<string>(DEFAULT_ACCENT_COLOR)
+  const [accentCustom, setAccentCustom] = useState<string>('')
+  const [accentBgTint, setAccentBgTint] = useState<boolean>(false)
+  const [themeMode, setThemeMode] = useState<ThemeMode>('dark')
+  const [focusActiveTitle, setFocusActiveTitle] = useState<boolean>(true)
+  const [launchDelayMs, setLaunchDelayMs] = useState<number>(1000)
+  const [startWithWindows, setStartWithWindows] = useState<boolean>(false)
+  const [startMinimized, setStartMinimized] = useState<boolean>(false)
+  const [minimizeToTray, setMinimizeToTray] = useState<boolean>(false)
+  const [autoCheckUpdates, setAutoCheckUpdates] = useState<boolean>(true)
+  const [zoomFactor, setZoomFactor] = useState<number>(1.0)
+
+  const [isCustomColor, setIsCustomColor] = useState(false)
+  const [appIcons, setAppIcons] = useState<Record<string, string>>({})
+  const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
+  const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
+  const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
+  const latestSettingsObjects = useRef<SettingsObjectRecords>({
+    appPaths,
+    appNames,
+    appArgs,
+    gamePaths
+  })
+
+  const updateSettingsObject = useCallback(
+    (
+      field: SettingsObjectField,
+      setter: Dispatch<SetStateAction<Record<string, string>>>,
+      updater: (current: Record<string, string>) => Record<string, string>
+    ) => {
+      settingsObjectEditVersions.current[field] += 1
+      setter((current) => {
+        const next = updater(current)
+        latestSettingsObjects.current = {
+          ...latestSettingsObjects.current,
+          [field]: next
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const currentSettingsState = useMemo(
+    () => ({
+      appPaths,
+      appNames,
+      appArgs,
+      profiles,
+      gamePaths,
+      customSlots,
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      focusActiveTitle,
+      launchDelayMs,
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      autoCheckUpdates,
+      zoomFactor
+    }),
+    [
+      appPaths,
+      appNames,
+      appArgs,
+      profiles,
+      gamePaths,
+      customSlots,
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      focusActiveTitle,
+      launchDelayMs,
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      autoCheckUpdates,
+      zoomFactor
+    ]
+  )
+
+  return {
+    state: {
+      loading,
+      appPaths,
+      appNames,
+      appArgs,
+      profiles,
+      gamePaths,
+      customSlots,
+      accentPreset,
+      accentCustom,
+      accentBgTint,
+      themeMode,
+      focusActiveTitle,
+      launchDelayMs,
+      startWithWindows,
+      startMinimized,
+      minimizeToTray,
+      autoCheckUpdates,
+      zoomFactor,
+      isCustomColor,
+      appIcons,
+      gameIcons,
+      iconLoadErrors
+    },
+    setters: {
+      setLoading,
+      setAppPaths,
+      setAppNames,
+      setAppArgs,
+      setProfiles,
+      setGamePaths,
+      setCustomSlots,
+      setAccentPreset,
+      setAccentCustom,
+      setAccentBgTint,
+      setThemeMode,
+      setFocusActiveTitle,
+      setLaunchDelayMs,
+      setStartWithWindows,
+      setStartMinimized,
+      setMinimizeToTray,
+      setAutoCheckUpdates,
+      setZoomFactor,
+      setIsCustomColor,
+      setAppIcons,
+      setGameIcons,
+      setIconLoadErrors
+    },
+    updateSettingsObject,
+    settingsObjectEditVersions,
+    latestSettingsObjects,
+    currentSettingsState
+  }
+}


### PR DESCRIPTION
## Summary

Extracts the state-management bundle out of `SettingsContext.tsx` into a new `useSettingsState` hook, per the revised plan in issue #340 (after the post-critique comment).

**What moved into `useSettingsState`:**
- All `useState` declarations
- `settingsObjectEditVersions` and `latestSettingsObjects` refs
- `updateSettingsObject` callback
- `currentSettingsState` memo (17-key shape, byte-identical)

**What stays in the `SettingsProvider` shell:**
- `useTheme`, `useNotify`
- All 12 handlers (no `useSettingsHandlers` hook — dropped per critique)
- `useDirtyTracking`, `useSettingsLoad`, `useCustomSlots`, `useConfigIO`, `useSettingsSave` wiring
- 5 inline `useMemo` for context values (no `useSettingsContextValues` hook — dropped per critique)
- `onDirtyChange` effect, pending-minimize-to-tray effect
- Nested provider JSX

## Critical invariants preserved

- `currentSettingsState` keeps the same 17 keys in the same order, with the same memo dep list
- `latestSettingsObjects` and `settingsObjectEditVersions` are returned as the *same* `MutableRefObject` instances (not recreated)
- `SettingsProvider` public signature is unchanged
- `useSettingsLoad` consumes ~18 individual setters — they are spread back at the call site from the hook's `setters` bundle, so no behavior change

## Line counts

- `SettingsContext.tsx`: 496 → 467 lines (shell, mostly handler / context-value glue)
- `useSettingsState.ts`: 243 lines (new)

The shell ended up larger than the ~280-line target because retaining all handlers and context-value memos in the shell (per the critique) keeps the file's responsibilities cohesive instead of fragmenting them across more hooks.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `npx eslint` on changed files passes
- [x] `npm test` — all 140 tests pass across 16 files
- [x] `npm run build` succeeds

Refs #340

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>