### PR TITLE
fix: clear stale utility icon on Browse re-pick (#428)

### DIFF
--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -216,6 +216,22 @@ export function SettingsProvider({
               next.delete(key)
               return next
             })
+          } else {
+            // The new exe has no extractable icon — drop any stale icon from a
+            // previous Browse pick on this slot so the initial-letter fallback
+            // renders instead of the old app's icon bleeding through (#428).
+            setAppIcons((prev) => {
+              if (!(key in prev)) return prev
+              const next = { ...prev }
+              delete next[key]
+              return next
+            })
+            setIconLoadErrors((prev) => {
+              if (!prev.has(key)) return prev
+              const next = new Set(prev)
+              next.delete(key)
+              return next
+            })
           }
         }
       }


### PR DESCRIPTION
## Summary
- Settings utility-slot Browse handler only updated `appIcons[key]` when `getFileIcon` returned a non-null icon. If the user re-picked a slot to an exe with no extractable icon, the previous app's icon URL stayed in state and kept rendering instead of the initial-letter fallback.
- Add the missing else branch: drop the stale entry from `appIcons` and clear the slot's `iconLoadErrors` flag so the fallback path in `AppsSection` takes over immediately.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (172 passed)
- [x] `npx prettier --check src/renderer/src/components/settings/SettingsContext.tsx`
- [x] Smoke: Settings → utility slot → Browse picks an exe with an icon (icon shows) → Browse again, pick an exe with no extractable icon (initial-letter fallback renders, old icon does not bleed through)

<!-- auto-closes -->
Closes #428
<!-- auto-closes -->