### PR TITLE
refactor: migrate process-tracking Maps/Sets to normalizePathForComparison (refs #362 PR B)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -8,7 +8,13 @@ import {
   isUtilityEnabled
 } from '../profiles'
 import { getStoredStringRecord } from '../store'
-import { getErrorMessage, getExeName, isValidExePath } from '../utils'
+import {
+  getErrorMessage,
+  getExeName,
+  isValidExePath,
+  normalizePathForComparison,
+  pathsEqual
+} from '../utils'
 
 import {
   processNameMismatchWarnings,
@@ -306,10 +312,6 @@ export function pruneUnclosedProcesses(processNames: Set<string>) {
   })
 }
 
-function normalizePathForComparison(appPath: string) {
-  return path.resolve(appPath.trim()).toLowerCase()
-}
-
 function getStoredAppPathTargets() {
   const storedAppPaths = getStoredStringRecord('appPaths')
 
@@ -407,12 +409,13 @@ async function finalizeKillAttempts(
     }
 
     clearUnclosedProcess(attempt.gameKey, attempt.appPath, attempt.processName)
-    runningProcesses.forEach((_appProcess, runningPath) => {
+    const attemptKey = attempt.appPath ? normalizePathForComparison(attempt.appPath) : ''
+    runningProcesses.forEach((appProcess, runningKey) => {
       if (
-        (attempt.appPath && runningPath.toLowerCase() === attempt.appPath.toLowerCase()) ||
-        getExeName(runningPath) === attempt.processName
+        (attemptKey && runningKey === attemptKey) ||
+        getExeName(appProcess.path) === attempt.processName
       ) {
-        runningProcesses.delete(runningPath)
+        runningProcesses.delete(runningKey)
       }
     })
   })
@@ -498,12 +501,12 @@ export async function killLaunchedApps(gameKey?: string) {
   const companionTargets = getProfileCompanionTargets(gameKey)
   const killTasks: Promise<KillAttemptResult>[] = []
 
-  runningProcesses.forEach(({ process: child }, appPath) => {
-    const appProcess = runningProcesses.get(appPath)
-    if (gameKey && appProcess?.gameKey !== gameKey) {
+  runningProcesses.forEach((appProcess, runningKey) => {
+    const { process: child, path: appPath } = appProcess
+    if (gameKey && appProcess.gameKey !== gameKey) {
       return
     }
-    if (appProcess?.isGame) {
+    if (appProcess.isGame) {
       return
     }
 
@@ -512,9 +515,9 @@ export async function killLaunchedApps(gameKey?: string) {
 
     if (processNames.has(processName)) {
       suppressProcessNameMismatchWarning(appPath)
-      killTasks.push(killProcessTree(child, appPath, appProcess?.gameKey))
+      killTasks.push(killProcessTree(child, appPath, appProcess.gameKey))
     } else {
-      runningProcesses.delete(appPath)
+      runningProcesses.delete(runningKey)
     }
   })
 
@@ -532,7 +535,7 @@ export async function killLaunchedApps(gameKey?: string) {
 export async function killProfileApps(gameKey: string, appPathsToKill: string[]) {
   const { processNames } = await readRunningProcessNames()
   const gamePaths = getStoredStringRecord('gamePaths')
-  const gamePath = gamePaths?.[gameKey]?.toLowerCase()
+  const gamePath = gamePaths?.[gameKey]
   const storedAppPathTargets = getStoredAppPathTargets()
   const validAppPathsToKill: string[] = []
   const killTasks: Promise<KillAttemptResult>[] = []
@@ -556,22 +559,16 @@ export async function killProfileApps(gameKey: string, appPathsToKill: string[])
   }
 
   validAppPathsToKill.forEach((appPath) => {
-    if (gamePath && appPath.toLowerCase() === gamePath) {
+    if (gamePath && pathsEqual(appPath, gamePath)) {
       return
     }
     if (!processNames.has(getExeName(appPath))) {
       return
     }
 
-    const runningAppEntry = Array.from(runningProcesses.entries()).find(
-      ([runningPath, runningApp]) =>
-        runningPath.toLowerCase() === appPath.toLowerCase() &&
-        runningApp.gameKey === gameKey &&
-        !runningApp.isGame
-    )
+    const runningApp = runningProcesses.get(normalizePathForComparison(appPath))
 
-    if (runningAppEntry) {
-      const [, runningApp] = runningAppEntry
+    if (runningApp && runningApp.gameKey === gameKey && !runningApp.isGame) {
       suppressProcessNameMismatchWarning(appPath)
       killTasks.push(killProcessTree(runningApp.process, appPath, runningApp.gameKey))
       killedExeNames.add(getExeName(appPath))
@@ -580,7 +577,7 @@ export async function killProfileApps(gameKey: string, appPathsToKill: string[])
   })
 
   validAppPathsToKill.forEach((appPath) => {
-    if (gamePath && appPath.toLowerCase() === gamePath) {
+    if (gamePath && pathsEqual(appPath, gamePath)) {
       return
     }
 

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -8,7 +8,7 @@ import {
   getStoredProfiles
 } from '../profiles'
 import { getStoredStringRecord } from '../store'
-import { getExeName, isValidExePath } from '../utils'
+import { getExeName, isValidExePath, normalizePathForComparison } from '../utils'
 
 import { pruneUnclosedProcesses } from './kill'
 import {
@@ -115,7 +115,7 @@ async function getTrackedRunningApps(
 
     pathsToTrack.forEach((trackedPath) => {
       const processName = getExeName(trackedPath)
-      const dedupeKey = `${gameKey}:${trackedPath.toLowerCase()}`
+      const dedupeKey = `${gameKey}:${normalizePathForComparison(trackedPath)}`
 
       if (processNames.has(processName) && !seen.has(dedupeKey)) {
         trackedApps.push({
@@ -143,8 +143,8 @@ export async function getRunningApps(): Promise<RunningApp[]> {
   }
   pruneExpiredProcessNameMismatchWarnings()
 
-  const launchedApps = Array.from(runningProcesses.entries()).map(([appPath, appProcess]) => ({
-    path: appPath,
+  const launchedApps = Array.from(runningProcesses.values()).map((appProcess) => ({
+    path: appProcess.path,
     name: appProcess.name,
     gameKey: appProcess.gameKey,
     tracked: false
@@ -170,14 +170,16 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       warning: entry.warning
     }))
   const warningKeys = new Set(
-    mismatchWarnings.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+    mismatchWarnings.map(
+      (appProcess) => `${appProcess.gameKey}:${normalizePathForComparison(appProcess.path)}`
+    )
   )
   const launchedKeys = new Set(
-    surfacedApps.map((appProcess) => `${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+    surfacedApps.map(
+      (appProcess) => `${appProcess.gameKey}:${normalizePathForComparison(appProcess.path)}`
+    )
   )
-  const launchedExeNames = new Set(
-    surfacedApps.map((appProcess) => path.basename(appProcess.path).toLowerCase())
-  )
+  const launchedExeNames = new Set(surfacedApps.map((appProcess) => getExeName(appProcess.path)))
   const profiles = getStoredProfiles()
   const appPaths = getStoredStringRecord('appPaths')
   const gamePaths = getStoredStringRecord('gamePaths')
@@ -201,17 +203,19 @@ export async function getRunningApps(): Promise<RunningApp[]> {
     )
   ).filter(
     (appProcess) =>
-      !launchedKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`) &&
-      !launchedExeNames.has(path.basename(appProcess.path).toLowerCase())
+      !launchedKeys.has(`${appProcess.gameKey}:${normalizePathForComparison(appProcess.path)}`) &&
+      !launchedExeNames.has(getExeName(appProcess.path))
   )
 
   return [
     ...surfacedApps,
     ...mismatchWarnings.filter(
-      (appProcess) => !launchedKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+      (appProcess) =>
+        !launchedKeys.has(`${appProcess.gameKey}:${normalizePathForComparison(appProcess.path)}`)
     ),
     ...trackedApps.filter(
-      (appProcess) => !warningKeys.has(`${appProcess.gameKey}:${appProcess.path.toLowerCase()}`)
+      (appProcess) =>
+        !warningKeys.has(`${appProcess.gameKey}:${normalizePathForComparison(appProcess.path)}`)
     )
   ]
 }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -4,7 +4,15 @@ import fs from 'fs'
 import path from 'path'
 
 import { getStoredStringRecord, store } from '../store'
-import { getErrorCode, getErrorMessage, getExeName, isValidExePath, wait } from '../utils'
+import {
+  getErrorCode,
+  getErrorMessage,
+  getExeName,
+  isValidExePath,
+  normalizePathForComparison,
+  pathsEqual,
+  wait
+} from '../utils'
 
 import {
   consumeProcessNameMismatchWarningSuppression,
@@ -40,7 +48,7 @@ export async function launchProfileApps(
   activeLaunches.add(gameKey)
   const launchDelayMs = getLaunchDelayMs()
   const gamePaths = getStoredStringRecord('gamePaths')
-  const gamePath = gamePaths?.[gameKey]?.toLowerCase()
+  const gamePath = gamePaths?.[gameKey]
   const { processNames } = await readRunningProcessNames()
   const normalizedEntries = profileApps.map((input) => normalizeLaunchInput(input, gameKey))
   const validApps = normalizedEntries.filter((entry) => {
@@ -199,10 +207,7 @@ function getAppArgs(appKey: string) {
 
 function resolveAppKeyFromPath(appPath: string): string | undefined {
   const appPaths = getStoredStringRecord('appPaths')
-  const normalizedAppPath = appPath.trim().toLowerCase()
-  const appEntry = Object.entries(appPaths).find(
-    ([, value]) => value.trim().toLowerCase() === normalizedAppPath
-  )
+  const appEntry = Object.entries(appPaths).find(([, value]) => pathsEqual(value, appPath))
   return appEntry?.[0]
 }
 
@@ -213,10 +218,7 @@ function normalizeLaunchInput(input: ProfileLaunchInput, gameKey: string): Profi
 
   const gamePaths = getStoredStringRecord('gamePaths')
   const matchingGamePath = gamePaths?.[gameKey]
-  if (
-    typeof matchingGamePath === 'string' &&
-    matchingGamePath.trim().toLowerCase() === input.trim().toLowerCase()
-  ) {
+  if (typeof matchingGamePath === 'string' && pathsEqual(matchingGamePath, input)) {
     return { key: gameKey, path: input }
   }
 
@@ -319,11 +321,13 @@ function spawnDetachedApp(
     try {
       const args = getAppArgs(appKey)
       const child = spawn(appPath, args, { detached: true, stdio: 'ignore' })
-      runningProcesses.set(appPath, {
+      const runningKey = normalizePathForComparison(appPath)
+      runningProcesses.set(runningKey, {
         process: child,
+        path: appPath,
         name: path.basename(appPath),
         gameKey,
-        isGame: !!gamePath && appPath.toLowerCase() === gamePath
+        isGame: !!gamePath && pathsEqual(appPath, gamePath)
       })
 
       child.once('spawn', () => {
@@ -336,7 +340,7 @@ function spawnDetachedApp(
       })
 
       child.once('error', async (err) => {
-        runningProcesses.delete(appPath)
+        runningProcesses.delete(runningKey)
         if (fallbackTimer) {
           clearTimeout(fallbackTimer)
         }
@@ -357,16 +361,16 @@ function spawnDetachedApp(
       })
 
       child.once('exit', () => {
-        const processEntry = runningProcesses.get(appPath)
+        const processEntry = runningProcesses.get(runningKey)
         const wasGame = processEntry?.isGame ?? false
-        runningProcesses.delete(appPath)
+        runningProcesses.delete(runningKey)
         const exitedDuringPostLaunchWindow = Date.now() - launchStartedAt <= POST_LAUNCH_BLOCK_MS
         const wasClosedBySimLauncher = consumeProcessNameMismatchWarningSuppression(appPath)
 
         if (exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
           const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add that executable to this slot under tracked processes. Right-click the icon to dismiss this warning.`
 
-          processNameMismatchWarnings.set(appPath.toLowerCase(), {
+          processNameMismatchWarnings.set(normalizePathForComparison(appPath), {
             path: appPath,
             name: path.basename(appPath),
             gameKey,

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -1,4 +1,6 @@
-import { getExeName } from '../utils'
+import path from 'path'
+
+import { getExeName, normalizePathForComparison } from '../utils'
 
 import type {
   ProcessNameMismatchWarningEntry,
@@ -12,20 +14,20 @@ export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWa
 export const suppressedProcessNameMismatchWarnings = new Set<string>()
 
 export function suppressProcessNameMismatchWarning(appPath: string) {
-  suppressedProcessNameMismatchWarnings.add(appPath.toLowerCase())
+  suppressedProcessNameMismatchWarnings.add(normalizePathForComparison(appPath))
 }
 
 export function consumeProcessNameMismatchWarningSuppression(appPath: string) {
-  const key = appPath.toLowerCase()
+  const key = normalizePathForComparison(appPath)
   const suppressed = suppressedProcessNameMismatchWarnings.has(key)
   suppressedProcessNameMismatchWarnings.delete(key)
   return suppressed
 }
 
 export function pruneStoppedRunningProcesses(processNames: Set<string>) {
-  runningProcesses.forEach((_appProcess, appPath) => {
-    if (!processNames.has(getExeName(appPath))) {
-      runningProcesses.delete(appPath)
+  runningProcesses.forEach((appProcess, key) => {
+    if (!processNames.has(getExeName(appProcess.path))) {
+      runningProcesses.delete(key)
     }
   })
 }
@@ -43,11 +45,20 @@ export function getUnclosedProcessKey(
   appPath: string,
   processName: string
 ) {
-  return `${gameKey || 'unknown'}:${(appPath || processName).toLowerCase()}`
+  // Callers occasionally pass a bare process name (e.g. "foo.exe") as the
+  // appPath fallback. Bare names lack drive/separator info, so resolving them
+  // via normalizePathForComparison would pin the key to the launcher's cwd —
+  // not what we want. Detect the bare-name case and lowercase it directly;
+  // otherwise canonicalise the full path the same way every other Maps/Sets
+  // site does.
+  const fallback = appPath || processName
+  const isBareName = path.win32.basename(fallback) === fallback
+  const pathPart = isBareName ? fallback.toLowerCase() : normalizePathForComparison(fallback)
+  return `${gameKey || 'unknown'}:${pathPart}`
 }
 
 export function dismissAppIcon(appPath: string, gameKey?: string) {
-  const normalizedPath = appPath.toLowerCase()
+  const normalizedPath = normalizePathForComparison(appPath)
   processNameMismatchWarnings.delete(normalizedPath)
   unclosedProcesses.delete(getUnclosedProcessKey(gameKey, appPath, getExeName(appPath)))
 }

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -49,6 +49,7 @@ export type ProfileLaunchInput = string | ProfileLaunchEntry
 
 export interface RunningProcessEntry {
   process: ChildProcess
+  path: string
   name: string
   gameKey: string
   isGame: boolean

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -636,6 +636,47 @@ test('process mismatch warnings persist until manually dismissed (#360)', async 
   dateNow.mockRestore()
 })
 
+// Regression for PR B of #362: the wrapper-mismatch warning is written using
+// the launched (mixed-case, forward-slash) path, and dismissAppIcon is later
+// called with a differently-cased / different-separator string from the
+// renderer. Both sites must canonicalise via normalizePathForComparison so the
+// delete finds the entry — pre-migration this silently failed because writes
+// used `appPath.toLowerCase()` while reads built a key the same way only when
+// the casing happened to line up.
+test('dismissAppIcon clears a wrapper warning regardless of casing or separators (#362)', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  // Launched path uses forward slashes + mixed case.
+  markExistingPath('C:/Program Files/Cheat Engine/Cheat Engine.exe')
+  const { dismissAppIcon, launchProfileApps, processNameMismatchWarnings } =
+    await loadProcessModules()
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', [
+    'C:/Program Files/Cheat Engine/Cheat Engine.exe'
+  ])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  processNames.delete('cheat engine.exe')
+  childHandlers.get('exit')?.()
+  expect(processNameMismatchWarnings.size).toBe(1)
+
+  // Dismiss with backslash separators and a different casing — the renderer
+  // can hand us any form of the same path.
+  dismissAppIcon('c:\\Program Files\\CHEAT ENGINE\\Cheat Engine.exe', 'ac')
+  expect(processNameMismatchWarnings.size).toBe(0)
+})
+
 test('wrapper exit warning tells the user tracking is lost and how to fix it (#402)', async () => {
   const childHandlers = new Map<string, (...args: unknown[]) => void>()
   const child = {
@@ -1004,7 +1045,7 @@ test('launchProfileApps reports synchronous spawn failures without tracking the 
     launchedCount: 0,
     failedCount: 1
   })
-  expect(runningProcesses.has('C:/Tools/Broken.exe')).toBe(false)
+  expect(runningProcesses.has('c:\\tools\\broken.exe')).toBe(false)
 })
 
 test('launchProfileApps emits late launch errors to the renderer after initial spawn success', async () => {
@@ -1266,8 +1307,9 @@ test('killLaunchedApps keeps elevated access-denied app unclosed when path reche
   processNames.add('simhub.exe')
   accessDeniedPids.add('1234')
   inaccessibleExecutablePathProcesses.add('simhub.exe')
-  runningProcesses.set('C:/Tools/SimHub.exe', {
+  runningProcesses.set('c:\\tools\\simhub.exe', {
     process: { pid: 1234 } as never,
+    path: 'C:/Tools/SimHub.exe',
     name: 'SimHub.exe',
     gameKey: 'ac',
     isGame: false
@@ -1280,7 +1322,7 @@ test('killLaunchedApps keeps elevated access-denied app unclosed when path reche
     failures: [expect.objectContaining({ appPath: 'C:/Tools/SimHub.exe', reason: 'access_denied' })]
   })
 
-  expect(unclosedProcesses.get('ac:c:/tools/simhub.exe')).toMatchObject({
+  expect(unclosedProcesses.get('ac:c:\\tools\\simhub.exe')).toMatchObject({
     path: 'C:/Tools/SimHub.exe',
     gameKey: 'ac',
     reason: 'access_denied',
@@ -1321,12 +1363,12 @@ test('killLaunchedApps marks not-found full-path app as elevated when image stil
     failures: [expect.objectContaining({ appPath: 'C:/Tools/SimHub.exe', reason: 'access_denied' })]
   })
 
-  expect(unclosedProcesses.get('ac:c:/tools/simhub.exe')).toMatchObject({
+  expect(unclosedProcesses.get('ac:c:\\tools\\simhub.exe')).toMatchObject({
     path: 'C:/Tools/SimHub.exe',
     reason: 'access_denied',
     elevated: true
   })
-  expect(runningProcesses.has('C:/Tools/SimHub.exe')).toBe(false)
+  expect(runningProcesses.has('c:\\tools\\simhub.exe')).toBe(false)
 })
 
 test('killLaunchedApps treats not-found full-path app as closed when image no longer exists', async () => {
@@ -1353,7 +1395,7 @@ test('killLaunchedApps treats not-found full-path app as closed when image no lo
     failures: []
   })
 
-  expect(unclosedProcesses.has('ac:c:/tools/simhub.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
 })
 
 test('killLaunchedApps treats stale taskkill PID responses as closed', async () => {
@@ -1383,7 +1425,7 @@ test('killLaunchedApps treats stale taskkill PID responses as closed', async () 
     failures: []
   })
   expect(result.error).toBeUndefined()
-  expect(unclosedProcesses.has('ac:c:/tools/simhub.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
   expect(execFileCalls).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ command: 'taskkill', args: ['/PID', '4321', '/T', '/F'] })
@@ -1412,7 +1454,7 @@ test('killLaunchedApps keeps stale taskkill attempts failed when a replacement p
     failedCount: 1,
     failures: [expect.objectContaining({ appPath: 'C:/Tools/SimHub.exe', reason: 'still_running' })]
   })
-  expect(unclosedProcesses.get('ac:c:/tools/simhub.exe')).toMatchObject({
+  expect(unclosedProcesses.get('ac:c:\\tools\\simhub.exe')).toMatchObject({
     path: 'C:/Tools/SimHub.exe',
     reason: 'still_running'
   })
@@ -1478,7 +1520,7 @@ test('killLaunchedApps registers elevated utility companion when image-name fall
 
 test('pruneUnclosedProcesses removes stale entries and keeps running entries', async () => {
   const { pruneUnclosedProcesses, unclosedProcesses } = await loadProcessModules()
-  unclosedProcesses.set('ac:c:/tools/stale.exe', {
+  unclosedProcesses.set('ac:c:\\tools\\stale.exe', {
     path: 'C:/Tools/Stale.exe',
     name: 'Stale.exe',
     gameKey: 'ac',
@@ -1486,7 +1528,7 @@ test('pruneUnclosedProcesses removes stale entries and keeps running entries', a
     reason: 'still_running',
     elevated: false
   })
-  unclosedProcesses.set('ac:c:/tools/simhub.exe', {
+  unclosedProcesses.set('ac:c:\\tools\\simhub.exe', {
     path: 'C:/Tools/SimHub.exe',
     name: 'SimHub.exe',
     gameKey: 'ac',
@@ -1497,8 +1539,8 @@ test('pruneUnclosedProcesses removes stale entries and keeps running entries', a
 
   pruneUnclosedProcesses(new Set(['simhub.exe']))
 
-  expect(unclosedProcesses.has('ac:c:/tools/stale.exe')).toBe(false)
-  expect(unclosedProcesses.get('ac:c:/tools/simhub.exe')).toMatchObject({
+  expect(unclosedProcesses.has('ac:c:\\tools\\stale.exe')).toBe(false)
+  expect(unclosedProcesses.get('ac:c:\\tools\\simhub.exe')).toMatchObject({
     path: 'C:/Tools/SimHub.exe',
     elevated: true
   })
@@ -1533,13 +1575,14 @@ test('killProfileApps clears previous unclosed and running state after successfu
     await loadProcessModulesWithStore({
       appPaths: { simhub: 'C:/Tools/SimHub.exe' }
     })
-  runningProcesses.set('C:/Tools/SimHub.exe', {
+  runningProcesses.set('c:\\tools\\simhub.exe', {
     process: { pid: 1234 } as never,
+    path: 'C:/Tools/SimHub.exe',
     name: 'SimHub.exe',
     gameKey: 'ac',
     isGame: false
   })
-  unclosedProcesses.set('ac:c:/tools/simhub.exe', {
+  unclosedProcesses.set('ac:c:\\tools\\simhub.exe', {
     path: 'C:/Tools/SimHub.exe',
     name: 'SimHub.exe',
     gameKey: 'ac',
@@ -1559,8 +1602,8 @@ test('killProfileApps clears previous unclosed and running state after successfu
       expect.objectContaining({ command: 'taskkill', args: ['/PID', '1234', '/T', '/F'] })
     ])
   )
-  expect(unclosedProcesses.has('ac:c:/tools/simhub.exe')).toBe(false)
-  expect(runningProcesses.has('C:/Tools/SimHub.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
+  expect(runningProcesses.has('c:\\tools\\simhub.exe')).toBe(false)
 })
 
 test('killProfileApps suppresses wrapper warnings for SimLauncher-initiated profile switch closes', async () => {
@@ -1780,14 +1823,16 @@ test('killLaunchedApps skips entries flagged as isGame (#343)', async () => {
     appPaths: { simhub: 'C:/Tools/SimHub.exe' }
   })
 
-  runningProcesses.set('C:/Games/AssettoCorsa.exe', {
+  runningProcesses.set('c:\\games\\assettocorsa.exe', {
     process: { pid: 9999 } as never,
+    path: 'C:/Games/AssettoCorsa.exe',
     name: 'AssettoCorsa.exe',
     gameKey: 'ac',
     isGame: true
   })
-  runningProcesses.set('C:/Tools/SimHub.exe', {
+  runningProcesses.set('c:\\tools\\simhub.exe', {
     process: { pid: 4321 } as never,
+    path: 'C:/Tools/SimHub.exe',
     name: 'SimHub.exe',
     gameKey: 'ac',
     isGame: false
@@ -1860,8 +1905,9 @@ test('killLaunchedApps should skip game processes during kill (#350)', async () 
     },
     gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
   })
-  runningProcesses.set('C:/Games/AssettoCorsa.exe', {
+  runningProcesses.set('c:\\games\\assettocorsa.exe', {
     process: { pid: 9999 } as never,
+    path: 'C:/Games/AssettoCorsa.exe',
     name: 'AssettoCorsa.exe',
     gameKey: 'ac',
     isGame: true
@@ -1991,7 +2037,7 @@ test('finalize keeps stale-only attempts closed when image is gone (staleTask pr
     failedCount: 0,
     failures: []
   })
-  expect(unclosedProcesses.has('ac:c:/tools/simhub.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
 })
 
 test('killLaunchedApps non-full-path utility companion with replacement is reported unclosed (#326, #345)', async () => {
@@ -2053,7 +2099,7 @@ test('WMI returning 0 PIDs after taskkill is treated as closed (genuine exit) (#
     failedCount: 0,
     failures: []
   })
-  expect(unclosedProcesses.has('ac:c:/tools/simhub.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
   // Critically: no taskkill /PID call should have run for this companion -
   // the WMI lookup returned 0 PIDs so the elevated/exited branch was taken.
   expect(execFileCalls).not.toEqual(
@@ -2106,7 +2152,7 @@ test('pruneUnclosedProcesses removes entries whose image is no longer active (#3
   // names, it should be removed so it does not surface in getRunningApps.
   const { pruneUnclosedProcesses, unclosedProcesses } = await loadProcessModules()
 
-  unclosedProcesses.set('ac:c:/tools/active.exe', {
+  unclosedProcesses.set('ac:c:\\tools\\active.exe', {
     path: 'C:/Tools/Active.exe',
     name: 'Active.exe',
     gameKey: 'ac',
@@ -2114,7 +2160,7 @@ test('pruneUnclosedProcesses removes entries whose image is no longer active (#3
     reason: 'access_denied',
     elevated: true
   })
-  unclosedProcesses.set('ac:c:/tools/inactive.exe', {
+  unclosedProcesses.set('ac:c:\\tools\\inactive.exe', {
     path: 'C:/Tools/Inactive.exe',
     name: 'Inactive.exe',
     gameKey: 'ac',
@@ -2122,7 +2168,7 @@ test('pruneUnclosedProcesses removes entries whose image is no longer active (#3
     reason: 'still_running',
     elevated: false
   })
-  unclosedProcesses.set('ac:c:/tools/also-inactive.exe', {
+  unclosedProcesses.set('ac:c:\\tools\\also-inactive.exe', {
     path: 'C:/Tools/Also-Inactive.exe',
     name: 'Also-Inactive.exe',
     gameKey: 'ac',
@@ -2133,9 +2179,9 @@ test('pruneUnclosedProcesses removes entries whose image is no longer active (#3
 
   pruneUnclosedProcesses(new Set(['active.exe']))
 
-  expect(unclosedProcesses.has('ac:c:/tools/active.exe')).toBe(true)
-  expect(unclosedProcesses.has('ac:c:/tools/inactive.exe')).toBe(false)
-  expect(unclosedProcesses.has('ac:c:/tools/also-inactive.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\active.exe')).toBe(true)
+  expect(unclosedProcesses.has('ac:c:\\tools\\inactive.exe')).toBe(false)
+  expect(unclosedProcesses.has('ac:c:\\tools\\also-inactive.exe')).toBe(false)
 })
 
 test('kill is reported successful when the launched exe is gone from tasklist even if taskkill complained (#390)', async () => {
@@ -2176,7 +2222,9 @@ test('kill is reported successful when the launched exe is gone from tasklist ev
     failures: []
   })
   expect(
-    unclosedProcesses.has('ac:c:/users/test/appdata/local/programs/perplexity/perplexity.exe')
+    unclosedProcesses.has(
+      'ac:c:\\users\\test\\appdata\\local\\programs\\perplexity\\perplexity.exe'
+    )
   ).toBe(false)
 })
 
@@ -2222,5 +2270,5 @@ test('kill is NOT reported successful when taskkill failed and the post-kill tas
   })
   // The unclosed-process entry must be registered so the UI surfaces the
   // failure rather than silently clearing it.
-  expect(unclosedProcesses.has('ac:c:/tools/access-denied-app.exe')).toBe(true)
+  expect(unclosedProcesses.has('ac:c:\\tools\\access-denied-app.exe')).toBe(true)
 })


### PR DESCRIPTION
## Summary

PR B of 3 for the unified path normalization strategy (#362). Atomic migration of the read/write/delete sites for path-keyed Maps/Sets in `src/main/processes/{state,running,spawn,kill}.ts` — replaces the ad-hoc `appPath.toLowerCase()` canonicalisation with the win32-safe `normalizePathForComparison` utility from PR A (#411).

- `dismissAppIcon` and `suppressProcessNameMismatchWarning` now look up entries using the same canonical key the writers use, eliminating the silent-failure surface the critique flagged.
- `runningProcesses`, `processNameMismatchWarnings`, `suppressedProcessNameMismatchWarnings`, and `unclosedProcesses` all keyed via `normalizePathForComparison` (or a compound `${gameKey}:${normalizePathForComparison(path)}` for `unclosedProcesses`).
- `RunningProcessEntry` gained a `path: string` field so consumers (e.g. `getRunningApps`) can surface the original-cased path while the Map keys stay canonical.
- Path-equality comparisons in `spawn.ts` (gamePath check, store-lookup helpers) and `kill.ts` (game-vs-companion skip, running-app lookup) moved from `s.toLowerCase() === t.toLowerCase()` to `pathsEqual(s, t)` so the canonicalisation is host-independent.
- `kill.ts`'s local copy of `normalizePathForComparison` removed in favour of the shared utility.

Two `.toLowerCase()` calls intentionally remain:
- `state.ts:56` — bare process-name fallback in `getUnclosedProcessKey` (the value isn't a file path; resolving via `path.win32.resolve` would pin it to cwd). Commented with rationale.
- `kill.ts:472` — utility companion `processName` (e.g. `'Garage61 telemetry agent.exe'`) used as a Map key; same exe-name canonicalisation as `getExeName`.

PR C will follow with the remaining callers (`ipc/launch.ts`, `store.ts`, `profiles.ts`, `icons.ts`) plus the renderer dedupe for #329.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `eslint` on changed files clean
- [x] `npm test` — 154 passed (added 1 regression test below)
- [x] `npm run build` passes
- [x] Added regression test `dismissAppIcon clears a wrapper warning regardless of casing or separators (#362)` — writes the wrapper warning via launch (forward-slash mixed-case path) and dismisses with backslash + UPPERCASE — proves the migration's write/read symmetry.

Refs #362