### PR TITLE
fix: play-mark zoom misalignment (#367)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -215,7 +215,12 @@ textarea {
 }
 
 .launcher-play-mark {
-  transform: translateY(0.65px) skewX(-10deg);
+  /* display:block takes the SVG out of the inline baseline so it's centered
+     purely by the parent flex (items-center), instead of a hard-coded
+     translateY nudge that rounded to different physical pixels at each
+     Chromium zoom factor and drifted up/down except at 125% (#367). */
+  display: block;
+  transform: skewX(-10deg);
 }
 
 /* 2026 Design Overhaul Utils */


### PR DESCRIPTION
## Problem
The SIMLAUNCHER brand-pill play-mark (▶, top-left) rendered correctly only at 125% zoom; at every other zoom level it drifted up or down.

## Root cause
`.launcher-play-mark` applied `transform: translateY(0.65px)` — a hard-coded fractional CSS pixel on an inline SVG. Chromium's compositor zoom multiplies every length by the zoom factor then quantises to physical pixels; `0.65 * 1.25 = 0.81` happened to land right, but other factors rounded to different rows → visible up/down drift.

## Fix
`display: block` removes the SVG from the inline baseline so it's centered purely by the parent flex (`items-center` on the wordmark span), which scales correctly at every zoom. `skewX(-10deg)` italic styling preserved. One-line CSS, no markup change.

## Verification
build / format / lint / 172 tests all green. **Needs a visual eyeball at 100% / 125% / 150% before merge** (the bug is purely visual/zoom-dependent).

Closes #367

<!-- auto-closes -->
Closes #367
<!-- auto-closes -->