### PR TITLE
style: increase StickySaveBar fill contrast to prevent text bleed-through (#425)

### DIFF
--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -60,7 +60,7 @@ export function StickySaveBar(): ReactNode {
       role="region"
       aria-label="Unsaved changes"
     >
-      <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl">
+      <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl [--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!">
         <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
           <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />


### PR DESCRIPTION
## Summary

Closes #425. The app-level sticky save bar (added in #423) used `.glass-surface-elevated` which resolves to `rgba(255,255,255,0.05)` in dark theme — too translucent to defeat text bleeding through from underlying settings rows, making the bar's own "You have unsaved changes." copy unreadable.

## Fix shape

Override `--glass-surface-fill` locally on the bar's inner div using the same per-element Tailwind arbitrary-property pattern already established by the import-warning toast in `App.tsx`:

```
[--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!
```

Mix is 65% `--header-glass-bg` (themed: dark `rgba(18,18,18,0.7)` / light `rgba(252,252,254,0.75)`) + 35% `--glass-bg-elevated`. Resulting effective opacity:
- Dark: ≈ 0.47 — opaque enough to block underlying text
- Light: ≈ 0.785 — readable + still glassmorphic

Global tokens untouched, so the 8+ other consumers of `--glass-bg-elevated` (dropdowns, fallback icons, neutral buttons, scrollbar thumbs, skeleton placeholders, hover states) are unaffected.

Design proposed by Gemini, validated and committed here.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 172/172
- [x] Prettier check
- [x] Smoke: dirty Settings, scroll so toggle row sits right behind bar → text no longer bleeds through, both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)