### PR TITLE
fix: spawn console-subsystem apps with a console (closes #486)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -19,6 +19,7 @@ import {
   processNameMismatchWarnings,
   runningProcesses
 } from './state'
+import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { AppLaunchResult, LaunchResult, ProfileLaunchEntry, ProfileLaunchInput } from './types'
 import { publishRunningApps } from './running'
@@ -303,13 +304,19 @@ function launchElevated(appPath: string, args: string[] = []) {
   })
 }
 
-export function spawnDetachedApp(
+export async function spawnDetachedApp(
   sender: WebContents,
   gameKey: string,
   entry: ProfileLaunchEntry,
   gamePath?: string
 ): Promise<AppLaunchResult> {
   const { path: appPath, key: appKey } = entry
+  // Console-subsystem exes must NOT get DETACHED_PROCESS: without a console
+  // they can exit before doing anything (powershell.exe exits 0 without
+  // executing, #486). Spawned non-detached they allocate their own console,
+  // and children outlive the parent on Windows either way. GUI apps keep the
+  // long-standing detached behavior.
+  const consoleApp = await isConsoleExecutable(appPath)
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined
@@ -333,7 +340,7 @@ export function spawnDetachedApp(
       // inherit SimLauncher's CWD instead (#483).
       const child = spawn(appPath, args, {
         cwd: path.dirname(appPath),
-        detached: true,
+        detached: !consoleApp,
         stdio: 'ignore'
       })
       const runningKey = normalizePathForComparison(appPath)

--- a/src/main/processes/subsystem.ts
+++ b/src/main/processes/subsystem.ts
@@ -1,0 +1,48 @@
+import fs from 'fs'
+
+// PE optional-header Subsystem values (IMAGE_SUBSYSTEM_*).
+const SUBSYSTEM_WINDOWS_CUI = 3
+
+const DOS_HEADER_SIZE = 64
+const DOS_MAGIC = 0x5a4d // 'MZ'
+const PE_OFFSET_FIELD = 0x3c // e_lfanew
+const PE_SIGNATURE = 0x00004550 // 'PE\0\0'
+// 4-byte PE signature + 20-byte COFF header + Subsystem at optional-header
+// offset 68 (same offset for PE32 and PE32+).
+const SUBSYSTEM_OFFSET = 4 + 20 + 68
+const PE_HEADERS_READ_SIZE = SUBSYSTEM_OFFSET + 2
+
+/**
+ * Read the PE optional header's Subsystem field to detect console-subsystem
+ * executables. Spawning those with `detached: true` gives them
+ * DETACHED_PROCESS — no console is ever created and tools like powershell.exe
+ * exit without executing anything (#486), so the spawner needs to know.
+ *
+ * Fails open: any unreadable/odd file reports `false` (treated as GUI), which
+ * preserves the long-standing detached spawn behavior.
+ */
+export async function isConsoleExecutable(exePath: string): Promise<boolean> {
+  let file: fs.promises.FileHandle | undefined
+  try {
+    file = await fs.promises.open(exePath, 'r')
+
+    const dosHeader = Buffer.alloc(DOS_HEADER_SIZE)
+    const dosRead = await file.read(dosHeader, 0, DOS_HEADER_SIZE, 0)
+    if (dosRead.bytesRead < DOS_HEADER_SIZE || dosHeader.readUInt16LE(0) !== DOS_MAGIC) {
+      return false
+    }
+
+    const peOffset = dosHeader.readUInt32LE(PE_OFFSET_FIELD)
+    const peHeaders = Buffer.alloc(PE_HEADERS_READ_SIZE)
+    const peRead = await file.read(peHeaders, 0, PE_HEADERS_READ_SIZE, peOffset)
+    if (peRead.bytesRead < PE_HEADERS_READ_SIZE || peHeaders.readUInt32LE(0) !== PE_SIGNATURE) {
+      return false
+    }
+
+    return peHeaders.readUInt16LE(SUBSYSTEM_OFFSET) === SUBSYSTEM_WINDOWS_CUI
+  } catch {
+    return false
+  } finally {
+    await file?.close().catch(() => {})
+  }
+}

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -51,6 +51,9 @@ const execFileCalls: { command: string; args: string[]; options: Record<string, 
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnErrors = new Map<string, NodeJS.ErrnoException>()
 const invalidateProcessNameCacheMock = vi.fn()
+// Paths the mocked PE-subsystem sniffer reports as console-subsystem exes —
+// those must spawn WITHOUT detached so they get a console (#486).
+const consoleExePaths = new Set<string>()
 
 type ProcessRegistryEntry = {
   pid: string
@@ -247,6 +250,15 @@ async function loadProcessModules() {
     })
   }))
 
+  const subsystemMock = {
+    isConsoleExecutable: vi.fn((exePath: string) => Promise.resolve(consoleExePaths.has(exePath)))
+  }
+  vi.doMock('./subsystem', () => subsystemMock)
+  vi.doMock('/src/main/processes/subsystem.ts', () => subsystemMock)
+  vi.doMock('../../src/main/processes/subsystem', () => subsystemMock)
+  vi.doMock('../../src/main/processes/subsystem.ts', () => subsystemMock)
+  vi.doMock('../../src/main/processes/subsystem.js', () => subsystemMock)
+
   const tasklistMock = {
     invalidateProcessNameCache: invalidateProcessNameCacheMock,
     readRunningProcessNames: vi.fn(() => {
@@ -418,6 +430,7 @@ beforeEach(async () => {
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
+  consoleExePaths.clear()
   sender.send.mockClear()
   invalidateProcessNameCacheMock.mockClear()
   processNameMismatchWarnings.clear()
@@ -1034,6 +1047,43 @@ test('launchProfileApps resolves args per utility key when two slots share the s
   expect(spawnCalls[1]).toMatchObject({
     appPath: 'C:/Tools/Shared Utility.exe',
     args: ['--mode', 'silent']
+  })
+})
+
+// Console-subsystem exes spawned with detached get DETACHED_PROCESS on
+// Windows — no console is created and e.g. powershell.exe exits 0 without
+// executing anything. They must spawn non-detached so a console is allocated;
+// children outlive the parent on Windows either way (#486).
+test('launchProfileApps spawns console-subsystem apps without detached (#486)', async () => {
+  markExistingPath('C:/Tools/TelemetryCli.exe')
+  consoleExePaths.add('C:/Tools/TelemetryCli.exe')
+  const { launchProfileApps } = await loadProcessModules()
+
+  await expect(
+    launchProfileApps(sender, 'ac', ['C:/Tools/TelemetryCli.exe'])
+  ).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  expect(spawnCalls[0]).toMatchObject({
+    appPath: 'C:/Tools/TelemetryCli.exe',
+    options: { detached: false, stdio: 'ignore' }
+  })
+})
+
+test('launchProfileApps keeps GUI-subsystem apps detached (#486)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps } = await loadProcessModules()
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  expect(spawnCalls[0]).toMatchObject({
+    appPath: 'C:/Tools/SimHub.exe',
+    options: { detached: true, stdio: 'ignore' }
   })
 })
 

--- a/tests/main/subsystem.test.ts
+++ b/tests/main/subsystem.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, expect, test } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { isConsoleExecutable } from '../../src/main/processes/subsystem'
+
+const SUBSYSTEM_GUI = 2
+const SUBSYSTEM_CONSOLE = 3
+
+const tempFiles: string[] = []
+
+/**
+ * Build a minimal PE file: MZ header with e_lfanew at 0x3C pointing to a
+ * "PE\0\0" signature + COFF header (20 bytes) + optional header whose
+ * Subsystem field sits at optional-header offset 68.
+ */
+function buildPeFixture(opts: { subsystem?: number; corrupt?: 'no-mz' | 'no-pe' } = {}) {
+  const peOffset = 0x80
+  const buf = Buffer.alloc(0x200)
+  if (opts.corrupt !== 'no-mz') buf.writeUInt16LE(0x5a4d, 0) // 'MZ'
+  buf.writeUInt32LE(peOffset, 0x3c)
+  if (opts.corrupt !== 'no-pe') {
+    buf.writeUInt32LE(0x00004550, peOffset) // 'PE\0\0'
+    buf.writeUInt16LE(0x10b, peOffset + 24) // optional header magic (PE32)
+    buf.writeUInt16LE(opts.subsystem ?? SUBSYSTEM_GUI, peOffset + 24 + 68)
+  }
+  return buf
+}
+
+function writeFixture(name: string, content: Buffer) {
+  const filePath = path.join(os.tmpdir(), `simlauncher-subsystem-${name}-${process.pid}.exe`)
+  fs.writeFileSync(filePath, content)
+  tempFiles.push(filePath)
+  return filePath
+}
+
+afterAll(() => {
+  tempFiles.forEach((file) => {
+    try {
+      fs.unlinkSync(file)
+    } catch {
+      // best effort
+    }
+  })
+})
+
+test('detects a console-subsystem PE (#486)', async () => {
+  const file = writeFixture('console', buildPeFixture({ subsystem: SUBSYSTEM_CONSOLE }))
+  await expect(isConsoleExecutable(file)).resolves.toBe(true)
+})
+
+test('detects a GUI-subsystem PE as non-console (#486)', async () => {
+  const file = writeFixture('gui', buildPeFixture({ subsystem: SUBSYSTEM_GUI }))
+  await expect(isConsoleExecutable(file)).resolves.toBe(false)
+})
+
+test('fails open (non-console) on a file without an MZ header (#486)', async () => {
+  const file = writeFixture('no-mz', buildPeFixture({ corrupt: 'no-mz' }))
+  await expect(isConsoleExecutable(file)).resolves.toBe(false)
+})
+
+test('fails open (non-console) on a missing PE signature (#486)', async () => {
+  const file = writeFixture('no-pe', buildPeFixture({ corrupt: 'no-pe' }))
+  await expect(isConsoleExecutable(file)).resolves.toBe(false)
+})
+
+test('fails open (non-console) on a truncated file (#486)', async () => {
+  const file = writeFixture('truncated', buildPeFixture().subarray(0, 0x50))
+  await expect(isConsoleExecutable(file)).resolves.toBe(false)
+})
+
+test('fails open (non-console) on a nonexistent path (#486)', async () => {
+  await expect(isConsoleExecutable('C:/does/not/exist.exe')).resolves.toBe(false)
+})
+
+// Real-world sanity against actual Windows system binaries (skipped on the
+// Linux CI runner; runs on dev machines).
+test.runIf(process.platform === 'win32')('classifies real system executables (#486)', async () => {
+  await expect(isConsoleExecutable('C:/Windows/System32/cmd.exe')).resolves.toBe(true)
+  await expect(
+    isConsoleExecutable('C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe')
+  ).resolves.toBe(true)
+  await expect(isConsoleExecutable('C:/Windows/explorer.exe')).resolves.toBe(false)
+})


### PR DESCRIPTION
## Summary

Console-subsystem executables launched by SimLauncher got `DETACHED_PROCESS` (from `detached: true`), so Windows never allocated them a console — e.g. `powershell.exe` exits 0 without executing anything (discovered while verifying #483).

- new `processes/subsystem.ts` reads the PE optional-header `Subsystem` field; fails open (treated as GUI) on any unreadable or malformed file
- console exes (`Subsystem == 3`) now spawn with `detached: false`, so they allocate their own console; children outlive the parent on Windows either way
- GUI apps keep the long-standing `detached: true` behavior — zero change

Closes #486

## Test plan

- [x] TDD: parser + integration tests watched failing first (module missing / `detached: true`)
- [x] 9 new tests: PE fixtures (console/GUI/no-MZ/no-PE/truncated/missing) + real system exes on win32 (`cmd.exe`/`powershell.exe` → console, `explorer.exe` → GUI) + spawn-options integration both ways
- [x] `npm test` 207/207, `typecheck`, `lint`, `format:check` — clean
- [x] Non-detached console spawn behavior verified empirically earlier in the #483 investigation (powershell executes and writes its probe file when spawned without `DETACHED_PROCESS`)
