### PR TITLE
feat: per-profile game position in launch sequence (closes #471)

### DIFF
--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -5,8 +5,20 @@ import { isRecord, isValidExePath, normalizePathForComparison } from './utils'
 export interface StoredProfile extends Record<string, unknown> {
   utilities?: StoredProfileUtility[]
   launchAutomatically?: boolean
+  gamePosition?: GamePosition
   trackingEnabled?: boolean
   trackedProcessPaths?: string[]
+}
+
+export type GamePosition = 'first' | 'last'
+
+/**
+ * Resolve where the game sits in the launch sequence. Anything other than an
+ * explicit 'last' (absent, legacy, corrupted) means 'first' — the behavior
+ * every profile had before #471.
+ */
+export function getGamePosition(profile: StoredProfile): GamePosition {
+  return profile.gamePosition === 'last' ? 'last' : 'first'
 }
 
 export interface StoredNamedProfile extends StoredProfile {
@@ -130,39 +142,38 @@ export function getEnabledUtilityEntries(
   return entries
 }
 
-export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchEntry[] {
+function buildProfileLaunchEntries(gameKey: string, profile: StoredNamedProfile) {
   const appPaths = getStoredStringRecord('appPaths')
   const gamePaths = getStoredStringRecord('gamePaths')
-  const profiles = getStoredProfiles()
   const customSlots = store.get('customSlots')
-  const profile = resolveActiveProfile(profiles[gameKey])
   const entries: ProfileLaunchEntry[] = []
+  const gameEntry =
+    profile.launchAutomatically !== false && gamePaths[gameKey]
+      ? { key: gameKey, path: gamePaths[gameKey] }
+      : undefined
 
-  if (profile.launchAutomatically !== false && gamePaths[gameKey]) {
-    entries.push({ key: gameKey, path: gamePaths[gameKey] })
+  if (gameEntry && getGamePosition(profile) === 'first') {
+    entries.push(gameEntry)
   }
   getEnabledUtilityEntries(profile, appPaths, customSlots).forEach((entry) => entries.push(entry))
+  if (gameEntry && getGamePosition(profile) === 'last') {
+    entries.push(gameEntry)
+  }
 
   return entries
+}
+
+export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchEntry[] {
+  const profiles = getStoredProfiles()
+  return buildProfileLaunchEntries(gameKey, resolveActiveProfile(profiles[gameKey]))
 }
 
 export function buildNamedProfileLaunchEntries(
   gameKey: string,
   profileId: string
 ): ProfileLaunchEntry[] {
-  const appPaths = getStoredStringRecord('appPaths')
-  const gamePaths = getStoredStringRecord('gamePaths')
   const profiles = getStoredProfiles()
-  const customSlots = store.get('customSlots')
-  const profile = resolveNamedProfile(profiles[gameKey], profileId)
-  const entries: ProfileLaunchEntry[] = []
-
-  if (profile.launchAutomatically !== false && gamePaths[gameKey]) {
-    entries.push({ key: gameKey, path: gamePaths[gameKey] })
-  }
-  getEnabledUtilityEntries(profile, appPaths, customSlots).forEach((entry) => entries.push(entry))
-
-  return entries
+  return buildProfileLaunchEntries(gameKey, resolveNamedProfile(profiles[gameKey], profileId))
 }
 
 export function getUtilityKeys(customSlots: unknown): string[] {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -377,6 +377,12 @@ function sanitizeProfileFields(profile: Record<string, unknown>, utilityKeys: Se
     }
   })
 
+  // Only the two known positions survive; anything else (absent, legacy,
+  // corrupted) is stripped so readers fall back to game-first (#471).
+  if (profile.gamePosition === 'first' || profile.gamePosition === 'last') {
+    safeProfile.gamePosition = profile.gamePosition
+  }
+
   const utilities = sanitizeProfileUtilities(profile.utilities, utilityKeys)
   if (utilities) {
     safeProfile.utilities = utilities

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -124,8 +124,10 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
 
         <ProfileBehaviorSection
           launchAutomatically={editor.launchAutomatically}
+          gamePosition={editor.gamePosition}
           trackingEnabled={editor.trackingEnabled}
           onLaunchAutomaticallyChange={editor.setLaunchAutomatically}
+          onGamePositionChange={editor.setGamePosition}
           onTrackingEnabledChange={editor.setTrackingEnabled}
         />
 

--- a/src/renderer/src/components/profile-editor/ProfileBehaviorSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileBehaviorSection.tsx
@@ -1,17 +1,27 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
+import type { GamePosition } from '../../lib/config'
 import { ProfileToggleRow } from './ProfileToggleRow'
 
 interface ProfileBehaviorSectionProps {
   launchAutomatically: boolean
+  gamePosition: GamePosition
   trackingEnabled: boolean
   onLaunchAutomaticallyChange: Dispatch<SetStateAction<boolean>>
+  onGamePositionChange: Dispatch<SetStateAction<GamePosition>>
   onTrackingEnabledChange: Dispatch<SetStateAction<boolean>>
 }
 
+const GAME_POSITION_OPTIONS: { value: GamePosition; label: string }[] = [
+  { value: 'first', label: 'First' },
+  { value: 'last', label: 'After apps' }
+]
+
 export function ProfileBehaviorSection({
   launchAutomatically,
+  gamePosition,
   trackingEnabled,
   onLaunchAutomaticallyChange,
+  onGamePositionChange,
   onTrackingEnabledChange
 }: ProfileBehaviorSectionProps): ReactNode {
   return (
@@ -29,6 +39,31 @@ export function ProfileBehaviorSection({
           onToggle={() => onTrackingEnabledChange((value) => !value)}
           onChange={onTrackingEnabledChange}
         />
+        <div
+          className={`flex items-center justify-between rounded-xl bg-(--glass-bg) p-3 transition-opacity ${
+            launchAutomatically ? '' : 'pointer-events-none opacity-50'
+          }`}
+        >
+          <span className="text-sm font-medium text-(--text-secondary)">Game position</span>
+          <div role="group" aria-label="Game position" className="flex gap-1.5">
+            {GAME_POSITION_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                disabled={!launchAutomatically}
+                onClick={() => onGamePositionChange(option.value)}
+                aria-pressed={gamePosition === option.value}
+                className={`glass-surface action-hover-scale rounded-lg px-3 py-1.5 text-xs font-medium tracking-wide transition-colors ${
+                  gamePosition === option.value
+                    ? 'selected-surface text-(--text-primary)'
+                    : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -13,6 +13,7 @@ import {
   getUtilities,
   normalizeGameProfileSet,
   normalizeProfileUtilities,
+  type GamePosition,
   type ProfileUtility,
   type Profiles,
   type Utility
@@ -53,6 +54,8 @@ export interface UseProfileEditorResult {
   dropTarget: { id: string; placement: 'before' | 'after' } | null
   launchAutomatically: boolean
   setLaunchAutomatically: Dispatch<SetStateAction<boolean>>
+  gamePosition: GamePosition
+  setGamePosition: Dispatch<SetStateAction<GamePosition>>
   trackingEnabled: boolean
   setTrackingEnabled: Dispatch<SetStateAction<boolean>>
   killControlsEnabled: boolean
@@ -128,6 +131,7 @@ export function useProfileEditor({
     placement: 'before' | 'after'
   } | null>(null)
   const [launchAutomatically, setLaunchAutomatically] = useState(true)
+  const [gamePosition, setGamePosition] = useState<GamePosition>('first')
   const [trackingEnabled, setTrackingEnabled] = useState(true)
   const [killControlsEnabled, setKillControlsEnabled] = useState(false)
   const [relaunchControlsEnabled, setRelaunchControlsEnabled] = useState(false)
@@ -172,6 +176,8 @@ export function useProfileEditor({
       setProfileUtilities(normalizeProfileUtilities(profile, resolvedUtilities))
       // Default auto-launch to true unless explicitly disabled
       setLaunchAutomatically(profile.launchAutomatically !== false)
+      // Anything other than an explicit 'last' means game-first (#471)
+      setGamePosition(profile.gamePosition === 'last' ? 'last' : 'first')
       setTrackingEnabled(profile.trackingEnabled !== false)
       setKillControlsEnabled(profile.killControlsEnabled === true)
       setRelaunchControlsEnabled(profile.relaunchControlsEnabled === true)
@@ -242,6 +248,7 @@ export function useProfileEditor({
           .map((u) => ({ id: u.id, enabled: false }))
       ],
       launchAutomatically,
+      gamePosition,
       trackingEnabled,
       killControlsEnabled,
       relaunchControlsEnabled,
@@ -251,6 +258,7 @@ export function useProfileEditor({
       profileName,
       profileUtilities,
       launchAutomatically,
+      gamePosition,
       trackingEnabled,
       killControlsEnabled,
       relaunchControlsEnabled,
@@ -458,6 +466,7 @@ export function useProfileEditor({
           enabled: utility.enabled
         })),
         launchAutomatically,
+        gamePosition,
         trackingEnabled,
         killControlsEnabled,
         relaunchControlsEnabled,
@@ -513,6 +522,7 @@ export function useProfileEditor({
           enabled: utility.enabled
         })),
         launchAutomatically,
+        gamePosition,
         trackingEnabled,
         killControlsEnabled,
         relaunchControlsEnabled,
@@ -612,6 +622,8 @@ export function useProfileEditor({
     dropTarget,
     launchAutomatically,
     setLaunchAutomatically,
+    gamePosition,
+    setGamePosition,
     trackingEnabled,
     setTrackingEnabled,
     killControlsEnabled,

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -12,10 +12,12 @@ export interface ProfileUtility {
   id: string
   enabled: boolean
 }
+export type GamePosition = 'first' | 'last'
 export interface GameProfile {
   [key: string]: unknown
   utilities?: ProfileUtility[]
   launchAutomatically?: boolean
+  gamePosition?: GamePosition
   trackingEnabled?: boolean
   killControlsEnabled?: boolean
   relaunchControlsEnabled?: boolean

--- a/tests/main/profiles.test.ts
+++ b/tests/main/profiles.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const storeData: Record<string, unknown> = {}
+
+vi.mock('../../src/main/store', () => ({
+  getStoredStringRecord: vi.fn((key: string) => {
+    const value = storeData[key]
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string>)
+      : {}
+  }),
+  store: {
+    get: vi.fn((key: string) => storeData[key])
+  }
+}))
+
+import {
+  buildActiveProfileLaunchEntries,
+  buildNamedProfileLaunchEntries
+} from '../../src/main/profiles'
+
+function seedProfile(profileFields: Record<string, unknown>) {
+  storeData.gamePaths = { iracing: 'C:/Games/iRacingUI.exe' }
+  storeData.appPaths = {
+    simhub: 'C:/Tools/SimHub.exe',
+    crewchief: 'C:/Tools/CrewChief.exe'
+  }
+  storeData.customSlots = 1
+  storeData.profiles = {
+    iracing: {
+      activeProfileId: 'p1',
+      profiles: [
+        {
+          id: 'p1',
+          name: 'Default',
+          utilities: [
+            { id: 'simhub', enabled: true },
+            { id: 'crewchief', enabled: true }
+          ],
+          ...profileFields
+        }
+      ]
+    }
+  }
+}
+
+beforeEach(() => {
+  Object.keys(storeData).forEach((key) => delete storeData[key])
+})
+
+test('game launches first by default (no gamePosition)', () => {
+  seedProfile({})
+
+  expect(buildActiveProfileLaunchEntries('iracing').map((entry) => entry.key)).toEqual([
+    'iracing',
+    'simhub',
+    'crewchief'
+  ])
+})
+
+test('gamePosition last launches the game after all companion apps (#471)', () => {
+  seedProfile({ gamePosition: 'last' })
+
+  expect(buildActiveProfileLaunchEntries('iracing').map((entry) => entry.key)).toEqual([
+    'simhub',
+    'crewchief',
+    'iracing'
+  ])
+})
+
+test('gamePosition last with disabled game launch yields utilities only (#471)', () => {
+  seedProfile({ gamePosition: 'last', launchAutomatically: false })
+
+  expect(buildActiveProfileLaunchEntries('iracing').map((entry) => entry.key)).toEqual([
+    'simhub',
+    'crewchief'
+  ])
+})
+
+test('invalid gamePosition values fall back to game-first (#471)', () => {
+  seedProfile({ gamePosition: 'banana' })
+
+  expect(buildActiveProfileLaunchEntries('iracing').map((entry) => entry.key)).toEqual([
+    'iracing',
+    'simhub',
+    'crewchief'
+  ])
+})
+
+test('buildNamedProfileLaunchEntries honors gamePosition last (#471)', () => {
+  seedProfile({ gamePosition: 'last' })
+
+  expect(buildNamedProfileLaunchEntries('iracing', 'p1').map((entry) => entry.key)).toEqual([
+    'simhub',
+    'crewchief',
+    'iracing'
+  ])
+})

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -144,6 +144,30 @@ test('sanitizeSettingsPatch filters object settings like config import', async (
   })
 })
 
+test('profile sanitization keeps a valid gamePosition and strips invalid values (#471)', async () => {
+  const { sanitizeImportedConfig } = await loadStoreModule()
+  const sanitized = sanitizeImportedConfig({
+    customSlots: 1,
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [
+          { id: 'default', name: 'Default', gamePosition: 'last' },
+          { id: 'second', name: 'Second', gamePosition: 'banana' },
+          { id: 'third', name: 'Third', gamePosition: 42 }
+        ]
+      }
+    }
+  }) as {
+    profiles: { ac: { profiles: Array<Record<string, unknown>> } }
+  }
+
+  const [first, second, third] = sanitized.profiles.ac.profiles
+  expect(first.gamePosition).toBe('last')
+  expect(second).not.toHaveProperty('gamePosition')
+  expect(third).not.toHaveProperty('gamePosition')
+})
+
 test('sanitizeImportedConfig sanitizes profile sets and tracked process paths', async () => {
   const { sanitizeImportedConfig } = await loadStoreModule()
   expect(


### PR DESCRIPTION
## Summary

Implements the approved toggle-first design for #471 (spec: see issue comment): companion apps can now launch **before** the sim.

- new optional `StoredProfile.gamePosition: 'first' | 'last'`; absent/invalid = `'first'` = pre-#471 behavior, so **no migration** of existing profiles
- `gamePosition: 'last'` pushes the game after all enabled companions (shared `buildProfileLaunchEntries` helper behind both active- and named-profile builders); existing per-step `launchDelayMs` applies unchanged, so the sequence is `apps → delay → game`
- sanitizer (profile save + config import funnel through `sanitizeProfileFields`) whitelists the two valid values — without this the strict whitelist would silently strip the field on every save
- profile editor: **Game position — First | After apps** segmented control under "Launch game with profile" (matches the settings pill idiom incl. `role="group"`/`aria-pressed`), disabled while game launch is off; wired into the value-equality dirty machinery as a plain scalar
- profile-switch diffing is unaffected: it compares `{key, path}` identity sets, not order
- full interleaving (game as a draggable row) deferred to #492

Closes #471

## Test plan

- [x] TDD: 6 new tests watched failing first — entries order (`last` / default / invalid / `launchAutomatically: false` / named-profile variant) + sanitizer enum whitelist
- [x] `npm test` 215/215, `typecheck`, `lint`, `format:check`, `build` — clean
- [ ] Visual: editor control + real launch order (SimHub → game) — part of the weekend smoke batch
