### PR TITLE
test: main-process coverage for high-risk gaps (audit batch 1, refs #494)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -148,7 +148,8 @@ export async function launchProfileApps(
   }
 }
 
-function getLaunchDelayMs() {
+// Exported for unit tests only — not part of the processes barrel surface.
+export function getLaunchDelayMs(): number {
   const value = store.get('launchDelayMs')
 
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -212,7 +213,11 @@ function resolveAppKeyFromPath(appPath: string): string | undefined {
   return appEntry?.[0]
 }
 
-function normalizeLaunchInput(input: ProfileLaunchInput, gameKey: string): ProfileLaunchEntry {
+// Exported for unit tests only — not part of the processes barrel surface.
+export function normalizeLaunchInput(
+  input: ProfileLaunchInput,
+  gameKey: string
+): ProfileLaunchEntry {
   if (typeof input !== 'string') {
     return { key: input.key, path: input.path }
   }

--- a/tests/main/configImport.test.ts
+++ b/tests/main/configImport.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+type MockIpcHandler = (...args: unknown[]) => Promise<unknown>
+
+const migrateProfilesToNamedSets = vi.fn()
+const importedConfig = {
+  customSlots: 2,
+  appPaths: { simhub: 'C:/Tools/NewSimHub.exe' }
+}
+
+class MockStore {
+  data: Record<string, unknown>
+
+  constructor(initial: Record<string, unknown>) {
+    this.data = { ...initial }
+  }
+
+  get store() {
+    return { ...this.data }
+  }
+
+  get(key: string) {
+    return this.data[key]
+  }
+
+  set(key: string, value: unknown) {
+    this.data[key] = value
+  }
+
+  clear() {
+    this.data = {}
+  }
+}
+
+async function loadConfigHandlers(initialStore: Record<string, unknown>) {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  const mockStore = new MockStore(initialStore)
+
+  vi.doMock('fs', () => ({
+    default: {
+      promises: {
+        stat: vi.fn(async () => ({ size: 100 })),
+        readFile: vi.fn(async () => JSON.stringify({ customSlots: 2 })),
+        writeFile: vi.fn()
+      }
+    }
+  }))
+
+  const migratorMock = { migrateProfilesToNamedSets }
+  vi.doMock('../migrator', () => migratorMock)
+  vi.doMock('/src/main/migrator.ts', () => migratorMock)
+  vi.doMock('../../src/main/migrator', () => migratorMock)
+  vi.doMock('../../src/main/migrator.ts', () => migratorMock)
+
+  const windowMock = {
+    getMainWindow: vi.fn(() => null),
+    applyRuntimeConfigSettings: vi.fn(),
+    sendToRenderer: vi.fn()
+  }
+  vi.doMock('../window', () => windowMock)
+  vi.doMock('/src/main/window.ts', () => windowMock)
+  vi.doMock('../../src/main/window', () => windowMock)
+  vi.doMock('../../src/main/window.ts', () => windowMock)
+
+  const trayMock = { applyTrayVisibility: vi.fn() }
+  vi.doMock('../tray', () => trayMock)
+  vi.doMock('/src/main/tray.ts', () => trayMock)
+  vi.doMock('../../src/main/tray', () => trayMock)
+  vi.doMock('../../src/main/tray.ts', () => trayMock)
+
+  const storeMock = {
+    CONFIG_FILE_NAME: 'simlauncher-config.json',
+    KNOWN_GAME_KEYS: new Set(['iracing']),
+    MAX_CONFIG_IMPORT_BYTES: 1024 * 1024,
+    MAX_CUSTOM_SLOTS: 20,
+    getSupportedConfigValues: vi.fn(() => ({})),
+    getStoredZoomFactor: vi.fn(() => 1),
+    requireSafeZoomFactor: vi.fn((value: unknown) => value),
+    sanitizeImportedConfig: vi.fn(() => ({ ...importedConfig })),
+    sanitizeSettingsPatch: vi.fn(() => ({})),
+    store: mockStore
+  }
+  vi.doMock('../store', () => storeMock)
+  vi.doMock('/src/main/store.ts', () => storeMock)
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
+
+  const profilesMock = { isStoredProfileSet: vi.fn(() => false) }
+  vi.doMock('../profiles', () => profilesMock)
+  vi.doMock('/src/main/profiles.ts', () => profilesMock)
+  vi.doMock('../../src/main/profiles', () => profilesMock)
+  vi.doMock('../../src/main/profiles.ts', () => profilesMock)
+
+  const configModule = await import('../../src/main/ipc/config')
+  configModule.registerConfigHandlers()
+
+  const { dialog, __ipcHandlers } = await import('electron')
+  vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+    canceled: false,
+    filePaths: ['C:/Backups/simlauncher-config.json']
+  } as never)
+
+  return {
+    handlers: __ipcHandlers as Record<string, MockIpcHandler>,
+    mockStore
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('import-config replaces the store with the sanitized config', async () => {
+  const { handlers, mockStore } = await loadConfigHandlers({
+    customSlots: 5,
+    gamePaths: { iracing: 'C:/Games/Old.exe' }
+  })
+
+  await expect(handlers['import-config']({})).resolves.toEqual({
+    success: true,
+    filePath: 'C:/Backups/simlauncher-config.json'
+  })
+  // clear() before apply: keys absent from the import must not survive.
+  expect(mockStore.data).toEqual(importedConfig)
+  expect(migrateProfilesToNamedSets).toHaveBeenCalled()
+})
+
+// Data-loss guard: a mid-apply failure leaves the store half-written unless
+// the snapshot is restored — the user's entire config is on the line.
+test('import-config rolls the store back when applying the config throws', async () => {
+  const initial = { customSlots: 5, gamePaths: { iracing: 'C:/Games/Old.exe' } }
+  const { handlers, mockStore } = await loadConfigHandlers(initial)
+  migrateProfilesToNamedSets.mockImplementationOnce(() => {
+    throw new Error('corrupted profile set')
+  })
+
+  const result = (await handlers['import-config']({})) as { success: boolean; error?: string }
+
+  expect(result.success).toBe(false)
+  expect(result.error).toContain('corrupted profile set')
+  expect(mockStore.data).toEqual(initial)
+})
+
+test('apply-import-config only accepts the token issued by the matching preview', async () => {
+  const { handlers, mockStore } = await loadConfigHandlers({ customSlots: 5 })
+
+  const preview = (await handlers['preview-import-config']({})) as {
+    success: boolean
+    token: string
+  }
+  expect(preview.success).toBe(true)
+
+  await expect(handlers['apply-import-config']({}, 'forged-token')).resolves.toMatchObject({
+    success: false
+  })
+  expect(mockStore.data).toEqual({ customSlots: 5 })
+
+  await expect(handlers['apply-import-config']({}, preview.token)).resolves.toMatchObject({
+    success: true
+  })
+  expect(mockStore.data).toEqual(importedConfig)
+
+  // The token is single-use: a replay after apply must fail.
+  await expect(handlers['apply-import-config']({}, preview.token)).resolves.toMatchObject({
+    success: false
+  })
+})
+
+test('apply-import-config rejects a preview token after the 5-minute TTL', async () => {
+  vi.useFakeTimers()
+  try {
+    const { handlers, mockStore } = await loadConfigHandlers({ customSlots: 5 })
+
+    const preview = (await handlers['preview-import-config']({})) as { token: string }
+    vi.setSystemTime(Date.now() + 5 * 60 * 1000 + 1)
+
+    const result = (await handlers['apply-import-config']({}, preview.token)) as {
+      success: boolean
+      error?: string
+    }
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('expired')
+    expect(mockStore.data).toEqual({ customSlots: 5 })
+  } finally {
+    vi.useRealTimers()
+  }
+})

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+type MockIpcHandler = (...args: unknown[]) => Promise<unknown>
+
+const launchProfileApps = vi.fn()
+const killProfileApps = vi.fn()
+const readRunningProcessNames = vi.fn()
+const buildActiveProfileLaunchEntries = vi.fn()
+const buildNamedProfileLaunchEntries = vi.fn()
+
+const GAME_ENTRY = { key: 'iracing', path: 'C:/Games/iRacingUI.exe' }
+const SIMHUB_ENTRY = { key: 'simhub', path: 'C:/Tools/SimHub.exe' }
+const CREWCHIEF_ENTRY = { key: 'crewchief', path: 'C:/Tools/CrewChief.exe' }
+
+function exeNameOf(appPath: string) {
+  return appPath.split(/[\\/]/).pop()!.toLowerCase()
+}
+
+async function loadLaunchHandlers() {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  const processesMock = {
+    launchProfileApps,
+    killProfileApps,
+    killLaunchedApps: vi.fn(),
+    readRunningProcessNames,
+    isRunningExePath: (processNames: Set<string>, appPath: string) =>
+      processNames.has(exeNameOf(appPath)),
+    getRunningApps: vi.fn(async () => []),
+    subscribeRunningApps: vi.fn(),
+    unsubscribeRunningApps: vi.fn()
+  }
+  vi.doMock('../processes', () => processesMock)
+  vi.doMock('/src/main/processes.ts', () => processesMock)
+  vi.doMock('../../src/main/processes', () => processesMock)
+  vi.doMock('../../src/main/processes.ts', () => processesMock)
+
+  const profilesMock = { buildActiveProfileLaunchEntries, buildNamedProfileLaunchEntries }
+  vi.doMock('../profiles', () => profilesMock)
+  vi.doMock('/src/main/profiles.ts', () => profilesMock)
+  vi.doMock('../../src/main/profiles', () => profilesMock)
+  vi.doMock('../../src/main/profiles.ts', () => profilesMock)
+
+  const storeMock = {
+    KNOWN_GAME_KEYS: new Set(['iracing']),
+    getStoredStringRecord: vi.fn((key: string) =>
+      key === 'gamePaths' ? { iracing: GAME_ENTRY.path } : {}
+    )
+  }
+  vi.doMock('../store', () => storeMock)
+  vi.doMock('/src/main/store.ts', () => storeMock)
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
+
+  const launchModule = await import('../../src/main/ipc/launch')
+  launchModule.registerLaunchHandlers()
+  const { __ipcHandlers } = await import('electron')
+  return __ipcHandlers as Record<string, MockIpcHandler>
+}
+
+const sender = { id: 1 }
+const event = { sender }
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  readRunningProcessNames.mockResolvedValue({ processNames: new Set(), succeeded: true })
+  launchProfileApps.mockResolvedValue({ success: true, launchedCount: 1, skippedCount: 0 })
+  killProfileApps.mockResolvedValue({
+    success: true,
+    closedCount: 1,
+    failedCount: 0,
+    failures: []
+  })
+})
+
+test('launch-profile rejects unknown or malformed game keys without launching', async () => {
+  const handlers = await loadLaunchHandlers()
+
+  await expect(handlers['launch-profile'](event, 'doom')).resolves.toEqual({
+    success: false,
+    error: 'Unknown game key'
+  })
+  await expect(handlers['launch-profile'](event, 42)).resolves.toEqual({
+    success: false,
+    error: 'Invalid argument'
+  })
+  expect(launchProfileApps).not.toHaveBeenCalled()
+})
+
+test('launch-profile reports an empty profile instead of delegating', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildActiveProfileLaunchEntries.mockReturnValue([])
+
+  await expect(handlers['launch-profile'](event, 'iracing')).resolves.toEqual({
+    success: false,
+    error: 'No executable paths configured for this profile.'
+  })
+  expect(launchProfileApps).not.toHaveBeenCalled()
+})
+
+test('launch-profile delegates the built entries with the renderer sender', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+
+  await handlers['launch-profile'](event, 'iracing')
+
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [GAME_ENTRY, SIMHUB_ENTRY])
+})
+
+// Double-launch prevention: relaunch must only start the entries whose exe is
+// NOT already running, otherwise a second SimHub/game instance spawns.
+test('relaunch-missing-profile launches only entries that are not running', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY, CREWCHIEF_ENTRY])
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['simhub.exe']),
+    succeeded: true
+  })
+
+  await handlers['relaunch-missing-profile'](event, 'iracing')
+
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [GAME_ENTRY, CREWCHIEF_ENTRY])
+})
+
+test('relaunch-missing-profile is a no-op when everything is already running', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'simhub.exe']),
+    succeeded: true
+  })
+
+  await expect(handlers['relaunch-missing-profile'](event, 'iracing')).resolves.toEqual({
+    success: true,
+    message: 'All profile apps are already running.',
+    launchedCount: 0,
+    skippedCount: 0
+  })
+  expect(launchProfileApps).not.toHaveBeenCalled()
+})
+
+// THE profile-switch invariant: switching profiles mid-session must never
+// stop (or relaunch) the running sim itself — only the companion apps differ.
+test('switch-profile-apps never kills or relaunches the game executable', async () => {
+  const handlers = await loadLaunchHandlers()
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+
+  const result = (await handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')) as {
+    success: boolean
+  }
+
+  expect(result.success).toBe(true)
+  expect(killProfileApps).toHaveBeenCalledWith('iracing', [utilA.path])
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [utilB])
+})
+
+test('get-profile-switch-diff counts stops/starts without the game executable', async () => {
+  const handlers = await loadLaunchHandlers()
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+
+  await expect(
+    handlers['get-profile-switch-diff'](event, 'iracing', 'p-from', 'p-to')
+  ).resolves.toEqual({ toStopCount: 1, toStartCount: 1 })
+})

