### PR TITLE
fix: process-tracking warning copy (#443)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -340,7 +340,7 @@ export async function finalizeKillAttempts(
     return {
       success: true,
       message: hasMismatchWarnings
-        ? 'No closable companion apps found. Some apps may be running under a different process name; add the shown process under tracked processes to manage it.'
+        ? 'No closable companion apps found. Some apps may be running under a different process name; add the shown process under "Secondary executables to watch" in the profile editor to manage it.'
         : 'No running companion apps to close.',
       closedCount: 0,
       failedCount: 0,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -377,7 +377,7 @@ export function spawnDetachedApp(
         const wasClosedBySimLauncher = consumeProcessNameMismatchWarningSuppression(appPath)
 
         if (exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
-          const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add that executable to this slot under tracked processes. Right-click the icon to dismiss this warning.`
+          const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add it under "Secondary executables to watch" in the profile editor. Right-click the icon to dismiss this warning.`
 
           processNameMismatchWarnings.set(normalizePathForComparison(appPath), {
             path: appPath,

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -713,11 +713,11 @@ test('wrapper exit warning tells the user tracking is lost and how to fix it (#4
   const payload = mismatchCall?.[1] as { app: string; warning: string }
   expect(payload.app).toBe('C:/Tools/Perplexity.exe')
   // Wording must (a) name the exited wrapper, (b) state SimLauncher loses
-  // tracking, (c) point the user at Task Manager + tracked processes to fix.
+  // tracking, (c) point the user at Task Manager + the profile editor control to fix.
   expect(payload.warning).toContain('Perplexity.exe')
   expect(payload.warning).toMatch(/no longer detect when you close it/i)
   expect(payload.warning).toMatch(/task manager/i)
-  expect(payload.warning).toMatch(/tracked processes/i)
+  expect(payload.warning).toMatch(/Secondary executables to watch/i)
 
   // Persistent strip warning carries the same actionable copy so the user
   // doesn't only see it during the 5s toast window.


### PR DESCRIPTION
## Summary

- Both process-tracking warning strings referenced **"tracked processes"** / **"this slot under tracked processes"** — a label that does not exist anywhere in the UI, leaving users unable to act on the instructions.
- Updated both messages to point to the real control: **"Secondary executables to watch"** in the profile editor.
- **Copy-only change** — no logic, no API, no behaviour altered.

## Files changed

- `src/main/processes/spawn.ts` — post-launch wrapper-exit warning
- `src/main/processes/kill.ts` — no-closable-apps kill result message
- `tests/main/processes.test.ts` — regex assertion updated to match new wording (`/Secondary executables to watch/i` replaces `/tracked processes/i`)

## Verification

- `npm run typecheck` — pass
- `npm test` — 172/172 pass
- `npm run format:check` — pass
- `npm run lint` — pass

closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)