### PR TITLE
fix: route Profile Editor toggle X through dirty-confirm flow (#427)

### DIFF
--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -11,10 +11,15 @@ import { useProfileEditor, type ProfileEditorProps } from '../hooks/useProfileEd
 
 export function ProfileEditor(props: ProfileEditorProps): ReactNode {
   const editor = useProfileEditor(props)
-  const { reportProfileEditorDirty, registerSaveHandler, registerDiscardHandler } = useAppDirty()
+  const {
+    reportProfileEditorDirty,
+    registerSaveHandler,
+    registerDiscardHandler,
+    registerProfileEditorCloseRequestHandler
+  } = useAppDirty()
   const scopeId = `${props.gameKey}:${props.activeProfileId}`
   const { onClose } = props
-  const { isDirty, handleSave } = editor
+  const { isDirty, handleSave, handleCloseAttempt } = editor
 
   useEffect(() => {
     reportProfileEditorDirty(scopeId, isDirty)
@@ -50,6 +55,19 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
       registerDiscardHandler('profile-editor', null)
     }
   }, [isDirty, onClose, registerDiscardHandler])
+
+  useEffect(() => {
+    // Always route external close requests (GameRow toggle X, etc.) through
+    // handleCloseAttempt so the editor's own dirty-confirm dialog fires when
+    // there are unsaved edits. Without this the X button just unmounts the
+    // editor and silently drops user changes (#427).
+    registerProfileEditorCloseRequestHandler(() => {
+      handleCloseAttempt()
+    })
+    return () => {
+      registerProfileEditorCloseRequestHandler(null)
+    }
+  }, [handleCloseAttempt, registerProfileEditorCloseRequestHandler])
 
   if (editor.loading) return null
 

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -21,6 +21,7 @@ import { GameIcon } from './GameIcon'
 import { RunningAppsStrip, type RunningAppIcon } from './RunningAppsStrip'
 import { GameRowActions } from './GameRowActions'
 import { ConfirmDialog } from '../ConfirmDialog'
+import { useAppDirty } from '../../contexts/AppDirtyContext'
 
 const POST_LAUNCH_BLOCK_MS = 10000
 
@@ -297,8 +298,16 @@ export function GameRow({
   }
 
   const rowRef = useRef<HTMLDivElement | null>(null)
+  const { requestProfileEditorClose } = useAppDirty()
 
   const handleToggle = () => {
+    // Closing: route through the editor's own dirty-confirm flow so unsaved
+    // edits aren't silently dropped when the user clicks the X (#427). When
+    // no editor is registered (clean / wrong row), the call returns false
+    // and we fall through to the plain toggle.
+    if (isActive && requestProfileEditorClose()) {
+      return
+    }
     onToggleEditor()
     if (!isActive && rowRef.current) {
       setTimeout(() => {

--- a/src/renderer/src/contexts/AppDirtyContext.tsx
+++ b/src/renderer/src/contexts/AppDirtyContext.tsx
@@ -32,6 +32,14 @@ export interface AppDirtyContextValue {
    */
   requestSaveAll: () => Promise<boolean>
   requestDiscardAll: () => void
+  /**
+   * Routes external "close the profile editor" requests (e.g. the toggle X
+   * button in GameRowActions) through the editor's own dirty-confirm flow,
+   * instead of letting the caller unmount the editor and lose unsaved edits.
+   * When no handler is registered (no editor open), the call is a no-op.
+   */
+  registerProfileEditorCloseRequestHandler: (handler: (() => void) | null) => void
+  requestProfileEditorClose: () => boolean
 }
 
 const AppDirtyContext = createContext<AppDirtyContextValue | null>(null)
@@ -48,6 +56,7 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
   const profileSaveHandlerRef = useRef<SaveHandler | null>(null)
   const settingsDiscardHandlerRef = useRef<(() => void) | null>(null)
   const profileDiscardHandlerRef = useRef<(() => void) | null>(null)
+  const profileCloseRequestHandlerRef = useRef<(() => void) | null>(null)
 
   const reportSettingsDirty = useCallback((isDirty: boolean) => {
     setIsSettingsDirty(isDirty)
@@ -108,6 +117,19 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
     settingsDiscardHandlerRef.current?.()
   }, [])
 
+  const registerProfileEditorCloseRequestHandler = useCallback((handler: (() => void) | null) => {
+    profileCloseRequestHandlerRef.current = handler
+  }, [])
+
+  const requestProfileEditorClose = useCallback((): boolean => {
+    const handler = profileCloseRequestHandlerRef.current
+    if (!handler) {
+      return false
+    }
+    handler()
+    return true
+  }, [])
+
   const value = useMemo<AppDirtyContextValue>(
     () => ({
       isAnyDirty: isSettingsDirty || profileEditorDirtyScope !== null,
@@ -119,7 +141,9 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
       registerSaveHandler,
       registerDiscardHandler,
       requestSaveAll,
-      requestDiscardAll
+      requestDiscardAll,
+      registerProfileEditorCloseRequestHandler,
+      requestProfileEditorClose
     }),
     [
       isSettingsDirty,
@@ -129,7 +153,9 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
       registerSaveHandler,
       registerDiscardHandler,
       requestSaveAll,
-      requestDiscardAll
+      requestDiscardAll,
+      registerProfileEditorCloseRequestHandler,
+      requestProfileEditorClose
     ]
   )
 


### PR DESCRIPTION
## Summary

Closes #427. The "Close Profile Settings" X button in GameRowActions called `onToggleEditor` directly, unmounting the editor and silently dropping any unsaved edits. The Cancel button inside the editor already went through the editor's `handleCloseAttempt` (showing the existing confirm dialog when dirty), but the external X bypassed it.

## Fix shape

Extends `AppDirtyContext` with a `registerProfileEditorCloseRequestHandler` slot following the same ref-based pattern as save/discard handlers. ProfileEditor registers `handleCloseAttempt` whenever mounted. GameRow's toggle, on close, calls `requestProfileEditorClose()`:

- Editor mounted + **dirty** → request travels through `handleCloseAttempt` → existing confirm dialog appears (Save / Discard / Cancel)
- Editor mounted + **clean** → `handleCloseAttempt` calls `onClose`, which is the same toggle → editor closes
- No editor mounted (opening from clean) → request returns false → original toggle + scrollIntoView path runs unchanged

## Test plan

- [x] `npm test` — 172/172 pass
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Prettier check on touched files
- [x] Smoke: edit profile name → click X in row header → confirm dialog appears
- [x] Smoke: open editor on clean profile → click X → closes immediately, no dialog
- [x] Smoke: existing Cancel button still works (regression)
- [x] Smoke: Escape key still works (registered by useProfileEditor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)