### PR TITLE
chore: upgrade Electron 39 to 42 (closes #382)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
 git clone https://github.com/Stashpeak/SimLauncher
 cd SimLauncher
 npm install
+npx install-electron   # Electron >=42 no longer downloads its binary via postinstall
 npm run dev
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.2",
-        "electron": "^39.8.8",
+        "electron": "^42.4.0",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
         "eslint": "^10.4.1",
@@ -546,6 +546,16 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz",
+      "integrity": "sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-4.2.0.tgz",
@@ -619,25 +629,61 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -2499,13 +2545,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.18.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
-      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/plist": {
@@ -2557,17 +2603,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
@@ -3515,16 +3550,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4340,22 +4365,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.8.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.8.tgz",
-      "integrity": "sha512-24MMLdwCg8xwlWzDxC1XZU2MqW0Xx2UPxt9EU15vMDoRSMHPqmi/BgRCEINXZaBLfFSeXEKGpg+QlBRdL5uwaw==",
+      "version": "42.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
+      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -5012,27 +5037,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -5079,16 +5083,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5207,21 +5201,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fsevents": {
@@ -6804,13 +6783,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7819,9 +7791,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8260,17 +8232,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.2",
-    "electron": "^39.8.8",
+    "electron": "^42.4.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "eslint": "^10.4.1",

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -420,7 +420,14 @@ export function registerConfigHandlers(): void {
 
   ipcMain.handle('set-zoom', (_event, factor: unknown) => {
     const zoomFactor = requireSafeZoomFactor(factor)
-    getMainWindow()?.webContents.setZoomFactor(zoomFactor)
+    const webContents = getMainWindow()?.webContents
+    if (!webContents) return
+    // Skip same-value calls: re-setting the current zoom on a still-hidden
+    // window suppresses 'ready-to-show' on Electron 42 (#382), and the
+    // renderer's boot-time set-zoom is always same-value (both sides read the
+    // same store).
+    if (Math.abs(webContents.getZoomFactor() - zoomFactor) < 0.001) return
+    webContents.setZoomFactor(zoomFactor)
   })
 
   ipcMain.handle('get-settings', () => {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -16,6 +16,10 @@ import { clamp } from './utils'
 
 let mainWindow: BrowserWindow | null = null
 
+// Grace period between the renderer finishing its load and force-showing the
+// window when 'ready-to-show' did not arrive (see the #382 comment below).
+const READY_TO_SHOW_FALLBACK_MS = 500
+
 export type CloseAction = 'quit' | 'hide' | 'confirm-close' | 'confirm-minimize'
 
 /**
@@ -197,12 +201,27 @@ export function createWindow(): void {
   // Show window once ready, or keep it hidden when starting minimized to tray.
   // Only stay hidden if BOTH startMinimized AND the tray exists — otherwise the
   // window would be stranded with no way to restore it.
-  mainWindow.once('ready-to-show', () => {
+  const showWindowWhenReady = () => {
+    if (!mainWindow || mainWindow.isDestroyed() || mainWindow.isVisible()) {
+      return
+    }
     const startMinimized = getStoredBoolean('startMinimized')
     const showTrayIcon = getStoredBoolean('showTrayIcon', true)
     if (!startMinimized || !showTrayIcon) {
-      mainWindow!.show()
+      mainWindow.show()
     }
+  }
+
+  mainWindow.once('ready-to-show', showWindowWhenReady)
+
+  // Electron 42 regression (#382): a webContents.setZoomFactor() call landing
+  // between did-finish-load and the hidden window's first paint suppresses
+  // 'ready-to-show' permanently — and the renderer's boot does exactly that via
+  // the set-zoom IPC. The handler now skips same-value calls, but keep a
+  // fallback here so the window can never be stranded invisible if the event
+  // is lost for any other reason.
+  mainWindow.webContents.once('did-finish-load', () => {
+    setTimeout(showWindowWhenReady, READY_TO_SHOW_FALLBACK_MS)
   })
 
   // Apply login-item setting on startup

--- a/tests/main/configZoom.test.ts
+++ b/tests/main/configZoom.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const setZoomFactor = vi.fn()
+const getZoomFactor = vi.fn(() => 1.5)
+
+async function loadConfigZoomHandler() {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  vi.doMock('../../src/main/window', () => ({
+    getMainWindow: vi.fn(() => ({ webContents: { setZoomFactor, getZoomFactor } })),
+    applyRuntimeConfigSettings: vi.fn(),
+    sendToRenderer: vi.fn()
+  }))
+  vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
+  vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
+  vi.doMock('../../src/main/store', () => ({
+    CONFIG_FILE_NAME: 'config.json',
+    KNOWN_GAME_KEYS: new Set(['iracing']),
+    MAX_CONFIG_IMPORT_BYTES: 1024 * 1024,
+    MAX_CUSTOM_SLOTS: 20,
+    getSupportedConfigValues: vi.fn(() => ({})),
+    getStoredZoomFactor: vi.fn(() => 1.5),
+    requireSafeZoomFactor: vi.fn((value: unknown) => {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error('Invalid zoom factor')
+      }
+      return value
+    }),
+    sanitizeImportedConfig: vi.fn(() => ({})),
+    sanitizeSettingsPatch: vi.fn(() => ({})),
+    store: { get: vi.fn(), set: vi.fn(), store: {} }
+  }))
+
+  const mod = await import('../../src/main/ipc/config')
+  mod.registerConfigHandlers()
+  const { __ipcHandlers } = await import('electron')
+  return __ipcHandlers as Record<string, (...args: unknown[]) => unknown>
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+// Re-setting the current zoom factor on a still-hidden window suppresses
+// 'ready-to-show' forever on Electron 42 — and the renderer's boot-time
+// set-zoom call is always a same-value call (both sides read the same store).
+// The handler must skip the Chromium call when nothing changes. (#382)
+test('set-zoom skips the Chromium call when the factor matches the current zoom (#382)', async () => {
+  const handlers = await loadConfigZoomHandler()
+
+  await handlers['set-zoom']({}, 1.5)
+
+  expect(setZoomFactor).not.toHaveBeenCalled()
+})
+
+test('set-zoom applies a changed factor (#382)', async () => {
+  const handlers = await loadConfigZoomHandler()
+
+  await handlers['set-zoom']({}, 1.25)
+
+  expect(setZoomFactor).toHaveBeenCalledWith(1.25)
+})

--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -1,8 +1,110 @@
 import { vi } from 'vitest'
 
 type MockIpcHandler = (...args: unknown[]) => unknown | Promise<unknown>
+type MockEventHandler = (...args: unknown[]) => void
 
 export const __ipcHandlers: Record<string, MockIpcHandler> = {}
+
+class MockEventTarget {
+  private listeners = new Map<string, MockEventHandler[]>()
+
+  private add(event: string, handler: MockEventHandler) {
+    const existing = this.listeners.get(event) ?? []
+    existing.push(handler)
+    this.listeners.set(event, existing)
+  }
+
+  private remove(event: string, handler: MockEventHandler) {
+    const existing = this.listeners.get(event) ?? []
+    const index = existing.indexOf(handler)
+    if (index >= 0) existing.splice(index, 1)
+  }
+
+  on = vi.fn((event: string, handler: MockEventHandler) => {
+    this.add(event, handler)
+    return this
+  })
+
+  once = vi.fn((event: string, handler: MockEventHandler) => {
+    const wrapped = (...args: unknown[]) => {
+      this.remove(event, wrapped)
+      handler(...args)
+    }
+    this.add(event, wrapped)
+    return this
+  })
+
+  emit(event: string, ...args: unknown[]) {
+    for (const handler of [...(this.listeners.get(event) ?? [])]) {
+      handler(...args)
+    }
+  }
+}
+
+class MockWebContents extends MockEventTarget {
+  send = vi.fn()
+  setWindowOpenHandler = vi.fn()
+  setZoomFactor = vi.fn()
+  getZoomFactor = vi.fn(() => 1)
+  isLoading = vi.fn(() => false)
+}
+
+export class BrowserWindow extends MockEventTarget {
+  static instances: BrowserWindow[] = []
+
+  static getAllWindows() {
+    return BrowserWindow.instances.filter((w) => !w.destroyed)
+  }
+
+  options: Record<string, unknown>
+  webContents = new MockWebContents()
+  private visible = false
+  private minimized = false
+  private destroyed = false
+
+  constructor(options: Record<string, unknown> = {}) {
+    super()
+    this.options = options
+    BrowserWindow.instances.push(this)
+  }
+
+  show = vi.fn(() => {
+    this.visible = true
+    this.minimized = false
+  })
+
+  hide = vi.fn(() => {
+    this.visible = false
+  })
+
+  focus = vi.fn()
+
+  minimize = vi.fn(() => {
+    this.minimized = true
+  })
+
+  restore = vi.fn(() => {
+    this.minimized = false
+  })
+
+  close = vi.fn()
+
+  destroy = vi.fn(() => {
+    this.destroyed = true
+  })
+
+  isVisible = vi.fn(() => this.visible)
+  isMinimized = vi.fn(() => this.minimized)
+  isDestroyed = vi.fn(() => this.destroyed)
+  isMaximized = vi.fn(() => false)
+  getBounds = vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 }))
+  loadFile = vi.fn()
+  loadURL = vi.fn()
+}
+
+export const screen = {
+  getDisplayMatching: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }))
+}
 
 export const app = {
   getVersion: vi.fn().mockReturnValue('1.0.0'),

--- a/tests/main/window.test.ts
+++ b/tests/main/window.test.ts
@@ -33,9 +33,101 @@ async function loadWindowModule() {
   return mod
 }
 
+async function loadWindowModuleForCreate(
+  opts: { startMinimized?: boolean; showTrayIcon?: boolean } = {}
+) {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  vi.doMock('../../src/main/store', () => ({
+    getStoredBoolean: vi.fn((key: string, defaultValue = false) => {
+      if (key === 'startMinimized') return opts.startMinimized ?? false
+      if (key === 'showTrayIcon') return opts.showTrayIcon ?? true
+      return defaultValue
+    }),
+    getStoredZoomFactor: vi.fn(() => 1),
+    isWindowBounds: vi.fn(() => false),
+    store: { get: vi.fn(() => undefined), set: vi.fn() }
+  }))
+  vi.doMock('../../src/main/updater', () => ({
+    registerUpdaterEvents: vi.fn(),
+    checkForUpdates: vi.fn().mockResolvedValue(null)
+  }))
+
+  return await import('../../src/main/window')
+}
+
+async function getCreatedWindow() {
+  const { BrowserWindow } = await import('electron')
+  type MockWindow = {
+    show: ReturnType<typeof vi.fn>
+    webContents: { emit: (event: string, ...args: unknown[]) => void }
+    emit: (event: string, ...args: unknown[]) => void
+  }
+  return (BrowserWindow as unknown as { instances: MockWindow[] }).instances[0]
+}
+
 beforeEach(() => {
   vi.resetModules()
   vi.clearAllMocks()
+})
+
+// Electron 42 regression context (#382): the renderer's boot-time set-zoom IPC
+// lands between did-finish-load and the first paint of the still-hidden window,
+// which permanently suppresses 'ready-to-show'. The window must not stay
+// stranded hidden when that event never arrives.
+test('createWindow shows the window via did-finish-load fallback when ready-to-show never fires (#382)', async () => {
+  vi.useFakeTimers()
+  try {
+    const { createWindow } = await loadWindowModuleForCreate()
+    createWindow()
+    const win = await getCreatedWindow()
+
+    expect(win.show).not.toHaveBeenCalled()
+    win.webContents.emit('did-finish-load')
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(win.show).toHaveBeenCalled()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('createWindow fallback respects start-minimized-to-tray and keeps the window hidden (#382)', async () => {
+  vi.useFakeTimers()
+  try {
+    const { createWindow } = await loadWindowModuleForCreate({
+      startMinimized: true,
+      showTrayIcon: true
+    })
+    createWindow()
+    const win = await getCreatedWindow()
+
+    win.emit('ready-to-show')
+    win.webContents.emit('did-finish-load')
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(win.show).not.toHaveBeenCalled()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('createWindow does not double-show when ready-to-show fired before the fallback (#382)', async () => {
+  vi.useFakeTimers()
+  try {
+    const { createWindow } = await loadWindowModuleForCreate()
+    createWindow()
+    const win = await getCreatedWindow()
+
+    win.emit('ready-to-show')
+    win.webContents.emit('did-finish-load')
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(win.show).toHaveBeenCalledTimes(1)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 test('browse-path echoes only string input ids', async () => {


### PR DESCRIPTION
## Summary

Upgrades Electron `^39.8.8` → `^42.4.0` (latest stable). Electron 39 has been EOL since early May 2026 with zero security backports; 42 ships Chromium 148.

- **No app code changes**: breaking-changes audit for 40/41/42 found nothing in use — `clipboard` only as the web `navigator.clipboard` API, no `clearStorageData(quotas)`, no offscreen rendering, macOS-only changes moot (Windows-only app), no native `.node` modules (no ABI risk)
- **Electron ≥42 no longer downloads its binary via npm postinstall** (now `npx install-electron` / first `npx electron` run). Documented in CONTRIBUTING dev setup. CI needs no change: the build job never launches Electron, and electron-builder downloads its own dist zip via `@electron/get` (verified in the local dist:win build log)
- electron-vite 5.0.0 + electron-builder 26.8.1 both work with 42 (#475 toolchain alignment stays open — electron-vite 6 is still beta-only)

Closes #382

## Test plan

- [x] `npm test` 193/193, `typecheck`, `lint`, `npm run build` — all green on 42
- [x] Binary verified: `electron --version` → v42.4.0 (with `ELECTRON_RUN_AS_NODE` cleared)
- [x] Local `npm run dist:win` — packaged electron 42.4.0, NSIS installer + blockmap built, signing steps OK
- [x] David: install the local `dist\SimLauncher Setup 0.9.10.exe`, app smoke (launch profile, tray, settings, DevTools console clean) + updater UI check


<!-- auto-closes -->
Closes #382
<!-- auto-closes -->