### PR TITLE
fix: smoke round 2 — discard pipeline orphan, hidden-tab focus leak, ghost dirty dot (#478, #479, #480)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -121,8 +121,11 @@ function AppContent() {
     setView(nextView)
   }
 
-  const handleDiscardAll = useCallback(() => {
-    requestDiscardAll()
+  const handleDiscardAll = useCallback(async () => {
+    // Await the discard pipeline BEFORE remounting: GameRow's pending "+"
+    // profile cleanup writes to the store, and bumping refreshKey first would
+    // tear the row down mid-cleanup and reload the orphan from the store (#478).
+    await requestDiscardAll()
     reportSettingsDirty(false)
     // Reset main-process state the renderer forwarded ahead of save (the pending
     // Minimize-to-tray toggle), remount the SettingsProvider so discarded toggles
@@ -135,8 +138,8 @@ function AppContent() {
     })
   }, [reportSettingsDirty, requestDiscardAll, syncThemeFromStore])
 
-  const handleConfirmDiscard = useCallback(() => {
-    handleDiscardAll()
+  const handleConfirmDiscard = useCallback(async () => {
+    await handleDiscardAll()
     if (pendingView) {
       setView(pendingView)
       setPendingView(null)
@@ -192,7 +195,9 @@ function AppContent() {
   }, [closeConfirmMinimizeMode, notify, requestSaveAll])
 
   const handleCloseConfirmDiscard = useCallback(async () => {
-    requestDiscardAll()
+    // Await async discard work (pending "+" profile removal, #478) before the
+    // remount and the close/minimize IPC tear the renderer state down.
+    await requestDiscardAll()
     reportSettingsDirty(false)
     // Mirror the tab-switch discard: clear any pending Minimize-to-tray
     // override, remount the SettingsProvider, and re-sync theme so a
@@ -256,7 +261,11 @@ function AppContent() {
       >
         <main className="h-full relative overflow-hidden">
           {/* Games View */}
+          {/* `inert` removes the hidden view from the Tab order and the a11y
+              tree — pointer-events-none only blocks the mouse, so without it
+              keyboard users tab through invisible controls (#479). */}
           <div
+            inert={view !== 'games'}
             className={`h-full flex flex-col transition-all duration-300 ${
               view === 'games'
                 ? 'opacity-100 scale-100 pointer-events-auto'
@@ -272,6 +281,7 @@ function AppContent() {
 
           {/* Settings View */}
           <div
+            inert={view !== 'settings'}
             className={`absolute inset-0 z-10 h-full flex flex-col transition-all duration-300 ${
               view === 'settings'
                 ? 'opacity-100 scale-100 pointer-events-auto'
@@ -296,7 +306,9 @@ function AppContent() {
         onSave={() => {
           void handleConfirmSave()
         }}
-        onDiscard={handleConfirmDiscard}
+        onDiscard={() => {
+          void handleConfirmDiscard()
+        }}
         onCancel={handleConfirmCancel}
       />
 
@@ -329,7 +341,7 @@ function AppContent() {
         discardClassName="neutral-action"
         onSave={() => {
           setDiscardConfirmOpen(false)
-          handleDiscardAll()
+          void handleDiscardAll()
         }}
         onDiscard={() => setDiscardConfirmOpen(false)}
         onCancel={() => setDiscardConfirmOpen(false)}

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -23,7 +23,7 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
     registerProfileEditorCloseRequestHandler
   } = useAppDirty()
   const scopeId = `${props.gameKey}:${props.activeProfileId}`
-  const { onClose } = props
+  const { onClose, onDiscarded } = props
   const { isDirty, handleSave, handleCloseAttempt } = editor
 
   useEffect(() => {
@@ -53,13 +53,18 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
       registerDiscardHandler('profile-editor', null)
       return
     }
-    registerDiscardHandler('profile-editor', () => {
+    registerDiscardHandler('profile-editor', async () => {
       onClose()
+      // Chain the owner's async discard work (removing a pending "+" profile
+      // from the store, #478) so requestDiscardAll resolves only after the
+      // store has settled — the App-level discard bumps refreshKey right
+      // after, and the remounted GameList must not reload the orphan.
+      await onDiscarded?.()
     })
     return () => {
       registerDiscardHandler('profile-editor', null)
     }
-  }, [isDirty, onClose, registerDiscardHandler])
+  }, [isDirty, onClose, onDiscarded, registerDiscardHandler])
 
   useEffect(() => {
     // Always route external close requests (GameRow toggle X, etc.) through

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -182,6 +182,21 @@ export function GameRow({
     }
   }, [isActive, discardPendingProfile])
 
+  // Safety net for unmount paths that never flip isActive — e.g. the
+  // refreshKey remount after a config import. Fire-and-forget through a
+  // latest-value ref so the empty-deps cleanup can't go stale; double-runs
+  // with the discard pipeline (#478) are no-ops because discardPendingProfile
+  // clears its ref up front.
+  const discardPendingProfileRef = useRef(discardPendingProfile)
+  useEffect(() => {
+    discardPendingProfileRef.current = discardPendingProfile
+  }, [discardPendingProfile])
+  useEffect(() => {
+    return () => {
+      void discardPendingProfileRef.current()
+    }
+  }, [])
+
   const switchToProfile = async (nextProfileId: string, skipRunningConfirm = false) => {
     if (nextProfileId === '__new__') {
       setNewProfileFormOpen(true)
@@ -480,6 +495,7 @@ export function GameRow({
                 onProfileCommitted={() => {
                   pendingNewProfileRef.current = null
                 }}
+                onDiscarded={discardPendingProfile}
                 onLaunchRequest={(launcher) => {
                   handleLaunchRequest.current = launcher
                 }}

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -12,6 +12,7 @@ import { getProfiles, getSettings, onStoreConfigChanged } from '../../lib/store'
 import { normalizeThemeMode, type ThemeMode } from '../../lib/theme'
 import { normalizeLaunchDelayMs } from './settingsUtils'
 import type { SettingsObjectRecords } from './saveRace'
+import type { SettingsStateSnapshot } from './useSettingsState'
 
 type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] extends (
   payload: infer Payload
@@ -22,7 +23,7 @@ type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] exten
 interface UseSettingsLoadArgs {
   themeRef: MutableRefObject<{ setThemeMode: (mode: ThemeMode) => void }>
   latestSettingsObjects: MutableRefObject<SettingsObjectRecords>
-  resetDirty: () => void
+  resetDirty: (state?: SettingsStateSnapshot) => void
   setLoading: (loading: boolean) => void
   setAppPaths: (appPaths: Record<string, string>) => void
   setAppNames: (appNames: Record<string, string>) => void
@@ -73,46 +74,68 @@ export function useSettingsLoad({
   setIsCustomColor,
   setAppIcons,
   setGameIcons
-}: UseSettingsLoadArgs): { loadSettingsFromStore: () => Promise<void> } {
-  const loadSettingsFromStore = useCallback(async () => {
+}: UseSettingsLoadArgs): { loadSettingsFromStore: () => Promise<SettingsStateSnapshot> } {
+  const loadSettingsFromStore = useCallback(async (): Promise<SettingsStateSnapshot> => {
     const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
     const typedProfiles = normalizeProfiles(savedProfiles)
+    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
 
-    latestSettingsObjects.current = {
+    // Snapshot of exactly what lands in state below. Key order mirrors the
+    // currentSettingsState memo in useSettingsState — the dirty baseline is a
+    // JSON string compare, so a re-ordered snapshot would read as permanently
+    // dirty (#480).
+    const snapshot: SettingsStateSnapshot = {
       appPaths: settings.appPaths,
       appNames: settings.appNames,
       appArgs: settings.appArgs,
-      gamePaths: settings.gamePaths
-    }
-
-    setAppPaths(settings.appPaths)
-    setAppNames(settings.appNames)
-    setAppArgs(settings.appArgs)
-    setProfiles(typedProfiles)
-    setGamePaths(settings.gamePaths)
-    setCustomSlots(
-      resolveCustomSlots(
+      profiles: typedProfiles,
+      gamePaths: settings.gamePaths,
+      customSlots: resolveCustomSlots(
         settings.customSlots,
         settings.appPaths,
         settings.appNames,
         ...Object.values(typedProfiles).filter(isRecord)
-      )
-    )
-    const loadedThemeMode = normalizeThemeMode(settings.themeMode)
+      ),
+      accentPreset: settings.accentPreset || DEFAULT_ACCENT_COLOR,
+      accentCustom: settings.accentCustom || '',
+      accentBgTint: settings.accentBgTint || false,
+      themeMode: loadedThemeMode,
+      focusActiveTitle: settings.focusActiveTitle !== false,
+      launchDelayMs: normalizeLaunchDelayMs(settings.launchDelayMs),
+      startWithWindows: settings.startWithWindows || false,
+      startMinimized: settings.startMinimized || false,
+      minimizeToTray: settings.minimizeToTray || false,
+      showTrayIcon: settings.showTrayIcon ?? true,
+      autoCheckUpdates: settings.autoCheckUpdates !== false,
+      zoomFactor: Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0
+    }
 
-    setAccentPreset(settings.accentPreset || DEFAULT_ACCENT_COLOR)
-    setAccentCustom(settings.accentCustom || '')
-    setAccentBgTint(settings.accentBgTint || false)
-    setThemeMode(loadedThemeMode)
-    themeRef.current.setThemeMode(loadedThemeMode)
-    setFocusActiveTitle(settings.focusActiveTitle !== false)
-    setLaunchDelayMs(normalizeLaunchDelayMs(settings.launchDelayMs))
-    setStartWithWindows(settings.startWithWindows || false)
-    setStartMinimized(settings.startMinimized || false)
-    setMinimizeToTray(settings.minimizeToTray || false)
-    setShowTrayIcon(settings.showTrayIcon ?? true)
-    setAutoCheckUpdates(settings.autoCheckUpdates !== false)
-    setZoomFactor(Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0)
+    latestSettingsObjects.current = {
+      appPaths: snapshot.appPaths,
+      appNames: snapshot.appNames,
+      appArgs: snapshot.appArgs,
+      gamePaths: snapshot.gamePaths
+    }
+
+    setAppPaths(snapshot.appPaths)
+    setAppNames(snapshot.appNames)
+    setAppArgs(snapshot.appArgs)
+    setProfiles(snapshot.profiles)
+    setGamePaths(snapshot.gamePaths)
+    setCustomSlots(snapshot.customSlots)
+    setAccentPreset(snapshot.accentPreset)
+    setAccentCustom(snapshot.accentCustom)
+    setAccentBgTint(snapshot.accentBgTint)
+    setThemeMode(snapshot.themeMode)
+    themeRef.current.setThemeMode(snapshot.themeMode)
+    setFocusActiveTitle(snapshot.focusActiveTitle)
+    setLaunchDelayMs(snapshot.launchDelayMs)
+    setStartWithWindows(snapshot.startWithWindows)
+    setStartMinimized(snapshot.startMinimized)
+    setMinimizeToTray(snapshot.minimizeToTray)
+    setShowTrayIcon(snapshot.showTrayIcon)
+    setAutoCheckUpdates(snapshot.autoCheckUpdates)
+    setZoomFactor(snapshot.zoomFactor)
 
     setIsCustomColor(settings.accentPreset === 'custom')
 
@@ -140,6 +163,7 @@ export function useSettingsLoad({
     setGameIcons(gIcons)
 
     setLoading(false)
+    return snapshot
   }, [
     latestSettingsObjects,
     setAccentBgTint,
@@ -168,13 +192,21 @@ export function useSettingsLoad({
   ])
 
   useEffect(() => {
-    loadSettingsFromStore()
+    void loadSettingsFromStore()
   }, [loadSettingsFromStore])
 
   useEffect(() => {
     return onStoreConfigChanged((payload: StoreConfigChangePayload) => {
+      // Skip only the bulk writes this provider itself performs on save.
+      // 'save-profile' (singular, the per-game editor/GameRow save) must keep
+      // reloading: it refreshes our profiles copy (which the settings save
+      // writes back to the store) so it can't resurrect deleted profiles.
       if (payload.reason === 'save-settings' || payload.reason === 'save-profiles') return
-      void loadSettingsFromStore().then(() => resetDirty())
+      // Re-baseline from the EXACT snapshot that was loaded. resetDirty()
+      // without arguments would serialize a previous render's currentState and
+      // leave a phantom dirty diff on whatever the reload changed — that was
+      // the ghost "Utility Apps" dot after every profile save (#480).
+      void loadSettingsFromStore().then((snapshot) => resetDirty(snapshot))
     })
   }, [loadSettingsFromStore, resetDirty])
 

--- a/src/renderer/src/components/settings/useSettingsState.ts
+++ b/src/renderer/src/components/settings/useSettingsState.ts
@@ -96,6 +96,11 @@ export interface SettingsStateBundle {
   }
 }
 
+// The dirty-tracking baseline is a JSON string compare against
+// currentSettingsState, so anything passed to resetDirty must carry these keys
+// in this exact order (see the currentSettingsState memo below).
+export type SettingsStateSnapshot = SettingsStateBundle['currentSettingsState']
+
 export function useSettingsState(): SettingsStateBundle {
   const [loading, setLoading] = useState(true)
 

--- a/src/renderer/src/contexts/AppDirtyContext.tsx
+++ b/src/renderer/src/contexts/AppDirtyContext.tsx
@@ -12,6 +12,8 @@ export type DirtyScopeId = 'settings' | string
 
 export type SaveHandler = () => Promise<boolean> | boolean
 
+export type DiscardHandler = () => Promise<void> | void
+
 export interface AppDirtyContextValue {
   isAnyDirty: boolean
   isSettingsDirty: boolean
@@ -22,7 +24,7 @@ export interface AppDirtyContextValue {
   registerSaveHandler: (scope: 'settings' | 'profile-editor', handler: SaveHandler | null) => void
   registerDiscardHandler: (
     scope: 'settings' | 'profile-editor',
-    handler: (() => void) | null
+    handler: DiscardHandler | null
   ) => void
   /**
    * Runs every registered save handler in turn and returns `true` only if every
@@ -31,7 +33,13 @@ export interface AppDirtyContextValue {
    * can keep dirty UI/dialogs open and surface an error toast.
    */
   requestSaveAll: () => Promise<boolean>
-  requestDiscardAll: () => void
+  /**
+   * Runs every registered discard handler and resolves once their async work
+   * (e.g. removing a pending "+" profile from the store, #478) has completed.
+   * Callers that remount state afterwards (refreshKey bump) must await this so
+   * the remounted views reload a store the discards have already settled.
+   */
+  requestDiscardAll: () => Promise<void>
   /**
    * Routes external "close the profile editor" requests (e.g. the toggle X
    * button in GameRowActions) through the editor's own dirty-confirm flow,
@@ -54,8 +62,8 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
   // `handleSave` from a hook).
   const settingsSaveHandlerRef = useRef<SaveHandler | null>(null)
   const profileSaveHandlerRef = useRef<SaveHandler | null>(null)
-  const settingsDiscardHandlerRef = useRef<(() => void) | null>(null)
-  const profileDiscardHandlerRef = useRef<(() => void) | null>(null)
+  const settingsDiscardHandlerRef = useRef<DiscardHandler | null>(null)
+  const profileDiscardHandlerRef = useRef<DiscardHandler | null>(null)
   const profileCloseRequestHandlerRef = useRef<(() => void) | null>(null)
 
   const reportSettingsDirty = useCallback((isDirty: boolean) => {
@@ -83,7 +91,7 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
   )
 
   const registerDiscardHandler = useCallback(
-    (scope: 'settings' | 'profile-editor', handler: (() => void) | null) => {
+    (scope: 'settings' | 'profile-editor', handler: DiscardHandler | null) => {
       if (scope === 'settings') {
         settingsDiscardHandlerRef.current = handler
       } else {
@@ -112,9 +120,19 @@ export function AppDirtyProvider({ children }: { children: ReactNode }): ReactNo
     return profileOk && settingsOk
   }, [runHandler])
 
-  const requestDiscardAll = useCallback(() => {
-    profileDiscardHandlerRef.current?.()
-    settingsDiscardHandlerRef.current?.()
+  const requestDiscardAll = useCallback(async (): Promise<void> => {
+    // A throwing discard handler must not block the other scope's discard —
+    // mirror runHandler's containment, but there is no success to report.
+    try {
+      await profileDiscardHandlerRef.current?.()
+    } catch (err) {
+      console.error('Profile discard handler threw', err)
+    }
+    try {
+      await settingsDiscardHandlerRef.current?.()
+    } catch (err) {
+      console.error('Settings discard handler threw', err)
+    }
   }, [])
 
   const registerProfileEditorCloseRequestHandler = useCallback((handler: (() => void) | null) => {

--- a/src/renderer/src/hooks/useDirtyTracking.ts
+++ b/src/renderer/src/hooks/useDirtyTracking.ts
@@ -17,26 +17,41 @@ export function useDirtyTracking<T>(
   const [isDirty, setIsDirty] = useState(false)
   // Baseline snapshot (JSON) kept in state, not a ref, so that resetting it
   // after a save recomputes derived values (getDirtySubset → per-section dots)
-  // even when currentState itself didn't change (#279).
-  const [baseline, setBaseline] = useState<string | null>(null)
+  // even when currentState itself didn't change (#279). Wrapped in an object so
+  // every reset has a fresh identity: resetting to a string EQUAL to the
+  // previous baseline would otherwise bail out of the state update, skip the
+  // comparison effect, and leave the forced `isDirty=false` inconsistent with
+  // what getDirtySubset derives at render time (#480 — the ghost section dot
+  // with no save bar).
+  const [baseline, setBaseline] = useState<{ json: string } | null>(null)
 
   useEffect(() => {
     // Capture the baseline once loading has finished.
     if (!loading && baseline === null) {
-      setBaseline(JSON.stringify(currentState))
+      setBaseline({ json: JSON.stringify(currentState) })
     }
   }, [loading, currentState, baseline])
 
   useEffect(() => {
     if (baseline === null) return
 
-    setIsDirty(JSON.stringify(currentState) !== baseline)
+    setIsDirty(JSON.stringify(currentState) !== baseline.json)
   }, [currentState, baseline])
 
-  const resetDirty = (newState?: T) => {
-    setBaseline(JSON.stringify(newState ?? currentState))
-    setIsDirty(false)
-  }
+  // Memoized so long-lived subscribers (the settings store-changed listener)
+  // don't resubscribe every render; prefer passing the explicit snapshot —
+  // the currentState fallback reflects the render this callback was created
+  // in, which can lag behind freshly-loaded state (#480).
+  const resetDirty = useCallback(
+    (newState?: T) => {
+      // Optimistically clear; the comparison effect re-derives against the
+      // committed state right after (the fresh baseline identity guarantees it
+      // runs), so a baseline that doesn't actually match stays visibly dirty.
+      setBaseline({ json: JSON.stringify(newState ?? currentState) })
+      setIsDirty(false)
+    },
+    [currentState]
+  )
 
   // Whether any of the given top-level keys differ from the captured baseline.
   // Powers per-section dirty indicators (#279) off the same baseline as isDirty;
@@ -44,7 +59,7 @@ export function useDirtyTracking<T>(
   const getDirtySubset = useCallback(
     (keys: (keyof T)[]): boolean => {
       if (baseline === null) return false
-      const parsed = JSON.parse(baseline) as T
+      const parsed = JSON.parse(baseline.json) as T
       return keys.some((key) => JSON.stringify(currentState[key]) !== JSON.stringify(parsed[key]))
     },
     [currentState, baseline]

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -33,6 +33,10 @@ export interface ProfileEditorProps {
   // launched, or deleted) so a freshly-created "+" profile is no longer a
   // discard-on-close candidate (#453).
   onProfileCommitted?: () => void
+  // Awaited by the app-level discard pipeline after the editor closes, so the
+  // owner can finish async cleanup (delete a pending "+" profile) before the
+  // caller remounts views that reload from the store (#478).
+  onDiscarded?: () => Promise<void> | void
   onLaunchRequest?: (handleLaunch: () => void) => void
   onLaunchStart?: () => void
   onLaunchEnd?: (cooldownMs: number) => void

--- a/tests/renderer/dirtyBaselineSnapshot.test.tsx
+++ b/tests/renderer/dirtyBaselineSnapshot.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for #480: after the settings store-changed listener
+ * reloads state, it must re-baseline via `resetDirty(loadedSnapshot)` — the
+ * no-argument form serializes the currentState captured by an earlier
+ * render's closure, leaving a phantom diff on whatever the reload changed
+ * (the ghost "Utility Apps" dirty dot after every profile save). These tests
+ * pin the snapshot contract of useDirtyTracking:
+ *   1. resetDirty(snapshot) where snapshot equals the live state → clean,
+ *      including per-section subsets.
+ *   2. resetDirty(staleSnapshot) that differs from live state → dirty, and
+ *      only the differing key's subset reports dirty (the #480 symptom).
+ */
+
+import { describe, expect, test } from 'vitest'
+import { act, useEffect, useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { useDirtyTracking } from '../../src/renderer/src/hooks/useDirtyTracking'
+
+interface TrackedState {
+  profiles: Record<string, string>
+  gamePaths: Record<string, string>
+}
+
+interface ProbeApi {
+  isDirty: boolean
+  profilesSubsetDirty: boolean
+  gamePathsSubsetDirty: boolean
+  setState: (next: TrackedState) => void
+  resetDirty: (snapshot?: TrackedState) => void
+}
+
+function Probe({ onRender }: { onRender: (api: ProbeApi) => void }) {
+  const [state, setState] = useState<TrackedState>({
+    profiles: { iracing: 'Default' },
+    gamePaths: { iracing: 'C:/iracing.exe' }
+  })
+  const { isDirty, resetDirty, getDirtySubset } = useDirtyTracking(state, false)
+  const onRenderRef = useRef(onRender)
+  onRenderRef.current = onRender
+
+  // getDirtySubset/resetDirty are recreated whenever state or the baseline
+  // change, so these deps re-publish fresh values after every update.
+  useEffect(() => {
+    onRenderRef.current({
+      isDirty,
+      profilesSubsetDirty: getDirtySubset(['profiles']),
+      gamePathsSubsetDirty: getDirtySubset(['gamePaths']),
+      setState,
+      resetDirty
+    })
+  }, [isDirty, getDirtySubset, resetDirty])
+
+  return null
+}
+
+async function renderProbe(): Promise<{ unmount: () => void; getApi: () => ProbeApi }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: ProbeApi | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Probe onRender={(api) => (captured = api)} />)
+  })
+
+  if (!captured) {
+    throw new Error('Probe did not initialize')
+  }
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getApi: () => {
+      if (!captured) {
+        throw new Error('Probe did not capture state')
+      }
+      return captured
+    }
+  }
+}
+
+describe('useDirtyTracking snapshot re-baseline (#480)', () => {
+  test('resetDirty(snapshot) matching the live state clears dirty and subsets', async () => {
+    const harness = await renderProbe()
+    try {
+      const reloaded: TrackedState = {
+        profiles: { iracing: 'Default', acc: 'New Profile' },
+        gamePaths: { iracing: 'C:/iracing.exe' }
+      }
+
+      // Simulates the store-changed reload: state updates, then the listener
+      // re-baselines from the exact snapshot it just loaded.
+      await act(async () => {
+        harness.getApi().setState(reloaded)
+      })
+      expect(harness.getApi().isDirty).toBe(true)
+
+      await act(async () => {
+        harness.getApi().resetDirty(reloaded)
+      })
+
+      expect(harness.getApi().isDirty).toBe(false)
+      expect(harness.getApi().profilesSubsetDirty).toBe(false)
+      expect(harness.getApi().gamePathsSubsetDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('a stale snapshot leaves exactly the differing key dirty (the #480 symptom)', async () => {
+    const harness = await renderProbe()
+    try {
+      const reloaded: TrackedState = {
+        profiles: { iracing: 'Default', acc: 'New Profile' },
+        gamePaths: { iracing: 'C:/iracing.exe' }
+      }
+      const staleSnapshot: TrackedState = {
+        profiles: { iracing: 'Default' },
+        gamePaths: { iracing: 'C:/iracing.exe' }
+      }
+
+      await act(async () => {
+        harness.getApi().setState(reloaded)
+      })
+      await act(async () => {
+        harness.getApi().resetDirty(staleSnapshot)
+      })
+
+      // Baseline poisoned by the stale closure: profiles differ, gamePaths
+      // don't — the phantom dot appears on exactly one section.
+      expect(harness.getApi().isDirty).toBe(true)
+      expect(harness.getApi().profilesSubsetDirty).toBe(true)
+      expect(harness.getApi().gamePathsSubsetDirty).toBe(false)
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/discardPipeline.test.tsx
+++ b/tests/renderer/discardPipeline.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for #478: the App-level discard flow bumps refreshKey
+ * (remounting GameList/SettingsProvider) right after requesting discards, so
+ * `requestDiscardAll` must AWAIT the registered handlers — GameRow's pending
+ * "+" profile cleanup writes to the store, and remounting first reloads the
+ * orphan before the delete lands. These tests pin the pipeline contract:
+ *   1. requestDiscardAll resolves only after async handler work completes,
+ *      profile scope before settings scope.
+ *   2. A throwing handler doesn't block the other scope (and still resolves).
+ */
+
+import { describe, expect, test, vi } from 'vitest'
+import { act, useEffect, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import {
+  AppDirtyProvider,
+  useAppDirty,
+  type DiscardHandler
+} from '../../src/renderer/src/contexts/AppDirtyContext'
+
+interface ProbeApi {
+  requestDiscardAll: () => Promise<void>
+  registerProfileDiscard: (handler: DiscardHandler | null) => void
+  registerSettingsDiscard: (handler: DiscardHandler | null) => void
+}
+
+function Probe({ onReady }: { onReady: (api: ProbeApi) => void }) {
+  const { requestDiscardAll, registerDiscardHandler } = useAppDirty()
+  const onReadyRef = useRef(onReady)
+  onReadyRef.current = onReady
+
+  useEffect(() => {
+    onReadyRef.current({
+      requestDiscardAll,
+      registerProfileDiscard: (handler) => registerDiscardHandler('profile-editor', handler),
+      registerSettingsDiscard: (handler) => registerDiscardHandler('settings', handler)
+    })
+  }, [registerDiscardHandler, requestDiscardAll])
+
+  return null
+}
+
+async function renderProbe(): Promise<{ unmount: () => void; getApi: () => ProbeApi }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: ProbeApi | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <Probe onReady={(api) => (captured = api)} />
+      </AppDirtyProvider>
+    )
+  })
+
+  if (!captured) {
+    throw new Error('Probe did not initialize')
+  }
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getApi: () => {
+      if (!captured) {
+        throw new Error('Probe did not capture state')
+      }
+      return captured
+    }
+  }
+}
+
+describe('requestDiscardAll pipeline (#478)', () => {
+  test('awaits async profile discard work before resolving; profile runs before settings', async () => {
+    const harness = await renderProbe()
+    try {
+      const order: string[] = []
+
+      await act(async () => {
+        harness.getApi().registerProfileDiscard(async () => {
+          // Simulates GameRow's discardPendingProfile: store read + write.
+          await new Promise((resolve) => setTimeout(resolve, 10))
+          order.push('profile')
+        })
+        harness.getApi().registerSettingsDiscard(() => {
+          order.push('settings')
+        })
+      })
+
+      await act(async () => {
+        await harness.getApi().requestDiscardAll()
+      })
+
+      expect(order).toEqual(['profile', 'settings'])
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('a throwing profile discard does not block the settings discard and still resolves', async () => {
+    const harness = await renderProbe()
+    try {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const settingsDiscard = vi.fn()
+
+      await act(async () => {
+        harness.getApi().registerProfileDiscard(() => {
+          throw new Error('boom')
+        })
+        harness.getApi().registerSettingsDiscard(settingsDiscard)
+      })
+
+      await act(async () => {
+        await harness.getApi().requestDiscardAll()
+      })
+
+      expect(settingsDiscard).toHaveBeenCalledTimes(1)
+      consoleSpy.mockRestore()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('resolves when no handlers are registered', async () => {
+    const harness = await renderProbe()
+    try {
+      await act(async () => {
+        await harness.getApi().requestDiscardAll()
+      })
+    } finally {
+      harness.unmount()
+    }
+  })
+})


### PR DESCRIPTION
Closes #478. Closes #479. Closes #480.

Three fixes for the findings from the second 0.9.9 smoke pass.

## #478 — orphan "+" profile survives App-level discard (#453 regression)
`handleDiscardAll` fired `requestDiscardAll()` without awaiting and synchronously bumped `refreshKey`, remounting `GameList` in the same commit — GameRow was torn down before its pending-profile cleanup ever ran (the `isActive` effect has no unmount path), and even when it ran it raced the remount's profile load.
- `requestDiscardAll()` is now async and awaits both scope handlers (a throwing handler can't block the other scope).
- ProfileEditor's discard handler chains the new `onDiscarded` prop (GameRow passes `discardPendingProfile`), so the pipeline resolves only after the store has settled.
- App awaits the pipeline **before** bumping `refreshKey` on all three discard paths (sticky-bar, tab-switch, Discard & Close).
- GameRow adds an unmount safety net (latest-value ref, idempotent) for remount paths that never flip `isActive` — e.g. the config-import remount.

## #479 — hidden tab view stays in the Tab order
Both views stay mounted; the inactive one was hidden with `opacity-0 … pointer-events-none`, which blocks the mouse but not keyboard focus or the a11y tree. The inactive view wrapper is now `inert`.

## #480 — ghost "Utility Apps" dirty dot with no save bar
Every profile save (`store-config-changed` reason `save-profile`, which the settings listener deliberately reloads on) re-baselined via a stale `resetDirty()` closure. Re-baselining to a string **equal** to the previous baseline bailed out of the state update, so the comparison effect never re-ran — `isDirty` stayed forced-`false` (no save bar) while render-time `getDirtySubset` kept deriving from live state (dot on exactly the `apps` section, whose subset includes `profiles`).
- `loadSettingsFromStore` now returns a snapshot shaped (and key-ordered) exactly like `currentSettingsState`; the listener re-baselines from that snapshot.
- `useDirtyTracking` baselines now carry a fresh object identity on every reset, so the comparison effect always re-derives `isDirty` against committed state — the forced-false/derived-true divergence class is gone.
- `resetDirty` is memoized so the listener doesn't resubscribe every render.

## Test plan
- New `tests/renderer/discardPipeline.test.tsx` (3 tests): pipeline awaits async handler work (profile before settings), a throwing handler doesn't block the other scope, resolves with no handlers.
- New `tests/renderer/dirtyBaselineSnapshot.test.tsx` (2 tests): snapshot re-baseline clears dirty + subsets; a stale snapshot leaves exactly the differing key dirty (the #480 symptom) — this test **failed against the old hook** (it surfaced the bail-out divergence) and passes with the fix.
- Full gates green: typecheck, eslint (0 warnings), prettier, **191/191** tests (was 186 + 5 new).
- Manual re-check on the rebuilt installer (part of the running smoke pass):
  - editor "+" → edit → sticky-bar Discard → orphan removed, previous profile restored
  - Settings tab → Tab-cycle never reaches invisible Games-view controls (and vice versa)
  - save a profile, open Settings → no dirty dot on Utility Apps


<!-- auto-closes -->
Closes #478
Closes #479
Closes #480
<!-- auto-closes -->