### PR TITLE
chore(deps-dev): bump tmp to 0.2.7 and brace-expansion to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3388,9 +3388,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5075,9 +5075,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6339,9 +6339,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7599,9 +7599,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What
Bumps two **dev-only transitive** dependencies to clear Dependabot advisories.

| Pkg | From → To | Advisory | Alert | Pulled via |
|-----|-----------|----------|:-----:|------------|
| `tmp` | 0.2.5 → 0.2.7 | GHSA-ph9p-34f9-6g65 (CVE-2026-44705, path traversal) | #2 (high) | electron-builder → @malept/flatpak-bundler → tmp-promise |
| `brace-expansion` | 5.0.5 → 5.0.6 | GHSA-jxxr-4gwj-5jf2 (CVE-2026-45149, DoS) | #1 (medium) | eslint → minimatch |

## Impact on the shipped app: none
Both are **build-time** deps and are not bundled into the NSIS installer (`electron-builder.yml` ships `out/**/* + package.json` only). `tmp` is reachable solely through electron-builder's **Flatpak** bundler, which this Windows-only project (`win: nsis`) never invokes. `brace-expansion` lives under the eslint/minimatch glob matcher. Neither is exploitable in this build.

## Change scope
Surgical, lockfile-only — 5 transitive entries (`tmp`, plus brace-expansion 1.1.15 / 2.1.1 ×2 / 5.0.6). No runtime dependency touched.

## Verification (local, Windows)
- ✅ `npm audit`: 0 vulnerabilities
- ✅ lint, typecheck, build, format:check
- ✅ 172 tests pass

## ⏱️ Merge timing
**Recommend merging AFTER v0.9.8 is published.** main is currently exactly the `v0.9.8` tag (94561eb); the draft installer is already built and frozen at that tag, so this PR cannot affect the released artifact either way. Holding until publish keeps main == tag in case v0.9.8 needs a re-tag after smoke testing. Zero urgency (dev-only, non-shipping).