### PR TITLE
docs: README Troubleshooting/Building/Trust/Security + CHANGELOG (#58, #71, #116, #231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to SimLauncher are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Full per-release notes — including every linked issue and PR — are published on the
+[GitHub Releases page](https://github.com/Stashpeak/SimLauncher/releases).
+
+## [0.9.8] - 2026-06-01
+
+### Added
+
+- Unified unsaved-changes UX across Settings and the Profile Editor: an app-level sticky save bar, tab/close confirmation dialogs, and profile-name dirty tracking.
+- Dynamic context-menu labels for utility icon dismissal — labels reflect the actual app instead of generic text.
+- Per-utility-key argument resolution, enabling dual-slot same-exe profiles with distinct launch arguments.
+
+### Fixed
+
+- Clearer wrapper-exit messaging explaining lost tracking and how to restore it.
+- Suppressed the misleading "couldn't be closed" toast when the launched exe is already gone.
+- Hardened kill verification and the spawn exit handler against tasklist-read failures and same-key relaunch races.
+- A Settings-tab window close now shows the confirm dialog instead of silently minimizing to tray.
+- The Profile Editor close (X) no longer drops unsaved changes silently.
+- The accent color picker is now a floating popover, so it no longer shifts the layout.
+
+### Changed
+
+- Split the process logic into `processes/{kill,spawn,state,running,tasklist}.ts` with clean layered imports.
+- Unified path normalization across the main and renderer processes.
+- Explicit return types on all exported functions, hooks, and components, plus broader test coverage.
+
+## [0.9.7] - 2026-05-21
+
+### Added
+
+- Renderer Content Security Policy, enforced via a build-time meta tag (packaged builds) and an HTTP response header (dev mode).
+
+### Fixed
+
+- Process-mismatch warning icons now persist until manually dismissed instead of auto-clearing after 60s.
+
+### Changed
+
+- Hardened IPC handlers with deep input validation, prototype-pollution guards, and game-key allow-lists.
+- Added runtime type guards for all store-backed data, so a tampered config file can no longer crash settings reads.
+
+## Earlier releases
+
+SimLauncher has shipped continuously since **v0.1.0 (2026-04-17)** — including the
+per-sim profile system, config export/import, dynamic custom app slots, the
+auto-updater and tray UX, and the 2026 design overhaul. See the
+[GitHub Releases page](https://github.com/Stashpeak/SimLauncher/releases) for the
+complete history and detailed notes.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,62 @@ SimHub, Crew Chief, Trading Paints, Garage 61, Second Monitor, plus 20 custom ap
 
 ---
 
+## Troubleshooting
+
+### "Windows protected your PC" (SmartScreen)
+
+The installer isn't code-signed yet, so SmartScreen may warn on first launch. Click **More info → Run anyway**.
+
+### A game won't launch
+
+- Check that the executable path in Settings points to the correct `.exe`.
+- Make sure the game isn't already running.
+- If the game needs elevated permissions, try running SimLauncher as Administrator.
+
+### A utility isn't detected as running
+
+- Some utilities (e.g. SimHub) take longer to start — increase the launch delay in Settings.
+- Process detection matches by executable name, so custom-named copies won't be detected.
+
+### Auto-updater isn't working
+
+- Make sure your firewall/proxy allows `github.com` and `objects.githubusercontent.com`.
+- If an update hangs, restart SimLauncher — it retries on the next launch.
+
+---
+
+## Building from source
+
+SimLauncher is a standard Electron + electron-vite project. You need [Node.js](https://nodejs.org/) (LTS) and npm.
+
+```bash
+git clone https://github.com/Stashpeak/SimLauncher.git
+cd SimLauncher
+npm install
+npm run dev        # run in development
+npm run dist:win   # build a Windows installer into dist/
+```
+
+Other useful scripts: `npm test` (unit tests), `npm run lint`, and `npm run typecheck`.
+
+---
+
+## Trust & transparency
+
+- **The source is public** and licensed under **GPL-3.0** — you can read every line, the full commit history, issues, pull requests, and CI runs before trusting a binary.
+- **You can build it yourself** from source (see above) instead of running the published installer.
+- **Releases are built in CI** from tagged commits, and each release's notes link the issues and PRs behind every change.
+- **Development is AI-assisted** (Claude Code) with human review on every change, disclosed openly in the commit history.
+- **Security issues** should be reported privately — see [Security](#security).
+
+---
+
+## Security
+
+Please **don't** open a public issue for security vulnerabilities. Report them privately via [GitHub Security Advisories](https://github.com/Stashpeak/SimLauncher/security/advisories/new). More detail is in [SECURITY.md](SECURITY.md).
+
+---
+
 ## Support
 
 If SimLauncher saves you time on race day, a small tip is appreciated: [paypal.me/shieldxx](https://paypal.me/shieldxx)


### PR DESCRIPTION
## Summary
Documentation pass closing four long-standing docs issues. **Docs only — no code changes.**

- **Troubleshooting** README section — SmartScreen, launch failures, utility detection, auto-updater (#58).
- **Building from source** — clone / `npm install` / `npm run dev` / `npm run dist:win` (#231).
- **Trust & transparency** — public GPL-3.0 source, build-it-yourself, CI-built releases, AI-assisted-development disclosure (#231).
- **Security** README section → [GitHub Security Advisories](https://github.com/Stashpeak/SimLauncher/security/advisories/new) + `SECURITY.md` (which already existed) (#71).
- **CHANGELOG.md** — Keep a Changelog format with accurate 0.9.8 / 0.9.7 entries and a pointer to GitHub Releases for the full history (#116).

Closes #58, closes #71, closes #116, closes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #58
Closes #71
Closes #116
Closes #231
<!-- auto-closes -->