### PR TITLE
chore: import launchProfile statically, drop ineffective dynamic import (#473)

### DIFF
--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -19,7 +19,7 @@ import {
 } from '../lib/config'
 import { useNotify } from '../components/Notify'
 import { getSettings, getProfiles, saveProfile } from '../lib/store'
-import { getFileIcon, browsePath } from '../lib/electron'
+import { getFileIcon, browsePath, launchProfile } from '../lib/electron'
 import { useAppsSettings } from '../components/settings/AppsContext'
 import { syncProfileUtilitiesWithSettings } from '../lib/profileEditorSettingsSync'
 
@@ -400,7 +400,6 @@ export function useProfileEditor({
     onLaunchStart?.()
     let cooldownMs = 0
     try {
-      const { launchProfile } = await import('../lib/electron')
       const result = await launchProfile(gameKey)
       cooldownMs = result.launchedCount === 0 ? 0 : 10000
       if (!result.success) {


### PR DESCRIPTION
Closes #473.

`executeLaunch` in `useProfileEditor.tsx` dynamically imported `../lib/electron`, but the module is statically imported by ~10 other renderer modules (and by this file itself for `getFileIcon`/`browsePath`). The dynamic import could never move the module into a separate chunk, so Rollup printed `[INEFFECTIVE_DYNAMIC_IMPORT]` on every production build. Replaced with the static import — no behavior change, `launchProfile` call site is identical.

## Test plan
- `npm run build` no longer prints the `INEFFECTIVE_DYNAMIC_IMPORT` warning (verified locally; main/preload/renderer all build clean)
- `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- `npm test` — 181/181 passing
- Launch flow unchanged: profile launch from the editor still goes through the same `launchProfile(gameKey)` call

<!-- auto-closes -->
Closes #473
<!-- auto-closes -->