### PR TITLE
fix: clarify elevated launch warning copy (#426)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -125,7 +125,7 @@ export async function launchProfileApps(
       elevatedResults.length === 1
         ? elevatedResults[0].warning
         : elevatedResults.length > 1
-          ? `${elevatedResults.length} apps requested administrator permission. SimLauncher cannot track or close elevated apps after launch.`
+          ? `${elevatedResults.length} apps requested administrator permission. SimLauncher will detect when they're running but cannot close them from here.`
           : undefined
 
     return {
@@ -289,7 +289,7 @@ function launchElevated(appPath: string, args: string[] = []) {
         resolve({
           status: 'elevated',
           appPath,
-          warning: `${path.basename(appPath)} requested administrator permission. SimLauncher cannot track or close elevated apps after launch.`
+          warning: `${path.basename(appPath)} requested administrator permission. SimLauncher will detect when it's running but cannot close it from here.`
         })
       }
     )


### PR DESCRIPTION
## Summary
- The previous warning said SimLauncher cannot track or close elevated apps after launch, but tracking via image-name match works fine (verified during 0.9.8 smoke with OpenTrack/OTT). What we cannot do is close them from a non-elevated launcher.
- Updates both the single-app warning in `launchElevated` and the N-app summary in the multi-launch path so users know the app stays visible but the close button will not work.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (172 passed)
- [x] `npx prettier --check src/main/processes/spawn.ts`
- [x] Smoke: launch OpenTrack via a profile that triggers UAC, confirm it still appears in the running-apps strip and the new warning reads naturally