### PR TITLE
refactor: explicit return types on exported functions and hooks

### DIFF
--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -2,26 +2,26 @@ let isQuitting = false
 let rendererDirty = false
 let pendingMinimizeToTray: boolean | null = null
 
-export function getIsQuitting() {
+export function getIsQuitting(): boolean {
   return isQuitting
 }
 
-export function setIsQuitting(value = true) {
+export function setIsQuitting(value = true): void {
   isQuitting = value
 }
 
-export function getRendererDirty() {
+export function getRendererDirty(): boolean {
   return rendererDirty
 }
 
-export function setRendererDirty(value: boolean) {
+export function setRendererDirty(value: boolean): void {
   rendererDirty = value
 }
 
-export function getPendingMinimizeToTray() {
+export function getPendingMinimizeToTray(): boolean | null {
   return pendingMinimizeToTray
 }
 
-export function setPendingMinimizeToTray(value: boolean | null) {
+export function setPendingMinimizeToTray(value: boolean | null): void {
   pendingMinimizeToTray = value
 }

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -280,7 +280,7 @@ function getSanitizedProfileRecord(profiles: unknown) {
   return Object.keys(safeProfiles).length > 0 ? safeProfiles : undefined
 }
 
-export function registerConfigHandlers() {
+export function registerConfigHandlers(): void {
   ipcMain.handle('export-config', async () => {
     try {
       const options = {

--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -30,7 +30,7 @@ export function buildDismissLabel(
   return displayName ? `${action} for ${displayName}` : action
 }
 
-export function registerContextMenuHandlers() {
+export function registerContextMenuHandlers(): void {
   ipcMain.handle(
     'show-app-context-menu',
     (event, appPath: string, gameKey: string, options?: ShowAppContextMenuOptions) => {

--- a/src/main/ipc/icons.ts
+++ b/src/main/ipc/icons.ts
@@ -20,7 +20,7 @@ const recentlyBrowsedPaths = new Set<string>()
  * Paths are stored canonicalised so case/slash variants of the same file
  * collapse to one entry (see `normalizePathForComparison`).
  */
-export function markRecentlyBrowsedPath(filePath: string) {
+export function markRecentlyBrowsedPath(filePath: string): void {
   if (typeof filePath !== 'string' || !filePath) return
   const key = normalizePathForComparison(filePath)
   if (!key) return
@@ -91,7 +91,7 @@ function getGenericIconFingerprint() {
   return genericIconFingerprintPromise
 }
 
-export function registerIconHandlers() {
+export function registerIconHandlers(): void {
   ipcMain.handle('get-asset-data', async (_event, filename: unknown) => {
     if (typeof filename !== 'string' || path.basename(filename) !== filename || !filename)
       return null

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -5,7 +5,7 @@ import { registerContextMenuHandlers } from './context-menu'
 import { registerIconHandlers } from './icons'
 import { registerLaunchHandlers } from './launch'
 
-export function registerHandlers() {
+export function registerHandlers(): void {
   registerConfigHandlers()
   registerLaunchHandlers()
   registerIconHandlers()

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -24,11 +24,11 @@ import { getExeName, normalizePathForComparison, pathsEqual } from '../utils'
  * the slots may carry different `appArgs`, so a slot move must still trigger
  * a stop + relaunch with the new args.
  */
-export function getProfileLaunchEntryId(entry: ProfileLaunchEntry) {
+export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
   return `${entry.key} ${normalizePathForComparison(entry.path)}`
 }
 
-export function validateGameKey(gameKey: unknown) {
+export function validateGameKey(gameKey: unknown): { success: false; error: string } | undefined {
   if (typeof gameKey !== 'string') {
     return { success: false, error: 'Invalid argument' }
   }
@@ -40,7 +40,9 @@ export function validateGameKey(gameKey: unknown) {
   return undefined
 }
 
-export function validateProfileIds(...profileIds: unknown[]) {
+export function validateProfileIds(
+  ...profileIds: unknown[]
+): { success: false; error: string } | undefined {
   if (profileIds.some((profileId) => typeof profileId !== 'string')) {
     return { success: false, error: 'Invalid argument' }
   }
@@ -48,7 +50,7 @@ export function validateProfileIds(...profileIds: unknown[]) {
   return undefined
 }
 
-export function registerLaunchHandlers() {
+export function registerLaunchHandlers(): void {
   ipcMain.handle('launch-profile', async (event, gameKey: string) => {
     const validationError = validateGameKey(gameKey)
     if (validationError) {

--- a/src/main/migrator.ts
+++ b/src/main/migrator.ts
@@ -144,7 +144,7 @@ function normalizeStoredProfileSet(profileEntry: StoredProfileEntry, utilityKeys
   }
 }
 
-export function migrateProfilesToNamedSets() {
+export function migrateProfilesToNamedSets(): void {
   if (store.get('profileSetsMigrated') === true) {
     return
   }

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -274,7 +274,9 @@ async function publishRunningAppsInternal(
   return payload
 }
 
-export function publishRunningApps(reason: RunningAppsChangeReason = 'scan') {
+export function publishRunningApps(
+  reason: RunningAppsChangeReason = 'scan'
+): Promise<RunningAppsChangedPayload | null> {
   const next = (publishRunningAppsPromise || Promise.resolve(null))
     .catch(() => null)
     .then(() => publishRunningAppsInternal(reason))
@@ -300,7 +302,9 @@ function startRunningAppsMonitor() {
   }, RUNNING_APPS_SCAN_INTERVAL_MS)
 }
 
-export async function subscribeRunningApps(webContents: WebContents) {
+export async function subscribeRunningApps(
+  webContents: WebContents
+): Promise<RunningAppsChangedPayload> {
   runningAppsSubscribers.add(webContents)
   webContents.once('destroyed', () => removeRunningAppsSubscriber(webContents))
   startRunningAppsMonitor()
@@ -310,6 +314,6 @@ export async function subscribeRunningApps(webContents: WebContents) {
   return { apps, reason: 'initial', updatedAt: Date.now() } satisfies RunningAppsChangedPayload
 }
 
-export function unsubscribeRunningApps(webContents: WebContents) {
+export function unsubscribeRunningApps(webContents: WebContents): void {
   removeRunningAppsSubscriber(webContents)
 }

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -13,18 +13,18 @@ export const unclosedProcesses = new Map<string, UnclosedProcessEntry>()
 export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWarningEntry>()
 export const suppressedProcessNameMismatchWarnings = new Set<string>()
 
-export function suppressProcessNameMismatchWarning(appPath: string) {
+export function suppressProcessNameMismatchWarning(appPath: string): void {
   suppressedProcessNameMismatchWarnings.add(normalizePathForComparison(appPath))
 }
 
-export function consumeProcessNameMismatchWarningSuppression(appPath: string) {
+export function consumeProcessNameMismatchWarningSuppression(appPath: string): boolean {
   const key = normalizePathForComparison(appPath)
   const suppressed = suppressedProcessNameMismatchWarnings.has(key)
   suppressedProcessNameMismatchWarnings.delete(key)
   return suppressed
 }
 
-export function pruneStoppedRunningProcesses(processNames: Set<string>) {
+export function pruneStoppedRunningProcesses(processNames: Set<string>): void {
   runningProcesses.forEach((appProcess, key) => {
     if (!processNames.has(getExeName(appProcess.path))) {
       runningProcesses.delete(key)
@@ -32,7 +32,7 @@ export function pruneStoppedRunningProcesses(processNames: Set<string>) {
   })
 }
 
-export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()) {
+export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()): void {
   processNameMismatchWarnings.forEach((entry, key) => {
     if (entry.expiresAt !== undefined && entry.expiresAt <= now) {
       processNameMismatchWarnings.delete(key)
@@ -44,7 +44,7 @@ export function getUnclosedProcessKey(
   gameKey: string | undefined,
   appPath: string,
   processName: string
-) {
+): string {
   // Callers occasionally pass a bare process name (e.g. "foo.exe") as the
   // appPath fallback. Bare names lack drive/separator info, so resolving them
   // via normalizePathForComparison would pin the key to the launcher's cwd —
@@ -57,7 +57,7 @@ export function getUnclosedProcessKey(
   return `${gameKey || 'unknown'}:${pathPart}`
 }
 
-export function dismissAppIcon(appPath: string, gameKey?: string) {
+export function dismissAppIcon(appPath: string, gameKey?: string): void {
   const normalizedPath = normalizePathForComparison(appPath)
   processNameMismatchWarnings.delete(normalizedPath)
   unclosedProcesses.delete(getUnclosedProcessKey(gameKey, appPath, getExeName(appPath)))

--- a/src/main/processes/tasklist.ts
+++ b/src/main/processes/tasklist.ts
@@ -59,7 +59,7 @@ export function readRunningProcessNames(): Promise<RunningProcessNamesResult> {
   return inflight
 }
 
-export function invalidateProcessNameCache() {
+export function invalidateProcessNameCache(): void {
   cachedResult = undefined
   cachedAt = 0
 }

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -50,7 +50,7 @@ export function isStoredProfileSet(value: unknown): value is StoredProfileSet {
   return typeof value.activeProfileId === 'string' && Array.isArray(value.profiles)
 }
 
-export function getStoredProfiles() {
+export function getStoredProfiles(): Record<string, StoredProfileEntry> {
   const value = store.get('profiles')
 
   if (!isRecord(value)) {
@@ -181,7 +181,7 @@ export function buildNamedProfileLaunchPaths(gameKey: string, profileId: string)
   return buildNamedProfileLaunchEntries(gameKey, profileId).map((entry) => entry.path)
 }
 
-export function getUtilityKeys(customSlots: unknown) {
+export function getUtilityKeys(customSlots: unknown): string[] {
   const slotCount =
     typeof customSlots === 'number' && Number.isFinite(customSlots)
       ? Math.max(1, Math.floor(customSlots))
@@ -193,7 +193,7 @@ export function getUtilityKeys(customSlots: unknown) {
   ]
 }
 
-export function getEnabledUtilityKeys(profile: StoredProfile | undefined) {
+export function getEnabledUtilityKeys(profile: StoredProfile | undefined): string[] {
   if (!profile) {
     return []
   }
@@ -209,7 +209,7 @@ export function getEnabledUtilityKeys(profile: StoredProfile | undefined) {
     .map(([key]) => key)
 }
 
-export function isUtilityEnabled(profile: StoredProfile | undefined, utilityKey: string) {
+export function isUtilityEnabled(profile: StoredProfile | undefined, utilityKey: string): boolean {
   if (!profile) {
     return false
   }
@@ -223,7 +223,9 @@ export function isUtilityEnabled(profile: StoredProfile | undefined, utilityKey:
   return profile[utilityKey] === true
 }
 
-export function getActiveStoredProfile(profileEntry: StoredProfileEntry | undefined) {
+export function getActiveStoredProfile(
+  profileEntry: StoredProfileEntry | undefined
+): StoredProfile | StoredNamedProfile | undefined {
   if (!profileEntry) {
     return undefined
   }
@@ -243,7 +245,7 @@ export function getProfileTrackablePaths(
   profile: StoredProfile | undefined,
   appPaths: Record<string, string> | undefined,
   gamePaths: Record<string, string> | undefined
-) {
+): string[] {
   const trackablePaths = [
     gamePaths?.[gameKey],
     ...getEnabledUtilityKeys(profile)

--- a/src/main/security.ts
+++ b/src/main/security.ts
@@ -24,7 +24,7 @@ const DEV_CSP = [
 // time (see electron.vite.config.ts). This header injection covers the dev
 // renderer served from Vite's HTTP server, where it also provides
 // frame-ancestors enforcement that the meta tag cannot.
-export function registerContentSecurityPolicy() {
+export function registerContentSecurityPolicy(): void {
   if (app.isPackaged) {
     return
   }

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -135,7 +135,7 @@ export function isWindowBounds(value: unknown): value is WindowBounds {
   })
 }
 
-export function requireSafeZoomFactor(value: unknown) {
+export function requireSafeZoomFactor(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     throw new Error(
       `Zoom factor must be a finite number from ${MIN_ZOOM_FACTOR} to ${MAX_ZOOM_FACTOR}.`
@@ -153,7 +153,7 @@ function getSafeZoomFactor(value: unknown) {
   return clamp(value, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR)
 }
 
-export function getStoredZoomFactor() {
+export function getStoredZoomFactor(): number {
   const storedZoomFactor = store.get('zoomFactor')
   const safeZoomFactor = getSafeZoomFactor(storedZoomFactor)
 
@@ -164,12 +164,12 @@ export function getStoredZoomFactor() {
   return safeZoomFactor
 }
 
-export function getStoredBoolean(key: string, fallback = false) {
+export function getStoredBoolean(key: string, fallback = false): boolean {
   const value = store.get(key)
   return typeof value === 'boolean' ? value : fallback
 }
 
-export function getStoredStringRecord(key: string) {
+export function getStoredStringRecord(key: string): Record<string, string> {
   const value = store.get(key)
 
   if (!isRecord(value)) {
@@ -458,7 +458,7 @@ function sanitizeProfiles(value: unknown, utilityKeys: Set<string>) {
   return safeProfiles
 }
 
-export function sanitizeImportedConfig(value: unknown) {
+export function sanitizeImportedConfig(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) {
     throw new Error('Config file must contain a JSON object.')
   }
@@ -482,7 +482,7 @@ export function sanitizeImportedConfig(value: unknown) {
   return getSupportedConfigValues(value)
 }
 
-export function getSupportedConfigValues(config: Record<string, unknown>) {
+export function getSupportedConfigValues(config: Record<string, unknown>): Record<string, unknown> {
   const supportedConfig: Record<string, unknown> = {}
   const customSlots = getSafeCustomSlots(config.customSlots)
   const utilityKeys = getUtilityKeySet(customSlots ?? 1)
@@ -598,7 +598,7 @@ export function getSupportedConfigValues(config: Record<string, unknown>) {
   return supportedConfig
 }
 
-export function sanitizeSettingsPatch(patch: Record<string, unknown>) {
+export function sanitizeSettingsPatch(patch: Record<string, unknown>): Record<string, unknown> {
   const currentCustomSlots = getSafeCustomSlots(store.get('customSlots'))
   const patchCustomSlots = getSafeCustomSlots(patch.customSlots)
   const config: Record<string, unknown> = {

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -8,7 +8,7 @@ interface CreateTrayOptions {
   quitApp: () => void
 }
 
-export function createTray({ getIconPath, showMainWindow, quitApp }: CreateTrayOptions) {
+export function createTray({ getIconPath, showMainWindow, quitApp }: CreateTrayOptions): void {
   if (tray) {
     return
   }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -13,7 +13,7 @@ let availableUpdate: UpdateAvailability | null = null
 
 autoUpdater.autoDownload = false
 
-export function registerUpdaterEvents(rendererSender: SendToRenderer) {
+export function registerUpdaterEvents(rendererSender: SendToRenderer): void {
   sendToRenderer = rendererSender
 
   autoUpdater.on('update-available', (info) => {
@@ -53,7 +53,9 @@ function quitAndInstallUpdate() {
   autoUpdater.quitAndInstall()
 }
 
-export async function checkForUpdates() {
+export async function checkForUpdates(): Promise<Awaited<
+  ReturnType<typeof autoUpdater.checkForUpdates>
+> | null> {
   if (!app.isPackaged) {
     availableUpdate = { version: '99.0.0' }
     sendToRenderer('update-available', availableUpdate)
@@ -63,11 +65,11 @@ export async function checkForUpdates() {
   return await autoUpdater.checkForUpdates()
 }
 
-export function getAvailableUpdate() {
+export function getAvailableUpdate(): UpdateAvailability | null {
   return availableUpdate
 }
 
-export function registerUpdaterHandlers(rendererSender: SendToRenderer) {
+export function registerUpdaterHandlers(rendererSender: SendToRenderer): void {
   sendToRenderer = rendererSender
 
   ipcMain.handle('install-update', async () => {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-export function clamp(value: number, min: number, max: number) {
+export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
 
@@ -81,15 +81,15 @@ export function pathsEqual(a: unknown, b: unknown): boolean {
   return normalizedA === normalizedB
 }
 
-export function wait(ms: number) {
+export function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export function getErrorMessage(err: unknown) {
+export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-export function getErrorCode(err: unknown) {
+export function getErrorCode(err: unknown): string | undefined {
   return err && typeof err === 'object' && 'code' in err
     ? String((err as { code?: unknown }).code)
     : undefined

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -37,11 +37,11 @@ function getInitialWindowBounds() {
   }
 }
 
-export function getMainWindow() {
+export function getMainWindow(): BrowserWindow | null {
   return mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
 }
 
-export function sendToRenderer(channel: string, payload: unknown) {
+export function sendToRenderer(channel: string, payload: unknown): void {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return
   }
@@ -49,7 +49,7 @@ export function sendToRenderer(channel: string, payload: unknown) {
   mainWindow.webContents.send(channel, payload)
 }
 
-export function getAppIconPath() {
+export function getAppIconPath(): string {
   return app.isPackaged
     ? path.join(process.resourcesPath, 'SimLauncher.ico')
     : path.join(app.getAppPath(), 'SimLauncher.ico')
@@ -79,7 +79,7 @@ function getLocalDevRendererUrl() {
   return parsedUrl.toString()
 }
 
-export function showMainWindow() {
+export function showMainWindow(): void {
   if (!mainWindow || mainWindow.isDestroyed()) {
     createWindow()
     return
@@ -93,7 +93,7 @@ export function showMainWindow() {
   mainWindow.focus()
 }
 
-export function createWindow() {
+export function createWindow(): void {
   const zoomFactor = getStoredZoomFactor()
   const windowBounds = getInitialWindowBounds()
 
@@ -187,14 +187,14 @@ export function createWindow() {
   }
 }
 
-export function applyRuntimeConfigSettings() {
+export function applyRuntimeConfigSettings(): void {
   const startWithWindows = getStoredBoolean('startWithWindows')
   app.setLoginItemSettings({ openAtLogin: startWithWindows })
 
   mainWindow?.webContents.setZoomFactor(getStoredZoomFactor())
 }
 
-export function registerWindowHandlers() {
+export function registerWindowHandlers(): void {
   /**
    * Opens a file dialog to select an executable file and sends the path back.
    * @param inputId The ID of the input field in the Renderer to update.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { NotifyProvider, useNotify } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
@@ -18,7 +18,7 @@ import { useTheme } from './contexts/ThemeContext'
 import { SettingsProvider } from './components/settings/SettingsContext'
 import { AppDirtyProvider, useAppDirty } from './contexts/AppDirtyContext'
 
-export default function App() {
+export default function App(): ReactNode {
   return (
     <NotifyProvider>
       <AppDirtyProvider>

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -1,4 +1,11 @@
-import { useLayoutEffect, useRef, useState, type CSSProperties, type RefObject } from 'react'
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type RefObject
+} from 'react'
 import { createPortal } from 'react-dom'
 import { HexColorPicker } from 'react-colorful'
 
@@ -19,7 +26,7 @@ export function ColorPickerPopover({
   onChange,
   onClose,
   anchorRef
-}: ColorPickerPopoverProps) {
+}: ColorPickerPopoverProps): ReactNode {
   const popoverRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<CSSProperties | null>(null)
 

--- a/src/renderer/src/components/ConfirmDialog.tsx
+++ b/src/renderer/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
 interface ConfirmDialogProps {
@@ -27,7 +27,7 @@ export function ConfirmDialog({
   cancelLabel = 'Cancel',
   saveClassName = 'accent-action',
   discardClassName = 'danger-action'
-}: ConfirmDialogProps) {
+}: ConfirmDialogProps): ReactNode {
   useEffect(() => {
     if (!isOpen) return
 

--- a/src/renderer/src/components/EmptyState.tsx
+++ b/src/renderer/src/components/EmptyState.tsx
@@ -10,7 +10,7 @@ interface EmptyStateProps {
   }
 }
 
-export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+export function EmptyState({ icon, title, description, action }: EmptyStateProps): ReactNode {
   return (
     <div className="relative flex flex-col items-center justify-center py-20 px-8 text-center">
       <div className="relative glass-surface-elevated animate-fade-slide max-w-md w-full rounded-3xl p-10 flex flex-col items-center gap-6 shadow-2xl">

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { GAMES, type Game } from '../lib/config'
 import { getSettings } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
@@ -11,7 +11,11 @@ import { GamepadIcon } from './icons'
 
 const normalizePath = (path: string) => path.toLowerCase()
 
-export function GameList({ onNavigate }: { onNavigate: (view: 'games' | 'settings') => void }) {
+export function GameList({
+  onNavigate
+}: {
+  onNavigate: (view: 'games' | 'settings') => void
+}): ReactNode {
   const [configuredGames, setConfiguredGames] = useState<Game[]>([])
   const [settingsLoaded, setSettingsLoaded] = useState(false)
   const [activeEditorKey, setActiveEditorKey] = useState<string | null>(null)

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -126,7 +126,7 @@ function ToastCard({
   )
 }
 
-export function NotifyProvider({ children }: { children: ReactNode }) {
+export function NotifyProvider({ children }: { children: ReactNode }): ReactNode {
   const [toasts, setToasts] = useState<Toast[]>([])
   const [dismissingToastIds, setDismissingToastIds] = useState<Set<number>>(() => new Set())
   const dismissTimersRef = useRef<Map<number, number>>(new Map())
@@ -218,7 +218,7 @@ export function NotifyProvider({ children }: { children: ReactNode }) {
   )
 }
 
-export function useNotify() {
+export function useNotify(): NotifyContextValue {
   const context = useContext(NotifyContext)
 
   if (!context) {

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ProfileBehaviorSection } from './profile-editor/ProfileBehaviorSection'
 import { ProfileEditorActions } from './profile-editor/ProfileEditorActions'
@@ -9,7 +9,7 @@ import { StickySaveBar } from './StickySaveBar'
 import { useAppDirty } from '../contexts/AppDirtyContext'
 import { useProfileEditor, type ProfileEditorProps } from '../hooks/useProfileEditor'
 
-export function ProfileEditor(props: ProfileEditorProps) {
+export function ProfileEditor(props: ProfileEditorProps): ReactNode {
   const editor = useProfileEditor(props)
   const { reportProfileEditorDirty, registerSaveHandler, registerDiscardHandler } = useAppDirty()
   const scopeId = `${props.gameKey}:${props.activeProfileId}`

--- a/src/renderer/src/components/ScrollFade.tsx
+++ b/src/renderer/src/components/ScrollFade.tsx
@@ -5,7 +5,7 @@ interface ScrollFadeProps {
   className?: string
 }
 
-export function ScrollFade({ children, className = '' }: ScrollFadeProps) {
+export function ScrollFade({ children, className = '' }: ScrollFadeProps): ReactNode {
   const scrollAreaRef = useRef<HTMLDivElement>(null)
   const [fade, setFade] = useState({ top: false, bottom: false })
 

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useNotify } from './Notify'
 import { AboutSection } from './settings/AboutSection'
 import { AppearanceSection } from './settings/AppearanceSection'
@@ -19,7 +19,7 @@ export function SettingsView({
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
-}) {
+}): ReactNode {
   return <SettingsViewContent onClose={onClose} updateInfo={updateInfo} />
 }
 

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -27,7 +27,7 @@ export function StickySaveBar({
   onSecondary,
   ariaLabel,
   extra
-}: StickySaveBarProps) {
+}: StickySaveBarProps): ReactNode {
   if (!isDirty) {
     return null
   }

--- a/src/renderer/src/components/Toggle.tsx
+++ b/src/renderer/src/components/Toggle.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 
 interface ToggleProps {
   checked: boolean
@@ -7,7 +7,7 @@ interface ToggleProps {
   'aria-label'?: string
 }
 
-export function Toggle({ checked, onChange, id, 'aria-label': ariaLabel }: ToggleProps) {
+export function Toggle({ checked, onChange, id, 'aria-label': ariaLabel }: ToggleProps): ReactNode {
   return (
     <label className="relative inline-flex items-center cursor-pointer no-drag">
       <input

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { minimize, maximize, close } from '../lib/electron'
 import { PlayMarkIcon, SettingsIcon, MinimizeIcon, MaximizeIcon, CloseWindowIcon } from './icons'
 
@@ -8,7 +8,7 @@ interface WindowControlsProps {
   updateInfo: { version: string } | null
 }
 
-export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsProps) {
+export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsProps): ReactNode {
   const [isMaximized, setIsMaximized] = useState(false)
 
   const handleMinimize = () => minimize()

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import type { Game } from '../../lib/config'
 
 interface GameIconProps {
@@ -7,7 +7,7 @@ interface GameIconProps {
   iconUrl?: string
 }
 
-export function GameIcon({ game, isRunning, iconUrl }: GameIconProps) {
+export function GameIcon({ game, isRunning, iconUrl }: GameIconProps): ReactNode {
   const [iconLoadFailed, setIconLoadFailed] = useState(false)
 
   useEffect(() => {

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useRef, useState, type ReactNode } from 'react'
 import {
   createProfileId,
   getActiveGameProfile,
@@ -52,7 +52,7 @@ export function GameRow({
   onRunningStateRefresh: () => Promise<void>
   onToggleEditor: () => void
   cacheInitialized: boolean
-}) {
+}): ReactNode {
   const { notify } = useNotify()
   const [profileSwitchConfirm, setProfileSwitchConfirm] = useState<{
     nextProfileId: string

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { GameRowProfileMenu, type GameRowProfileMenuProps } from './GameRowProfileMenu'
 import { RefreshIcon, KillIcon, PlayMarkIcon, SettingsIcon } from '../icons'
 
@@ -25,7 +27,7 @@ export function GameRowActions({
   onRelaunchMissing,
   onToggleEditor,
   profileMenuProps
-}: GameRowActionsProps) {
+}: GameRowActionsProps): ReactNode {
   const primaryAction = canKill ? onKill : onPrimary
   const primaryButtonClass = canKill ? 'danger-action' : 'accent-surface-action'
   const primaryTitle = isLaunching && !canKill ? 'Launching' : canKill ? 'Close Apps' : 'Launch'

--- a/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, KeyboardEvent, MutableRefObject, SetStateAction } from 'react'
+import type { Dispatch, KeyboardEvent, MutableRefObject, ReactNode, SetStateAction } from 'react'
 import type { GameProfileSet, NamedGameProfile } from '../../lib/config'
 import { ChevronDownIcon, CheckIcon, PlusIcon } from '../icons'
 
@@ -40,7 +40,7 @@ export function GameRowProfileMenu({
   gameName,
   onProfileSelect,
   onNewProfileSubmit
-}: GameRowProfileMenuProps) {
+}: GameRowProfileMenuProps): ReactNode {
   return (
     <div ref={profileMenuRef} className="relative">
       <button

--- a/src/renderer/src/components/game-list/ProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/ProfileMenu.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import type { NamedGameProfile } from '../../lib/config'
 import { ChevronDownIcon, CheckIcon, PlusIcon } from '../icons'
 
@@ -42,7 +42,7 @@ export function ProfileMenu({
   onProfileSelect,
   onNewProfileNameChange,
   onNewProfileSubmit
-}: ProfileMenuProps) {
+}: ProfileMenuProps): ReactNode {
   return (
     <div ref={profileMenuRef} className="relative">
       <button

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { showAppContextMenu } from '../../lib/electron'
 
 export interface RunningAppIcon {
@@ -16,7 +16,10 @@ interface RunningAppsStripProps {
   cacheInitialized: boolean
 }
 
-export function RunningAppsStrip({ runningAppIcons, cacheInitialized }: RunningAppsStripProps) {
+export function RunningAppsStrip({
+  runningAppIcons,
+  cacheInitialized
+}: RunningAppsStripProps): ReactNode {
   const [failedRunningIcons, setFailedRunningIcons] = useState<Record<string, true>>({})
 
   if (runningAppIcons.length === 0) return null

--- a/src/renderer/src/components/icons/index.tsx
+++ b/src/renderer/src/components/icons/index.tsx
@@ -1,4 +1,4 @@
-import type { SVGProps } from 'react'
+import type { ReactNode, SVGProps } from 'react'
 
 type IconProps = SVGProps<SVGSVGElement>
 
@@ -6,7 +6,7 @@ function Icon(props: IconProps) {
   return <svg {...props} />
 }
 
-export function WarningTriangleIcon(props: IconProps) {
+export function WarningTriangleIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -26,7 +26,7 @@ export function WarningTriangleIcon(props: IconProps) {
   )
 }
 
-export function CloseIcon(props: IconProps) {
+export function CloseIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -45,7 +45,7 @@ export function CloseIcon(props: IconProps) {
   )
 }
 
-export function GamepadIcon(props: IconProps) {
+export function GamepadIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -65,7 +65,7 @@ export function GamepadIcon(props: IconProps) {
   )
 }
 
-export function SettingsIcon(props: IconProps) {
+export function SettingsIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -84,7 +84,7 @@ export function SettingsIcon(props: IconProps) {
   )
 }
 
-export function MinimizeIcon(props: IconProps) {
+export function MinimizeIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 16}
@@ -100,7 +100,7 @@ export function MinimizeIcon(props: IconProps) {
   )
 }
 
-export function MaximizeIcon(props: IconProps) {
+export function MaximizeIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 16}
@@ -118,7 +118,7 @@ export function MaximizeIcon(props: IconProps) {
   )
 }
 
-export function CloseWindowIcon(props: IconProps) {
+export function CloseWindowIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 16}
@@ -136,7 +136,7 @@ export function CloseWindowIcon(props: IconProps) {
   )
 }
 
-export function RefreshIcon(props: IconProps) {
+export function RefreshIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -155,7 +155,7 @@ export function RefreshIcon(props: IconProps) {
   )
 }
 
-export function CopyIcon(props: IconProps) {
+export function CopyIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -174,7 +174,7 @@ export function CopyIcon(props: IconProps) {
   )
 }
 
-export function ChevronDownIcon(props: IconProps) {
+export function ChevronDownIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 16}
@@ -192,7 +192,7 @@ export function ChevronDownIcon(props: IconProps) {
   )
 }
 
-export function PlusIcon(props: IconProps) {
+export function PlusIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -210,7 +210,7 @@ export function PlusIcon(props: IconProps) {
   )
 }
 
-export function CheckIcon(props: IconProps) {
+export function CheckIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -228,7 +228,7 @@ export function CheckIcon(props: IconProps) {
   )
 }
 
-export function ErrorIcon(props: IconProps) {
+export function ErrorIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -248,7 +248,7 @@ export function ErrorIcon(props: IconProps) {
   )
 }
 
-export function KillIcon(props: IconProps) {
+export function KillIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -267,7 +267,7 @@ export function KillIcon(props: IconProps) {
   )
 }
 
-export function ReloadIcon(props: IconProps) {
+export function ReloadIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}
@@ -285,7 +285,7 @@ export function ReloadIcon(props: IconProps) {
   )
 }
 
-export function PlayMarkIcon(props: IconProps) {
+export function PlayMarkIcon(props: IconProps): ReactNode {
   return (
     <Icon
       width={props.width ?? 24}

--- a/src/renderer/src/components/profile-editor/ProcessTrackingSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProcessTrackingSection.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import { ProfileToggleRow } from './ProfileToggleRow'
 
 interface ProcessTrackingSectionProps {
@@ -21,7 +21,7 @@ export function ProcessTrackingSection({
   onAddTrackedProcess,
   onBrowseTrackedProcess,
   onRemoveTrackedProcess
-}: ProcessTrackingSectionProps) {
+}: ProcessTrackingSectionProps): ReactNode {
   return (
     <div className="space-y-4 border-t border-(--glass-border) pt-4">
       <p className="text-xs font-medium uppercase tracking-wider text-(--text-muted)">

--- a/src/renderer/src/components/profile-editor/ProfileBehaviorSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileBehaviorSection.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import { ProfileToggleRow } from './ProfileToggleRow'
 
 interface ProfileBehaviorSectionProps {
@@ -13,7 +13,7 @@ export function ProfileBehaviorSection({
   trackingEnabled,
   onLaunchAutomaticallyChange,
   onTrackingEnabledChange
-}: ProfileBehaviorSectionProps) {
+}: ProfileBehaviorSectionProps): ReactNode {
   return (
     <div className="border-t border-(--glass-border) pt-4">
       <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">

--- a/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 interface ProfileEditorActionsProps {
   isDirty: boolean
   canDeleteProfile: boolean
@@ -12,7 +14,7 @@ export function ProfileEditorActions({
   onSave,
   onCloseAttempt,
   onDeleteProfile
-}: ProfileEditorActionsProps) {
+}: ProfileEditorActionsProps): ReactNode {
   return (
     <div className="flex gap-3 pt-2">
       <button

--- a/src/renderer/src/components/profile-editor/ProfileNameSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileNameSection.tsx
@@ -1,9 +1,14 @@
+import type { ReactNode } from 'react'
+
 interface ProfileNameSectionProps {
   profileName: string
   onProfileNameChange: (profileName: string) => void
 }
 
-export function ProfileNameSection({ profileName, onProfileNameChange }: ProfileNameSectionProps) {
+export function ProfileNameSection({
+  profileName,
+  onProfileNameChange
+}: ProfileNameSectionProps): ReactNode {
   return (
     <div className="space-y-2">
       <p className="text-xs font-medium uppercase tracking-wider text-(--text-muted)">

--- a/src/renderer/src/components/profile-editor/ProfileToggleRow.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileToggleRow.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { Toggle } from '../Toggle'
 
 interface ProfileToggleRowProps {
@@ -7,7 +9,12 @@ interface ProfileToggleRowProps {
   onChange: (checked: boolean) => void
 }
 
-export function ProfileToggleRow({ label, checked, onToggle, onChange }: ProfileToggleRowProps) {
+export function ProfileToggleRow({
+  label,
+  checked,
+  onToggle,
+  onChange
+}: ProfileToggleRowProps): ReactNode {
   return (
     <div
       role="switch"

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -1,4 +1,4 @@
-import type { DragEvent } from 'react'
+import type { DragEvent, ReactNode } from 'react'
 import type { ProfileUtility, Utility } from '../../lib/config'
 import { Toggle } from '../Toggle'
 
@@ -22,7 +22,7 @@ interface ProfileUtilitiesSectionProps {
   onIconFailed: (utilityKey: string) => void
 }
 
-export function ProfileUtilitiesSection(props: ProfileUtilitiesSectionProps) {
+export function ProfileUtilitiesSection(props: ProfileUtilitiesSectionProps): ReactNode {
   const { availableUtilities, enabledUtilityEntries, disabledUtilityEntries } = props
 
   return (

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { Toggle } from '../Toggle'
 import { useSettingsMeta } from './SettingsMetaContext'
 import type { UpdateInfo, UpdateStatus } from './types'
@@ -22,7 +24,7 @@ export function AboutSection({
   updateStatus,
   onManualCheck,
   onInstallUpdate
-}: AboutSectionProps) {
+}: AboutSectionProps): ReactNode {
   const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettingsMeta()
 
   return (

--- a/src/renderer/src/components/settings/AppearanceContext.tsx
+++ b/src/renderer/src/components/settings/AppearanceContext.tsx
@@ -19,7 +19,7 @@ export interface AppearanceContextValue {
 
 export const AppearanceContext = createContext<AppearanceContextValue | null>(null)
 
-export function useAppearanceSettings() {
+export function useAppearanceSettings(): AppearanceContextValue {
   const context = useContext(AppearanceContext)
 
   if (!context) {

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type CSSProperties } from 'react'
+import { useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { DEFAULT_ACCENT_COLOR } from '../../lib/config'
 import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
@@ -28,7 +28,7 @@ const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
   { label: 'System', value: 'system' }
 ]
 
-export function AppearanceSection() {
+export function AppearanceSection(): ReactNode {
   const [showPicker, setShowPicker] = useState(false)
   const customSwatchRef = useRef<HTMLButtonElement>(null)
   const {

--- a/src/renderer/src/components/settings/AppsContext.tsx
+++ b/src/renderer/src/components/settings/AppsContext.tsx
@@ -21,7 +21,7 @@ export interface AppsContextValue {
 
 export const AppsContext = createContext<AppsContextValue | null>(null)
 
-export function useAppsSettings() {
+export function useAppsSettings(): AppsContextValue {
   const context = useContext(AppsContext)
 
   if (!context) {

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { MAX_CUSTOM_SLOTS } from '../../lib/config'
 import { useAppsSettings } from './AppsContext'
 import { ChevronDownIcon } from '../icons'
@@ -21,7 +21,7 @@ function getCustomSlotNumber(key: string) {
   return Number(key.replace('customapp', ''))
 }
 
-export function AppsSection() {
+export function AppsSection(): ReactNode {
   const {
     utilities,
     appPaths,

--- a/src/renderer/src/components/settings/BehaviorContext.tsx
+++ b/src/renderer/src/components/settings/BehaviorContext.tsx
@@ -13,7 +13,7 @@ export interface BehaviorContextValue {
 
 export const BehaviorContext = createContext<BehaviorContextValue | null>(null)
 
-export function useBehaviorSettings() {
+export function useBehaviorSettings(): BehaviorContextValue {
   const context = useContext(BehaviorContext)
 
   if (!context) {

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { Toggle } from '../Toggle'
 import { useBehaviorSettings } from './BehaviorContext'
 import { normalizeLaunchDelayMs } from './settingsUtils'
@@ -8,7 +10,7 @@ const DELAY_PRESETS = [
   { label: '2s', value: 2000 }
 ]
 
-export function BehaviorSection() {
+export function BehaviorSection(): ReactNode {
   const {
     startWithWindows,
     startMinimized,

--- a/src/renderer/src/components/settings/ConfigSection.tsx
+++ b/src/renderer/src/components/settings/ConfigSection.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react'
+
 import { useSettingsMeta } from './SettingsMetaContext'
 
-export function ConfigSection() {
+export function ConfigSection(): ReactNode {
   const { exportingConfig, importingConfig, onExportConfig, onImportConfig } = useSettingsMeta()
 
   return (

--- a/src/renderer/src/components/settings/GamesContext.tsx
+++ b/src/renderer/src/components/settings/GamesContext.tsx
@@ -9,7 +9,7 @@ export interface GamesContextValue {
 
 export const GamesContext = createContext<GamesContextValue | null>(null)
 
-export function useGamesSettings() {
+export function useGamesSettings(): GamesContextValue {
   const context = useContext(GamesContext)
 
   if (!context) {

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from 'react'
+
 import { GAMES } from '../../lib/config'
 import { useGamesSettings } from './GamesContext'
 
-export function GamesSection() {
+export function GamesSection(): ReactNode {
   const { gamePaths, gameIcons, onBrowse, onGamePathChange } = useGamesSettings()
 
   return (

--- a/src/renderer/src/components/settings/ImportPreviewDialog.tsx
+++ b/src/renderer/src/components/settings/ImportPreviewDialog.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 export interface ConfigImportPreviewSummary {
   changedKeys: string[]
   gamePaths: Array<{ key: string; path?: string; args?: string }>
@@ -24,7 +26,7 @@ function PreviewSection({
   title: string
   items: Array<{ key: string; path?: string; args?: string }>
   valueKey: 'path' | 'args'
-}) {
+}): ReactNode {
   if (items.length === 0) return null
 
   return (
@@ -50,7 +52,7 @@ export function ImportPreviewDialog({
   summary,
   onImport,
   onCancel
-}: ImportPreviewDialogProps) {
+}: ImportPreviewDialogProps): ReactNode {
   if (!isOpen || !summary) return null
 
   const previewCount =

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -34,7 +34,7 @@ export function SettingsProvider({
   shouldSaveTrigger?: boolean
   onSaved?: (success: boolean) => void
   onConfigImported?: () => void
-}) {
+}): ReactNode {
   const { notify } = useNotify()
   const theme = useTheme()
   const themeRef = useRef(theme)

--- a/src/renderer/src/components/settings/SettingsMetaContext.tsx
+++ b/src/renderer/src/components/settings/SettingsMetaContext.tsx
@@ -14,7 +14,7 @@ export interface SettingsMetaContextValue {
 
 export const SettingsMetaContext = createContext<SettingsMetaContextValue | null>(null)
 
-export function useSettingsMeta() {
+export function useSettingsMeta(): SettingsMetaContextValue {
   const context = useContext(SettingsMetaContext)
 
   if (!context) {

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -7,7 +7,12 @@ interface SettingsSectionProps {
   children: ReactNode
 }
 
-export function SettingsSection({ title, open, onOpenChange, children }: SettingsSectionProps) {
+export function SettingsSection({
+  title,
+  open,
+  onOpenChange,
+  children
+}: SettingsSectionProps): ReactNode {
   return (
     <section className="space-y-4">
       <button

--- a/src/renderer/src/components/settings/customSlots.ts
+++ b/src/renderer/src/components/settings/customSlots.ts
@@ -11,7 +11,7 @@ export const shiftCustomSlotRecord = <T>(
   record: Record<string, T>,
   removedSlot: number,
   slotCount: number
-) => {
+): Record<string, T> => {
   const next = { ...record }
 
   for (let slot = removedSlot; slot <= slotCount; slot += 1) {
@@ -28,7 +28,11 @@ export const shiftCustomSlotRecord = <T>(
   return next
 }
 
-export const shiftCustomSlotSet = (values: Set<string>, removedSlot: number, slotCount: number) => {
+export const shiftCustomSlotSet = (
+  values: Set<string>,
+  removedSlot: number,
+  slotCount: number
+): Set<string> => {
   const shifted = new Set<string>()
 
   values.forEach((value) => {
@@ -87,7 +91,7 @@ export const shiftProfileCustomSlots = (
   profile: Profiles[string],
   removedSlot: number,
   slotCount: number
-) => {
+): Profiles[string] => {
   if (isGameProfileSet(profile)) {
     return {
       ...profile,

--- a/src/renderer/src/components/settings/settingsUtils.ts
+++ b/src/renderer/src/components/settings/settingsUtils.ts
@@ -1,4 +1,4 @@
-export function normalizeLaunchDelayMs(value: number) {
+export function normalizeLaunchDelayMs(value: number): number {
   if (!Number.isFinite(value)) {
     return 1000
   }

--- a/src/renderer/src/components/settings/useConfigIO.tsx
+++ b/src/renderer/src/components/settings/useConfigIO.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, type ReactNode } from 'react'
 import {
   applyImportConfig,
   cancelImportConfig,
@@ -13,7 +13,15 @@ interface UseConfigIOArgs {
   onConfigImported?: () => void
 }
 
-export function useConfigIO({ notify, onConfigImported }: UseConfigIOArgs) {
+export interface UseConfigIOResult {
+  exportingConfig: boolean
+  importingConfig: boolean
+  handleExportConfig: () => Promise<void>
+  handleImportConfig: () => Promise<void>
+  configImportDialogs: ReactNode
+}
+
+export function useConfigIO({ notify, onConfigImported }: UseConfigIOArgs): UseConfigIOResult {
   const [exportingConfig, setExportingConfig] = useState(false)
   const [importingConfig, setImportingConfig] = useState(false)
   const [importConfirmOpen, setImportConfirmOpen] = useState(false)

--- a/src/renderer/src/components/settings/useCustomSlots.tsx
+++ b/src/renderer/src/components/settings/useCustomSlots.tsx
@@ -1,8 +1,14 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
 import { getCustomUtilityKey, type Profiles } from '../../lib/config'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { shiftCustomSlotRecord, shiftCustomSlotSet, shiftProfileCustomSlots } from './customSlots'
 import type { SettingsObjectField } from './saveRace'
+
+export interface UseCustomSlotsResult {
+  handleAddCustomSlot: () => void
+  handleRemoveCustomSlot: (slotNumber: number) => void
+  customSlotRemoveDialog: ReactNode
+}
 
 interface UseCustomSlotsArgs {
   appNames: Record<string, string>
@@ -36,7 +42,7 @@ export function useCustomSlots({
   setIconLoadErrors,
   setProfiles,
   setCustomSlots
-}: UseCustomSlotsArgs) {
+}: UseCustomSlotsArgs): UseCustomSlotsResult {
   const [customSlotRemoveConfirm, setCustomSlotRemoveConfirm] = useState<{
     slotNumber: number
     slotName: string

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -71,7 +71,7 @@ export function useSettingsLoad({
   setIsCustomColor,
   setAppIcons,
   setGameIcons
-}: UseSettingsLoadArgs) {
+}: UseSettingsLoadArgs): { loadSettingsFromStore: () => Promise<void> } {
   const loadSettingsFromStore = useCallback(async () => {
     const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
     const typedProfiles = normalizeProfiles(savedProfiles)

--- a/src/renderer/src/components/settings/useSettingsSave.ts
+++ b/src/renderer/src/components/settings/useSettingsSave.ts
@@ -102,7 +102,7 @@ export function useSettingsSave({
   setLaunchDelayMs,
   shouldSaveTrigger,
   onSaved
-}: UseSettingsSaveArgs) {
+}: UseSettingsSaveArgs): { handleSave: () => Promise<boolean> } {
   const handleSave = useCallback(async (): Promise<boolean> => {
     try {
       const normalizedLaunchDelayMs = normalizeLaunchDelayMs(launchDelayMs)

--- a/src/renderer/src/components/settings/useUpdateStatus.ts
+++ b/src/renderer/src/components/settings/useUpdateStatus.ts
@@ -14,13 +14,23 @@ import type { UpdateInfo, UpdateStatus } from './types'
 
 type Notify = (message: string, type: 'success' | 'warn' | 'error', durationMs?: number) => void
 
+export interface UseUpdateStatusResult {
+  appVersion: string
+  checkingUpdate: boolean
+  installingUpdate: boolean
+  updateProgress: number | null
+  updateStatus: UpdateStatus
+  handleManualCheck: () => Promise<void>
+  handleInstallUpdate: () => Promise<void>
+}
+
 export function useUpdateStatus({
   updateInfo,
   notify
 }: {
   updateInfo: UpdateInfo
   notify: Notify
-}) {
+}): UseUpdateStatusResult {
   const [appVersion, setAppVersion] = useState<string>('')
   const [checkingUpdate, setCheckingUpdate] = useState(false)
   const [installingUpdate, setInstallingUpdate] = useState(false)

--- a/src/renderer/src/contexts/AppDirtyContext.tsx
+++ b/src/renderer/src/contexts/AppDirtyContext.tsx
@@ -36,7 +36,7 @@ export interface AppDirtyContextValue {
 
 const AppDirtyContext = createContext<AppDirtyContextValue | null>(null)
 
-export function AppDirtyProvider({ children }: { children: ReactNode }) {
+export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNode {
   const [isSettingsDirty, setIsSettingsDirty] = useState(false)
   const [profileEditorDirtyScope, setProfileEditorDirtyScope] = useState<string | null>(null)
   // Handlers live in refs (not state) so re-registering on every parent render
@@ -136,7 +136,7 @@ export function AppDirtyProvider({ children }: { children: ReactNode }) {
   return <AppDirtyContext.Provider value={value}>{children}</AppDirtyContext.Provider>
 }
 
-export function useAppDirty() {
+export function useAppDirty(): AppDirtyContextValue {
   const context = useContext(AppDirtyContext)
   if (!context) {
     throw new Error('useAppDirty must be used within AppDirtyProvider')

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -27,7 +27,7 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
-export function useTheme() {
+export function useTheme(): ThemeContextValue {
   const context = useContext(ThemeContext)
 
   if (!context) {
@@ -37,7 +37,7 @@ export function useTheme() {
   return context
 }
 
-export function ThemeProvider({ children }: { children: ReactNode }) {
+export function ThemeProvider({ children }: { children: ReactNode }): ReactNode {
   const [accentPreset, setAccentPresetState] = useState(DEFAULT_ACCENT_COLOR)
   const [accentCustom, setAccentCustomState] = useState('')
   const [accentBgTint, setAccentBgTintState] = useState(false)

--- a/src/renderer/src/hooks/useDirtyTracking.ts
+++ b/src/renderer/src/hooks/useDirtyTracking.ts
@@ -4,7 +4,15 @@ import { useEffect, useRef, useState } from 'react'
  * A simple hook to track if a state object has changed from its initial value.
  * Optimized for Settings and Profile data structures.
  */
-export function useDirtyTracking<T>(currentState: T, loading: boolean = false) {
+export interface UseDirtyTrackingResult<T> {
+  isDirty: boolean
+  resetDirty: (newState?: T) => void
+}
+
+export function useDirtyTracking<T>(
+  currentState: T,
+  loading: boolean = false
+): UseDirtyTrackingResult<T> {
   const [isDirty, setIsDirty] = useState(false)
   const initialSnapshot = useRef<string | null>(null)
 

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -41,7 +41,19 @@ const getProfileState = (profileSet: GameProfileSet): ProfileState => {
   }
 }
 
-export function useGameProfile(gameKey: string, isActive: boolean, activeProfileId?: string) {
+export interface UseGameProfileResult {
+  profileSet: GameProfileSet
+  profileState: ProfileState
+  loadProfileSet: () => Promise<GameProfileSet>
+  getProfileRuntimeConfig: () => Promise<GameProfileSet>
+  saveProfileSet: (nextProfileSet: GameProfileSet) => Promise<void>
+}
+
+export function useGameProfile(
+  gameKey: string,
+  isActive: boolean,
+  activeProfileId?: string
+): UseGameProfileResult {
   const [profileSet, setProfileSet] = useState<GameProfileSet>(() =>
     normalizeGameProfileSet(undefined)
   )

--- a/src/renderer/src/hooks/useLaunchBlock.ts
+++ b/src/renderer/src/hooks/useLaunchBlock.ts
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 
-export function useLaunchBlock() {
+export interface UseLaunchBlockResult {
+  launchingGameKey: string | null
+  handleLaunchStart: (gameKey: string) => void
+  handleLaunchEnd: (finishedGameKey: string, cooldownMs?: number) => void
+}
+
+export function useLaunchBlock(): UseLaunchBlockResult {
   const [launchingGameKey, setLaunchingGameKey] = useState<string | null>(null)
   const launchBlockTimeoutRef = useRef<number | null>(null)
 

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useState, useMemo, type DragEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+  type Dispatch,
+  type DragEvent,
+  type SetStateAction
+} from 'react'
 import { useDirtyTracking } from './useDirtyTracking'
 import {
   getActiveGameProfile,
@@ -25,6 +33,58 @@ export interface ProfileEditorProps {
   onLaunchEnd?: (cooldownMs: number) => void
 }
 
+export interface UseProfileEditorResult {
+  loading: boolean
+  appPaths: Record<string, string>
+  appNames: Record<string, string>
+  profileName: string
+  setProfileName: Dispatch<SetStateAction<string>>
+  profileCount: number
+  dragUtilityId: string | null
+  dropTarget: { id: string; placement: 'before' | 'after' } | null
+  launchAutomatically: boolean
+  setLaunchAutomatically: Dispatch<SetStateAction<boolean>>
+  trackingEnabled: boolean
+  setTrackingEnabled: Dispatch<SetStateAction<boolean>>
+  killControlsEnabled: boolean
+  setKillControlsEnabled: Dispatch<SetStateAction<boolean>>
+  relaunchControlsEnabled: boolean
+  setRelaunchControlsEnabled: Dispatch<SetStateAction<boolean>>
+  trackedProcessPaths: string[]
+  appIconCache: Record<string, string>
+  failedIcons: Record<string, boolean>
+  setFailedIcons: Dispatch<SetStateAction<Record<string, boolean>>>
+  fetchingIcons: boolean
+  showConfirm: boolean
+  setShowConfirm: Dispatch<SetStateAction<boolean>>
+  showLaunchConfirm: boolean
+  setShowLaunchConfirm: Dispatch<SetStateAction<boolean>>
+  profileDeleteConfirm: { profileId: string; profileName: string } | null
+  setProfileDeleteConfirm: Dispatch<
+    SetStateAction<{ profileId: string; profileName: string } | null>
+  >
+  setDragUtilityId: Dispatch<SetStateAction<string | null>>
+  setDropTarget: Dispatch<SetStateAction<{ id: string; placement: 'before' | 'after' } | null>>
+  isDirty: boolean
+  handleCloseAttempt: () => void
+  handleToggleUtility: (key: string) => void
+  moveEnabledUtility: (draggedId: string, targetId: string, placement: 'before' | 'after') => void
+  startUtilityDrag: (event: DragEvent<HTMLDivElement>, utilityKey: string) => void
+  handleAddTrackedProcess: () => void
+  handleBrowseTrackedProcess: (index: number) => Promise<void>
+  handleRemoveTrackedProcess: (index: number) => void
+  handleIconFailed: (utilityKey: string) => void
+  handleLaunch: () => Promise<void>
+  handleDiscardAndLaunch: () => void
+  handleSave: (shouldLaunch?: boolean) => Promise<boolean>
+  handleDeleteProfile: () => Promise<void>
+  confirmDeleteProfile: () => Promise<void>
+  utilityByKey: Map<string, Utility>
+  availableUtilities: Utility[]
+  enabledUtilityEntries: ProfileUtility[]
+  disabledUtilityEntries: ProfileUtility[]
+}
+
 export function useProfileEditor({
   gameKey,
   activeProfileId,
@@ -33,7 +93,7 @@ export function useProfileEditor({
   onLaunchRequest,
   onLaunchStart,
   onLaunchEnd
-}: ProfileEditorProps) {
+}: ProfileEditorProps): UseProfileEditorResult {
   const { notify } = useNotify()
   const {
     appPaths: settingsAppPaths,

--- a/src/renderer/src/hooks/useProfileMenu.ts
+++ b/src/renderer/src/hooks/useProfileMenu.ts
@@ -1,6 +1,32 @@
-import { type KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  type Dispatch,
+  type KeyboardEvent,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
-export function useProfileMenu() {
+export interface UseProfileMenuResult {
+  profileMenuOpen: boolean
+  setProfileMenuOpen: Dispatch<SetStateAction<boolean>>
+  openProfileMenu: (focusSelectedProfileOnOpen?: boolean) => void
+  closeProfileMenu: (returnFocusToTrigger?: boolean) => void
+  newProfileFormOpen: boolean
+  setNewProfileFormOpen: Dispatch<SetStateAction<boolean>>
+  newProfileName: string
+  setNewProfileName: Dispatch<SetStateAction<string>>
+  profileMenuRef: RefObject<HTMLDivElement | null>
+  menuRef: RefObject<HTMLDivElement | null>
+  triggerRef: RefObject<HTMLButtonElement | null>
+  handleProfileMenuTriggerKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void
+  handleProfileMenuKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void
+  newProfileInputRef: RefObject<HTMLInputElement | null>
+}
+
+export function useProfileMenu(): UseProfileMenuResult {
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [newProfileFormOpen, setNewProfileFormOpen] = useState(false)
   const [newProfileName, setNewProfileName] = useState('')

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -24,7 +24,13 @@ export interface RunningAppsChangedPayload {
   updatedAt: number
 }
 
-export function useRunningApps(configuredGames: Game[]) {
+export interface UseRunningAppsResult {
+  runningApps: RunningApp[]
+  runningStatus: Record<string, boolean>
+  refreshRunningState: (isMounted?: () => boolean) => Promise<void>
+}
+
+export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
   const [runningApps, setRunningApps] = useState<RunningApp[]>([])
   const [runningStatus, setRunningStatus] = useState<Record<string, boolean>>({})
 

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -74,7 +74,7 @@ export const BUILT_IN_UTILITIES: Utility[] = [
   { key: 'secondmonitor', name: 'Second Monitor' }
 ]
 
-export function normalizeCustomSlots(value: unknown) {
+export function normalizeCustomSlots(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return DEFAULT_CUSTOM_SLOTS
   }
@@ -82,7 +82,7 @@ export function normalizeCustomSlots(value: unknown) {
   return Math.max(1, Math.min(Math.floor(value), MAX_CUSTOM_SLOTS))
 }
 
-export function getCustomUtilityKey(index: number) {
+export function getCustomUtilityKey(index: number): string {
   return `customapp${index}`
 }
 
@@ -103,7 +103,9 @@ function getCustomSlotNumberFromKey(key: string) {
   return match ? Number(match[1]) : null
 }
 
-export function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
+export function getHighestCustomSlot(
+  ...records: Array<Record<string, unknown> | undefined>
+): number {
   let highestSlot = 0
 
   const scanRecord = (record: Record<string, unknown> | undefined) => {
@@ -151,7 +153,7 @@ export function getHighestCustomSlot(...records: Array<Record<string, unknown> |
 export function resolveCustomSlots(
   value: unknown,
   ...records: Array<Record<string, unknown> | undefined>
-) {
+): number {
   return Math.min(
     Math.max(normalizeCustomSlots(value), getHighestCustomSlot(...records)),
     MAX_CUSTOM_SLOTS
@@ -184,7 +186,10 @@ export function isProfileUtility(value: unknown): value is ProfileUtility {
   return typeof value.id === 'string' && typeof value.enabled === 'boolean'
 }
 
-export function normalizeProfileUtilities(profile: GameProfile | undefined, utilities: Utility[]) {
+export function normalizeProfileUtilities(
+  profile: GameProfile | undefined,
+  utilities: Utility[]
+): ProfileUtility[] {
   const utilityIds = new Set(utilities.map((utility) => utility.key))
   const orderedUtilities: ProfileUtility[] = []
   const seen = new Set<string>()
@@ -215,11 +220,17 @@ export function normalizeProfileUtilities(profile: GameProfile | undefined, util
   return orderedUtilities
 }
 
-export function getEnabledProfileUtilities(profile: GameProfile | undefined, utilities: Utility[]) {
+export function getEnabledProfileUtilities(
+  profile: GameProfile | undefined,
+  utilities: Utility[]
+): ProfileUtility[] {
   return normalizeProfileUtilities(profile, utilities).filter((utility) => utility.enabled)
 }
 
-export function migrateProfileToUtilityOrder(profile: GameProfile, utilities: Utility[]) {
+export function migrateProfileToUtilityOrder(
+  profile: GameProfile,
+  utilities: Utility[]
+): GameProfile {
   const migratedProfile: GameProfile = {
     ...profile,
     utilities: normalizeProfileUtilities(profile, utilities)
@@ -256,7 +267,7 @@ export function normalizeProfiles(value: unknown): Profiles {
   return profiles
 }
 
-export function createProfileId() {
+export function createProfileId(): string {
   return `profile-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
@@ -320,7 +331,7 @@ export function normalizeGameProfileSet(value: StoredGameProfile | undefined): G
   }
 }
 
-export function getActiveGameProfile(value: StoredGameProfile | undefined) {
+export function getActiveGameProfile(value: StoredGameProfile | undefined): NamedGameProfile {
   const profileSet = normalizeGameProfileSet(value)
   return (
     profileSet.profiles.find((profile) => profile.id === profileSet.activeProfileId) ||

--- a/src/renderer/src/lib/migrations.ts
+++ b/src/renderer/src/lib/migrations.ts
@@ -66,7 +66,7 @@ function getStringRecord(value: unknown) {
   )
 }
 
-export async function migrateFromLocalStorage() {
+export async function migrateFromLocalStorage(): Promise<void> {
   const flags = await getMigrationFlags()
   if (flags.migrated) return
 
@@ -124,7 +124,7 @@ export async function migrateFromLocalStorage() {
   })
 }
 
-export async function runStartupMigrations() {
+export async function runStartupMigrations(): Promise<void> {
   try {
     await migrateFromLocalStorage()
   } catch (err) {

--- a/src/renderer/src/lib/profileEditorSettingsSync.ts
+++ b/src/renderer/src/lib/profileEditorSettingsSync.ts
@@ -2,7 +2,8 @@ import {
   getUtilities,
   normalizeProfileUtilities,
   resolveCustomSlots,
-  type ProfileUtility
+  type ProfileUtility,
+  type Utility
 } from './config'
 
 export function syncProfileUtilitiesWithSettings(
@@ -10,7 +11,7 @@ export function syncProfileUtilitiesWithSettings(
   settingsCustomSlots: number,
   settingsAppPaths: Record<string, string>,
   settingsAppNames: Record<string, string>
-) {
+): { utilities: Utility[]; profileUtilities: ProfileUtility[] } {
   const resolvedUtilities = getUtilities(
     resolveCustomSlots(settingsCustomSlots, settingsAppPaths, settingsAppNames)
   )

--- a/src/renderer/src/lib/theme.ts
+++ b/src/renderer/src/lib/theme.ts
@@ -27,7 +27,7 @@ function getContrastRatio(lighterLuminance: number, darkerLuminance: number) {
   return (lighterLuminance + 0.05) / (darkerLuminance + 0.05)
 }
 
-export function getAccentForeground(hex: string) {
+export function getAccentForeground(hex: string): '#000000' | '#ffffff' {
   const accentLuminance = getRelativeLuminance(hex)
   const whiteContrast = getContrastRatio(1, accentLuminance)
   const blackContrast = getContrastRatio(accentLuminance, 0)
@@ -35,7 +35,7 @@ export function getAccentForeground(hex: string) {
   return blackContrast >= whiteContrast ? '#000000' : '#ffffff'
 }
 
-export function applyAccentTheme(hex: string) {
+export function applyAccentTheme(hex: string): void {
   const normalizedHex = hex.trim()
 
   if (!HEX_COLOR_PATTERN.test(normalizedHex)) {
@@ -61,7 +61,7 @@ export function normalizeThemeMode(value: unknown): ThemeMode {
   return value === 'light' || value === 'dark' || value === 'system' ? value : DEFAULT_THEME_MODE
 }
 
-export function applyThemeMode(mode: ThemeMode) {
+export function applyThemeMode(mode: ThemeMode): void {
   themeMediaCleanup?.()
   themeMediaCleanup = null
 


### PR DESCRIPTION
## Summary
Adds explicit return type annotations to all exported functions, hooks, and React components across `src/`. No behaviour changes — pure type-level additions.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 161/161 pass
- [x] `npm run build` — clean

Closes #338

<!-- auto-closes -->
Closes #338
<!-- auto-closes -->