--- a/tests/main/profiles.test.ts
+++ b/tests/main/profiles.test.ts
@@ -14,9 +14,24 @@ vi.mock('../../src/main/store', () => ({
   }
 }))
 
+// utils.isValidExePath checks fs.existsSync; pretend every .exe exists except
+// paths containing "missing", so trackable-path tests stay host-independent.
+vi.mock('fs', () => ({
+  default: {
+    existsSync: (filePath: unknown) =>
+      typeof filePath === 'string' &&
+      /\.exe$/i.test(filePath) &&
+      !filePath.toLowerCase().includes('missing')
+  }
+}))
+
 import {
   buildActiveProfileLaunchEntries,
-  buildNamedProfileLaunchEntries
+  buildNamedProfileLaunchEntries,
+  getActiveStoredProfile,
+  getProfileTrackablePaths,
+  resolveActiveProfile,
+  type StoredProfileEntry
 } from '../../src/main/profiles'
 
 function seedProfile(profileFields: Record<string, unknown>) {
@@ -95,4 +110,99 @@ test('buildNamedProfileLaunchEntries honors gamePosition last (#471)', () => {
     'crewchief',
     'iracing'
   ])
+})
+
+test('resolveActiveProfile falls back through stale ids, invalid entries, and legacy shapes', () => {
+  expect(resolveActiveProfile(undefined)).toEqual({ id: 'default', name: 'Default' })
+
+  // Stale activeProfileId (profile was deleted) → first valid profile.
+  expect(
+    resolveActiveProfile({
+      activeProfileId: 'deleted',
+      profiles: [{ id: 'p1', name: 'Race' }]
+    })
+  ).toEqual({ id: 'p1', name: 'Race' })
+
+  // Corrupted entries are skipped when picking the fallback.
+  expect(
+    resolveActiveProfile({
+      activeProfileId: 'deleted',
+      profiles: [null, { name: 'no-id' }, { id: 'p2', name: 'Valid' }]
+    } as unknown as StoredProfileEntry)
+  ).toEqual({ id: 'p2', name: 'Valid' })
+
+  // A set with no valid profiles still yields a usable default.
+  expect(
+    resolveActiveProfile({
+      activeProfileId: 'x',
+      profiles: [{ name: 'no-id' }]
+    } as unknown as StoredProfileEntry)
+  ).toEqual({ id: 'default', name: 'Default' })
+
+  // Legacy flat profile (pre-named-sets) keeps its fields under the default id.
+  expect(resolveActiveProfile({ launchAutomatically: false })).toEqual({
+    id: 'default',
+    name: 'Default',
+    launchAutomatically: false
+  })
+})
+
+test('getActiveStoredProfile resolves sets, stale ids, and legacy flat entries', () => {
+  expect(getActiveStoredProfile(undefined)).toBeUndefined()
+
+  const active = { id: 'p2', name: 'Race', trackingEnabled: true }
+  expect(
+    getActiveStoredProfile({
+      activeProfileId: 'p2',
+      profiles: [{ id: 'p1', name: 'Default' }, active]
+    })
+  ).toBe(active)
+
+  expect(
+    getActiveStoredProfile({
+      activeProfileId: 'deleted',
+      profiles: [{ id: 'p1', name: 'Default' }]
+    })
+  ).toEqual({ id: 'p1', name: 'Default' })
+
+  const legacyProfile = { simhub: true }
+  expect(getActiveStoredProfile(legacyProfile)).toBe(legacyProfile)
+})
+
+// Close-all and tracking both consume this list: a disabled utility leaking in
+// means SimLauncher would kill processes the profile explicitly left alone.
+test('getProfileTrackablePaths includes only the game, enabled utilities, and extra watched paths', () => {
+  const profile = {
+    utilities: [
+      { id: 'simhub', enabled: true },
+      { id: 'crewchief', enabled: false }
+    ],
+    trackedProcessPaths: ['C:/Tools/Extra.exe', 'c:\\tools\\extra.exe', 'C:/Tools/MissingTool.exe']
+  }
+
+  expect(
+    getProfileTrackablePaths(
+      'iracing',
+      profile,
+      { simhub: 'C:/Tools/SimHub.exe', crewchief: 'C:/Tools/CrewChief.exe' },
+      { iracing: 'C:/Games/iRacingUI.exe' }
+    )
+  ).toEqual([
+    // Game first, then enabled utilities, then extra watched paths — with the
+    // disabled crewchief excluded, the separator/case duplicate deduped, and
+    // the non-existent exe dropped.
+    'C:/Games/iRacingUI.exe',
+    'C:/Tools/SimHub.exe',
+    'C:/Tools/Extra.exe'
+  ])
+})
+
+test('getProfileTrackablePaths tolerates a missing profile and missing path records', () => {
+  expect(
+    getProfileTrackablePaths('iracing', undefined, undefined, {
+      iracing: 'C:/Games/iRacingUI.exe'
+    })
+  ).toEqual(['C:/Games/iRacingUI.exe'])
+
+  expect(getProfileTrackablePaths('iracing', undefined, undefined, undefined)).toEqual([])
 })

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -1,0 +1,116 @@
+import type { ChildProcess } from 'child_process'
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const readRunningProcessNamesMock = vi.fn()
+const pruneUnclosedProcessesMock = vi.fn()
+
+async function loadRunningModule() {
+  const tasklistMock = {
+    readRunningProcessNames: readRunningProcessNamesMock,
+    invalidateProcessNameCache: vi.fn()
+  }
+  vi.doMock('./tasklist', () => tasklistMock)
+  vi.doMock('/src/main/processes/tasklist.ts', () => tasklistMock)
+  vi.doMock('../../src/main/processes/tasklist', () => tasklistMock)
+  vi.doMock('../../src/main/processes/tasklist.ts', () => tasklistMock)
+
+  const killMock = {
+    pruneUnclosedProcesses: pruneUnclosedProcessesMock,
+    killLaunchedApps: vi.fn(),
+    killProfileApps: vi.fn()
+  }
+  vi.doMock('./kill', () => killMock)
+  vi.doMock('/src/main/processes/kill.ts', () => killMock)
+  vi.doMock('../../src/main/processes/kill', () => killMock)
+  vi.doMock('../../src/main/processes/kill.ts', () => killMock)
+
+  const profilesMock = {
+    getStoredProfiles: vi.fn(() => ({})),
+    getActiveStoredProfile: vi.fn(() => undefined),
+    getProfileTrackablePaths: vi.fn(() => [])
+  }
+  vi.doMock('../profiles', () => profilesMock)
+  vi.doMock('/src/main/profiles.ts', () => profilesMock)
+  vi.doMock('../../src/main/profiles', () => profilesMock)
+  vi.doMock('../../src/main/profiles.ts', () => profilesMock)
+
+  const storeMock = {
+    getStoredStringRecord: vi.fn(() => ({}))
+  }
+  vi.doMock('../store', () => storeMock)
+  vi.doMock('/src/main/store.ts', () => storeMock)
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
+
+  const runningModule = await import('../../src/main/processes/running')
+  const stateModule = await import('../../src/main/processes/state')
+  return { runningModule, stateModule }
+}
+
+function seedState(stateModule: Awaited<ReturnType<typeof loadRunningModule>>['stateModule']) {
+  stateModule.runningProcesses.set('launched', {
+    process: {} as ChildProcess,
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'iracing',
+    isGame: false
+  })
+  stateModule.unclosedProcesses.set('iracing:c:\\tools\\crewchief.exe', {
+    path: 'C:/Tools/CrewChief.exe',
+    name: 'CrewChief.exe',
+    gameKey: 'iracing',
+    error: 'still running',
+    reason: 'still_running'
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+// A failed tasklist read returns an empty Set carrying no signal value.
+// Treating it as "everything exited" would wipe running/unclosed state and
+// silently drop kill/relaunch controls mid-session (#399).
+test('a failed tasklist read does not prune running or unclosed state (#399)', async () => {
+  const { runningModule, stateModule } = await loadRunningModule()
+  seedState(stateModule)
+  readRunningProcessNamesMock.mockResolvedValue({ processNames: new Set(), succeeded: false })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(stateModule.runningProcesses.size).toBe(1)
+  expect(stateModule.unclosedProcesses.size).toBe(1)
+  expect(pruneUnclosedProcessesMock).not.toHaveBeenCalled()
+  // Launched apps stay surfaced even when the scan is blind.
+  expect(apps.map((app) => app.path)).toContain('C:/Tools/SimHub.exe')
+})
+
+test('a successful tasklist read prunes processes that are gone', async () => {
+  const { runningModule, stateModule } = await loadRunningModule()
+  seedState(stateModule)
+  readRunningProcessNamesMock.mockResolvedValue({ processNames: new Set(), succeeded: true })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(stateModule.runningProcesses.size).toBe(0)
+  expect(pruneUnclosedProcessesMock).toHaveBeenCalledWith(new Set())
+  expect(apps).toEqual([])
+})
+
+test('a successful tasklist read keeps entries whose exe is still running', async () => {
+  const { runningModule, stateModule } = await loadRunningModule()
+  seedState(stateModule)
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['simhub.exe', 'crewchief.exe']),
+    succeeded: true
+  })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(stateModule.runningProcesses.size).toBe(1)
+  expect(apps.map((app) => app.path).sort()).toEqual([
+    'C:/Tools/CrewChief.exe',
+    'C:/Tools/SimHub.exe'
+  ])
+})

