### PR TITLE
feat: single-instance lock (#429)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,21 +7,37 @@ import { registerContentSecurityPolicy } from './security'
 import { createTray } from './tray'
 import { createWindow, getAppIconPath, showMainWindow } from './window'
 
-app.on('before-quit', () => {
-  setIsQuitting(true)
-})
+// Prevent multiple instances: the first instance acquires the lock; any
+// subsequent launch is redirected to focus the already-running window.
+const gotTheLock = app.requestSingleInstanceLock()
 
-app.whenReady().then(() => {
-  registerContentSecurityPolicy()
-  migrateProfilesToNamedSets()
-  registerHandlers()
-  createTray({
-    getIconPath: getAppIconPath,
-    showMainWindow,
-    quitApp: () => {
-      setIsQuitting(true)
-      app.quit()
-    }
+if (!gotTheLock) {
+  // This is a second (or later) instance — quit immediately so the user sees
+  // the existing window pop to the front instead of a duplicate starting up.
+  app.quit()
+} else {
+  // First instance: listen for future launch attempts and bring our window
+  // to the foreground when they occur.
+  app.on('second-instance', () => {
+    showMainWindow()
   })
-  createWindow()
-})
+
+  app.on('before-quit', () => {
+    setIsQuitting(true)
+  })
+
+  app.whenReady().then(() => {
+    registerContentSecurityPolicy()
+    migrateProfilesToNamedSets()
+    registerHandlers()
+    createTray({
+      getIconPath: getAppIconPath,
+      showMainWindow,
+      quitApp: () => {
+        setIsQuitting(true)
+        app.quit()
+      }
+    })
+    createWindow()
+  })
+}


### PR DESCRIPTION
## What changed

`src/main/index.ts` — single file, minimal delta:

- `app.requestSingleInstanceLock()` is called **before** `app.whenReady()`, as required by Electron docs.
- If the lock is **not** acquired (second instance): `app.quit()` is called immediately and the module exits — no window, no store writes.
- If the lock **is** acquired (first instance): a `second-instance` listener is registered that calls **`showMainWindow()`** — the existing exported helper in `src/main/window.ts`.
- The entire `before-quit` + `whenReady` startup block is wrapped in the `else` branch so it only runs in the first instance.

## Second-instance focus / restore / unhide behavior

`showMainWindow()` already handles all the edge cases needed:
- Window hidden in tray → `mainWindow.show()` surfaces it
- Window minimized → `mainWindow.restore()` then `mainWindow.show()` + `mainWindow.focus()`
- Window destroyed (shouldn't happen, but defensive) → `createWindow()` recreates it

No new show/focus logic was written — the existing tray-click helper is reused verbatim.

## Verification checklist

- [x] `npm run typecheck` — passes (0 errors)
- [x] `npm test` — 172/172 tests pass
- [x] `npm run format:check` — all files pass Prettier
- [x] `npm run lint` — no ESLint errors

## Runtime smoke test required before merge

The lock logic depends on the real Electron `app` singleton (impossible to unit-test without a live process), so no automated test was added. Before merging, please:

1. Run the app in dev or packaged form — it must start normally as a single instance.
2. While it is running, launch a second instance — the second process must exit immediately and the first instance's window must come to the foreground (unhide from tray if hidden, restore if minimized).

Closes #429

<!-- auto-closes -->
Closes #429
<!-- auto-closes -->