### PR TITLE
style: global select-none default with opt-in selection (#359)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -150,6 +150,21 @@ body {
     sans-serif;
 }
 
+/* Desktop-app convention: text is not selectable by default (#359).
+   Re-enable selection only for native editable controls below; opt back in
+   elsewhere with Tailwind's `select-text` where copy-paste is useful. */
+body {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+input,
+textarea,
+[contenteditable] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -41,7 +41,7 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
         >
           <BrandWordmarkIcon
             aria-hidden="true"
-            className={`launcher-wordmark h-[15px] w-auto shrink-0 select-none transition-colors ${
+            className={`launcher-wordmark h-[15px] w-auto shrink-0 transition-colors ${
               view === 'games'
                 ? 'text-(--accent)'
                 : 'text-(--text-muted) group-hover:text-(--accent)'

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -416,9 +416,7 @@ export function GameRow({
           <GameIcon game={game} isRunning={isRunning} iconUrl={gameIconUrl} />
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
-              <h3 className="game-title select-none font-normal text-(--text-primary)">
-                {game.name}
-              </h3>
+              <h3 className="game-title font-normal text-(--text-primary)">{game.name}</h3>
             </div>
             <RunningAppsStrip
               runningAppIcons={runningAppIcons}

--- a/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
@@ -66,7 +66,7 @@ export function GameRowProfileMenu({
           height={10}
           className={`shrink-0 text-(--text-muted) transition-transform ${profileMenuOpen ? 'rotate-180' : ''}`}
         />
-        <span className="min-w-0 select-none truncate">{activeProfile.name}</span>
+        <span className="min-w-0 truncate">{activeProfile.name}</span>
       </button>
       {profileMenuOpen && (
         <div

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -63,7 +63,7 @@ export function RunningAppsStrip({
         return (
           <div
             key={i}
-            className={`fallback-initial-icon select-none h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
+            className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
             title={app.warning || app.name}
             onContextMenu={(e) => {
               if (app.warning) {

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -101,7 +101,7 @@ function renderUtilityRow(
         props.onDragUtilityIdChange(null)
         props.onDropTargetChange(null)
       }}
-      className={`accent-subtle-hover group relative flex select-none items-center justify-between rounded-xl bg-(--glass-bg) p-3 ${isEnabled ? 'cursor-grab active:cursor-grabbing' : 'opacity-55'} ${props.dragUtilityId === utility.key ? 'ring-1 ring-(--accent)/35 shadow-[0_0_18px_-14px_var(--accent)]' : ''}`}
+      className={`accent-subtle-hover group relative flex items-center justify-between rounded-xl bg-(--glass-bg) p-3 ${isEnabled ? 'cursor-grab active:cursor-grabbing' : 'opacity-55'} ${props.dragUtilityId === utility.key ? 'ring-1 ring-(--accent)/35 shadow-[0_0_18px_-14px_var(--accent)]' : ''}`}
     >
       {dropPlacement && (
         <span

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -31,7 +31,7 @@ export function AboutSection({
     <>
       <div className="settings-row">
         <span className="settings-label text-(--text-secondary)">Installed Version</span>
-        <span className="text-xs font-mono text-(--text-muted)">v{appVersion}</span>
+        <span className="select-text text-xs font-mono text-(--text-muted)">v{appVersion}</span>
       </div>
 
       <div className="settings-row">

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -120,7 +120,7 @@ export function AppsSection(): ReactNode {
               />
             ) : (
               <div
-                className="fallback-initial-icon select-none flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
+                className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
                 title={`${appNames[utility.key] || utility.name} icon fallback`}
               >
                 {getInitials(appNames[utility.key] || utility.name)}


### PR DESCRIPTION
## Summary

Implements a global opt-out approach to text selection for the desktop app, replacing the scattered case-by-case `select-none` utility classes with a single source of truth in CSS.

- **`App.css`**: Adds a `body { -webkit-user-select: none; user-select: none; }` rule (with a comment explaining the desktop-app rationale and `#359`). Native editable controls (`input`, `textarea`, `[contenteditable]`) immediately follow with `user-select: text` so they remain usable without any class needed.
- **`AboutSection.tsx`**: Adds `select-text` to the "Installed Version" value span (`v{appVersion}`) so users can copy a version string into bug reports.
- **6 redundant `select-none` removals**: `WindowControls.tsx`, `RunningAppsStrip.tsx`, `GameRow.tsx`, `GameRowProfileMenu.tsx`, `ProfileUtilitiesSection.tsx`, `AppsSection.tsx` — the global rule now covers all of these.

Native `<input>` and `<textarea>` elements (including the readonly path input in `ProcessTrackingSection`) remain selectable via the CSS `input, textarea` rule — no per-element changes needed.

Closes #359.