--- a/tests/main/spawnHelpers.test.ts
+++ b/tests/main/spawnHelpers.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const storeData: Record<string, unknown> = {}
+
+async function loadSpawnModule() {
+  const storeMock = {
+    getStoredStringRecord: vi.fn((key: string) => {
+      const value = storeData[key]
+      return value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, string>)
+        : {}
+    }),
+    store: {
+      get: vi.fn((key: string) => storeData[key])
+    }
+  }
+  vi.doMock('../store', () => storeMock)
+  vi.doMock('/src/main/store.ts', () => storeMock)
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
+
+  return await import('../../src/main/processes/spawn')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  Object.keys(storeData).forEach((key) => delete storeData[key])
+})
+
+test('getLaunchDelayMs clamps stored values into the 0–30000 ms range', async () => {
+  const { getLaunchDelayMs } = await loadSpawnModule()
+
+  storeData.launchDelayMs = -500
+  expect(getLaunchDelayMs()).toBe(0)
+
+  storeData.launchDelayMs = 35000
+  expect(getLaunchDelayMs()).toBe(30000)
+
+  storeData.launchDelayMs = 1234.6
+  expect(getLaunchDelayMs()).toBe(1235)
+})
+
+test('getLaunchDelayMs falls back to 1000 ms for missing or non-finite values', async () => {
+  const { getLaunchDelayMs } = await loadSpawnModule()
+
+  for (const value of [undefined, NaN, Infinity, 'fast']) {
+    storeData.launchDelayMs = value
+    expect(getLaunchDelayMs()).toBe(1000)
+  }
+})
+
+test('normalizeLaunchInput passes {key, path} entries through unchanged', async () => {
+  const { normalizeLaunchInput } = await loadSpawnModule()
+
+  expect(
+    normalizeLaunchInput({ key: 'customapp2', path: 'C:/Tools/Overlay.exe' }, 'iracing')
+  ).toEqual({ key: 'customapp2', path: 'C:/Tools/Overlay.exe' })
+})
+
+// The key drives both per-slot launch args (#357) and the isGame flag on the
+// running-process entry, which in turn feeds kill exclusion — a wrong key here
+// means a profile switch could treat the running sim as a closable utility.
+test('normalizeLaunchInput resolves a plain game path to the game key', async () => {
+  const { normalizeLaunchInput } = await loadSpawnModule()
+  storeData.gamePaths = { iracing: 'C:/Games/iRacingUI.exe' }
+  storeData.appPaths = { simhub: 'C:/Tools/SimHub.exe' }
+
+  expect(normalizeLaunchInput('c:\\games\\IRACINGUI.EXE', 'iracing')).toEqual({
+    key: 'iracing',
+    path: 'c:\\games\\IRACINGUI.EXE'
+  })
+})
+
+test('normalizeLaunchInput resolves a plain utility path via appPaths reverse lookup', async () => {
+  const { normalizeLaunchInput } = await loadSpawnModule()
+  storeData.gamePaths = { iracing: 'C:/Games/iRacingUI.exe' }
+  storeData.appPaths = { simhub: 'C:/Tools/SimHub.exe' }
+
+  expect(normalizeLaunchInput('C:/Tools/SimHub.exe', 'iracing')).toEqual({
+    key: 'simhub',
+    path: 'C:/Tools/SimHub.exe'
+  })
+
+  // Unknown paths keep the path itself as the key (no args lookup match).
+  expect(normalizeLaunchInput('C:/Tools/Unknown.exe', 'iracing')).toEqual({
+    key: 'C:/Tools/Unknown.exe',
+    path: 'C:/Tools/Unknown.exe'
+  })
+})

