### PR TITLE
chore: dead-code + vestigial save-request chain cleanup (#445)

### DIFF
--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -130,14 +130,6 @@ export function getEnabledUtilityEntries(
   return entries
 }
 
-export function getEnabledUtilityPaths(
-  profile: StoredProfile,
-  appPaths: Record<string, string>,
-  customSlots: unknown
-): string[] {
-  return getEnabledUtilityEntries(profile, appPaths, customSlots).map((entry) => entry.path)
-}
-
 export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchEntry[] {
   const appPaths = getStoredStringRecord('appPaths')
   const gamePaths = getStoredStringRecord('gamePaths')
@@ -152,10 +144,6 @@ export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchE
   getEnabledUtilityEntries(profile, appPaths, customSlots).forEach((entry) => entries.push(entry))
 
   return entries
-}
-
-export function buildActiveProfileLaunchPaths(gameKey: string): string[] {
-  return buildActiveProfileLaunchEntries(gameKey).map((entry) => entry.path)
 }
 
 export function buildNamedProfileLaunchEntries(
@@ -175,10 +163,6 @@ export function buildNamedProfileLaunchEntries(
   getEnabledUtilityEntries(profile, appPaths, customSlots).forEach((entry) => entries.push(entry))
 
   return entries
-}
-
-export function buildNamedProfileLaunchPaths(gameKey: string, profileId: string): string[] {
-  return buildNamedProfileLaunchEntries(gameKey, profileId).map((entry) => entry.path)
 }
 
 export function getUtilityKeys(customSlots: unknown): string[] {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -42,7 +42,6 @@ function AppContent() {
   // quitting. Set from the `close-requested` payload so the dialog labels and
   // the terminal IPC call both match the user's current tray preference.
   const [closeConfirmMinimizeMode, setCloseConfirmMinimizeMode] = useState(false)
-  const [saveRequested, setSaveRequested] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const { isAnyDirty, reportSettingsDirty, requestSaveAll, requestDiscardAll } = useAppDirty()
 
@@ -129,7 +128,6 @@ function AppContent() {
 
   const handleConfirmCancel = () => {
     setPendingView(null)
-    setSaveRequested(false)
   }
 
   const handleConfirmSave = useCallback(async () => {
@@ -233,16 +231,7 @@ function AppContent() {
       <SettingsProvider
         key={refreshKey}
         onDirtyChange={reportSettingsDirty}
-        shouldSaveTrigger={saveRequested}
         onConfigImported={handleConfigImported}
-        onSaved={(success) => {
-          setSaveRequested(false)
-          setRefreshKey((k) => k + 1)
-          if (success && pendingView) {
-            setView(pendingView)
-            setPendingView(null)
-          }
-        }}
       >
         <main className="h-full relative overflow-hidden">
           {/* Games View */}

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -25,14 +25,10 @@ import { useSettingsState } from './useSettingsState'
 export function SettingsProvider({
   children,
   onDirtyChange,
-  shouldSaveTrigger,
-  onSaved,
   onConfigImported
 }: {
   children: ReactNode
   onDirtyChange?: (isDirty: boolean) => void
-  shouldSaveTrigger?: boolean
-  onSaved?: (success: boolean) => void
   onConfigImported?: () => void
 }): ReactNode {
   const { notify } = useNotify()
@@ -330,9 +326,7 @@ export function SettingsProvider({
     setAppPaths,
     setGamePaths,
     setAppArgs,
-    setLaunchDelayMs,
-    shouldSaveTrigger,
-    onSaved
+    setLaunchDelayMs
   })
 
   const utilities = useMemo(() => getUtilities(customSlots), [customSlots])

--- a/src/renderer/src/components/settings/useSettingsSave.ts
+++ b/src/renderer/src/components/settings/useSettingsSave.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, type MutableRefObject } from 'react'
+import { useCallback, type MutableRefObject } from 'react'
 import { saveProfiles, saveSettings as persistSettings } from '../../lib/store'
 import type { Profiles } from '../../lib/config'
 import type { ThemeMode } from '../../lib/theme'
@@ -69,8 +69,6 @@ interface UseSettingsSaveArgs {
   setGamePaths: (gamePaths: Record<string, string>) => void
   setAppArgs: (appArgs: Record<string, string>) => void
   setLaunchDelayMs: (launchDelayMs: number) => void
-  shouldSaveTrigger?: boolean
-  onSaved?: (success: boolean) => void
 }
 
 export function useSettingsSave({
@@ -99,9 +97,7 @@ export function useSettingsSave({
   setAppPaths,
   setGamePaths,
   setAppArgs,
-  setLaunchDelayMs,
-  shouldSaveTrigger,
-  onSaved
+  setLaunchDelayMs
 }: UseSettingsSaveArgs): { handleSave: () => Promise<boolean> } {
   const handleSave = useCallback(async (): Promise<boolean> => {
     try {
@@ -193,14 +189,6 @@ export function useSettingsSave({
     setAppArgs,
     setLaunchDelayMs
   ])
-
-  useEffect(() => {
-    if (shouldSaveTrigger) {
-      handleSave().then((success) => {
-        onSaved?.(success)
-      })
-    }
-  }, [handleSave, onSaved, shouldSaveTrigger])
 
   return { handleSave }
 }


### PR DESCRIPTION
## What was removed

### (A) Dead functions in `src/main/profiles.ts`

Three exported functions with zero call sites anywhere in the repo (pre-#357 refactor leftovers):
- `getEnabledUtilityPaths` — thin wrapper over `getEnabledUtilityEntries`, 0 callers
- `buildActiveProfileLaunchPaths` — thin wrapper over `buildActiveProfileLaunchEntries`, 0 callers
- `buildNamedProfileLaunchPaths` — thin wrapper over `buildNamedProfileLaunchEntries`, 0 callers

Grep confirmation (only definitions found, no call sites):
```
./src/main/profiles.ts:133:export function getEnabledUtilityPaths(
./src/main/profiles.ts:157:export function buildActiveProfileLaunchPaths(
./src/main/profiles.ts:180:export function buildNamedProfileLaunchPaths(
```

### (B) Vestigial save-request chain (~30 LOC across 3 files)

`setSaveRequested(true)` was never called anywhere in the codebase — confirmed by `grep -rn "setSaveRequested(true)"` returning nothing. Therefore `saveRequested` was always `false`, `shouldSaveTrigger` was always `false`, and the effect in `useSettingsSave.ts` that consumed it was permanently unreachable.

Removed:
- **`App.tsx`**: `const [saveRequested, setSaveRequested] = useState(false)` state; `setSaveRequested(false)` call in `handleConfirmCancel`; `shouldSaveTrigger={saveRequested}` and `onSaved={...}` props on `<SettingsProvider>`
- **`SettingsContext.tsx`**: `shouldSaveTrigger` and `onSaved` from the `SettingsProvider` props interface; both params removed from the `useSettingsSave(...)` call
- **`useSettingsSave.ts`**: `shouldSaveTrigger?: boolean` and `onSaved?: (success: boolean) => void` from `UseSettingsSaveArgs`; both destructured params from the function signature; the unreachable `useEffect` that checked `shouldSaveTrigger`; now-unused `useEffect` import

## Deferred

`SettingsView.tsx` line 75 registers a no-op discard handler (`registerDiscardHandler('settings', () => {})`). This was flagged in review but overlaps with save-bar work in #442 — left untouched to avoid scope conflict.

## Verification

- `npm run typecheck` — pass
- `npm test` — 172/172 pass
- `npm exec prettier -- --write <changed files>` — all unchanged (already formatted)
- `npm run format:check` — pass
- `npm run lint` — clean

Net: **-48 LOC** across 4 files. Zero behavior change.

closes #445