### PR TITLE
fix: launch apps with their own folder as working directory (closes #483)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -250,11 +250,18 @@ function encodePowerShellCommand(command: string) {
 }
 
 function createElevatedLaunchCommand(appPath: string, args: string[]) {
-  const payload = JSON.stringify({ filePath: appPath, args })
+  // -WorkingDirectory mirrors the non-elevated cwd fix (#483). Best effort:
+  // Windows may not propagate it across the elevation boundary, but stating
+  // the intent is harmless and covers configurations where it does.
+  const payload = JSON.stringify({
+    filePath: appPath,
+    args,
+    workingDirectory: path.dirname(appPath)
+  })
   const startProcessCommand =
     args.length > 0
-      ? 'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -Verb RunAs'
-      : 'Start-Process -FilePath $payload.filePath -Verb RunAs'
+      ? 'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -WorkingDirectory $payload.workingDirectory -Verb RunAs'
+      : 'Start-Process -FilePath $payload.filePath -WorkingDirectory $payload.workingDirectory -Verb RunAs'
 
   return encodePowerShellCommand(
     [
@@ -320,7 +327,15 @@ export function spawnDetachedApp(
 
     try {
       const args = getAppArgs(appKey)
-      const child = spawn(appPath, args, { detached: true, stdio: 'ignore' })
+      // Always start an app in its own folder, the way Explorer/Steam do.
+      // Apps that resolve assets relative to their CWD (e.g. iOverlay's WIC
+      // sprite loads) break — and can leak memory until OOM — when they
+      // inherit SimLauncher's CWD instead (#483).
+      const child = spawn(appPath, args, {
+        cwd: path.dirname(appPath),
+        detached: true,
+        stdio: 'ignore'
+      })
       const runningKey = normalizePathForComparison(appPath)
       runningProcesses.set(runningKey, {
         process: child,

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -954,7 +954,7 @@ test('launchProfileApps uses encoded PowerShell command for elevated launches wi
   const decodedCommand = Buffer.from(elevatedCall!.args[3], 'base64').toString('utf16le')
   expect(decodedCommand).toContain("$payload = ConvertFrom-Json @'")
   expect(decodedCommand).toContain(
-    'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -Verb RunAs'
+    'Start-Process -FilePath $payload.filePath -ArgumentList $payload.args -WorkingDirectory $payload.workingDirectory -Verb RunAs'
   )
   expect(JSON.parse(decodedCommand.split("@'\n")[1].split("\n'@")[0])).toEqual({
     filePath: 'C:/Tools/Admin Tool.exe',
@@ -963,7 +963,8 @@ test('launchProfileApps uses encoded PowerShell command for elevated launches wi
       'C:/Users/Driver/Sim Configs',
       '--literal',
       "$(Start-Process calc); 'single' & value"
-    ]
+    ],
+    workingDirectory: 'C:/Tools'
   })
 })
 
@@ -988,11 +989,14 @@ test('launchProfileApps omits PowerShell ArgumentList for elevated launches with
   })
 
   const decodedCommand = Buffer.from(elevatedCall!.args[3], 'base64').toString('utf16le')
-  expect(decodedCommand).toContain('Start-Process -FilePath $payload.filePath -Verb RunAs')
+  expect(decodedCommand).toContain(
+    'Start-Process -FilePath $payload.filePath -WorkingDirectory $payload.workingDirectory -Verb RunAs'
+  )
   expect(decodedCommand).not.toContain('-ArgumentList')
   expect(JSON.parse(decodedCommand.split("@'\n")[1].split("\n'@")[0])).toEqual({
     filePath: 'C:/Tools/Admin Tool.exe',
-    args: []
+    args: [],
+    workingDirectory: 'C:/Tools'
   })
 })
 
@@ -1030,6 +1034,47 @@ test('launchProfileApps resolves args per utility key when two slots share the s
   expect(spawnCalls[1]).toMatchObject({
     appPath: 'C:/Tools/Shared Utility.exe',
     args: ['--mode', 'silent']
+  })
+})
+
+// Apps like iOverlay resolve asset paths relative to their CWD; inheriting
+// SimLauncher's CWD makes every WIC sprite load fail (hr=0x80070003) and the
+// failed render loop leaks memory until OOM. The launcher must always start
+// an app in its own folder, the same way Explorer/Steam/DisplayMagician do.
+test('launchProfileApps starts each app with its own folder as the working directory (#483)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps } = await loadProcessModules()
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  expect(spawnCalls[0]).toMatchObject({
+    appPath: 'C:/Tools/SimHub.exe',
+    options: { cwd: 'C:/Tools', detached: true, stdio: 'ignore' }
+  })
+})
+
+test('elevated launches pass the app folder as -WorkingDirectory (#483)', async () => {
+  markExistingPath('C:/Tools/Admin Tool.exe')
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+  const { launchProfileApps } = await loadProcessModules()
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])).resolves.toMatchObject(
+    {
+      success: true,
+      launchedCount: 1,
+      elevatedCount: 1
+    }
+  )
+
+  const elevatedCall = execFileCalls.find((call) => call.command === 'powershell.exe')
+  const decodedCommand = Buffer.from(elevatedCall!.args[3], 'base64').toString('utf16le')
+  expect(decodedCommand).toContain('-WorkingDirectory $payload.workingDirectory')
+  expect(JSON.parse(decodedCommand.split("@'\n")[1].split("\n'@")[0])).toMatchObject({
+    filePath: 'C:/Tools/Admin Tool.exe',
+    workingDirectory: 'C:/Tools'
   })
 })
 


### PR DESCRIPTION
## Summary

Apps launched by SimLauncher inherited SimLauncher's working directory (install dir, or `C:\Windows\System32` when starting with Windows) instead of their own folder. Apps that resolve assets relative to their CWD break: iOverlay's WIC sprite loads fail every render tick (`hr=0x80070003`, `ERROR_PATH_NOT_FOUND`) and the failed render loop leaks memory until system OOM (reproduced: ~290 MB → 750+ MB within minutes).

- `spawnDetachedApp` now spawns with `cwd: path.dirname(appPath)` — the same behavior as Explorer/Steam/DisplayMagician
- the elevated PowerShell fallback passes `-WorkingDirectory $payload.workingDirectory` (best effort: Windows may not propagate it across the elevation boundary, but it is correct intent and harmless)

Closes #483

## Test plan

- [x] TDD: both new tests watched failing first (`cwd` missing / `-WorkingDirectory` missing), green after the fix
- [x] `npm test` — 193/193
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- [x] Mini-smoke before release (0.9.10 milestone batch): iOverlay launched via SimLauncher shows its window, no console error spam, stable RAM; a regular app launches normally; an elevated app still triggers UAC and starts