--- a/tests/main/state.test.ts
+++ b/tests/main/state.test.ts
@@ -1,0 +1,111 @@
+import type { ChildProcess } from 'child_process'
+import { beforeEach, expect, test } from 'vitest'
+
+import {
+  consumeProcessNameMismatchWarningSuppression,
+  dismissAppIcon,
+  getUnclosedProcessKey,
+  processNameMismatchWarnings,
+  pruneExpiredProcessNameMismatchWarnings,
+  pruneStoppedRunningProcesses,
+  runningProcesses,
+  suppressProcessNameMismatchWarning,
+  suppressedProcessNameMismatchWarnings,
+  unclosedProcesses
+} from '../../src/main/processes/state'
+import { normalizePathForComparison } from '../../src/main/utils'
+
+function runningEntry(appPath: string) {
+  return {
+    process: {} as ChildProcess,
+    path: appPath,
+    name: appPath.split(/[\\/]/).pop()!,
+    gameKey: 'iracing',
+    isGame: false
+  }
+}
+
+function unclosedEntry(appPath: string) {
+  return {
+    path: appPath,
+    name: appPath.split(/[\\/]/).pop()!,
+    gameKey: 'iracing',
+    error: 'still running',
+    reason: 'still_running' as const
+  }
+}
+
+beforeEach(() => {
+  runningProcesses.clear()
+  unclosedProcesses.clear()
+  processNameMismatchWarnings.clear()
+  suppressedProcessNameMismatchWarnings.clear()
+})
+
+test('pruneStoppedRunningProcesses drops only entries whose exe is no longer running', () => {
+  runningProcesses.set('a', runningEntry('C:/Tools/SimHub.exe'))
+  runningProcesses.set('b', runningEntry('C:/Tools/CrewChief.exe'))
+
+  pruneStoppedRunningProcesses(new Set(['simhub.exe']))
+
+  expect(runningProcesses.has('a')).toBe(true)
+  expect(runningProcesses.has('b')).toBe(false)
+})
+
+test('pruneExpiredProcessNameMismatchWarnings removes only expired entries', () => {
+  const now = 1_000_000
+  const warning = { path: 'C:/Tools/App.exe', name: 'App.exe', gameKey: 'iracing', warning: 'w' }
+  processNameMismatchWarnings.set('expired', { ...warning, expiresAt: now - 1 })
+  processNameMismatchWarnings.set('expiring-now', { ...warning, expiresAt: now })
+  processNameMismatchWarnings.set('future', { ...warning, expiresAt: now + 1 })
+  processNameMismatchWarnings.set('no-ttl', warning)
+
+  pruneExpiredProcessNameMismatchWarnings(now)
+
+  expect([...processNameMismatchWarnings.keys()]).toEqual(['future', 'no-ttl'])
+})
+
+test('getUnclosedProcessKey lowercases bare process names instead of resolving them to cwd', () => {
+  // A bare name resolved via normalizePathForComparison would get the
+  // launcher's cwd prefixed, making the key unstable across working dirs.
+  expect(getUnclosedProcessKey('iracing', '', 'Foo.exe')).toBe('iracing:foo.exe')
+  expect(getUnclosedProcessKey('iracing', 'Foo.exe', 'foo.exe')).toBe('iracing:foo.exe')
+  expect(getUnclosedProcessKey(undefined, '', 'Foo.exe')).toBe('unknown:foo.exe')
+})
+
+test('getUnclosedProcessKey canonicalises full paths like every other comparison site', () => {
+  expect(getUnclosedProcessKey('iracing', 'C:\\Apps\\Foo.exe', 'foo.exe')).toBe(
+    `iracing:${normalizePathForComparison('c:/apps/FOO.EXE')}`
+  )
+})
+
+test('mismatch-warning suppression is consume-once and separator/case-insensitive', () => {
+  suppressProcessNameMismatchWarning('C:/Apps/Foo.exe')
+
+  expect(consumeProcessNameMismatchWarningSuppression('c:\\apps\\FOO.EXE')).toBe(true)
+  expect(consumeProcessNameMismatchWarningSuppression('C:/Apps/Foo.exe')).toBe(false)
+})
+
+test('dismissAppIcon clears both the mismatch warning and the unclosed entry for the app', () => {
+  const appPath = 'C:\\Apps\\Foo.exe'
+  processNameMismatchWarnings.set(normalizePathForComparison(appPath), {
+    path: appPath,
+    name: 'Foo.exe',
+    gameKey: 'iracing',
+    warning: 'w'
+  })
+  unclosedProcesses.set(
+    getUnclosedProcessKey('iracing', appPath, 'foo.exe'),
+    unclosedEntry(appPath)
+  )
+  unclosedProcesses.set(getUnclosedProcessKey('acc', appPath, 'foo.exe'), {
+    ...unclosedEntry(appPath),
+    gameKey: 'acc'
+  })
+
+  dismissAppIcon('c:/apps/foo.exe', 'iracing')
+
+  expect(processNameMismatchWarnings.size).toBe(0)
+  // Only the matching game's unclosed entry is dismissed.
+  expect([...unclosedProcesses.keys()]).toEqual([getUnclosedProcessKey('acc', appPath, 'foo.exe')])
+})

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -19,6 +19,7 @@ async function loadStoreModule() {
   return {
     getStoredBoolean: storeModule.getStoredBoolean,
     getStoredStringRecord: storeModule.getStoredStringRecord,
+    EXPECTED_CONFIG_KEYS: storeModule.EXPECTED_CONFIG_KEYS,
     MAX_CUSTOM_SLOTS: storeModule.MAX_CUSTOM_SLOTS,
     sanitizeSettingsPatch: storeModule.sanitizeSettingsPatch,
     sanitizeImportedConfig: storeModule.sanitizeImportedConfig,
@@ -142,6 +143,70 @@ test('sanitizeSettingsPatch filters object settings like config import', async (
     appNames: { simhub: 'SimHub', customapp2: 'Overlay' },
     appArgs: { customapp2: '--safe' }
   })
+})
+
+// Data-loss guard: 'save-settings' runs every patch through
+// sanitizeSettingsPatch. If profiles/windowBounds/migration flags ever slip
+// through, a settings save would clobber the user's profiles wholesale.
+test('sanitizeSettingsPatch strips profiles, windowBounds, and migration flags', async () => {
+  const { sanitizeSettingsPatch } = await loadStoreModule()
+
+  expect(
+    sanitizeSettingsPatch({
+      themeMode: 'light',
+      profiles: { iracing: { activeProfileId: 'default', profiles: [] } },
+      windowBounds: { x: 0, y: 0, width: 800, height: 600 },
+      migrated: true,
+      profileSetsMigrated: true,
+      profileUtilityOrderMigrated: true
+    })
+  ).toEqual({ themeMode: 'light' })
+})
+
+// Drift alarm: every Settings key must survive sanitization round-trip with a
+// valid value. When a new key is added to EXPECTED_CONFIG_KEYS, this test
+// fails until a sample value is added here AND getSupportedConfigValues
+// actually handles the key — catching the "key added but silently dropped on
+// save" failure mode.
+test('sanitizeSettingsPatch round-trips every settings key with valid values', async () => {
+  const { EXPECTED_CONFIG_KEYS, sanitizeSettingsPatch } = await loadStoreModule()
+
+  const NON_SETTINGS_KEYS = new Set([
+    'profiles',
+    'windowBounds',
+    'profileUtilityOrderMigrated',
+    'profileSetsMigrated',
+    'migrated'
+  ])
+  const sampleValues: Record<string, unknown> = {
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    gamePaths: { iracing: 'C:/Games/iRacing/iRacingSim64DX11.exe' },
+    appNames: { simhub: 'SimHub' },
+    appArgs: { customapp1: '--safe' },
+    customSlots: 2,
+    accentPreset: 'ocean',
+    accentCustom: '#AABBCC',
+    accentBgTint: true,
+    themeMode: 'light',
+    focusActiveTitle: false,
+    launchDelayMs: 2000,
+    startWithWindows: true,
+    startMinimized: true,
+    minimizeToTray: true,
+    showTrayIcon: false,
+    autoCheckUpdates: false,
+    zoomFactor: 1.5
+  }
+
+  const settingsKeys = [...EXPECTED_CONFIG_KEYS].filter((key) => !NON_SETTINGS_KEYS.has(key))
+  const missingSamples = settingsKeys.filter(
+    (key) => !Object.prototype.hasOwnProperty.call(sampleValues, key)
+  )
+  expect(missingSamples, 'add a sample value for every new settings key').toEqual([])
+
+  const patch = Object.fromEntries(settingsKeys.map((key) => [key, sampleValues[key]]))
+
+  expect(sanitizeSettingsPatch(patch)).toEqual(patch)
 })
 
 test('profile sanitization keeps a valid gamePosition and strips invalid values (#471)', async () => {

--- a/tests/main/updater.test.ts
+++ b/tests/main/updater.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+type UpdaterEventHandler = (...args: unknown[]) => void
+
+const autoUpdaterHandlers: Record<string, UpdaterEventHandler> = {}
+const quitAndInstall = vi.fn()
+const downloadUpdate = vi.fn()
+const autoUpdaterCheckForUpdates = vi.fn()
+
+async function loadUpdaterModule({ isPackaged = true } = {}) {
+  const { clearIpcHandlers, app } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+  ;(app as { isPackaged: boolean }).isPackaged = isPackaged
+
+  Object.keys(autoUpdaterHandlers).forEach((key) => delete autoUpdaterHandlers[key])
+  vi.doMock('electron-updater', () => ({
+    autoUpdater: {
+      autoDownload: true,
+      on: vi.fn((event: string, handler: UpdaterEventHandler) => {
+        autoUpdaterHandlers[event] = handler
+      }),
+      quitAndInstall,
+      downloadUpdate,
+      checkForUpdates: autoUpdaterCheckForUpdates
+    }
+  }))
+
+  const updaterModule = await import('../../src/main/updater')
+  const appState = await import('../../src/main/app-state')
+  const { autoUpdater } = await import('electron-updater')
+  const sendToRenderer = vi.fn()
+  updaterModule.registerUpdaterEvents(sendToRenderer)
+  updaterModule.registerUpdaterHandlers(sendToRenderer)
+  const { __ipcHandlers } = await import('electron')
+  return {
+    updaterModule,
+    appState,
+    autoUpdater,
+    sendToRenderer,
+    handlers: __ipcHandlers as Record<string, (...args: unknown[]) => Promise<unknown>>
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+// The preload bridge (src/preload/index.ts) subscribes to these literal
+// channel names. Renaming a channel on either side silently kills the updater
+// UI — there is no runtime error, updates just stop surfacing.
+test('updater events forward to the renderer on the channels the preload subscribes to', async () => {
+  const { sendToRenderer, autoUpdater } = await loadUpdaterModule()
+
+  // Forced off at module load: downloads must wait for explicit user consent.
+  expect(autoUpdater.autoDownload).toBe(false)
+
+  autoUpdaterHandlers['update-available']({ version: '1.2.3' })
+  autoUpdaterHandlers['update-downloaded']({ version: '1.2.3' })
+  autoUpdaterHandlers['update-not-available']({ version: '1.2.3' })
+  autoUpdaterHandlers['download-progress']({ percent: 50 })
+  autoUpdaterHandlers['error'](new Error('boom'))
+
+  expect(sendToRenderer.mock.calls.map((call) => call[0])).toEqual([
+    'update-available',
+    'update-downloaded',
+    'update-not-available',
+    'update-download-progress',
+    'update-error'
+  ])
+})
+
+test('install-update with a downloaded update sets isQuitting before quitAndInstall', async () => {
+  const { appState, handlers } = await loadUpdaterModule()
+  let isQuittingWhenInstalling: boolean | undefined
+  quitAndInstall.mockImplementationOnce(() => {
+    isQuittingWhenInstalling = appState.getIsQuitting()
+  })
+
+  autoUpdaterHandlers['update-downloaded']({ version: '1.2.3' })
+  quitAndInstall.mockClear()
+  await handlers['install-update']({})
+
+  expect(quitAndInstall).toHaveBeenCalledTimes(1)
+  // The window 'close' interceptor must see isQuitting=true, otherwise it
+  // would preventDefault the updater's quit and swallow the install.
+  expect(isQuittingWhenInstalling).toBe(true)
+})
+
+test('install-update before download latches and installs when the download lands', async () => {
+  const { handlers } = await loadUpdaterModule()
+  downloadUpdate.mockResolvedValue(undefined)
+
+  await handlers['install-update']({})
+
+  expect(downloadUpdate).toHaveBeenCalledTimes(1)
+  expect(quitAndInstall).not.toHaveBeenCalled()
+
+  autoUpdaterHandlers['update-downloaded']({ version: '1.2.3' })
+
+  expect(quitAndInstall).toHaveBeenCalledTimes(1)
+})
+
+test('a failed download resets the install latch', async () => {
+  const { handlers } = await loadUpdaterModule()
+  downloadUpdate.mockRejectedValue(new Error('network down'))
+
+  await expect(handlers['install-update']({})).rejects.toThrow('network down')
+
+  // A later download (e.g. user retried and it errored mid-flight elsewhere)
+  // must not auto-install from the stale latch.
+  autoUpdaterHandlers['update-downloaded']({ version: '1.2.3' })
+  expect(quitAndInstall).not.toHaveBeenCalled()
+})
+
+test('an updater error resets the install latch', async () => {
+  const { handlers } = await loadUpdaterModule()
+  let resolveDownload: () => void = () => {}
+  downloadUpdate.mockReturnValue(new Promise<void>((resolve) => (resolveDownload = resolve)))
+
+  const installPromise = handlers['install-update']({})
+  autoUpdaterHandlers['error'](new Error('checksum mismatch'))
+  resolveDownload()
+  await installPromise
+
+  autoUpdaterHandlers['update-downloaded']({ version: '1.2.3' })
+  expect(quitAndInstall).not.toHaveBeenCalled()
+})
+
+test('unpackaged builds simulate the update flow without touching electron-updater', async () => {
+  const { updaterModule, handlers, sendToRenderer } = await loadUpdaterModule({
+    isPackaged: false
+  })
+
+  await expect(updaterModule.checkForUpdates()).resolves.toBeNull()
+  expect(sendToRenderer).toHaveBeenCalledWith('update-available', { version: '99.0.0' })
+  expect(autoUpdaterCheckForUpdates).not.toHaveBeenCalled()
+
+  await expect(handlers['install-update']({})).resolves.toEqual({ success: true })
+  expect(sendToRenderer).toHaveBeenCalledWith('update-downloaded', { version: '99.0.0' })
+  expect(downloadUpdate).not.toHaveBeenCalled()
+  expect(quitAndInstall).not.toHaveBeenCalled()
+})

--- a/tests/main/window.test.ts
+++ b/tests/main/window.test.ts
@@ -34,34 +34,58 @@ async function loadWindowModule() {
 }
 
 async function loadWindowModuleForCreate(
-  opts: { startMinimized?: boolean; showTrayIcon?: boolean } = {}
+  opts: {
+    startMinimized?: boolean
+    showTrayIcon?: boolean
+    minimizeToTray?: boolean
+    autoCheckUpdates?: boolean
+  } = {}
 ) {
   const { clearIpcHandlers } = await import('electron')
   ;(clearIpcHandlers as () => void)()
 
+  const storeValues: Record<string, unknown> = {
+    startMinimized: opts.startMinimized ?? false,
+    showTrayIcon: opts.showTrayIcon ?? true,
+    minimizeToTray: opts.minimizeToTray ?? false,
+    autoCheckUpdates: opts.autoCheckUpdates ?? true
+  }
+  const storeSet = vi.fn((key: string, value: unknown) => {
+    storeValues[key] = value
+  })
+  const checkForUpdates = vi.fn().mockResolvedValue(null)
+
   vi.doMock('../../src/main/store', () => ({
     getStoredBoolean: vi.fn((key: string, defaultValue = false) => {
-      if (key === 'startMinimized') return opts.startMinimized ?? false
-      if (key === 'showTrayIcon') return opts.showTrayIcon ?? true
-      return defaultValue
+      const value = storeValues[key]
+      return typeof value === 'boolean' ? value : defaultValue
     }),
     getStoredZoomFactor: vi.fn(() => 1),
     isWindowBounds: vi.fn(() => false),
-    store: { get: vi.fn(() => undefined), set: vi.fn() }
+    store: { get: vi.fn((key: string) => storeValues[key]), set: storeSet }
   }))
   vi.doMock('../../src/main/updater', () => ({
     registerUpdaterEvents: vi.fn(),
-    checkForUpdates: vi.fn().mockResolvedValue(null)
+    checkForUpdates
   }))
 
-  return await import('../../src/main/window')
+  const mod = await import('../../src/main/window')
+  const appState = await import('../../src/main/app-state')
+  return { ...mod, appState, checkForUpdates, storeSet }
 }
 
 async function getCreatedWindow() {
   const { BrowserWindow } = await import('electron')
   type MockWindow = {
+    options: { webPreferences?: Record<string, unknown> }
     show: ReturnType<typeof vi.fn>
-    webContents: { emit: (event: string, ...args: unknown[]) => void }
+    hide: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+    webContents: {
+      emit: (event: string, ...args: unknown[]) => void
+      send: ReturnType<typeof vi.fn>
+      setWindowOpenHandler: ReturnType<typeof vi.fn>
+    }
     emit: (event: string, ...args: unknown[]) => void
   }
   return (BrowserWindow as unknown as { instances: MockWindow[] }).instances[0]
@@ -125,6 +149,210 @@ test('createWindow does not double-show when ready-to-show fired before the fall
     await vi.advanceTimersByTimeAsync(3000)
 
     expect(win.show).toHaveBeenCalledTimes(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('close quits by default and persists the window bounds first', async () => {
+  const { createWindow, storeSet } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+  const closeEvent = { preventDefault: vi.fn() }
+
+  win.emit('close', closeEvent)
+
+  // Bounds are saved on every close path so the next start restores them.
+  expect(storeSet).toHaveBeenCalledWith('windowBounds', { x: 0, y: 0, width: 800, height: 600 })
+  expect(closeEvent.preventDefault).not.toHaveBeenCalled()
+})
+
+test('close hides to tray when minimize-to-tray is enabled', async () => {
+  const { createWindow } = await loadWindowModuleForCreate({
+    showTrayIcon: true,
+    minimizeToTray: true
+  })
+  createWindow()
+  const win = await getCreatedWindow()
+  const closeEvent = { preventDefault: vi.fn() }
+
+  win.emit('close', closeEvent)
+
+  expect(closeEvent.preventDefault).toHaveBeenCalled()
+  expect(win.hide).toHaveBeenCalled()
+})
+
+test('minimize-to-tray without a tray icon does not swallow the close', async () => {
+  // No tray ⇒ nothing to minimize to; hiding would strand the only window.
+  const { createWindow } = await loadWindowModuleForCreate({
+    showTrayIcon: false,
+    minimizeToTray: true
+  })
+  createWindow()
+  const win = await getCreatedWindow()
+  const closeEvent = { preventDefault: vi.fn() }
+
+  win.emit('close', closeEvent)
+
+  expect(closeEvent.preventDefault).not.toHaveBeenCalled()
+  expect(win.hide).not.toHaveBeenCalled()
+})
+
+test('close with unsaved changes asks the renderer instead of closing or hiding', async () => {
+  const { createWindow, appState } = await loadWindowModuleForCreate()
+  appState.setRendererDirty(true)
+  createWindow()
+  const win = await getCreatedWindow()
+  const closeEvent = { preventDefault: vi.fn() }
+
+  win.emit('close', closeEvent)
+
+  expect(closeEvent.preventDefault).toHaveBeenCalled()
+  expect(win.hide).not.toHaveBeenCalled()
+  expect(win.webContents.send).toHaveBeenCalledWith('close-requested', { minimizeMode: false })
+})
+
+test('close with unsaved changes and tray enabled asks in minimize mode', async () => {
+  // Dirty must win over the tray preference — silently hiding would leave the
+  // pending edits invisible and lost on a later tray-menu quit.
+  const { createWindow, appState } = await loadWindowModuleForCreate({
+    showTrayIcon: true,
+    minimizeToTray: true
+  })
+  appState.setRendererDirty(true)
+  createWindow()
+  const win = await getCreatedWindow()
+  const closeEvent = { preventDefault: vi.fn() }
+
+  win.emit('close', closeEvent)
+
+  expect(closeEvent.preventDefault).toHaveBeenCalled()
+  expect(win.webContents.send).toHaveBeenCalledWith('close-requested', { minimizeMode: true })
+})
+
+test('explicit quit overrides both dirty state and tray preference', async () => {
+  const { createWindow, appState } = await loadWindowModuleForCreate({
+    showTrayIcon: true,
+    minimizeToTray: true
+  })
+  appState.setRendererDirty(true)
+  appState.setIsQuitting(true)
+  createWindow()
+  const win = await getCreatedWindow()
+  const closeEvent = { preventDefault: vi.fn() }
+
+  win.emit('close', closeEvent)
+
+  expect(closeEvent.preventDefault).not.toHaveBeenCalled()
+})
+
+test('window-close IPC marks the app as quitting only on a clean, tray-less close', async () => {
+  const { createWindow, registerWindowHandlers, appState } = await loadWindowModuleForCreate()
+  createWindow()
+  registerWindowHandlers()
+  const win = await getCreatedWindow()
+  const { __ipcHandlers } = await import('electron')
+  const handlers = __ipcHandlers as Record<string, MockIpcHandler>
+
+  await handlers['window-close']()
+
+  // Without the isQuitting flag the 'close' interceptor would re-enter the
+  // hide/confirm logic and the titlebar X could never actually quit.
+  expect(appState.getIsQuitting()).toBe(true)
+  expect(win.close).toHaveBeenCalled()
+})
+
+test('window-close IPC keeps the app alive when minimize-to-tray is on', async () => {
+  const { createWindow, registerWindowHandlers, appState } = await loadWindowModuleForCreate({
+    showTrayIcon: true,
+    minimizeToTray: true
+  })
+  createWindow()
+  registerWindowHandlers()
+  const { __ipcHandlers } = await import('electron')
+  const handlers = __ipcHandlers as Record<string, MockIpcHandler>
+
+  await handlers['window-close']()
+
+  expect(appState.getIsQuitting()).toBe(false)
+})
+
+test('createWindow pins the renderer security hardening', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  expect(win.options.webPreferences).toMatchObject({
+    contextIsolation: true,
+    nodeIntegration: false,
+    sandbox: true
+  })
+
+  // window.open and in-place navigation are both dead ends for the renderer.
+  const openHandler = win.webContents.setWindowOpenHandler.mock.calls[0][0] as () => unknown
+  expect(openHandler()).toEqual({ action: 'deny' })
+
+  const navigateEvent = { preventDefault: vi.fn() }
+  win.webContents.emit('will-navigate', navigateEvent)
+  expect(navigateEvent.preventDefault).toHaveBeenCalled()
+})
+
+// Packaged-mode tests run outside real Electron, where process.resourcesPath
+// (used for the window icon path) does not exist — stub it for the duration.
+function withResourcesPath() {
+  const processWithResources = process as NodeJS.Process & { resourcesPath?: string }
+  processWithResources.resourcesPath = 'C:/resources'
+  return () => delete processWithResources.resourcesPath
+}
+
+test('packaged builds check for updates on load only when auto-check is enabled', async () => {
+  const restoreResourcesPath = withResourcesPath()
+  const { app } = await import('electron')
+  ;(app as { isPackaged: boolean }).isPackaged = true
+  try {
+    const { createWindow, checkForUpdates } = await loadWindowModuleForCreate({
+      autoCheckUpdates: false
+    })
+    createWindow()
+    const win = await getCreatedWindow()
+
+    win.webContents.emit('did-finish-load')
+    expect(checkForUpdates).not.toHaveBeenCalled()
+  } finally {
+    ;(app as { isPackaged: boolean }).isPackaged = false
+    restoreResourcesPath()
+  }
+})
+
+test('packaged builds check for updates immediately on load', async () => {
+  const restoreResourcesPath = withResourcesPath()
+  const { app } = await import('electron')
+  ;(app as { isPackaged: boolean }).isPackaged = true
+  try {
+    const { createWindow, checkForUpdates } = await loadWindowModuleForCreate()
+    createWindow()
+    const win = await getCreatedWindow()
+
+    win.webContents.emit('did-finish-load')
+    expect(checkForUpdates).toHaveBeenCalledTimes(1)
+  } finally {
+    ;(app as { isPackaged: boolean }).isPackaged = false
+    restoreResourcesPath()
+  }
+})
+
+test('dev builds simulate the update check on a delay', async () => {
+  vi.useFakeTimers()
+  try {
+    const { createWindow, checkForUpdates } = await loadWindowModuleForCreate()
+    createWindow()
+    const win = await getCreatedWindow()
+
+    win.webContents.emit('did-finish-load')
+    expect(checkForUpdates).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(checkForUpdates).toHaveBeenCalledTimes(1)
   } finally {
     vi.useRealTimers()
   }


### PR DESCRIPTION
﻿## Summary

Batch 1 of the test-coverage audit (#494): 50 new main-process tests covering the high-risk gaps identified by the phase-1 audit. One production change: `getLaunchDelayMs` and `normalizeLaunchInput` in `spawn.ts` are now exported for unit tests (not added to the processes barrel).

### What is covered

| Area | Tests | Key invariant |
| --- | --- | --- |
| `store.ts` | strip guard + round-trip drift alarm | a settings save can never clobber profiles/windowBounds/migration flags; every settings key must survive sanitization (new-key drift fails the suite) |
| `profiles.ts` | fallback chain, trackable paths | disabled utilities never leak into the kill/tracking scope |
| `processes/running.ts` | #399 guard | a failed tasklist read must not wipe running/unclosed state |
| `processes/state.ts` | prune/TTL/bare-name keys, suppression, dismiss | unclosed keys stay cwd-independent; suppression is consume-once |
| `processes/spawn.ts` | delay clamp, input normalization | wrong key would feed isGame → kill exclusion |
| `window.ts` | close-action wiring, window-close IPC, security pinning, update gate | dirty > tray precedence; no tray ⇒ no stranded hidden window; sandbox/contextIsolation pinned |
| `ipc/launch.ts` | validation, relaunch filter, switch diff/apply | profile switch never kills or relaunches the running sim |
| `ipc/config.ts` | import rollback, preview token | mid-apply throw restores the full store snapshot; token is single-use with 5-min TTL |
| `updater.ts` | channel contract, install latches, quit ordering | renaming an update channel now fails tests instead of silently killing the updater UI; isQuitting is set before quitAndInstall |

### Test plan

- `npm test` — 264 tests green (50 new)
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean

Part of #494 (batch 1/3 — batch 2: tray/boot + mock infra, batch 3: renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
