### PR TITLE
style: unify overlay glass (save bar + profile dropdown) (#439)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -36,10 +36,10 @@
   --launcher-play: #48c774;
   --header-glass-bg: rgba(18, 18, 18, 0.7);
   --header-glass-border: rgba(255, 255, 255, 0.05);
-  /* Shared frosted material for floating overlays (sticky save bar + dropdown
-     menus). Aliases the header glass so all three read as one material; resolves
-     per-theme via the themed --header-glass-bg (#439). */
-  --overlay-glass-bg: var(--header-glass-bg);
+  /* Frosted material for floating overlays (sticky save bar + dropdown menus).
+     More opaque than the header so busy content behind doesn't bleed through;
+     the blur keeps it reading as glass rather than a flat panel (#439). */
+  --overlay-glass-bg: rgba(18, 18, 18, 0.9);
   --surface-recessed-bg: linear-gradient(180deg, rgba(18, 18, 22, 0.24), rgba(8, 8, 11, 0.16));
   --surface-recessed-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.045), inset 0 -10px 24px rgba(0, 0, 0, 0.12),
@@ -96,6 +96,7 @@
   --status-running: #16a34a;
   --header-glass-bg: rgba(252, 252, 254, 0.75);
   --header-glass-border: rgba(20, 20, 24, 0.08);
+  --overlay-glass-bg: rgba(252, 252, 254, 0.92);
   --surface-recessed-bg: linear-gradient(
     180deg,
     rgba(235, 232, 242, 0.65),

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -38,8 +38,9 @@
   --header-glass-border: rgba(255, 255, 255, 0.05);
   /* Frosted material for floating overlays (sticky save bar + dropdown menus).
      More opaque than the header so busy content behind doesn't bleed through;
-     the blur keeps it reading as glass rather than a flat panel (#439). */
-  --overlay-glass-bg: rgba(18, 18, 18, 0.9);
+     the blur keeps it reading as glass rather than a flat panel (#439).
+     Keep opacity at 0.75 so the backdrop-filter blur is actually visible. */
+  --overlay-glass-bg: rgba(18, 18, 18, 0.75);
   --surface-recessed-bg: linear-gradient(180deg, rgba(18, 18, 22, 0.24), rgba(8, 8, 11, 0.16));
   --surface-recessed-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.045), inset 0 -10px 24px rgba(0, 0, 0, 0.12),
@@ -96,7 +97,7 @@
   --status-running: #16a34a;
   --header-glass-bg: rgba(252, 252, 254, 0.75);
   --header-glass-border: rgba(20, 20, 24, 0.08);
-  --overlay-glass-bg: rgba(252, 252, 254, 0.92);
+  --overlay-glass-bg: rgba(252, 252, 254, 0.8);
   --surface-recessed-bg: linear-gradient(
     180deg,
     rgba(235, 232, 242, 0.65),
@@ -168,7 +169,8 @@ textarea {
   border: 1px solid transparent;
   -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
-  will-change: transform;
+  /* will-change: transform is omitted here because promoting the element
+     to its own compositing layer breaks backdrop-filter rendering in Chromium/Electron. */
 }
 
 .header-glass {
@@ -501,8 +503,8 @@ textarea {
    order) on each surface. */
 .overlay-glass {
   background: var(--overlay-glass-bg);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
 }
 
 .dropdown-trigger-surface {
@@ -544,7 +546,7 @@ textarea {
 }
 
 .animate-fade-slide {
-  animation: fadeSlide 0.25s ease-out forwards;
+  animation: fadeSlide 0.25s ease-out backwards;
 }
 
 @keyframes fadeSlideInline {

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -36,6 +36,10 @@
   --launcher-play: #48c774;
   --header-glass-bg: rgba(18, 18, 18, 0.7);
   --header-glass-border: rgba(255, 255, 255, 0.05);
+  /* Shared frosted material for floating overlays (sticky save bar + dropdown
+     menus). Aliases the header glass so all three read as one material; resolves
+     per-theme via the themed --header-glass-bg (#439). */
+  --overlay-glass-bg: var(--header-glass-bg);
   --surface-recessed-bg: linear-gradient(180deg, rgba(18, 18, 22, 0.24), rgba(8, 8, 11, 0.16));
   --surface-recessed-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.045), inset 0 -10px 24px rgba(0, 0, 0, 0.12),
@@ -486,6 +490,18 @@ textarea {
 .dropdown-surface {
   background: var(--surface-floating-bg);
   box-shadow: var(--surface-floating-shadow);
+}
+
+/* Unified frosted glass for floating overlays so the sticky save bar and the
+   profile dropdown read as the same material — neither the near-transparent
+   glass-bg nor the near-opaque surface-floating-bg (#439). Unlayered so its
+   background/blur win over both the utility `backdrop-blur-*` and the
+   `glass-surface-*` blur(5px); applied alongside those classes (later source
+   order) on each surface. */
+.overlay-glass {
+  background: var(--overlay-glass-bg);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
 }
 
 .dropdown-trigger-surface {

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -60,7 +60,7 @@ export function StickySaveBar({ onRequestDiscard }: { onRequestDiscard: () => vo
       role="region"
       aria-label="Unsaved changes"
     >
-      <div className="glass-surface-elevated mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040] backdrop-blur-xl [--glass-surface-fill:color-mix(in_srgb,var(--header-glass-bg)_65%,var(--glass-bg-elevated))]!">
+      <div className="glass-surface-elevated overlay-glass mx-auto flex max-w-3xl items-center gap-3 rounded-2xl border border-(--glass-border) p-3 shadow-[0_12px_30px_#00000040]">
         <span className="relative flex h-2 w-2 shrink-0 items-center justify-center">
           <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />

--- a/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
@@ -73,7 +73,7 @@ export function GameRowProfileMenu({
           ref={menuRef}
           role="menu"
           onKeyDown={handleProfileMenuKeyDown}
-          className="dropdown-surface absolute right-0 top-full z-50 mt-1.5 min-w-44 overflow-hidden rounded-xl p-1 backdrop-blur-xl animate-fade-slide"
+          className="dropdown-surface overlay-glass absolute right-0 top-full z-50 mt-1.5 min-w-44 overflow-hidden rounded-xl p-1 animate-fade-slide"
         >
           {profileSet.profiles.map((profile) => {
             const selected = profile.id === profileSet.activeProfileId


### PR DESCRIPTION
## Summary
The two floating overlay surfaces read as different materials:
- **Sticky save bar** — near-transparent (~0.47 fill; its `backdrop-blur-xl` was actually dead, since the unlayered `glass-surface-elevated` `blur(5px)` overrode the utility), so content bled through.
- **Profile dropdown** — near-opaque (`--surface-floating-bg` ~0.95), so its `backdrop-blur-xl` was wasted.

## Change
Reuse the existing glass design tokens — no new material. Add a shared `.overlay-glass` class (`background: var(--overlay-glass-bg)` + `blur(20px)`), with `--overlay-glass-bg` aliased to the existing `--header-glass-bg` so the save bar, dropdown, and header all read as **one** frosted material. Applied to both surfaces alongside their existing classes; it's unlayered and later in source order, so it wins over both the utility `backdrop-blur-*` and the `glass-surface` `blur(5px)`. Resolves per-theme via the themed `--header-glass-bg`.

## Testing
- lint / typecheck / 181 tests / build all pass.
- **Visual — needs maintainer verification** (light + dark): save bar and dropdown should now read as the same frosted glass as the header. Opacity is tunable in one place via `--overlay-glass-bg` if it wants nudging.

Closes #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #439
<!-- auto-closes -->