### PR TITLE
release: v0.9.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "repository": {


### PR DESCRIPTION
## Summary

Hotfix release for #483:

- fix: launched apps now start with their own folder as the working directory — apps that resolve assets relative to their CWD (e.g. iOverlay's WIC sprite loads) no longer fail every render tick and leak memory until system OOM (#483, #484)
- elevated launches pass `-WorkingDirectory` in the `Start-Process -Verb RunAs` payload (best effort)

## Milestone

0.9.10 - Hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
