### PR TITLE
feat: custom Tooltip + styled context menu (#252, #466)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.8",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@floating-ui/react": "^0.27.19",
         "@tailwindcss/vite": "^4.3.0",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.3.0",
@@ -1488,6 +1489,59 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -7399,6 +7453,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tagged-tag": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "Stashpeak",
   "license": "GPL-3.0-only",
   "dependencies": {
+    "@floating-ui/react": "^0.27.19",
     "@tailwindcss/vite": "^4.3.0",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.3.0",

--- a/src/main/ipc/context-menu.ts
+++ b/src/main/ipc/context-menu.ts
@@ -1,57 +1,17 @@
-import { BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain } from 'electron'
-import path from 'path'
+import { ipcMain } from 'electron'
 import { dismissAppIcon, publishRunningApps } from '../processes'
 
-interface ShowAppContextMenuOptions {
-  tracked?: boolean
-  name?: string
-}
-
-// Strip the `.exe` suffix so context-menu labels read naturally (e.g. "Dismiss
-// OTT Warning" instead of "Dismiss OTT.exe Warning"). Electron treats `&` in
-// menu labels as a mnemonic prefix on Windows, so we double-escape it to
-// preserve the original character in app names like "AT&T".
-function formatAppDisplayName(appPath: string, providedName?: string): string {
-  const rawName = providedName?.trim() || path.basename(appPath)
-  const stripped = rawName.replace(/\.exe$/i, '') || rawName
-  return stripped.replace(/&/g, '&&')
-}
-
-export function buildDismissLabel(
-  appPath: string,
-  options: ShowAppContextMenuOptions = {}
-): string {
-  const displayName = formatAppDisplayName(appPath, options.name)
-  // Tracked utilities keep their icon visible after the warning clears, so
-  // labeling the action "Dismiss Icon" is misleading (see #363). Use
-  // "Dismiss Warning" for tracked apps and "Dismiss Icon" only for untracked
-  // mismatches where the icon truly disappears.
-  const action = options.tracked ? 'Dismiss Warning' : 'Dismiss Icon'
-  return displayName ? `${action} for ${displayName}` : action
-}
-
 export function registerContextMenuHandlers(): void {
-  ipcMain.handle(
-    'show-app-context-menu',
-    (event, appPath: string, gameKey: string, options?: ShowAppContextMenuOptions) => {
-      const template: MenuItemConstructorOptions[] = [
-        {
-          label: buildDismissLabel(appPath, options),
-          click: () => {
-            dismissAppIcon(appPath, gameKey)
-            publishRunningApps('scan').catch((err) => {
-              console.error('Failed to publish running apps after dismissing icon', err)
-            })
-          }
-        }
-      ]
-
-      const menu = Menu.buildFromTemplate(template)
-      const window = BrowserWindow.fromWebContents(event.sender)
-
-      if (window) {
-        menu.popup({ window })
-      }
+  ipcMain.handle('dismiss-app-icon', async (_event, appPath: string, gameKey: string) => {
+    if (typeof appPath !== 'string' || appPath.trim().length === 0) {
+      return { success: false, error: 'Invalid argument: appPath must be a non-empty string' }
     }
-  )
+    if (typeof gameKey !== 'string' || gameKey.trim().length === 0) {
+      return { success: false, error: 'Invalid argument: gameKey must be a non-empty string' }
+    }
+
+    dismissAppIcon(appPath, gameKey)
+    await publishRunningApps('scan')
+    return { success: true }
+  })
 }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -188,9 +188,8 @@ export interface ElectronAPI {
   getAssetData: (filename: string) => Promise<string | null>
   getFileIcon: (filePath: string) => Promise<string | null>
   getVersion: () => Promise<string>
-  showAppContextMenu: (
+  dismissAppIcon: (
     appPath: string,
-    gameKey: string,
-    options?: { tracked?: boolean; name?: string }
-  ) => Promise<void>
+    gameKey: string
+  ) => Promise<{ success: boolean; error?: string }>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -112,11 +112,8 @@ const electronAPI: ElectronAPI = {
   getAssetData: (filename: string) => ipcRenderer.invoke('get-asset-data', filename),
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
   getVersion: () => ipcRenderer.invoke('get-version'),
-  showAppContextMenu: (
-    appPath: string,
-    gameKey: string,
-    options?: { tracked?: boolean; name?: string }
-  ) => ipcRenderer.invoke('show-app-context-menu', appPath, gameKey, options)
+  dismissAppIcon: (appPath: string, gameKey: string) =>
+    ipcRenderer.invoke('dismiss-app-icon', appPath, gameKey)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -564,6 +564,22 @@ textarea {
   animation: fadeSlide 0.25s ease-out backwards;
 }
 
+@keyframes tooltipIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.animate-tooltip-in {
+  animation: tooltipIn 0.15s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+
 @keyframes fadeSlideInline {
   from {
     opacity: 0;

--- a/src/renderer/src/components/Tooltip.tsx
+++ b/src/renderer/src/components/Tooltip.tsx
@@ -84,14 +84,27 @@ export function Tooltip({ label, children, placement = 'top', disabled }: Toolti
 
       {isOpen && (
         <FloatingPortal>
-          {/* style is required: @floating-ui/react writes dynamic x/y/transform position values */}
+          {/*
+            Outer wrapper handles absolute positioning and event composition from floating-ui.
+            Keep it visually unstyled to prevent CSS transforms from promoting this element
+            to a separate compositing layer, which breaks `backdrop-filter` (blur) in Chromium.
+          */}
           <div
             ref={refs.setFloating}
             style={floatingStyles}
             {...getFloatingProps()}
-            className="pointer-events-none z-9999 max-w-xs rounded-lg border border-(--glass-border) bg-(--surface-floating-bg) px-2.5 py-1.5 text-xs font-medium text-(--text-primary) shadow-(--surface-floating-shadow) backdrop-blur-md animate-fade-slide"
+            className="pointer-events-none z-9999"
           >
-            {label}
+            {/*
+              Inner container holds the actual visuals and entrance animation.
+              - Uses `overlay-glass` to match other floating surfaces (frosted glass look).
+              - Uses `animate-tooltip-in` (snappy fade/scale) to eliminate vertical bounciness.
+              - Since this element has no persistent position transforms, the backdrop-filter
+                (blur) renders at 100% fidelity.
+            */}
+            <div className="max-w-xs rounded-lg border border-(--glass-border) overlay-glass shadow-(--surface-floating-shadow) px-2.5 py-1.5 text-xs font-medium text-(--text-primary) animate-tooltip-in">
+              {label}
+            </div>
           </div>
         </FloatingPortal>
       )}

--- a/src/renderer/src/components/Tooltip.tsx
+++ b/src/renderer/src/components/Tooltip.tsx
@@ -1,0 +1,94 @@
+import { useState, type ReactElement, type ReactNode } from 'react'
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useMergeRefs,
+  useRole,
+  type Placement
+} from '@floating-ui/react'
+
+interface TooltipProps {
+  /** Tooltip content. If falsy, renders the child untouched (no tooltip). */
+  label: ReactNode
+  /**
+   * A single DOM element (button, div, img, span, input, …).
+   * Must accept a ref and spread arbitrary HTML event props.
+   */
+  children: ReactElement<Record<string, unknown>>
+  /** Where to prefer rendering the tooltip. Defaults to 'top'. */
+  placement?: Placement
+  /**
+   * When true, the child is rendered untouched — useful for conditionally
+   * disabling tooltips without changing the call site.
+   */
+  disabled?: boolean
+}
+
+/**
+ * Glassmorphism tooltip powered by @floating-ui/react.
+ *
+ * - Shows on hover (350 ms delay) and keyboard focus.
+ * - Auto-flips and shifts near screen edges.
+ * - Rendered in a FloatingPortal (z-9999) so it appears above dialogs.
+ * - Merges refs so children that already carry a ref (e.g. customSwatchRef,
+ *   triggerRef) keep their original reference.
+ */
+export function Tooltip({ label, children, placement = 'top', disabled }: TooltipProps): ReactNode {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement,
+    middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate
+  })
+
+  const hover = useHover(context, { delay: { open: 350, close: 0 }, move: false })
+  const focus = useFocus(context)
+  const role = useRole(context, { role: 'tooltip' })
+  const dismiss = useDismiss(context)
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, role, dismiss])
+
+  // Merge our setReference with any ref the child already has so children
+  // that carry an existing ref (e.g. customSwatchRef, triggerRef) keep it.
+  const childRef = (children as { ref?: React.Ref<unknown> }).ref
+  const mergedRef = useMergeRefs([refs.setReference, childRef ?? null])
+
+  // If label is empty or disabled, render child without any tooltip machinery.
+  if (!label || disabled) {
+    return children
+  }
+
+  const referenceProps = getReferenceProps()
+
+  return (
+    <>
+      {/* React 19: ref is a regular prop; we spread it together with interaction handlers */}
+      {<children.type {...children.props} ref={mergedRef} {...referenceProps} />}
+
+      {isOpen && (
+        <FloatingPortal>
+          {/* style is required: @floating-ui/react writes dynamic x/y/transform position values */}
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className="pointer-events-none z-9999 max-w-xs rounded-lg border border-(--glass-border) bg-(--surface-floating-bg) px-2.5 py-1.5 text-xs font-medium text-(--text-primary) shadow-(--surface-floating-shadow) backdrop-blur-md animate-fade-slide"
+          >
+            {label}
+          </div>
+        </FloatingPortal>
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/components/Tooltip.tsx
+++ b/src/renderer/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement, type ReactNode } from 'react'
+import { cloneElement, useState, type ReactElement, type ReactNode, type Ref } from 'react'
 import {
   autoUpdate,
   flip,
@@ -59,22 +59,28 @@ export function Tooltip({ label, children, placement = 'top', disabled }: Toolti
 
   const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, role, dismiss])
 
-  // Merge our setReference with any ref the child already has so children
-  // that carry an existing ref (e.g. customSwatchRef, triggerRef) keep it.
-  const childRef = (children as { ref?: React.Ref<unknown> }).ref
-  const mergedRef = useMergeRefs([refs.setReference, childRef ?? null])
+  // React 19 stores ref as a regular prop, so read it from children.props (the
+  // children.ref accessor is deprecated) and merge it with floating-ui's
+  // reference ref. Children that already carry a ref — customSwatchRef (the
+  // color-picker anchor) and triggerRef (the dropdown's focus-return) — must
+  // keep it, or those features break.
+  const childRef = (children.props as { ref?: Ref<unknown> }).ref ?? null
+  const mergedRef = useMergeRefs([refs.setReference, childRef])
 
   // If label is empty or disabled, render child without any tooltip machinery.
   if (!label || disabled) {
     return children
   }
 
-  const referenceProps = getReferenceProps()
-
   return (
     <>
-      {/* React 19: ref is a regular prop; we spread it together with interaction handlers */}
-      {<children.type {...children.props} ref={mergedRef} {...referenceProps} />}
+      {/* Pass children.props INTO getReferenceProps so floating-ui COMPOSES the
+          child's own event handlers with its hover/focus/dismiss handlers rather
+          than overwriting them; cloneElement then applies the merged ref. */}
+      {cloneElement(children, {
+        ...getReferenceProps(children.props as Parameters<typeof getReferenceProps>[0]),
+        ref: mergedRef
+      })}
 
       {isOpen && (
         <FloatingPortal>

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -7,6 +7,7 @@ import {
   MaximizeIcon,
   CloseWindowIcon
 } from './icons'
+import { Tooltip } from './Tooltip'
 
 interface WindowControlsProps {
   view: 'games' | 'settings'
@@ -54,18 +55,19 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
         <div className="relative z-10 h-4 w-px bg-(--glass-border) opacity-35" />
 
         {/* Settings gear */}
-        <button
-          type="button"
-          onClick={() => onNavigate('settings')}
-          className={`icon-action cursor-pointer flex items-center rounded-r-full py-1.5 pl-2 pr-2.5 ${
-            view === 'settings' ? 'icon-action-active' : ''
-          }`}
-          title="Settings"
-          aria-label="Settings"
-          aria-current={view === 'settings' ? 'page' : undefined}
-        >
-          <SettingsIcon width={13} height={13} />
-        </button>
+        <Tooltip label="Settings" placement="bottom">
+          <button
+            type="button"
+            onClick={() => onNavigate('settings')}
+            className={`icon-action cursor-pointer flex items-center rounded-r-full py-1.5 pl-2 pr-2.5 ${
+              view === 'settings' ? 'icon-action-active' : ''
+            }`}
+            aria-label="Settings"
+            aria-current={view === 'settings' ? 'page' : undefined}
+          >
+            <SettingsIcon width={13} height={13} />
+          </button>
+        </Tooltip>
       </div>
 
       {/* Update Pill */}
@@ -90,33 +92,36 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
 
       {/* Window controls */}
       <div className="no-drag flex items-center gap-1">
-        <button
-          type="button"
-          onClick={handleMinimize}
-          className="icon-action cursor-pointer rounded-full p-2"
-          title="Minimize"
-          aria-label="Minimize"
-        >
-          <MinimizeIcon width={14} height={14} />
-        </button>
-        <button
-          type="button"
-          onClick={handleMaximize}
-          className="icon-action cursor-pointer rounded-full p-2"
-          title={isMaximized ? 'Restore' : 'Maximize'}
-          aria-label={isMaximized ? 'Restore' : 'Maximize'}
-        >
-          <MaximizeIcon width={14} height={14} />
-        </button>
-        <button
-          type="button"
-          onClick={handleClose}
-          className="icon-action danger-action cursor-pointer rounded-full p-2"
-          title="Close"
-          aria-label="Close"
-        >
-          <CloseWindowIcon width={14} height={14} />
-        </button>
+        <Tooltip label="Minimize" placement="bottom">
+          <button
+            type="button"
+            onClick={handleMinimize}
+            className="icon-action cursor-pointer rounded-full p-2"
+            aria-label="Minimize"
+          >
+            <MinimizeIcon width={14} height={14} />
+          </button>
+        </Tooltip>
+        <Tooltip label={isMaximized ? 'Restore' : 'Maximize'} placement="bottom">
+          <button
+            type="button"
+            onClick={handleMaximize}
+            className="icon-action cursor-pointer rounded-full p-2"
+            aria-label={isMaximized ? 'Restore' : 'Maximize'}
+          >
+            <MaximizeIcon width={14} height={14} />
+          </button>
+        </Tooltip>
+        <Tooltip label="Close" placement="bottom">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="icon-action danger-action cursor-pointer rounded-full p-2"
+            aria-label="Close"
+          >
+            <CloseWindowIcon width={14} height={14} />
+          </button>
+        </Tooltip>
       </div>
     </div>
   )

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -33,23 +33,24 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
       {/* Pill: branding + settings gear */}
       <div className="no-drag glass-surface rounded-full flex items-center shrink-0 overflow-hidden">
         {/* Launcher branding */}
-        <button
-          type="button"
-          onClick={() => onNavigate('games')}
-          className="group cursor-pointer flex items-center rounded-l-full py-1.5 pl-3 pr-2"
-          title="SimLauncher"
-          aria-label="SimLauncher"
-          aria-current={view === 'games' ? 'page' : undefined}
-        >
-          <BrandWordmarkIcon
-            aria-hidden="true"
-            className={`launcher-wordmark h-[15px] w-auto shrink-0 transition-colors ${
-              view === 'games'
-                ? 'text-(--accent)'
-                : 'text-(--text-muted) group-hover:text-(--accent)'
-            }`}
-          />
-        </button>
+        <Tooltip label="SimLauncher" placement="bottom">
+          <button
+            type="button"
+            onClick={() => onNavigate('games')}
+            className="group cursor-pointer flex items-center rounded-l-full py-1.5 pl-3 pr-2"
+            aria-label="SimLauncher"
+            aria-current={view === 'games' ? 'page' : undefined}
+          >
+            <BrandWordmarkIcon
+              aria-hidden="true"
+              className={`launcher-wordmark h-[15px] w-auto shrink-0 transition-colors ${
+                view === 'games'
+                  ? 'text-(--accent)'
+                  : 'text-(--text-muted) group-hover:text-(--accent)'
+              }`}
+            />
+          </button>
+        </Tooltip>
 
         {/* Divider */}
         <div className="relative z-10 h-4 w-px bg-(--glass-border) opacity-35" />

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import type { Game } from '../../lib/config'
+import { Tooltip } from '../Tooltip'
 
 interface GameIconProps {
   game: Game
@@ -27,12 +28,11 @@ export function GameIcon({ game, isRunning, iconUrl }: GameIconProps): ReactNode
         <div aria-hidden="true" className="h-12 w-12 skeleton-icon animate-pulse" />
       ) : null}
       {isRunning && (
-        <div
-          className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]"
-          title="Running"
-        >
-          <span className="sr-only">{game.name} is running</span>
-        </div>
+        <Tooltip label="Running">
+          <div className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]">
+            <span className="sr-only">{game.name} is running</span>
+          </div>
+        </Tooltip>
       )}
     </div>
   )

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 
 import { GameRowProfileMenu, type GameRowProfileMenuProps } from './GameRowProfileMenu'
 import { RefreshIcon, KillIcon, PlayMarkIcon, SettingsIcon } from '../icons'
+import { Tooltip } from '../Tooltip'
 
 export interface GameRowActionsProps {
   isActive: boolean
@@ -40,21 +41,22 @@ export function GameRowActions({
     <div className="flex items-center gap-3 no-drag">
       <div className="flex h-9 w-9 items-center justify-center">
         {canRelaunch && (
-          <button
-            type="button"
-            onClick={onRelaunchMissing}
-            disabled={isLaunchBlocked}
-            className="icon-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
-            title="Relaunch missing apps"
-            aria-label={`Relaunch missing apps for ${gameName}`}
-          >
-            <RefreshIcon
-              width={18}
-              height={18}
-              strokeWidth="2.2"
-              className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
-            />
-          </button>
+          <Tooltip label="Relaunch missing apps">
+            <button
+              type="button"
+              onClick={onRelaunchMissing}
+              disabled={isLaunchBlocked}
+              className="icon-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
+              aria-label={`Relaunch missing apps for ${gameName}`}
+            >
+              <RefreshIcon
+                width={18}
+                height={18}
+                strokeWidth="2.2"
+                className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+              />
+            </button>
+          </Tooltip>
         )}
       </div>
 
@@ -63,66 +65,68 @@ export function GameRowActions({
 
         <div className="relative z-10 h-4 w-px bg-(--glass-border) opacity-15" />
 
-        <button
-          type="button"
-          onClick={primaryAction}
-          disabled={isLaunchBlocked && !canKill}
-          className={`launcher-play-btn group/btn flex h-9 w-[54px] shrink-0 cursor-pointer items-center justify-center rounded-r-full transition-all ${primaryButtonClass}`}
-          title={primaryTitle}
-          aria-label={
-            isLaunching && !canKill
-              ? `Launching ${gameName}`
-              : canKill
-                ? `Close companion apps for ${gameName}`
-                : `Launch ${gameName}`
-          }
-          aria-busy={isLaunching && !canKill ? true : undefined}
-        >
-          {isLaunching && !canKill ? (
-            <RefreshIcon
-              width={21}
-              height={21}
-              stroke="var(--launcher-play)"
-              strokeWidth="2.8"
-              className="animate-spin transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
-            />
-          ) : canKill ? (
-            <KillIcon
-              width={21}
-              height={21}
-              className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
-            />
-          ) : (
-            <PlayMarkIcon
-              width={24}
-              height={24}
-              className="ml-0.5 transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
-            />
-          )}
-        </button>
+        <Tooltip label={primaryTitle}>
+          <button
+            type="button"
+            onClick={primaryAction}
+            disabled={isLaunchBlocked && !canKill}
+            className={`launcher-play-btn group/btn flex h-9 w-[54px] shrink-0 cursor-pointer items-center justify-center rounded-r-full transition-all ${primaryButtonClass}`}
+            aria-label={
+              isLaunching && !canKill
+                ? `Launching ${gameName}`
+                : canKill
+                  ? `Close companion apps for ${gameName}`
+                  : `Launch ${gameName}`
+            }
+            aria-busy={isLaunching && !canKill ? true : undefined}
+          >
+            {isLaunching && !canKill ? (
+              <RefreshIcon
+                width={21}
+                height={21}
+                stroke="var(--launcher-play)"
+                strokeWidth="2.8"
+                className="animate-spin transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+              />
+            ) : canKill ? (
+              <KillIcon
+                width={21}
+                height={21}
+                className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+              />
+            ) : (
+              <PlayMarkIcon
+                width={24}
+                height={24}
+                className="ml-0.5 transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+              />
+            )}
+          </button>
+        </Tooltip>
       </div>
 
-      <button
-        type="button"
-        onClick={onToggleEditor}
-        className={`flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-full transition-all duration-300 ${
-          isActive
-            ? 'icon-action-active'
-            : 'icon-action opacity-40 group-hover/row:opacity-100 group-hover/row:bg-(--glass-bg)'
-        }`}
-        title={isActive ? 'Close Profile Settings' : 'Profile Settings'}
-        aria-label={
-          isActive ? `Close profile settings for ${gameName}` : `Profile settings for ${gameName}`
-        }
-        aria-expanded={isActive ? 'true' : 'false'}
-        aria-controls={editorId}
-      >
-        {isActive ? (
-          <KillIcon width={18} height={18} className="transition-transform hover:scale-110" />
-        ) : (
-          <SettingsIcon width={18} height={18} className="transition-transform hover:rotate-90" />
-        )}
-      </button>
+      <Tooltip label={isActive ? 'Close Profile Settings' : 'Profile Settings'}>
+        <button
+          type="button"
+          onClick={onToggleEditor}
+          className={`flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-full transition-all duration-300 ${
+            isActive
+              ? 'icon-action-active'
+              : 'icon-action opacity-40 group-hover/row:opacity-100 group-hover/row:bg-(--glass-bg)'
+          }`}
+          aria-label={
+            isActive ? `Close profile settings for ${gameName}` : `Profile settings for ${gameName}`
+          }
+          aria-expanded={isActive ? 'true' : 'false'}
+          aria-controls={editorId}
+        >
+          {isActive ? (
+            <KillIcon width={18} height={18} className="transition-transform hover:scale-110" />
+          ) : (
+            <SettingsIcon width={18} height={18} className="transition-transform hover:rotate-90" />
+          )}
+        </button>
+      </Tooltip>
     </div>
   )
 }

--- a/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
@@ -2,6 +2,7 @@ import { useId } from 'react'
 import type { Dispatch, KeyboardEvent, MutableRefObject, ReactNode, SetStateAction } from 'react'
 import type { GameProfileSet, NamedGameProfile } from '../../lib/config'
 import { ChevronDownIcon, CheckIcon, PlusIcon } from '../icons'
+import { Tooltip } from '../Tooltip'
 
 export interface GameRowProfileMenuProps {
   profileSet: GameProfileSet
@@ -45,32 +46,33 @@ export function GameRowProfileMenu({
   const menuId = useId()
   return (
     <div ref={profileMenuRef} className="relative">
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation()
-          if (profileMenuOpen) {
-            closeProfileMenu(false)
-          } else {
-            openProfileMenu(false)
-          }
-        }}
-        onKeyDown={handleProfileMenuTriggerKeyDown}
-        className="dropdown-trigger-surface group/dropdown flex h-9 w-[120px] cursor-pointer items-center gap-1.5 rounded-l-full py-2 pl-3 pr-2.5 text-[10px] font-semibold text-(--text-secondary) transition-all hover:text-(--text-primary)"
-        aria-haspopup="menu"
-        aria-expanded={profileMenuOpen}
-        aria-controls={profileMenuOpen ? menuId : undefined}
-        aria-label={`${gameName} profile: ${activeProfile.name}`}
-        title={activeProfile.name}
-      >
-        <ChevronDownIcon
-          width={10}
-          height={10}
-          className={`shrink-0 text-(--text-muted) transition-transform ${profileMenuOpen ? 'rotate-180' : ''}`}
-        />
-        <span className="min-w-0 truncate">{activeProfile.name}</span>
-      </button>
+      <Tooltip label={activeProfile.name} placement="bottom">
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            if (profileMenuOpen) {
+              closeProfileMenu(false)
+            } else {
+              openProfileMenu(false)
+            }
+          }}
+          onKeyDown={handleProfileMenuTriggerKeyDown}
+          className="dropdown-trigger-surface group/dropdown flex h-9 w-[120px] cursor-pointer items-center gap-1.5 rounded-l-full py-2 pl-3 pr-2.5 text-[10px] font-semibold text-(--text-secondary) transition-all hover:text-(--text-primary)"
+          aria-haspopup="menu"
+          aria-expanded={profileMenuOpen}
+          aria-controls={profileMenuOpen ? menuId : undefined}
+          aria-label={`${gameName} profile: ${activeProfile.name}`}
+        >
+          <ChevronDownIcon
+            width={10}
+            height={10}
+            className={`shrink-0 text-(--text-muted) transition-transform ${profileMenuOpen ? 'rotate-180' : ''}`}
+          />
+          <span className="min-w-0 truncate">{activeProfile.name}</span>
+        </button>
+      </Tooltip>
       {profileMenuOpen && (
         <div
           ref={menuRef}
@@ -124,15 +126,16 @@ export function GameRowProfileMenu({
                 className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-1.5 text-xs font-semibold text-(--text-primary) outline-none placeholder:text-(--text-subtle) focus:border-(--accent)"
                 aria-label="New profile name"
               />
-              <button
-                type="submit"
-                disabled={newProfileName.trim().length === 0}
-                className="accent-action flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md"
-                aria-label="Create profile"
-                title="Create profile"
-              >
-                <CheckIcon width={13} height={13} />
-              </button>
+              <Tooltip label="Create profile">
+                <button
+                  type="submit"
+                  disabled={newProfileName.trim().length === 0}
+                  className="accent-action flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md"
+                  aria-label="Create profile"
+                >
+                  <CheckIcon width={13} height={13} />
+                </button>
+              </Tooltip>
             </form>
           ) : (
             <button

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -1,6 +1,19 @@
-import { useState, type ReactNode } from 'react'
-import { showAppContextMenu } from '../../lib/electron'
+import { useState, type ReactNode, type ReactElement } from 'react'
+import { dismissAppIcon } from '../../lib/electron'
 import { Tooltip } from '../Tooltip'
+import { buildDismissLabel } from '../../lib/contextMenuLabel'
+import {
+  autoUpdate,
+  flip,
+  FloatingFocusManager,
+  FloatingPortal,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole
+} from '@floating-ui/react'
 
 export interface RunningAppIcon {
   icon: string | null
@@ -15,6 +28,131 @@ export interface RunningAppIcon {
 interface RunningAppsStripProps {
   runningAppIcons: RunningAppIcon[]
   cacheInitialized: boolean
+}
+
+interface RunningAppIconItemProps {
+  app: RunningAppIcon
+  isAvailable: boolean
+  isFailed: boolean
+  cacheInitialized: boolean
+  onError: () => void
+}
+
+function RunningAppIconItem({
+  app,
+  isAvailable,
+  isFailed,
+  cacheInitialized,
+  onError
+}: RunningAppIconItemProps): ReactNode {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isMenuOpen,
+    onOpenChange: setIsMenuOpen,
+    placement: 'bottom-start',
+    middleware: [offset(4), flip({ padding: 8 }), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate
+  })
+
+  const dismiss = useDismiss(context)
+  const role = useRole(context, { role: 'menu' })
+  const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, role])
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    if (app.warning) {
+      e.preventDefault()
+      setIsMenuOpen(true)
+    }
+  }
+
+  const handleDismissClick = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    // For untracked apps, the icon is unmounted when warning clears;
+    // for tracked apps, the icon remains, so close the menu explicitly.
+    setIsMenuOpen(false)
+    try {
+      await dismissAppIcon(app.path, app.gameKey)
+    } catch (err) {
+      console.error('Failed to dismiss app warning:', err)
+    }
+  }
+
+  // Accessibility trigger attributes composition
+  const triggerProps = getReferenceProps({
+    onContextMenu: handleContextMenu,
+    'aria-haspopup': app.warning ? ('menu' as const) : undefined,
+    'aria-expanded': app.warning ? isMenuOpen : undefined
+  })
+
+  const dismissLabel = buildDismissLabel(app.path, {
+    tracked: app.tracked,
+    name: app.name
+  })
+
+  let content: ReactElement<Record<string, unknown>>
+
+  if (isAvailable) {
+    content = (
+      <img
+        ref={refs.setReference}
+        src={app.icon ?? undefined}
+        alt={app.warning ? `${app.name}: ${app.warning}` : ''}
+        className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'cursor-pointer rounded-sm ring-1 ring-(--warning-text)' : ''}`}
+        onError={onError}
+        {...triggerProps}
+      />
+    )
+  } else if (app.icon === null && !isFailed && !cacheInitialized) {
+    return <div aria-hidden="true" className="h-4 w-4 skeleton-icon animate-pulse" />
+  } else {
+    content = (
+      <div
+        ref={refs.setReference}
+        role="img"
+        aria-label={app.warning ? `${app.name}: ${app.warning}` : app.name}
+        className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'cursor-pointer ring-1 ring-(--warning-text)' : ''}`}
+        {...triggerProps}
+      >
+        {app.name
+          .replace(/\.exe$/i, '')
+          .slice(0, 2)
+          .toUpperCase()}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Tooltip label={app.warning || app.name} disabled={isMenuOpen}>
+        {content}
+      </Tooltip>
+
+      {isMenuOpen && (
+        <FloatingPortal>
+          <FloatingFocusManager context={context} modal={false}>
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              {...getFloatingProps()}
+              className="z-9999"
+            >
+              <div className="dropdown-surface overlay-glass rounded-xl p-1 border border-(--glass-border) shadow-(--surface-floating-shadow) animate-fade-slide min-w-[180px]">
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleDismissClick}
+                  className="dropdown-item flex w-full cursor-pointer items-center rounded-lg px-2.5 py-1.5 text-left text-xs font-semibold"
+                >
+                  {dismissLabel}
+                </button>
+              </div>
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
+    </>
+  )
 }
 
 export function RunningAppsStrip({
@@ -33,56 +171,15 @@ export function RunningAppsStrip({
         const isAvailable = !!app.icon && !failedRunningIcons[app.icon]
         const isFailed = failedRunningIcons[app.icon!]
 
-        if (isAvailable) {
-          return (
-            <Tooltip key={i} label={app.warning || app.name}>
-              <img
-                src={app.icon ?? undefined}
-                alt={app.warning ? `${app.name}: ${app.warning}` : ''}
-                className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
-                onError={() =>
-                  setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
-                }
-                onContextMenu={(e) => {
-                  if (app.warning) {
-                    e.preventDefault()
-                    showAppContextMenu(app.path, app.gameKey, {
-                      tracked: app.tracked,
-                      name: app.name
-                    })
-                  }
-                }}
-              />
-            </Tooltip>
-          )
-        }
-
-        if (app.icon === null && !isFailed && !cacheInitialized) {
-          return <div key={i} aria-hidden="true" className="h-4 w-4 skeleton-icon animate-pulse" />
-        }
-
         return (
-          <Tooltip key={i} label={app.warning || app.name}>
-            <div
-              role="img"
-              aria-label={app.warning ? `${app.name}: ${app.warning}` : app.name}
-              className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
-              onContextMenu={(e) => {
-                if (app.warning) {
-                  e.preventDefault()
-                  showAppContextMenu(app.path, app.gameKey, {
-                    tracked: app.tracked,
-                    name: app.name
-                  })
-                }
-              }}
-            >
-              {app.name
-                .replace(/\.exe$/i, '')
-                .slice(0, 2)
-                .toUpperCase()}
-            </div>
-          </Tooltip>
+          <RunningAppIconItem
+            key={i}
+            app={app}
+            isAvailable={isAvailable}
+            isFailed={isFailed}
+            cacheInitialized={cacheInitialized}
+            onError={() => setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))}
+          />
         )
       })}
 

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from 'react'
 import { showAppContextMenu } from '../../lib/electron'
+import { Tooltip } from '../Tooltip'
 
 export interface RunningAppIcon {
   icon: string | null
@@ -34,15 +35,38 @@ export function RunningAppsStrip({
 
         if (isAvailable) {
           return (
-            <img
-              key={i}
-              src={app.icon ?? undefined}
-              alt={app.warning ? `${app.name}: ${app.warning}` : ''}
-              title={app.warning || app.name}
-              className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
-              onError={() =>
-                setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
-              }
+            <Tooltip key={i} label={app.warning || app.name}>
+              <img
+                src={app.icon ?? undefined}
+                alt={app.warning ? `${app.name}: ${app.warning}` : ''}
+                className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'rounded-sm ring-1 ring-(--warning-text)' : ''}`}
+                onError={() =>
+                  setFailedRunningIcons((current) => ({ ...current, [app.icon!]: true }))
+                }
+                onContextMenu={(e) => {
+                  if (app.warning) {
+                    e.preventDefault()
+                    showAppContextMenu(app.path, app.gameKey, {
+                      tracked: app.tracked,
+                      name: app.name
+                    })
+                  }
+                }}
+              />
+            </Tooltip>
+          )
+        }
+
+        if (app.icon === null && !isFailed && !cacheInitialized) {
+          return <div key={i} aria-hidden="true" className="h-4 w-4 skeleton-icon animate-pulse" />
+        }
+
+        return (
+          <Tooltip key={i} label={app.warning || app.name}>
+            <div
+              role="img"
+              aria-label={app.warning ? `${app.name}: ${app.warning}` : app.name}
+              className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
               onContextMenu={(e) => {
                 if (app.warning) {
                   e.preventDefault()
@@ -52,61 +76,39 @@ export function RunningAppsStrip({
                   })
                 }
               }}
-            />
-          )
-        }
-
-        if (app.icon === null && !isFailed && !cacheInitialized) {
-          return <div key={i} aria-hidden="true" className="h-4 w-4 skeleton-icon animate-pulse" />
-        }
-
-        return (
-          <div
-            key={i}
-            role="img"
-            aria-label={app.warning ? `${app.name}: ${app.warning}` : app.name}
-            className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'ring-1 ring-(--warning-text)' : ''}`}
-            title={app.warning || app.name}
-            onContextMenu={(e) => {
-              if (app.warning) {
-                e.preventDefault()
-                showAppContextMenu(app.path, app.gameKey, {
-                  tracked: app.tracked,
-                  name: app.name
-                })
-              }
-            }}
-          >
-            {app.name
-              .replace(/\.exe$/i, '')
-              .slice(0, 2)
-              .toUpperCase()}
-          </div>
+            >
+              {app.name
+                .replace(/\.exe$/i, '')
+                .slice(0, 2)
+                .toUpperCase()}
+            </div>
+          </Tooltip>
         )
       })}
 
       {hasElevated && (
-        <div
-          role="img"
-          aria-label="Some companion apps run elevated and cannot be closed by SimLauncher"
-          title="SimLauncher cannot close elevated companion apps."
-          className="flex items-center"
-        >
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="text-(--warning-text) opacity-80 shrink-0 w-3.5 h-3.5"
+        <Tooltip label="SimLauncher cannot close elevated companion apps.">
+          <div
+            role="img"
+            aria-label="Some companion apps run elevated and cannot be closed by SimLauncher"
+            className="flex items-center"
           >
-            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
-            <path d="M12 9v4" />
-            <path d="M12 17h.01" />
-          </svg>
-        </div>
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-(--warning-text) opacity-80 shrink-0 w-3.5 h-3.5"
+            >
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
+            </svg>
+          </div>
+        </Tooltip>
       )}
     </div>
   )

--- a/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileEditorActions.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { Tooltip } from '../Tooltip'
 
 interface ProfileEditorActionsProps {
   isDirty: boolean
@@ -42,31 +43,32 @@ export function ProfileEditorActions({
         Cancel
       </button>
       {canDeleteProfile && (
-        <button
-          type="button"
-          onClick={onDeleteProfile}
-          className="danger-action action-hover-scale flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
-          title="Delete profile"
-          aria-label="Delete profile"
-        >
-          <svg
-            aria-hidden="true"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+        <Tooltip label="Delete profile">
+          <button
+            type="button"
+            onClick={onDeleteProfile}
+            className="danger-action action-hover-scale flex h-11 w-11 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
+            aria-label="Delete profile"
           >
-            <path d="M3 6h18" />
-            <path d="M8 6V4h8v2" />
-            <path d="M19 6l-1 14H6L5 6" />
-            <path d="M10 11v5" />
-            <path d="M14 11v5" />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 6h18" />
+              <path d="M8 6V4h8v2" />
+              <path d="M19 6l-1 14H6L5 6" />
+              <path d="M10 11v5" />
+              <path d="M14 11v5" />
+            </svg>
+          </button>
+        </Tooltip>
       )}
     </div>
   )

--- a/src/renderer/src/components/profile-editor/ProfileNameSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileNameSection.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { Tooltip } from '../Tooltip'
 
 interface ProfileNameSectionProps {
   profileName: string
@@ -25,27 +26,28 @@ export function ProfileNameSection({
           aria-label="Profile name"
         />
         {onCreateProfile !== undefined && (
-          <button
-            type="button"
-            onClick={onCreateProfile}
-            className="accent-surface-action action-hover-scale cursor-pointer flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-all"
-            title="New profile"
-            aria-label="New profile"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+          <Tooltip label="New profile">
+            <button
+              type="button"
+              onClick={onCreateProfile}
+              className="accent-surface-action action-hover-scale cursor-pointer flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-all"
+              aria-label="New profile"
             >
-              <path d="M12 5v14" />
-              <path d="M5 12h14" />
-            </svg>
-          </button>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M12 5v14" />
+                <path d="M5 12h14" />
+              </svg>
+            </button>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -1,6 +1,7 @@
 import type { DragEvent, ReactNode } from 'react'
 import type { ProfileUtility, Utility } from '../../lib/config'
 import { Toggle } from '../Toggle'
+import { Tooltip } from '../Tooltip'
 
 interface ProfileUtilitiesSectionProps {
   appPaths: Record<string, string>
@@ -114,20 +115,21 @@ function renderUtilityRow(
             {orderIndex + 1}
           </span>
         )}
-        <div
-          className={`icon-action flex h-6 w-5 shrink-0 items-center justify-center rounded ${isEnabled ? 'cursor-grab group-active:cursor-grabbing' : ''}`}
-          title="Drag to reorder"
-          aria-hidden="true"
-        >
-          <svg width="12" height="16" viewBox="0 0 12 16" fill="currentColor" aria-hidden="true">
-            <circle cx="3" cy="3" r="1.2" />
-            <circle cx="9" cy="3" r="1.2" />
-            <circle cx="3" cy="8" r="1.2" />
-            <circle cx="9" cy="8" r="1.2" />
-            <circle cx="3" cy="13" r="1.2" />
-            <circle cx="9" cy="13" r="1.2" />
-          </svg>
-        </div>
+        <Tooltip label="Drag to reorder">
+          <div
+            className={`icon-action flex h-6 w-5 shrink-0 items-center justify-center rounded ${isEnabled ? 'cursor-grab group-active:cursor-grabbing' : ''}`}
+            aria-hidden="true"
+          >
+            <svg width="12" height="16" viewBox="0 0 12 16" fill="currentColor" aria-hidden="true">
+              <circle cx="3" cy="3" r="1.2" />
+              <circle cx="9" cy="3" r="1.2" />
+              <circle cx="3" cy="8" r="1.2" />
+              <circle cx="9" cy="8" r="1.2" />
+              <circle cx="3" cy="13" r="1.2" />
+              <circle cx="9" cy="13" r="1.2" />
+            </svg>
+          </div>
+        </Tooltip>
         <div className="relative flex h-6 w-6 shrink-0 items-center justify-center">
           {icon && !props.failedIcons[utility.key] ? (
             <img

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -4,6 +4,7 @@ import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
 import { ColorPickerPopover } from '../ColorPickerPopover'
 import { useAppearanceSettings } from './AppearanceContext'
+import { Tooltip } from '../Tooltip'
 
 const ZOOM_PRESETS = [
   { label: '100%', factor: 1.0 },
@@ -74,60 +75,61 @@ export function AppearanceSection(): ReactNode {
         <label className="settings-label text-(--text-secondary)">Accent Color</label>
         <div className="settings-control" role="group" aria-label="Accent color">
           {ACCENT_PRESETS.map((preset) => (
-            <button
-              key={preset.hex}
-              type="button"
-              onClick={() => onAccentChange(preset.hex)}
-              aria-label={`Accent color ${preset.name}`}
-              aria-pressed={accentPreset === preset.hex}
-              className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
-              style={{ '--preset-color': preset.hex } as CSSProperties}
-              title={preset.name}
-            />
+            <Tooltip key={preset.hex} label={preset.name}>
+              <button
+                type="button"
+                onClick={() => onAccentChange(preset.hex)}
+                aria-label={`Accent color ${preset.name}`}
+                aria-pressed={accentPreset === preset.hex}
+                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
+                style={{ '--preset-color': preset.hex } as CSSProperties}
+              />
+            </Tooltip>
           ))}
           <div className="relative">
-            <button
-              ref={customSwatchRef}
-              type="button"
-              onClick={() => {
-                setShowPicker(!showPicker)
-                if (!isCustomColor) onAccentChange('custom')
-              }}
-              aria-label="Custom accent color"
-              aria-haspopup="dialog"
-              aria-expanded={showPicker}
-              aria-controls={showPicker ? 'accent-color-picker' : undefined}
-              aria-pressed={isCustomColor}
-              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
-                isCustomColor ? 'scale-110' : ''
-              }`}
-              title="Custom Color"
-            >
-              {/* Background gradient/color */}
-              <div
-                aria-hidden="true"
-                className="absolute inset-0 rounded-full"
-                style={{
-                  background: isCustomColor
-                    ? accentCustom || '#ad46ff'
-                    : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
+            <Tooltip label="Custom Color">
+              <button
+                ref={customSwatchRef}
+                type="button"
+                onClick={() => {
+                  setShowPicker(!showPicker)
+                  if (!isCustomColor) onAccentChange('custom')
                 }}
-              />
-
-              {/* Glass overlay for unselected state */}
-              {!isCustomColor && (
+                aria-label="Custom accent color"
+                aria-haspopup="dialog"
+                aria-expanded={showPicker}
+                aria-controls={showPicker ? 'accent-color-picker' : undefined}
+                aria-pressed={isCustomColor}
+                className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
+                  isCustomColor ? 'scale-110' : ''
+                }`}
+              >
+                {/* Background gradient/color */}
                 <div
                   aria-hidden="true"
-                  className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none"
+                  className="absolute inset-0 rounded-full"
+                  style={{
+                    background: isCustomColor
+                      ? accentCustom || '#ad46ff'
+                      : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
+                  }}
                 />
-              )}
 
-              {/* Border to match presets */}
-              <div
-                aria-hidden="true"
-                className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
-              />
-            </button>
+                {/* Glass overlay for unselected state */}
+                {!isCustomColor && (
+                  <div
+                    aria-hidden="true"
+                    className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none"
+                  />
+                )}
+
+                {/* Border to match presets */}
+                <div
+                  aria-hidden="true"
+                  className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
+                />
+              </button>
+            </Tooltip>
 
             {showPicker && (
               <ColorPickerPopover

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { MAX_CUSTOM_SLOTS } from '../../lib/config'
 import { useAppsSettings } from './AppsContext'
 import { ChevronDownIcon } from '../icons'
+import { Tooltip } from '../Tooltip'
 
 function getInitials(label: string) {
   const words = label.trim().split(/\s+/).filter(Boolean)
@@ -78,15 +79,16 @@ export function AppsSection(): ReactNode {
                     <path d="M12 20h9" />
                     <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
                   </svg>
-                  <input
-                    type="text"
-                    value={appNames[utility.key] || utility.name}
-                    onChange={(e) => onAppNameChange(utility.key, e.target.value)}
-                    className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold normal-case tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
-                    placeholder="App Name"
-                    aria-label={`${utility.name} name`}
-                    title="Editable app name"
-                  />
+                  <Tooltip label="Editable app name">
+                    <input
+                      type="text"
+                      value={appNames[utility.key] || utility.name}
+                      onChange={(e) => onAppNameChange(utility.key, e.target.value)}
+                      className="min-w-0 flex-1 rounded-md border border-(--glass-border) bg-(--glass-bg) px-2 py-0.5 text-[10px] font-semibold normal-case tracking-wide text-(--text-secondary) outline-none transition-colors focus:border-(--accent) focus:text-(--text-primary)"
+                      placeholder="App Name"
+                      aria-label={`${utility.name} name`}
+                    />
+                  </Tooltip>
                 </div>
               ) : (
                 utility.name
@@ -121,12 +123,11 @@ export function AppsSection(): ReactNode {
                 onError={() => onIconLoadError(utility.key)}
               />
             ) : (
-              <div
-                className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black"
-                title={`${appNames[utility.key] || utility.name} icon fallback`}
-              >
-                {getInitials(appNames[utility.key] || utility.name)}
-              </div>
+              <Tooltip label={`${appNames[utility.key] || utility.name} icon fallback`}>
+                <div className="fallback-initial-icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[10px] font-black">
+                  {getInitials(appNames[utility.key] || utility.name)}
+                </div>
+              </Tooltip>
             )}
 
             <input
@@ -139,32 +140,33 @@ export function AppsSection(): ReactNode {
             />
 
             {utility.isCustom && (
-              <button
-                type="button"
-                onClick={() => onRemoveCustomSlot(getCustomSlotNumber(utility.key))}
-                disabled={customSlots <= 1}
-                className="danger-action action-hover-scale flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
-                title={`Remove ${appNames[utility.key] || utility.name}`}
-                aria-label={`Remove ${appNames[utility.key] || utility.name}`}
-              >
-                <svg
-                  aria-hidden="true"
-                  width="15"
-                  height="15"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+              <Tooltip label={`Remove ${appNames[utility.key] || utility.name}`}>
+                <button
+                  type="button"
+                  onClick={() => onRemoveCustomSlot(getCustomSlotNumber(utility.key))}
+                  disabled={customSlots <= 1}
+                  className="danger-action action-hover-scale flex h-9 w-9 cursor-pointer shrink-0 items-center justify-center rounded-xl transition-all"
+                  aria-label={`Remove ${appNames[utility.key] || utility.name}`}
                 >
-                  <path d="M3 6h18" />
-                  <path d="M8 6V4h8v2" />
-                  <path d="M19 6l-1 14H6L5 6" />
-                  <path d="M10 11v5" />
-                  <path d="M14 11v5" />
-                </svg>
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M3 6h18" />
+                    <path d="M8 6V4h8v2" />
+                    <path d="M19 6l-1 14H6L5 6" />
+                    <path d="M10 11v5" />
+                    <path d="M14 11v5" />
+                  </svg>
+                </button>
+              </Tooltip>
             )}
             <button
               onClick={() => onBrowse(utility.key, false)}

--- a/src/renderer/src/lib/contextMenuLabel.ts
+++ b/src/renderer/src/lib/contextMenuLabel.ts
@@ -1,0 +1,15 @@
+export function buildDismissLabel(
+  appPath: string,
+  options: { tracked?: boolean; name?: string } = {}
+): string {
+  const rawName = options.name?.trim() || getBasename(appPath)
+  const displayName = rawName.replace(/\.exe$/i, '') || rawName
+
+  const action = options.tracked ? 'Dismiss Warning' : 'Dismiss Icon'
+  return displayName ? `${action} for ${displayName}` : action
+}
+
+function getBasename(path: string): string {
+  const parts = path.split(/[/\\]/)
+  return parts[parts.length - 1] || ''
+}

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -33,4 +33,4 @@ export const setZoom = window.electronAPI.setZoom
 export const getAssetData = window.electronAPI.getAssetData
 export const getFileIcon = window.electronAPI.getFileIcon
 export const getVersion = () => window.electronAPI.getVersion()
-export const showAppContextMenu = window.electronAPI.showAppContextMenu
+export const dismissAppIcon = window.electronAPI.dismissAppIcon

--- a/tests/renderer/contextMenuLabel.test.ts
+++ b/tests/renderer/contextMenuLabel.test.ts
@@ -1,19 +1,5 @@
-import { describe, expect, test, vi } from 'vitest'
-
-// The module under test imports from '../processes', which transitively loads
-// Electron. Stub both before importing so the suite runs in a plain Node env.
-vi.mock('electron', () => ({
-  BrowserWindow: { fromWebContents: vi.fn() },
-  Menu: { buildFromTemplate: vi.fn() },
-  ipcMain: { handle: vi.fn() }
-}))
-
-vi.mock('../../src/main/processes', () => ({
-  dismissAppIcon: vi.fn(),
-  publishRunningApps: vi.fn(() => Promise.resolve())
-}))
-
-import { buildDismissLabel } from '../../src/main/ipc/context-menu'
+import { describe, expect, test } from 'vitest'
+import { buildDismissLabel } from '../../src/renderer/src/lib/contextMenuLabel'
 
 describe('buildDismissLabel', () => {
   test('untracked mismatch uses "Dismiss Icon"', () => {
@@ -46,12 +32,12 @@ describe('buildDismissLabel', () => {
     expect(buildDismissLabel('', { name: '' })).toBe('Dismiss Icon')
   })
 
-  test('escapes ampersands so Electron does not treat them as mnemonics', () => {
+  test('keeps single ampersand verbatim since HTML renders it natively', () => {
     expect(buildDismissLabel('C:/games/sim/AT&T.exe', { tracked: false })).toBe(
-      'Dismiss Icon for AT&&T'
+      'Dismiss Icon for AT&T'
     )
     expect(
       buildDismissLabel('C:/games/sim/utility.exe', { tracked: true, name: 'Foo & Bar' })
-    ).toBe('Dismiss Warning for Foo && Bar')
+    ).toBe('Dismiss Warning for Foo & Bar')
   })
 })


### PR DESCRIPTION
## Summary

Two related glassmorphism UI features built on `@floating-ui/react`:

### Custom Tooltip (#252)
- New `Tooltip` component (hover 350ms + focus, auto flip/shift, `FloatingPortal` z-9999, `role=tooltip`, ref-merge so children keep their own ref, handler composition for React 19).
- Replaced native `title` tooltips across ~22 call sites; all `aria-label`s preserved (tooltip is visual/descriptive, not the accessible name).
- Glass polish: blur on an inner layer so floating-ui's positioning transform doesn't kill `backdrop-filter` (the #439 lesson); `animate-tooltip-in`.
- Brand wordmark button now uses the custom Tooltip too (was still showing the native OS tooltip).

### Custom context menu for running-app warnings (#466)
- Replaced the native Electron right-click "Dismiss" menu with a styled React dropdown (`dropdown-surface overlay-glass`, `dropdown-item`).
- New `dismiss-app-icon` IPC (validates args → `dismissAppIcon` + `publishRunningApps`); removed the dead native `show-app-context-menu` path (handler + preload/api/electron + old label builder).
- Ported the #363 tracked/untracked label logic to the renderer (`lib/contextMenuLabel.ts`, no Electron `&&` escaping); test moved to `tests/renderer/`.
- a11y: `role=menu`/`menuitem`, `FloatingFocusManager`, `useDismiss` (Escape + outside-click), `aria-haspopup`/`aria-expanded`; tooltip suppressed while the menu is open.

## Verification
typecheck ✓ · eslint ✓ · prettier ✓ · 181/181 tests ✓ (label test moved). Visual/runtime smoke deferred to the batched 0.9.9 pre-release pass.

Closes #252
Closes #466

<!-- auto-closes -->
Closes #252
Closes #466
<!-- auto-closes -->