### PR TITLE
fix: dirty changes take precedence over tray on window close (#424)

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -16,6 +16,45 @@ import { clamp } from './utils'
 
 let mainWindow: BrowserWindow | null = null
 
+export type CloseAction = 'quit' | 'hide' | 'confirm-close' | 'confirm-minimize'
+
+/**
+ * Decide what the window's 'close' event should do based on the three inputs
+ * that govern its behavior. Pure function so the precedence rules are easy to
+ * unit-test and review.
+ *
+ * Precedence: explicit quit > unsaved changes > tray preference. Dirty must
+ * always win over tray so the user explicitly chooses what happens to their
+ * pending edits (the previous design silently minimized to tray and left
+ * changes "preserved in memory" — invisible to the user, and lost if they
+ * later quit from the tray menu).
+ */
+export function decideCloseAction(opts: {
+  isQuitting: boolean
+  isDirty: boolean
+  effectiveMinimizeToTray: boolean
+}): CloseAction {
+  if (opts.isQuitting) {
+    return 'quit'
+  }
+  if (opts.isDirty) {
+    return opts.effectiveMinimizeToTray ? 'confirm-minimize' : 'confirm-close'
+  }
+  if (opts.effectiveMinimizeToTray) {
+    return 'hide'
+  }
+  return 'quit'
+}
+
+/**
+ * Resolve the tray preference the user *currently intends*, falling back to the
+ * persisted store value when no pending toggle is in flight.
+ */
+function getEffectiveMinimizeToTray(): boolean {
+  const pending = getPendingMinimizeToTray()
+  return pending === null ? store.get('minimizeToTray') === true : pending
+}
+
 function getInitialWindowBounds() {
   const defaultBounds = { width: 800, height: 600 }
   const savedBounds = store.get('windowBounds')
@@ -125,26 +164,25 @@ export function createWindow(): void {
 
     store.set('windowBounds', mainWindow.getBounds())
 
-    // Honour the renderer's pending tray preference (e.g. when the user toggled
-    // Minimize-to-tray but has not saved yet) so the close button respects the
-    // user's current intent rather than the last persisted value.
-    const pendingMinimizeToTray = getPendingMinimizeToTray()
-    const effectiveMinimizeToTray =
-      pendingMinimizeToTray === null ? store.get('minimizeToTray') === true : pendingMinimizeToTray
+    const action = decideCloseAction({
+      isQuitting: getIsQuitting(),
+      isDirty: getRendererDirty(),
+      effectiveMinimizeToTray: getEffectiveMinimizeToTray()
+    })
 
-    // Tray takes precedence over the dirty-changes prompt: hiding to tray
-    // keeps the renderer alive so unsaved data is preserved. The unsaved-
-    // changes confirm only matters when the close would actually quit.
-    if (!getIsQuitting() && effectiveMinimizeToTray) {
-      event.preventDefault()
-      mainWindow.hide()
+    if (action === 'quit') {
       return
     }
 
-    if (!getIsQuitting() && getRendererDirty()) {
-      event.preventDefault()
-      mainWindow.webContents.send('close-requested')
+    event.preventDefault()
+    if (action === 'hide') {
+      mainWindow.hide()
+      return
     }
+    // Confirm dialog: tell the renderer whether picking Save/Discard should
+    // minimize (tray enabled) or fully close, so dialog labels and the final
+    // action both match the user's tray preference.
+    mainWindow.webContents.send('close-requested', { minimizeMode: action === 'confirm-minimize' })
   })
 
   // Show window once ready, or keep it hidden when starting minimized to tray.
@@ -233,11 +271,7 @@ export function registerWindowHandlers(): void {
   })
 
   ipcMain.handle('window-close', () => {
-    const pendingMinimizeToTray = getPendingMinimizeToTray()
-    const effectiveMinimizeToTray =
-      pendingMinimizeToTray === null ? store.get('minimizeToTray') === true : pendingMinimizeToTray
-
-    if (!effectiveMinimizeToTray && !getRendererDirty()) {
+    if (!getEffectiveMinimizeToTray() && !getRendererDirty()) {
       setIsQuitting(true)
     }
 
@@ -260,6 +294,13 @@ export function registerWindowHandlers(): void {
     setIsQuitting(true)
     setRendererDirty(false)
     mainWindow?.close()
+  })
+
+  ipcMain.handle('force-minimize-to-tray', () => {
+    // Renderer already ran its save/discard pipeline before invoking us; the
+    // dirty state in the renderer will propagate to false on next render. Do
+    // NOT setIsQuitting — the window keeps living in the tray.
+    mainWindow?.hide()
   })
 
   ipcMain.handle('restart-app', () => {

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -151,9 +151,10 @@ export interface ElectronAPI {
   maximize: () => Promise<void>
   close: () => Promise<void>
   forceClose: () => Promise<void>
+  forceMinimizeToTray: () => Promise<void>
   setRendererDirty: (isDirty: boolean) => Promise<void>
   setPendingMinimizeToTray: (value: boolean | null) => Promise<void>
-  onCloseRequested: (cb: () => void) => Unsubscribe
+  onCloseRequested: (cb: (payload: { minimizeMode: boolean }) => void) => Unsubscribe
   restartApp: () => Promise<void>
   getRunningApps: () => Promise<RunningApp[]>
   subscribeRunningApps: () => Promise<RunningAppsChangedPayload>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,11 +33,13 @@ const electronAPI: ElectronAPI = {
   maximize: () => ipcRenderer.invoke('window-maximize'),
   close: () => ipcRenderer.invoke('window-close'),
   forceClose: () => ipcRenderer.invoke('force-close-window'),
+  forceMinimizeToTray: () => ipcRenderer.invoke('force-minimize-to-tray'),
   setRendererDirty: (isDirty: boolean) => ipcRenderer.invoke('set-renderer-dirty', isDirty),
   setPendingMinimizeToTray: (value: boolean | null) =>
     ipcRenderer.invoke('set-pending-minimize-to-tray', value),
-  onCloseRequested: (cb: () => void) => {
-    const handler = () => cb()
+  onCloseRequested: (cb: (payload: { minimizeMode: boolean }) => void) => {
+    const handler = (_: unknown, payload: { minimizeMode: boolean } | undefined) =>
+      cb(payload ?? { minimizeMode: false })
     ipcRenderer.on('close-requested', handler)
     return () => ipcRenderer.removeListener('close-requested', handler)
   },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -174,6 +174,13 @@ function AppContent() {
   const handleCloseConfirmDiscard = useCallback(async () => {
     requestDiscardAll()
     reportSettingsDirty(false)
+    // Mirror the tab-switch discard: clear any pending Minimize-to-tray
+    // override and remount the SettingsProvider so a discarded tray toggle
+    // doesn't keep steering the main process on the next close. Matters most
+    // in minimize mode — the renderer stays alive in the tray, so a stale
+    // pending value would otherwise leak into the next close cycle.
+    void setPendingMinimizeToTray(null)
+    setRefreshKey((k) => k + 1)
     setCloseConfirmOpen(false)
     await (closeConfirmMinimizeMode ? forceMinimizeToTray() : forceClose())
   }, [closeConfirmMinimizeMode, reportSettingsDirty, requestDiscardAll])

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from './components/ConfirmDialog'
 import { WarningTriangleIcon, CloseIcon } from './components/icons'
 import {
   forceClose,
+  forceMinimizeToTray,
   getUpdateInfo,
   onCloseRequested,
   onUpdateAvailable,
@@ -36,6 +37,10 @@ function AppContent() {
   const [showImportWarning, setShowImportWarning] = useState(false)
   const [pendingView, setPendingView] = useState<'games' | 'settings' | null>(null)
   const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
+  // When true, the close dialog's actions minimize to tray instead of fully
+  // quitting. Set from the `close-requested` payload so the dialog labels and
+  // the terminal IPC call both match the user's current tray preference.
+  const [closeConfirmMinimizeMode, setCloseConfirmMinimizeMode] = useState(false)
   const [saveRequested, setSaveRequested] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const { isAnyDirty, reportSettingsDirty, requestSaveAll, requestDiscardAll } = useAppDirty()
@@ -49,7 +54,7 @@ function AppContent() {
   }, [isAnyDirty])
 
   useEffect(() => {
-    const unsubscribe = onCloseRequested(() => {
+    const unsubscribe = onCloseRequested(({ minimizeMode }: { minimizeMode: boolean }) => {
       // Avoid stacking the close dialog on top of the tab-switch dialog —
       // two simultaneous confirms attach independent Enter/Escape handlers
       // and a single keypress would trigger conflicting save/discard flows.
@@ -57,6 +62,7 @@ function AppContent() {
       // so let them finish it first.
       setPendingView((current) => {
         if (current === null) {
+          setCloseConfirmMinimizeMode(minimizeMode)
           setCloseConfirmOpen(true)
         }
         return current
@@ -162,15 +168,15 @@ function AppContent() {
       return
     }
     setCloseConfirmOpen(false)
-    await forceClose()
-  }, [notify, requestSaveAll])
+    await (closeConfirmMinimizeMode ? forceMinimizeToTray() : forceClose())
+  }, [closeConfirmMinimizeMode, notify, requestSaveAll])
 
   const handleCloseConfirmDiscard = useCallback(async () => {
     requestDiscardAll()
     reportSettingsDirty(false)
     setCloseConfirmOpen(false)
-    await forceClose()
-  }, [reportSettingsDirty, requestDiscardAll])
+    await (closeConfirmMinimizeMode ? forceMinimizeToTray() : forceClose())
+  }, [closeConfirmMinimizeMode, reportSettingsDirty, requestDiscardAll])
 
   const handleCloseConfirmCancel = () => {
     setCloseConfirmOpen(false)
@@ -265,9 +271,13 @@ function AppContent() {
       <ConfirmDialog
         isOpen={closeConfirmOpen}
         title="Unsaved Changes"
-        message="You have unsaved changes. Save them before closing SimLauncher?"
-        saveLabel="Save & Close"
-        discardLabel="Discard & Close"
+        message={
+          closeConfirmMinimizeMode
+            ? 'You have unsaved changes. Save them before minimizing SimLauncher to the tray?'
+            : 'You have unsaved changes. Save them before closing SimLauncher?'
+        }
+        saveLabel={closeConfirmMinimizeMode ? 'Save & Minimize' : 'Save & Close'}
+        discardLabel={closeConfirmMinimizeMode ? 'Discard & Minimize' : 'Discard & Close'}
         onSave={() => {
           void handleCloseConfirmSave()
         }}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -167,6 +167,10 @@ function AppContent() {
       notify('Failed to save changes. Window not closed.', 'error', 4000)
       return
     }
+    // Mirror handleConfirmSave: remount provider so cached settings-derived
+    // state (game list paths, etc.) reloads from store. Matters in minimize
+    // mode where the renderer keeps living; harmless on the force-close path.
+    setRefreshKey((k) => k + 1)
     setCloseConfirmOpen(false)
     await (closeConfirmMinimizeMode ? forceMinimizeToTray() : forceClose())
   }, [closeConfirmMinimizeMode, notify, requestSaveAll])
@@ -175,15 +179,19 @@ function AppContent() {
     requestDiscardAll()
     reportSettingsDirty(false)
     // Mirror the tab-switch discard: clear any pending Minimize-to-tray
-    // override and remount the SettingsProvider so a discarded tray toggle
-    // doesn't keep steering the main process on the next close. Matters most
-    // in minimize mode — the renderer stays alive in the tray, so a stale
-    // pending value would otherwise leak into the next close cycle.
+    // override, remount the SettingsProvider, and re-sync theme so a
+    // discarded tray/theme/accent toggle doesn't keep steering the main
+    // process or leak visually after the user picked Discard. Matters most
+    // in minimize mode — the renderer stays alive in the tray, so any
+    // stale state would otherwise surface on the next show.
     void setPendingMinimizeToTray(null)
     setRefreshKey((k) => k + 1)
+    syncThemeFromStore().catch((err) => {
+      console.error('Failed to re-sync theme after discard', err)
+    })
     setCloseConfirmOpen(false)
     await (closeConfirmMinimizeMode ? forceMinimizeToTray() : forceClose())
-  }, [closeConfirmMinimizeMode, reportSettingsDirty, requestDiscardAll])
+  }, [closeConfirmMinimizeMode, reportSettingsDirty, requestDiscardAll, syncThemeFromStore])
 
   const handleCloseConfirmCancel = () => {
     setCloseConfirmOpen(false)

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -9,6 +9,7 @@ export const minimize = () => window.electronAPI.minimize()
 export const maximize = () => window.electronAPI.maximize()
 export const close = () => window.electronAPI.close()
 export const forceClose = () => window.electronAPI.forceClose()
+export const forceMinimizeToTray = () => window.electronAPI.forceMinimizeToTray()
 export const setRendererDirty = (isDirty: boolean) => window.electronAPI.setRendererDirty(isDirty)
 export const setPendingMinimizeToTray = (value: boolean | null) =>
   window.electronAPI.setPendingMinimizeToTray(value)

--- a/tests/main/windowCloseDirty.test.ts
+++ b/tests/main/windowCloseDirty.test.ts
@@ -88,3 +88,51 @@ test('force-close-window sets quitting and clears renderer dirty flag (Closes #3
   expect(appState.getIsQuitting()).toBe(true)
   expect(appState.getRendererDirty()).toBe(false)
 })
+
+test('force-minimize-to-tray does NOT set quitting (renderer keeps living in tray, refs #424)', async () => {
+  await loadWindowModule()
+  const appState = await import('../../src/main/app-state')
+
+  await invokeWindowHandler('set-renderer-dirty', {}, true)
+  expect(appState.getRendererDirty()).toBe(true)
+  expect(appState.getIsQuitting()).toBe(false)
+
+  await invokeWindowHandler('force-minimize-to-tray', {})
+
+  // Quitting must stay false: the renderer keeps running in the tray and the
+  // dirty flag will propagate to false on the next render after the save or
+  // discard handler completes. We must NOT clear it here, otherwise a later
+  // tray menu "Quit" would lose any state that hadn't been propagated yet.
+  expect(appState.getIsQuitting()).toBe(false)
+  expect(appState.getRendererDirty()).toBe(true)
+})
+
+test('decideCloseAction: dirty takes precedence over tray (covers #424 scenarios 2 & 4)', async () => {
+  const { decideCloseAction } = await import('../../src/main/window')
+
+  // Scenario 1: tray off + dirty → confirm-close
+  expect(
+    decideCloseAction({ isQuitting: false, isDirty: true, effectiveMinimizeToTray: false })
+  ).toBe('confirm-close')
+
+  // Scenarios 2 & 4: tray on (persisted or pending) + dirty → confirm-minimize
+  // (previously: silent hide bypassed dirty confirm)
+  expect(
+    decideCloseAction({ isQuitting: false, isDirty: true, effectiveMinimizeToTray: true })
+  ).toBe('confirm-minimize')
+
+  // Clean state + tray on → silent hide (correct existing behavior)
+  expect(
+    decideCloseAction({ isQuitting: false, isDirty: false, effectiveMinimizeToTray: true })
+  ).toBe('hide')
+
+  // Clean state + tray off → quit
+  expect(
+    decideCloseAction({ isQuitting: false, isDirty: false, effectiveMinimizeToTray: false })
+  ).toBe('quit')
+
+  // Explicit quit short-circuits everything (force-close-window path)
+  expect(
+    decideCloseAction({ isQuitting: true, isDirty: true, effectiveMinimizeToTray: true })
+  ).toBe('quit')
+})


### PR DESCRIPTION
## Summary

Closes #424. Inverts the close-handler precedence so dirty changes always raise the confirm dialog, even when Minimize-to-tray is effective.

### The bug

Smoke test on 0.9.8 release candidate (#417, yanked) found that the X button silently minimizes to tray when tray is effective, bypassing dirty confirm. Matrix:

| Scenario | Tray state | Dirty source | Before | After |
|---|---|---|---|---|
| 1 | OFF saved | Non-tray | ✅ Confirm | ✅ Confirm |
| 2 | ON saved (no pending) | Non-tray | ❌ Silent minimize | ✅ Confirm (Save & Minimize) |
| 3 | ON saved → toggled OFF | Tray itself | ✅ Confirm | ✅ Confirm |
| 4 | ON saved (no pending) | Profile editor | ❌ Silent minimize | ✅ Confirm (Save & Minimize) |

Original "tray preserves data in memory" comment was technically true but invisible to the user — they had no idea changes were still pending, and lost them silently if they later quit from the tray menu.

### Fix shape

1. New pure helper `decideCloseAction({isQuitting, isDirty, effectiveMinimizeToTray})` returns `'quit' | 'hide' | 'confirm-close' | 'confirm-minimize'`. Precedence: explicit quit > unsaved changes > tray preference.
2. Close-event handler dispatches via this helper and sends the `close-requested` IPC with `{minimizeMode}` payload.
3. New `force-minimize-to-tray` IPC handler that hides the window WITHOUT setting `isQuitting` (renderer keeps living in tray, dirty propagates to false naturally on next render).
4. Renderer's close confirm dialog now uses dynamic labels:
   - tray OFF: "Save & Close" / "Discard & Close" → `forceClose()`
   - tray ON:  "Save & Minimize" / "Discard & Minimize" → `forceMinimizeToTray()`

Clean-state path unchanged: tray ON still hides silently, tray OFF still quits.

### Tests

- `decideCloseAction` unit test covering the four-input matrix from the smoke results.
- `force-minimize-to-tray` IPC handler must NOT set `isQuitting` and must NOT clear `rendererDirty` (the renderer's effect propagates dirty=false after save/discard completes).

172/172 tests pass, typecheck + lint + prettier clean.

## Test plan

- [x] `npm test` — 172/172
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Prettier check on touched files
- [x] Smoke: scenarios 2 & 4 from #424 should now show "Save & Minimize" / "Discard & Minimize" dialog
- [x] Smoke: scenarios 1 & 3 should still show "Save & Close" / "Discard & Close" dialog
- [x] Smoke: tray ON + clean state still hides silently on X

🤖 Generated with [Claude Code](https://claude.com/claude-code)