### PR TITLE
refactor: add normalizePathForComparison + pathsEqual utilities (refs #362 PR A)

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -20,8 +20,56 @@ export function isValidExePath(p: unknown): p is string {
   return trimmedPath.length > 0 && /\.exe$/i.test(trimmedPath) && fs.existsSync(resolvedPath)
 }
 
-export function getExeName(filePath: string) {
+export function getExeName(filePath: unknown): string {
+  if (typeof filePath !== 'string') {
+    return ''
+  }
+
+  const trimmed = filePath.trim()
+  if (trimmed.length === 0) {
+    return ''
+  }
+
   return path.basename(filePath).toLowerCase()
+}
+
+/**
+ * Canonical form for path comparison: trim, resolve to absolute, lowercase.
+ * Returns "" for invalid input (non-string, empty, whitespace-only).
+ *
+ * Stored exe paths in this app are validated via isValidExePath (which calls
+ * fs.existsSync(path.resolve(...))), so they are de-facto absolute by the time
+ * they reach comparison sites. path.resolve() here normalizes drive letter
+ * case and slashes consistently; the .toLowerCase() then yields a canonical
+ * key safe to use in Maps/Sets and equality checks.
+ */
+export function normalizePathForComparison(p: unknown): string {
+  if (typeof p !== 'string') {
+    return ''
+  }
+
+  const trimmed = p.trim()
+  if (trimmed.length === 0) {
+    return ''
+  }
+
+  return path.resolve(trimmed).toLowerCase()
+}
+
+/**
+ * Convenience for "are these two paths the same file" — both inputs are
+ * normalized via normalizePathForComparison and compared. Returns false
+ * for any invalid input pair (empty results don't match each other).
+ */
+export function pathsEqual(a: unknown, b: unknown): boolean {
+  const normalizedA = normalizePathForComparison(a)
+  const normalizedB = normalizePathForComparison(b)
+
+  if (normalizedA.length === 0 || normalizedB.length === 0) {
+    return false
+  }
+
+  return normalizedA === normalizedB
 }
 
 export function wait(ms: number) {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -30,18 +30,27 @@ export function getExeName(filePath: unknown): string {
     return ''
   }
 
-  return path.basename(filePath).toLowerCase()
+  // Use win32 basename explicitly: SimLauncher targets Windows exclusively, but
+  // CI/tests run on Linux where the platform-native path module treats
+  // backslashes as literal characters. Forcing win32 keeps the result
+  // consistent across host OSes.
+  return path.win32.basename(filePath).toLowerCase()
 }
 
 /**
- * Canonical form for path comparison: trim, resolve to absolute, lowercase.
- * Returns "" for invalid input (non-string, empty, whitespace-only).
+ * Canonical form for path comparison: trim, resolve to absolute (using win32
+ * semantics), lowercase. Returns "" for invalid input (non-string, empty,
+ * whitespace-only).
+ *
+ * SimLauncher targets Windows exclusively, but CI/tests run on Linux where
+ * the platform-native `path` module treats backslashes as literal characters
+ * and would not canonicalise e.g. `C:\Apps\foo.exe` and `c:/apps/FOO.EXE` to
+ * the same string. Forcing `path.win32` ensures host-independent canonical
+ * keys safe to use in Maps/Sets and equality checks.
  *
  * Stored exe paths in this app are validated via isValidExePath (which calls
  * fs.existsSync(path.resolve(...))), so they are de-facto absolute by the time
- * they reach comparison sites. path.resolve() here normalizes drive letter
- * case and slashes consistently; the .toLowerCase() then yields a canonical
- * key safe to use in Maps/Sets and equality checks.
+ * they reach comparison sites.
  */
 export function normalizePathForComparison(p: unknown): string {
   if (typeof p !== 'string') {
@@ -53,7 +62,7 @@ export function normalizePathForComparison(p: unknown): string {
     return ''
   }
 
-  return path.resolve(trimmed).toLowerCase()
+  return path.win32.resolve(trimmed).toLowerCase()
 }
 
 /**

--- a/tests/main/utils.test.ts
+++ b/tests/main/utils.test.ts
@@ -18,7 +18,7 @@ describe('normalizePathForComparison', () => {
 
   test('produces a consistent canonical form for an absolute path', () => {
     const normalized = normalizePathForComparison('C:\\Apps\\foo.exe')
-    expect(normalized).toBe(path.resolve('C:\\Apps\\foo.exe').toLowerCase())
+    expect(normalized).toBe(path.win32.resolve('C:\\Apps\\foo.exe').toLowerCase())
     expect(normalized).toMatch(/foo\.exe$/)
   })
 
@@ -36,7 +36,7 @@ describe('normalizePathForComparison', () => {
 
   test('resolves mixed separators and parent segments', () => {
     const normalized = normalizePathForComparison('C:\\A\\..\\B\\x.exe')
-    expect(normalized).toBe(path.resolve('C:\\B\\x.exe').toLowerCase())
+    expect(normalized).toBe(path.win32.resolve('C:\\B\\x.exe').toLowerCase())
     expect(normalized).toMatch(/[\\/]b[\\/]x\.exe$/)
   })
 })

--- a/tests/main/utils.test.ts
+++ b/tests/main/utils.test.ts
@@ -1,0 +1,83 @@
+import path from 'path'
+import { describe, expect, test } from 'vitest'
+
+import { getExeName, normalizePathForComparison, pathsEqual } from '../../src/main/utils'
+
+describe('normalizePathForComparison', () => {
+  test('returns "" for non-string inputs', () => {
+    expect(normalizePathForComparison(undefined)).toBe('')
+    expect(normalizePathForComparison(null)).toBe('')
+    expect(normalizePathForComparison(42)).toBe('')
+    expect(normalizePathForComparison({})).toBe('')
+  })
+
+  test('returns "" for empty or whitespace-only strings', () => {
+    expect(normalizePathForComparison('')).toBe('')
+    expect(normalizePathForComparison('   ')).toBe('')
+  })
+
+  test('produces a consistent canonical form for an absolute path', () => {
+    const normalized = normalizePathForComparison('C:\\Apps\\foo.exe')
+    expect(normalized).toBe(path.resolve('C:\\Apps\\foo.exe').toLowerCase())
+    expect(normalized).toMatch(/foo\.exe$/)
+  })
+
+  test('case and slash variants normalize to the same canonical form', () => {
+    const a = normalizePathForComparison('C:\\Apps\\foo.exe')
+    const b = normalizePathForComparison('c:/apps/FOO.EXE')
+    expect(a).toBe(b)
+  })
+
+  test('trims surrounding whitespace before normalizing', () => {
+    const padded = normalizePathForComparison('  C:\\foo.exe  ')
+    const plain = normalizePathForComparison('C:\\foo.exe')
+    expect(padded).toBe(plain)
+  })
+
+  test('resolves mixed separators and parent segments', () => {
+    const normalized = normalizePathForComparison('C:\\A\\..\\B\\x.exe')
+    expect(normalized).toBe(path.resolve('C:\\B\\x.exe').toLowerCase())
+    expect(normalized).toMatch(/[\\/]b[\\/]x\.exe$/)
+  })
+})
+
+describe('pathsEqual', () => {
+  test('returns true for two equivalent paths in different shapes', () => {
+    expect(pathsEqual('C:\\Apps\\foo.exe', 'c:/apps/FOO.EXE')).toBe(true)
+  })
+
+  test('returns false for two different paths', () => {
+    expect(pathsEqual('C:\\Apps\\foo.exe', 'C:\\Apps\\bar.exe')).toBe(false)
+  })
+
+  test('returns false when one input is invalid', () => {
+    expect(pathsEqual('C:\\Apps\\foo.exe', undefined)).toBe(false)
+    expect(pathsEqual(null, 'C:\\Apps\\foo.exe')).toBe(false)
+    expect(pathsEqual('C:\\Apps\\foo.exe', '')).toBe(false)
+    expect(pathsEqual('   ', 'C:\\Apps\\foo.exe')).toBe(false)
+  })
+
+  test('returns false when both inputs are invalid (empty does not equal empty)', () => {
+    expect(pathsEqual('', '')).toBe(false)
+    expect(pathsEqual(undefined, null)).toBe(false)
+    expect(pathsEqual('   ', '')).toBe(false)
+  })
+})
+
+describe('getExeName (relaxed input)', () => {
+  test('returns "" for non-string inputs', () => {
+    expect(getExeName(undefined)).toBe('')
+    expect(getExeName(null)).toBe('')
+    expect(getExeName(42)).toBe('')
+    expect(getExeName({})).toBe('')
+  })
+
+  test('returns "" for empty or whitespace-only strings', () => {
+    expect(getExeName('')).toBe('')
+    expect(getExeName('   ')).toBe('')
+  })
+
+  test('preserves current happy-path behaviour', () => {
+    expect(getExeName('C:\\Apps\\Foo.exe')).toBe('foo.exe')
+  })
+})


### PR DESCRIPTION
## Summary

PR A of 3 for the unified path normalization strategy (#362). Adds two new exports from `src/main/utils.ts` plus relaxes the existing `getExeName` signature to accept `unknown`. **No callers are migrated in this PR** - that's PR B (atomic Maps/Sets sites) and PR C (remaining callers + #329 renderer dedupe).

### Changes

- New: `normalizePathForComparison(p: unknown): string` - trim, `path.resolve`, lowercase. Returns `""` for invalid input.
- New: `pathsEqual(a: unknown, b: unknown): boolean` - normalizes both, returns `false` for any invalid/empty input pair.
- Relaxed: `getExeName(filePath: unknown): string` - now returns `""` for non-string/empty/whitespace input. Happy-path behaviour preserved byte-identical for existing callers (all call sites already pass strings).

### Why

Several sites across main and renderer normalize exe paths inconsistently (mix of `.toLowerCase()`, `path.basename`, `path.resolve`, sometimes none). Centralizing the canonical form here unblocks atomic migrations in PR B (Maps/Sets keyed on paths) and PR C (remaining ad-hoc comparisons + #329 renderer dedupe).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `npx eslint` on changed files passes
- [x] `npm test` - 17 files / 153 tests pass (13 new tests in `tests/main/utils.test.ts`)
- [x] `npm run build` succeeds
- [x] No existing callers modified - `git diff --stat` shows only `src/main/utils.ts` + new `tests/main/utils.test.ts`

Refs #362