### PR TITLE
feat: Discard button on sticky unsaved-changes bar (#442)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -109,22 +109,27 @@ function AppContent() {
     setView(nextView)
   }
 
-  const handleConfirmDiscard = useCallback(() => {
+  const handleDiscardAll = useCallback(() => {
     requestDiscardAll()
     reportSettingsDirty(false)
-    // Reset main-process state that the renderer had forwarded ahead of save.
-    // Currently this covers the pending Minimize-to-tray toggle: without
-    // clearing it, the close handler would still follow the discarded value.
+    // Reset main-process state the renderer forwarded ahead of save (the pending
+    // Minimize-to-tray toggle), remount the SettingsProvider so discarded toggles
+    // reload from the store, and re-sync theme so a discarded theme/accent preview
+    // reverts.
     void setPendingMinimizeToTray(null)
-    // Remount the SettingsProvider so it reloads UI state from the store
-    // (otherwise discarded toggles would still appear as enabled in the UI).
     setRefreshKey((k) => k + 1)
-    syncThemeFromStore()
+    syncThemeFromStore().catch((err) => {
+      console.error('Failed to re-sync theme after discard', err)
+    })
+  }, [reportSettingsDirty, requestDiscardAll, syncThemeFromStore])
+
+  const handleConfirmDiscard = useCallback(() => {
+    handleDiscardAll()
     if (pendingView) {
       setView(pendingView)
       setPendingView(null)
     }
-  }, [pendingView, reportSettingsDirty, requestDiscardAll, syncThemeFromStore])
+  }, [handleDiscardAll, pendingView])
 
   const handleConfirmCancel = () => {
     setPendingView(null)
@@ -266,7 +271,7 @@ function AppContent() {
         </main>
       </SettingsProvider>
 
-      <StickySaveBar />
+      <StickySaveBar onDiscard={handleDiscardAll} />
 
       <ConfirmDialog
         isOpen={pendingView !== null}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { NotifyProvider, useNotify } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
@@ -43,7 +43,19 @@ function AppContent() {
   // the terminal IPC call both match the user's current tray preference.
   const [closeConfirmMinimizeMode, setCloseConfirmMinimizeMode] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
+  // App-level discard confirm, opened by the sticky bar's Discard button. Lifted
+  // here (rather than living inside StickySaveBar) so the OS close-request
+  // handler can avoid stacking it with the close dialog — two open ConfirmDialogs
+  // would both bind global Enter/Escape and a single keypress could fire both.
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false)
   const { isAnyDirty, reportSettingsDirty, requestSaveAll, requestDiscardAll } = useAppDirty()
+
+  // Mirror so the once-registered close-request handler reads the latest value
+  // without re-subscribing.
+  const discardConfirmOpenRef = useRef(false)
+  useEffect(() => {
+    discardConfirmOpenRef.current = discardConfirmOpen
+  }, [discardConfirmOpen])
 
   useEffect(() => {
     runStartupMigrations()
@@ -55,13 +67,13 @@ function AppContent() {
 
   useEffect(() => {
     const unsubscribe = onCloseRequested(({ minimizeMode }: { minimizeMode: boolean }) => {
-      // Avoid stacking the close dialog on top of the tab-switch dialog —
-      // two simultaneous confirms attach independent Enter/Escape handlers
-      // and a single keypress would trigger conflicting save/discard flows.
-      // The tab-switch flow is more contextual (user just clicked a tab),
-      // so let them finish it first.
+      // Avoid stacking the close dialog on top of the tab-switch OR discard
+      // confirm — two simultaneous confirms attach independent Enter/Escape
+      // handlers and a single keypress would trigger conflicting flows. Those
+      // flows are more contextual (the user just clicked a tab / Discard), so
+      // let them finish first.
       setPendingView((current) => {
-        if (current === null) {
+        if (current === null && !discardConfirmOpenRef.current) {
           setCloseConfirmMinimizeMode(minimizeMode)
           setCloseConfirmOpen(true)
         }
@@ -271,7 +283,7 @@ function AppContent() {
         </main>
       </SettingsProvider>
 
-      <StickySaveBar onDiscard={handleDiscardAll} />
+      <StickySaveBar onRequestDiscard={() => setDiscardConfirmOpen(true)} />
 
       <ConfirmDialog
         isOpen={pendingView !== null}
@@ -301,6 +313,22 @@ function AppContent() {
           void handleCloseConfirmDiscard()
         }}
         onCancel={handleCloseConfirmCancel}
+      />
+
+      <ConfirmDialog
+        isOpen={discardConfirmOpen}
+        title="Discard changes?"
+        message="This reverts all unsaved changes across Settings and any open profile editor. This can't be undone."
+        saveLabel="Discard Changes"
+        discardLabel="Keep Editing"
+        saveClassName="danger-action"
+        discardClassName="neutral-action"
+        onSave={() => {
+          setDiscardConfirmOpen(false)
+          handleDiscardAll()
+        }}
+        onDiscard={() => setDiscardConfirmOpen(false)}
+        onCancel={() => setDiscardConfirmOpen(false)}
       />
     </div>
   )

--- a/src/renderer/src/components/ConfirmDialog.tsx
+++ b/src/renderer/src/components/ConfirmDialog.tsx
@@ -32,12 +32,18 @@ export function ConfirmDialog({
     if (!isOpen) return
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' && e.key !== 'Enter') return
+      // Consume Enter/Escape so background window keydown handlers (Settings and
+      // the profile editor both close-on-Escape) don't also fire and stack
+      // another dialog behind this one. Capture phase + stopImmediatePropagation
+      // is required because those listeners were registered earlier on window.
+      e.stopImmediatePropagation()
       if (e.key === 'Escape') onCancel()
-      if (e.key === 'Enter') onSave()
+      else onSave()
     }
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
   }, [isOpen, onCancel, onSave])
 
   if (!isOpen) return null

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { useAppDirty } from '../contexts/AppDirtyContext'
 import { useNotify } from './Notify'
+import { ConfirmDialog } from './ConfirmDialog'
 
 /**
  * App-level unsaved-changes bar pinned to the bottom of the viewport. Shown
@@ -14,10 +15,11 @@ import { useNotify } from './Notify'
  * usually shorter than the viewport, so sticky never pinned and the bar sat
  * at the natural end of the card (out of sight after any scroll, #423).
  */
-export function StickySaveBar(): ReactNode {
+export function StickySaveBar({ onDiscard }: { onDiscard: () => void }): ReactNode {
   const { isAnyDirty, requestSaveAll } = useAppDirty()
   const { notify } = useNotify()
   const [isSaving, setIsSaving] = useState(false)
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
   // Reset the local saving flag whenever dirty state clears externally (a
   // save dialog elsewhere, a discard, a tab-switch save). Without this the
@@ -55,28 +57,53 @@ export function StickySaveBar(): ReactNode {
   }
 
   return (
-    <div
-      className="fixed bottom-4 left-4 right-4 z-30 animate-fade-slide"
-      role="region"
-      aria-label="Unsaved changes"
-    >
-      <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl [--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!">
-        <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
-          <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
-        </span>
-        <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
-          You have unsaved changes.
-        </span>
-        <button
-          type="button"
-          onClick={() => void handleSave()}
-          disabled={isSaving}
-          className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isSaving ? 'Saving…' : 'Save Changes'}
-        </button>
+    <>
+      <div
+        className="fixed bottom-4 left-4 right-4 z-30 animate-fade-slide"
+        role="region"
+        aria-label="Unsaved changes"
+      >
+        <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl [--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!">
+          <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
+            <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
+          </span>
+          <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
+            You have unsaved changes.
+          </span>
+          <button
+            type="button"
+            onClick={() => setShowDiscardConfirm(true)}
+            disabled={isSaving}
+            className="neutral-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={isSaving}
+            className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSaving ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
       </div>
-    </div>
+      <ConfirmDialog
+        isOpen={showDiscardConfirm}
+        title="Discard changes?"
+        message="This reverts all unsaved changes across Settings and any open profile editor. This can't be undone."
+        saveLabel="Discard Changes"
+        discardLabel="Keep Editing"
+        saveClassName="danger-action"
+        discardClassName="neutral-action"
+        onSave={() => {
+          setShowDiscardConfirm(false)
+          onDiscard()
+        }}
+        onDiscard={() => setShowDiscardConfirm(false)}
+        onCancel={() => setShowDiscardConfirm(false)}
+      />
+    </>
   )
 }

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { useAppDirty } from '../contexts/AppDirtyContext'
 import { useNotify } from './Notify'
-import { ConfirmDialog } from './ConfirmDialog'
 
 /**
  * App-level unsaved-changes bar pinned to the bottom of the viewport. Shown
@@ -15,11 +14,10 @@ import { ConfirmDialog } from './ConfirmDialog'
  * usually shorter than the viewport, so sticky never pinned and the bar sat
  * at the natural end of the card (out of sight after any scroll, #423).
  */
-export function StickySaveBar({ onDiscard }: { onDiscard: () => void }): ReactNode {
+export function StickySaveBar({ onRequestDiscard }: { onRequestDiscard: () => void }): ReactNode {
   const { isAnyDirty, requestSaveAll } = useAppDirty()
   const { notify } = useNotify()
   const [isSaving, setIsSaving] = useState(false)
-  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
   // Reset the local saving flag whenever dirty state clears externally (a
   // save dialog elsewhere, a discard, a tab-switch save). Without this the
@@ -57,53 +55,36 @@ export function StickySaveBar({ onDiscard }: { onDiscard: () => void }): ReactNo
   }
 
   return (
-    <>
-      <div
-        className="fixed bottom-4 left-4 right-4 z-30 animate-fade-slide"
-        role="region"
-        aria-label="Unsaved changes"
-      >
-        <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl [--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!">
-          <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
-            <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
-          </span>
-          <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
-            You have unsaved changes.
-          </span>
-          <button
-            type="button"
-            onClick={() => setShowDiscardConfirm(true)}
-            disabled={isSaving}
-            className="neutral-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Discard
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleSave()}
-            disabled={isSaving}
-            className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isSaving ? 'Saving…' : 'Save Changes'}
-          </button>
-        </div>
+    <div
+      className="fixed bottom-4 left-4 right-4 z-30 animate-fade-slide"
+      role="region"
+      aria-label="Unsaved changes"
+    >
+      <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl [--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!">
+        <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
+          <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
+        </span>
+        <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
+          You have unsaved changes.
+        </span>
+        <button
+          type="button"
+          onClick={onRequestDiscard}
+          disabled={isSaving}
+          className="neutral-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Discard
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={isSaving}
+          className="accent-surface-action action-hover-scale cursor-pointer rounded-xl px-4 py-2 text-xs font-bold disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving ? 'Saving…' : 'Save Changes'}
+        </button>
       </div>
-      <ConfirmDialog
-        isOpen={showDiscardConfirm}
-        title="Discard changes?"
-        message="This reverts all unsaved changes across Settings and any open profile editor. This can't be undone."
-        saveLabel="Discard Changes"
-        discardLabel="Keep Editing"
-        saveClassName="danger-action"
-        discardClassName="neutral-action"
-        onSave={() => {
-          setShowDiscardConfirm(false)
-          onDiscard()
-        }}
-        onDiscard={() => setShowDiscardConfirm(false)}
-        onCancel={() => setShowDiscardConfirm(false)}
-      />
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a **Discard** button to the app-level `StickySaveBar`, placed immediately left of the existing Save Changes button.
- The button is gated behind a destructive confirm dialog (mirroring the delete-profile dialog pattern): primary action = "Discard Changes" (`danger-action`), secondary = "Keep Editing" (`neutral-action`), Enter triggers the destructive primary.
- Wired to a new `handleDiscardAll` in `App.tsx` that runs `requestDiscardAll`, clears the pending Minimize-to-tray main-process override, remounts the `SettingsProvider` via `refreshKey` so discarded settings reload from the store, and re-syncs theme so a discarded theme/accent preview reverts immediately.
- `handleConfirmDiscard` (tab-switch confirm flow) now delegates to `handleDiscardAll` and only adds the pending-view navigation on top — no duplicated logic.

## Testing

Lint, typecheck, all 181 tests, and production build all pass clean. The pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` build warning is unchanged.

Closes #442.

<!-- auto-closes -->
Closes #442
<!-- auto-closes -->