### PR TITLE
fix: remove orphan editor '+' profile on discard (#453)

### DIFF
--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -153,7 +153,10 @@ export function GameList({
               onLaunchEnd={handleLaunchEnd}
               onRunningStateRefresh={refreshRunningState}
               onToggleEditor={() =>
-                setActiveEditorKey(activeEditorKey === game.key ? null : game.key)
+                setActiveEditorKey((current) => (current === game.key ? null : game.key))
+              }
+              onCloseEditor={() =>
+                setActiveEditorKey((current) => (current === game.key ? null : current))
               }
               cacheInitialized={true}
             />

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import {
   createProfileId,
   getActiveGameProfile,
@@ -87,12 +87,42 @@ export function GameRow({
   // purpose (saved / launched / switched-away-from). If the editor is closed
   // while this is set, the profile is removed and the previously-active profile
   // is restored, so create-then-discard leaves no orphan (#453). A ref (not
-  // state) so the close handler reads the latest value synchronously and a
-  // deliberate save can clear it before its own onClose fires.
+  // state) so the cleanup reads the latest value synchronously and a deliberate
+  // commit can clear it before the close fires.
   const pendingNewProfileRef = useRef<{
     newProfileId: string
     previousActiveProfileId: string
   } | null>(null)
+  // Mirror of isActive readable from async tails (handleCreateProfile) where the
+  // captured prop would be stale.
+  const isActiveRef = useRef(isActive)
+  useEffect(() => {
+    isActiveRef.current = isActive
+  }, [isActive])
+
+  // Removes a still-pending "+" profile and restores the previously-active one.
+  // Clears the ref up front so the two callers (the close effect and the
+  // post-save guard) can't double-run, and reads the store fresh so it reflects
+  // a just-completed create.
+  const discardPendingProfile = useCallback(async () => {
+    const pending = pendingNewProfileRef.current
+    if (!pending) {
+      return
+    }
+    pendingNewProfileRef.current = null
+    const latest = await getProfileRuntimeConfig()
+    if (!latest.profiles.some((profile) => profile.id === pending.newProfileId)) {
+      return
+    }
+    const remaining = latest.profiles.filter((profile) => profile.id !== pending.newProfileId)
+    if (remaining.length === 0) {
+      return
+    }
+    const restoreId = remaining.some((profile) => profile.id === pending.previousActiveProfileId)
+      ? pending.previousActiveProfileId
+      : remaining[0].id
+    await saveProfileSet({ activeProfileId: restoreId, profiles: remaining })
+  }, [getProfileRuntimeConfig, saveProfileSet])
 
   const handleCreateProfile = async (name: string, options?: { trackAsPending?: boolean }) => {
     const trimmedName = name.trim()
@@ -127,39 +157,30 @@ export function GameRow({
     }
 
     await saveProfileSet(updatedProfileSet)
-    pendingNewProfileRef.current = options?.trackAsPending
-      ? { newProfileId: newProfile.id, previousActiveProfileId }
-      : null
+    if (options?.trackAsPending) {
+      pendingNewProfileRef.current = { newProfileId: newProfile.id, previousActiveProfileId }
+      // If the editor was closed while this save was in flight, the close effect
+      // already ran while the ref was still null and won't re-fire, so discard
+      // the freshly-persisted profile now that the store is consistent (#453).
+      if (!isActiveRef.current) {
+        void discardPendingProfile()
+      }
+    } else {
+      pendingNewProfileRef.current = null
+    }
     notify(`Created profile ${newProfile.name}`, 'success')
   }
 
   // When this row's editor closes for ANY reason -- explicit close / discard, or
-  // being collapsed because another row's (or Settings') editor was opened -- a
-  // still-pending "+" profile (never kept) is removed and the previously-active
-  // profile restored, so create-then-discard leaves no orphan (#453). Living in
-  // an isActive effect rather than the close handler so it also catches the
-  // close-by-opening-another-row path, which never routes through onClose.
+  // being collapsed because another row's (or Settings') editor was opened --
+  // discard a still-pending "+" profile. Living in an isActive effect rather
+  // than the close handler so it also catches the close-by-opening-another-row
+  // path, which never routes through onClose (#453).
   useEffect(() => {
-    if (isActive || !pendingNewProfileRef.current) {
-      return
+    if (!isActive) {
+      void discardPendingProfile()
     }
-    const pending = pendingNewProfileRef.current
-    pendingNewProfileRef.current = null
-    void (async () => {
-      const latest = await getProfileRuntimeConfig()
-      if (!latest.profiles.some((profile) => profile.id === pending.newProfileId)) {
-        return
-      }
-      const remaining = latest.profiles.filter((profile) => profile.id !== pending.newProfileId)
-      if (remaining.length === 0) {
-        return
-      }
-      const restoreId = remaining.some((profile) => profile.id === pending.previousActiveProfileId)
-        ? pending.previousActiveProfileId
-        : remaining[0].id
-      await saveProfileSet({ activeProfileId: restoreId, profiles: remaining })
-    })()
-  }, [isActive, getProfileRuntimeConfig, saveProfileSet])
+  }, [isActive, discardPendingProfile])
 
   const switchToProfile = async (nextProfileId: string, skipRunningConfirm = false) => {
     if (nextProfileId === '__new__') {

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -38,6 +38,7 @@ export function GameRow({
   onLaunchEnd,
   onRunningStateRefresh,
   onToggleEditor,
+  onCloseEditor,
   cacheInitialized
 }: {
   game: Game
@@ -52,6 +53,10 @@ export function GameRow({
   onLaunchEnd: (gameKey: string, cooldownMs?: number) => void
   onRunningStateRefresh: () => Promise<void>
   onToggleEditor: () => void
+  // Explicit close for this row's editor (key-guarded functional update) so the
+  // async discard path can close without a stale toggle reopening/closing the
+  // wrong row if the user opens another editor mid-await (#453 Codex P2).
+  onCloseEditor: () => void
   cacheInitialized: boolean
 }): ReactNode {
   const { notify } = useNotify()
@@ -145,7 +150,7 @@ export function GameRow({
         }
       }
     }
-    onToggleEditor()
+    onCloseEditor()
   }
 
   const switchToProfile = async (nextProfileId: string, skipRunningConfirm = false) => {

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -78,7 +78,18 @@ export function GameRow({
   const { profileSet, profileState, loadProfileSet, getProfileRuntimeConfig, saveProfileSet } =
     useGameProfile(game.key, isActive)
 
-  const handleCreateProfile = async (name: string) => {
+  // Tracks a profile created by the editor "+" that has not yet been kept on
+  // purpose (saved / launched / switched-away-from). If the editor is closed
+  // while this is set, the profile is removed and the previously-active profile
+  // is restored, so create-then-discard leaves no orphan (#453). A ref (not
+  // state) so the close handler reads the latest value synchronously and a
+  // deliberate save can clear it before its own onClose fires.
+  const pendingNewProfileRef = useRef<{
+    newProfileId: string
+    previousActiveProfileId: string
+  } | null>(null)
+
+  const handleCreateProfile = async (name: string, options?: { trackAsPending?: boolean }) => {
     const trimmedName = name.trim()
 
     if (trimmedName.length === 0) {
@@ -87,6 +98,19 @@ export function GameRow({
 
     const nextProfileSet = await getProfileRuntimeConfig()
     const activeProfile = getActiveGameProfile(nextProfileSet)
+
+    // If a previous editor "+" creation is still pending (never kept), drop it
+    // so chaining "Discard & Create New" doesn't leak an orphan, and carry its
+    // original previous-active id forward so discarding the new profile still
+    // restores the profile the user actually started from (#453).
+    const existingPending = options?.trackAsPending ? pendingNewProfileRef.current : null
+    const baseProfiles = existingPending
+      ? nextProfileSet.profiles.filter((profile) => profile.id !== existingPending.newProfileId)
+      : nextProfileSet.profiles
+    const previousActiveProfileId = existingPending
+      ? existingPending.previousActiveProfileId
+      : nextProfileSet.activeProfileId
+
     const newProfile: NamedGameProfile = {
       ...JSON.parse(JSON.stringify(activeProfile)),
       id: createProfileId(),
@@ -94,11 +118,34 @@ export function GameRow({
     }
     const updatedProfileSet = {
       activeProfileId: newProfile.id,
-      profiles: [...nextProfileSet.profiles, newProfile]
+      profiles: [...baseProfiles, newProfile]
     }
 
     await saveProfileSet(updatedProfileSet)
+    pendingNewProfileRef.current = options?.trackAsPending
+      ? { newProfileId: newProfile.id, previousActiveProfileId }
+      : null
     notify(`Created profile ${newProfile.name}`, 'success')
+  }
+
+  // Wraps the editor close: if a "+" profile is still pending (never kept),
+  // remove it and restore the previously-active profile before closing (#453).
+  const handleEditorClose = async () => {
+    const pending = pendingNewProfileRef.current
+    if (pending) {
+      pendingNewProfileRef.current = null
+      const latest = await getProfileRuntimeConfig()
+      if (latest.profiles.some((profile) => profile.id === pending.newProfileId)) {
+        const remaining = latest.profiles.filter((profile) => profile.id !== pending.newProfileId)
+        if (remaining.length > 0) {
+          const restoreId = remaining.some((p) => p.id === pending.previousActiveProfileId)
+            ? pending.previousActiveProfileId
+            : remaining[0].id
+          await saveProfileSet({ activeProfileId: restoreId, profiles: remaining })
+        }
+      }
+    }
+    onToggleEditor()
   }
 
   const switchToProfile = async (nextProfileId: string, skipRunningConfirm = false) => {
@@ -174,6 +221,9 @@ export function GameRow({
       }
 
       await saveProfileSet(updatedProfileSet)
+      // Switching to another profile keeps the pending "+" profile on purpose,
+      // so it's no longer a discard-on-close candidate (#453).
+      pendingNewProfileRef.current = null
       closeProfileMenu(true)
       notify(
         switchWarning || `Switched to ${nextProfile.name}`,
@@ -385,8 +435,13 @@ export function GameRow({
                 gameKey={game.key}
                 activeProfileId={profileSet.activeProfileId}
                 onProfilesChanged={loadProfileSet}
-                onClose={onToggleEditor}
-                onCreateProfile={() => void handleCreateProfile('New Profile')}
+                onClose={handleEditorClose}
+                onCreateProfile={() =>
+                  void handleCreateProfile('New Profile', { trackAsPending: true })
+                }
+                onProfileCommitted={() => {
+                  pendingNewProfileRef.current = null
+                }}
                 onLaunchRequest={(launcher) => {
                   handleLaunchRequest.current = launcher
                 }}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import {
   createProfileId,
   getActiveGameProfile,
@@ -133,25 +133,33 @@ export function GameRow({
     notify(`Created profile ${newProfile.name}`, 'success')
   }
 
-  // Wraps the editor close: if a "+" profile is still pending (never kept),
-  // remove it and restore the previously-active profile before closing (#453).
-  const handleEditorClose = async () => {
-    const pending = pendingNewProfileRef.current
-    if (pending) {
-      pendingNewProfileRef.current = null
-      const latest = await getProfileRuntimeConfig()
-      if (latest.profiles.some((profile) => profile.id === pending.newProfileId)) {
-        const remaining = latest.profiles.filter((profile) => profile.id !== pending.newProfileId)
-        if (remaining.length > 0) {
-          const restoreId = remaining.some((p) => p.id === pending.previousActiveProfileId)
-            ? pending.previousActiveProfileId
-            : remaining[0].id
-          await saveProfileSet({ activeProfileId: restoreId, profiles: remaining })
-        }
-      }
+  // When this row's editor closes for ANY reason -- explicit close / discard, or
+  // being collapsed because another row's (or Settings') editor was opened -- a
+  // still-pending "+" profile (never kept) is removed and the previously-active
+  // profile restored, so create-then-discard leaves no orphan (#453). Living in
+  // an isActive effect rather than the close handler so it also catches the
+  // close-by-opening-another-row path, which never routes through onClose.
+  useEffect(() => {
+    if (isActive || !pendingNewProfileRef.current) {
+      return
     }
-    onCloseEditor()
-  }
+    const pending = pendingNewProfileRef.current
+    pendingNewProfileRef.current = null
+    void (async () => {
+      const latest = await getProfileRuntimeConfig()
+      if (!latest.profiles.some((profile) => profile.id === pending.newProfileId)) {
+        return
+      }
+      const remaining = latest.profiles.filter((profile) => profile.id !== pending.newProfileId)
+      if (remaining.length === 0) {
+        return
+      }
+      const restoreId = remaining.some((profile) => profile.id === pending.previousActiveProfileId)
+        ? pending.previousActiveProfileId
+        : remaining[0].id
+      await saveProfileSet({ activeProfileId: restoreId, profiles: remaining })
+    })()
+  }, [isActive, getProfileRuntimeConfig, saveProfileSet])
 
   const switchToProfile = async (nextProfileId: string, skipRunningConfirm = false) => {
     if (nextProfileId === '__new__') {
@@ -440,7 +448,7 @@ export function GameRow({
                 gameKey={game.key}
                 activeProfileId={profileSet.activeProfileId}
                 onProfilesChanged={loadProfileSet}
-                onClose={handleEditorClose}
+                onClose={onCloseEditor}
                 onCreateProfile={() =>
                   void handleCreateProfile('New Profile', { trackAsPending: true })
                 }

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -101,12 +101,18 @@ export function useGameProfile(
     }
   }, [activeProfileId, applyProfileSet, isActive, readProfileSet])
 
-  const getProfileRuntimeConfig = async (): Promise<GameProfileSet> => readProfileSet()
+  const getProfileRuntimeConfig = useCallback(
+    async (): Promise<GameProfileSet> => readProfileSet(),
+    [readProfileSet]
+  )
 
-  const saveProfileSet = async (nextProfileSet: GameProfileSet) => {
-    await saveProfile(gameKey, nextProfileSet)
-    applyProfileSet(nextProfileSet)
-  }
+  const saveProfileSet = useCallback(
+    async (nextProfileSet: GameProfileSet) => {
+      await saveProfile(gameKey, nextProfileSet)
+      applyProfileSet(nextProfileSet)
+    },
+    [applyProfileSet, gameKey]
+  )
 
   return { profileSet, profileState, loadProfileSet, getProfileRuntimeConfig, saveProfileSet }
 }

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -29,6 +29,10 @@ export interface ProfileEditorProps {
   onProfilesChanged: () => Promise<unknown>
   onClose: () => void
   onCreateProfile?: () => void
+  // Signals the parent that the active profile was deliberately kept (saved,
+  // launched, or deleted) so a freshly-created "+" profile is no longer a
+  // discard-on-close candidate (#453).
+  onProfileCommitted?: () => void
   onLaunchRequest?: (handleLaunch: () => void) => void
   onLaunchStart?: () => void
   onLaunchEnd?: (cooldownMs: number) => void
@@ -96,6 +100,7 @@ export function useProfileEditor({
   onProfilesChanged,
   onClose,
   onCreateProfile,
+  onProfileCommitted,
   onLaunchRequest,
   onLaunchStart,
   onLaunchEnd
@@ -390,6 +395,7 @@ export function useProfileEditor({
 
   const executeLaunch = useCallback(async () => {
     setShowLaunchConfirm(false)
+    onProfileCommitted?.()
     onClose()
     onLaunchStart?.()
     let cooldownMs = 0
@@ -411,7 +417,15 @@ export function useProfileEditor({
     } finally {
       onLaunchEnd?.(cooldownMs)
     }
-  }, [gameKey, notify, onClose, onLaunchEnd, onLaunchStart, setShowLaunchConfirm])
+  }, [
+    gameKey,
+    notify,
+    onClose,
+    onLaunchEnd,
+    onLaunchStart,
+    onProfileCommitted,
+    setShowLaunchConfirm
+  ])
 
   const handleLaunch = useCallback(async () => {
     if (isDirty) {
@@ -457,6 +471,7 @@ export function useProfileEditor({
       })
       await onProfilesChanged()
       resetDirty()
+      onProfileCommitted?.()
 
       notify('Profile saved!', 'success', 2500)
 
@@ -511,6 +526,7 @@ export function useProfileEditor({
       })
       await onProfilesChanged()
       resetDirty()
+      onProfileCommitted?.()
       notify('Profile saved!', 'success', 2500)
       return true
     } catch (err) {
@@ -564,6 +580,7 @@ export function useProfileEditor({
     setProfileDeleteConfirm(null)
     await onProfilesChanged()
     notify('Profile deleted', 'warn', 2500)
+    onProfileCommitted?.()
     onClose()
   }
 


### PR DESCRIPTION
## Summary
The editor **"+"** (New profile) immediately persists and activates the new profile (there is no draft state), so backing out left an **orphan "New Profile"** created and selected instead of reverting to the profile the user started from (#453).

## Fix (option b - track + restore)
`GameRow` tracks the pending "+" profile (`{ newProfileId, previousActiveProfileId }`) in a **ref**. It is cleared the moment the profile is **kept on purpose**:
- **saved** - `onProfileCommitted` from `handleSave` / `handleSaveOnly`
- **launched** - `executeLaunch`
- **deleted** - `confirmDeleteProfile`
- **switched away from** - `switchToProfile`

If the editor is instead **closed / discarded** while the pending profile is still uncommitted, the new profile is removed and the **previously-active profile is restored** -> create-then-discard leaves no orphan. Chaining **"Discard & Create New"** drops the abandoned profile and carries the original previous-active id forward.

### Why a ref, not state
The close handler must read the latest value **synchronously** - a deliberate save clears it *before* `handleSave`'s own `onClose` fires, so a state value (stale closure) would incorrectly delete the just-saved profile.

## Scenarios verified (logic walk-through)
| Flow | Result |
|------|--------|
| Create -> X (clean) | new removed, previous restored ✓ |
| Create -> edit -> Discard | new removed, previous restored ✓ |
| Create -> edit -> Save (in dialog) | kept ✓ |
| Create -> Save button | kept ✓ |
| Create -> Save & Create New | first saved, second pending ✓ |
| Create -> Discard & Create New | first dropped, second from original ✓ |
| Create -> switch via header dropdown | kept (committed) ✓ |
| Create -> Delete Profile | deleted via delete flow, no double-delete ✓ |
| Normal edit (no create) | unchanged, no regression ✓ |

## Testing
- lint / typecheck / 181 unit tests / production build all green
- No GameRow integration harness exists; manual smoke recommended for the create-then-discard path that surfaced this.

Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #453
<!-- auto-closes -->