### PR TITLE
fix: render StickySaveBar at App level so it pins across all views (#423)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
 import { ConfirmDialog } from './components/ConfirmDialog'
+import { StickySaveBar } from './components/StickySaveBar'
 import { WarningTriangleIcon, CloseIcon } from './components/icons'
 import {
   forceClose,
@@ -252,7 +253,9 @@ function AppContent() {
                 : 'opacity-0 scale-95 pointer-events-none'
             }`}
           >
-            <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
+            <div
+              className={`flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
+            >
               <GameList key={refreshKey} onNavigate={handleNavigate} />
             </div>
           </div>
@@ -265,12 +268,16 @@ function AppContent() {
                 : 'opacity-0 scale-95 pointer-events-none'
             }`}
           >
-            <div className="flex-1 overflow-y-auto pt-16 px-4 custom-scrollbar">
+            <div
+              className={`flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
+            >
               <SettingsView onClose={() => handleNavigate('games')} updateInfo={updateInfo} />
             </div>
           </div>
         </main>
       </SettingsProvider>
+
+      <StickySaveBar />
 
       <ConfirmDialog
         isOpen={pendingView !== null}

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -5,9 +5,14 @@ import { ProfileEditorActions } from './profile-editor/ProfileEditorActions'
 import { ProfileNameSection } from './profile-editor/ProfileNameSection'
 import { ProfileUtilitiesSection } from './profile-editor/ProfileUtilitiesSection'
 import { ProcessTrackingSection } from './profile-editor/ProcessTrackingSection'
-import { StickySaveBar } from './StickySaveBar'
 import { useAppDirty } from '../contexts/AppDirtyContext'
 import { useProfileEditor, type ProfileEditorProps } from '../hooks/useProfileEditor'
+
+// The unsaved-changes bar lives at the App level now (#423) so it can pin to
+// the viewport bottom even when the editor card itself doesn't overflow the
+// scroll container. ProfileEditor's dirty state still flows into
+// AppDirtyContext via reportProfileEditorDirty, and the app-level bar reacts
+// to that.
 
 export function ProfileEditor(props: ProfileEditorProps): ReactNode {
   const editor = useProfileEditor(props)
@@ -129,12 +134,6 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
           onDeleteProfile={editor.handleDeleteProfile}
         />
       </div>
-
-      <StickySaveBar
-        isDirty={editor.isDirty}
-        onSave={() => void editor.handleSave(false)}
-        ariaLabel="Unsaved profile changes"
-      />
 
       <ConfirmDialog
         isOpen={editor.showConfirm}

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -10,8 +10,12 @@ import { SettingsSection } from './settings/SettingsSection'
 import { useSettingsMeta } from './settings/SettingsMetaContext'
 import type { UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
-import { StickySaveBar } from './StickySaveBar'
 import { useAppDirty } from '../contexts/AppDirtyContext'
+
+// The unsaved-changes bar is rendered at the App level now (#423) so it pins
+// to the viewport bottom regardless of which view is active or whether the
+// scroll container has overflowed. Settings dirty state still flows into
+// AppDirtyContext via the SettingsContext onDirtyChange chain.
 
 export function SettingsView({
   onClose,
@@ -155,12 +159,6 @@ function SettingsViewContent({
           Back to Games
         </button>
       </div>
-
-      <StickySaveBar
-        isDirty={isDirty}
-        onSave={() => void saveSettings()}
-        ariaLabel="Unsaved settings"
-      />
     </div>
   )
 }

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -41,11 +41,15 @@ export function StickySaveBar(): ReactNode {
       const ok = await requestSaveAll()
       if (!ok) {
         notify('Failed to save changes.', 'error', 4000)
-        setIsSaving(false)
       }
     } catch (err) {
       console.error('Sticky save handler threw', err)
       notify('Failed to save changes.', 'error', 4000)
+    } finally {
+      // Always reset the local flag — don't rely on isAnyDirty cascading to
+      // false. A successful save where another scope is still dirty (or the
+      // user edited again during an in-flight save) would otherwise leave
+      // the button permanently disabled.
       setIsSaving(false)
     }
   }

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -1,67 +1,76 @@
-import type { ReactNode } from 'react'
-
-interface StickySaveBarProps {
-  isDirty: boolean
-  onSave: () => void
-  saveLabel?: string
-  secondaryLabel?: string
-  onSecondary?: () => void
-  ariaLabel?: string
-  extra?: ReactNode
-}
+import { useEffect, useState, type ReactNode } from 'react'
+import { useAppDirty } from '../contexts/AppDirtyContext'
+import { useNotify } from './Notify'
 
 /**
- * A reusable sticky action bar that pins itself to the bottom of its scroll
- * container while there are unsaved changes. The bar slides in only when
- * `isDirty` is true so it never obscures the layout when nothing needs saving.
+ * App-level unsaved-changes bar pinned to the bottom of the viewport. Shown
+ * whenever any registered scope (Settings, Profile Editor) reports dirty
+ * state via AppDirtyContext, regardless of which view is currently visible.
+ * Save runs every registered save handler so the user's "Save Changes" click
+ * matches the close-dialog behavior — one button, all scopes.
  *
- * The component must be rendered inside a positioned (relative/absolute)
- * ancestor for `position: sticky` to anchor to the visible viewport bottom
- * of that scroll container.
+ * Lives at the App level rather than per-view because position: sticky needed
+ * the host scroll container to actually overflow; the Profile Editor card is
+ * usually shorter than the viewport, so sticky never pinned and the bar sat
+ * at the natural end of the card (out of sight after any scroll, #423).
  */
-export function StickySaveBar({
-  isDirty,
-  onSave,
-  saveLabel = 'Save Changes',
-  secondaryLabel,
-  onSecondary,
-  ariaLabel,
-  extra
-}: StickySaveBarProps): ReactNode {
-  if (!isDirty) {
+export function StickySaveBar(): ReactNode {
+  const { isAnyDirty, requestSaveAll } = useAppDirty()
+  const { notify } = useNotify()
+  const [isSaving, setIsSaving] = useState(false)
+
+  // Reset the local saving flag whenever dirty state clears externally (a
+  // save dialog elsewhere, a discard, a tab-switch save). Without this the
+  // bar could stay disabled after an out-of-band save completes.
+  useEffect(() => {
+    if (!isAnyDirty) {
+      setIsSaving(false)
+    }
+  }, [isAnyDirty])
+
+  if (!isAnyDirty) {
     return null
+  }
+
+  const handleSave = async () => {
+    if (isSaving) {
+      return
+    }
+    setIsSaving(true)
+    try {
+      const ok = await requestSaveAll()
+      if (!ok) {
+        notify('Failed to save changes.', 'error', 4000)
+        setIsSaving(false)
+      }
+    } catch (err) {
+      console.error('Sticky save handler threw', err)
+      notify('Failed to save changes.', 'error', 4000)
+      setIsSaving(false)
+    }
   }
 
   return (
     <div
-      className="sticky bottom-0 z-30 -mx-1 mt-4 animate-fade-slide px-1 pb-2 pt-3"
+      className="fixed bottom-4 left-4 right-4 z-30 animate-fade-slide"
       role="region"
-      aria-label={ariaLabel ?? 'Unsaved changes'}
+      aria-label="Unsaved changes"
     >
-      <div className="glass-surface-elevated flex items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl">
-        <span className="flex h-2 w-2 shrink-0 items-center justify-center">
+      <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl">
+        <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
           <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
         </span>
         <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
           You have unsaved changes.
         </span>
-        {extra}
-        {secondaryLabel && onSecondary && (
-          <button
-            type="button"
-            onClick={onSecondary}
-            className="neutral-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-semibold"
-          >
-            {secondaryLabel}
-          </button>
-        )}
         <button
           type="button"
-          onClick={onSave}
-          className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold"
+          onClick={() => void handleSave()}
+          disabled={isSaving}
+          className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {saveLabel}
+          {isSaving ? 'Saving…' : 'Save Changes'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #423. The unsaved-changes bar previously used `position: sticky`, which only activates when its host scroll container overflows. The Profile Editor card is usually shorter than the viewport, so the bar appeared at the natural end of the card and never pinned to the viewport bottom — the user couldn't see it after scrolling.

## Fix shape

Single app-level `<StickySaveBar />` rendered in `App.tsx`, driven by `useAppDirty()`:

- Shows whenever any registered scope (Settings, Profile Editor) reports dirty.
- Uses `position: fixed` so it always pins to the viewport bottom, regardless of scroll state.
- `Save Changes` button calls `requestSaveAll()` — matches the close/tab-switch dialog flow (one button, all scopes).
- Both scroll containers in `App.tsx` reserve `pb-24` while `isAnyDirty` so the fixed bar doesn't cover the last item.

`ProfileEditor` and `SettingsView` stop rendering their own `StickySaveBar`. Their dirty state still flows into `AppDirtyContext` via the existing `reportProfileEditorDirty` / `onDirtyChange` chains.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 172/172 pass
- [x] Prettier check on touched files
- [x] Smoke: dirty Profile Editor → bar pinned to viewport bottom regardless of scroll
- [x] Smoke: dirty Settings → bar pinned to viewport bottom (unchanged from before)
- [x] Smoke: both scopes dirty simultaneously → single bar, Save persists both
- [x] Smoke: last item in scroll container not covered by bar (pb-24 reservation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)