### PR TITLE
test: boot harness and tray coverage (audit batch 2, refs #494)

### DIFF
--- a/tests/main/boot.test.ts
+++ b/tests/main/boot.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import type { app as mockApp } from './electronMock'
+
+interface BootOptions {
+  lockAcquired?: boolean
+  showTrayIcon?: boolean
+}
+
+// Imports src/main/index for its side effects with every collaborator module
+// mocked, recording the boot sequence in callLog.
+async function bootApp(opts: BootOptions = {}) {
+  const callLog: string[] = []
+  const { app } = await import('electron')
+  ;(app as typeof mockApp).requestSingleInstanceLock.mockReturnValue(opts.lockAcquired ?? true)
+
+  const securityMock = {
+    registerContentSecurityPolicy: vi.fn(() => callLog.push('csp'))
+  }
+  vi.doMock('./security', () => securityMock)
+  vi.doMock('/src/main/security.ts', () => securityMock)
+  vi.doMock('../../src/main/security', () => securityMock)
+  vi.doMock('../../src/main/security.ts', () => securityMock)
+
+  const migratorMock = {
+    migrateProfilesToNamedSets: vi.fn(() => callLog.push('migrate'))
+  }
+  vi.doMock('./migrator', () => migratorMock)
+  vi.doMock('/src/main/migrator.ts', () => migratorMock)
+  vi.doMock('../../src/main/migrator', () => migratorMock)
+  vi.doMock('../../src/main/migrator.ts', () => migratorMock)
+
+  const ipcMock = {
+    registerHandlers: vi.fn(() => callLog.push('handlers'))
+  }
+  vi.doMock('./ipc', () => ipcMock)
+  vi.doMock('/src/main/ipc/index.ts', () => ipcMock)
+  vi.doMock('../../src/main/ipc', () => ipcMock)
+  vi.doMock('../../src/main/ipc/index', () => ipcMock)
+  vi.doMock('../../src/main/ipc/index.ts', () => ipcMock)
+
+  const trayMock = {
+    configureTray: vi.fn(() => callLog.push('configureTray')),
+    createTray: vi.fn(() => callLog.push('createTray')),
+    destroyTray: vi.fn(),
+    applyTrayVisibility: vi.fn()
+  }
+  vi.doMock('./tray', () => trayMock)
+  vi.doMock('/src/main/tray.ts', () => trayMock)
+  vi.doMock('../../src/main/tray', () => trayMock)
+  vi.doMock('../../src/main/tray.ts', () => trayMock)
+
+  const windowMock = {
+    createWindow: vi.fn(() => callLog.push('createWindow')),
+    getAppIconPath: vi.fn(() => 'C:/app/SimLauncher.ico'),
+    showMainWindow: vi.fn()
+  }
+  vi.doMock('./window', () => windowMock)
+  vi.doMock('/src/main/window.ts', () => windowMock)
+  vi.doMock('../../src/main/window', () => windowMock)
+  vi.doMock('../../src/main/window.ts', () => windowMock)
+
+  const storeMock = {
+    store: {
+      get: vi.fn((key: string) =>
+        key === 'showTrayIcon' ? (opts.showTrayIcon ?? true) : undefined
+      )
+    }
+  }
+  vi.doMock('./store', () => storeMock)
+  vi.doMock('/src/main/store.ts', () => storeMock)
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
+
+  await import('../../src/main/index')
+  // Let the whenReady().then(...) boot continuation run.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  const appState = await import('../../src/main/app-state')
+  return { app: app as typeof mockApp, appState, callLog, trayMock, windowMock, ipcMock }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('a second instance quits immediately without registering anything', async () => {
+  const { app, callLog } = await bootApp({ lockAcquired: false })
+
+  expect(app.quit).toHaveBeenCalled()
+  expect(app.whenReady).not.toHaveBeenCalled()
+  expect(app.on).not.toHaveBeenCalled()
+  expect(callLog).toEqual([])
+})
+
+// CSP must be in place before any window exists, migration before any handler
+// can read profiles, and the tray wired before the window can minimize to it.
+test('first instance boots in the documented order', async () => {
+  const { callLog } = await bootApp()
+
+  expect(callLog).toEqual([
+    'csp',
+    'migrate',
+    'handlers',
+    'configureTray',
+    'createTray',
+    'createWindow'
+  ])
+})
+
+test('tray is not created on boot when showTrayIcon is off (#391)', async () => {
+  const { callLog } = await bootApp({ showTrayIcon: false })
+
+  expect(callLog).toEqual(['csp', 'migrate', 'handlers', 'configureTray', 'createWindow'])
+})
+
+// Recovery path: with the window hidden in the tray, launching the exe again
+// is the user's way of getting the window back.
+test('a second launch attempt surfaces the existing window', async () => {
+  const { app, windowMock } = await bootApp()
+
+  app.emit('second-instance')
+
+  expect(windowMock.showMainWindow).toHaveBeenCalledTimes(1)
+})
+
+test('before-quit marks the app as quitting so the close interceptor lets it die', async () => {
+  const { app, appState } = await bootApp()
+
+  expect(appState.getIsQuitting()).toBe(false)
+  app.emit('before-quit')
+  expect(appState.getIsQuitting()).toBe(true)
+})
+
+test('the tray Quit hook sets isQuitting before asking the app to quit', async () => {
+  const { app, appState, trayMock } = await bootApp()
+  let isQuittingWhenQuitCalled: boolean | undefined
+  app.quit.mockImplementationOnce(() => {
+    isQuittingWhenQuitCalled = appState.getIsQuitting()
+  })
+
+  const configureOptions = trayMock.configureTray.mock.calls[0][0] as { quitApp: () => void }
+  configureOptions.quitApp()
+
+  expect(app.quit).toHaveBeenCalledTimes(1)
+  expect(isQuittingWhenQuitCalled).toBe(true)
+})

--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -102,16 +102,67 @@ export class BrowserWindow extends MockEventTarget {
   loadURL = vi.fn()
 }
 
+export class Tray extends MockEventTarget {
+  static instances: Tray[] = []
+
+  icon: unknown
+  tooltip = ''
+  contextMenu: unknown
+  private destroyed = false
+
+  constructor(icon: unknown) {
+    super()
+    this.icon = icon
+    Tray.instances.push(this)
+  }
+
+  setToolTip = vi.fn((tooltip: string) => {
+    this.tooltip = tooltip
+  })
+
+  setContextMenu = vi.fn((menu: unknown) => {
+    this.contextMenu = menu
+  })
+
+  destroy = vi.fn(() => {
+    this.destroyed = true
+  })
+
+  isDestroyed = vi.fn(() => this.destroyed)
+}
+
+export interface MockMenuItem {
+  label?: string
+  type?: string
+  click?: () => void
+}
+
+export const Menu = {
+  buildFromTemplate: vi.fn((template: MockMenuItem[]) => ({ template }))
+}
+
+export const nativeImage = {
+  createFromPath: vi.fn((imagePath: string) => ({ imagePath }))
+}
+
 export const screen = {
   getDisplayMatching: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }))
 }
 
-export const app = {
-  getVersion: vi.fn().mockReturnValue('1.0.0'),
-  isPackaged: false,
-  setLoginItemSettings: vi.fn(),
-  getAppPath: vi.fn().mockReturnValue(process.cwd())
+class MockApp extends MockEventTarget {
+  isPackaged = false
+  getVersion = vi.fn().mockReturnValue('1.0.0')
+  getAppPath = vi.fn().mockReturnValue(process.cwd())
+  setLoginItemSettings = vi.fn()
+  quit = vi.fn()
+  exit = vi.fn()
+  relaunch = vi.fn()
+  requestSingleInstanceLock = vi.fn(() => true)
+  whenReady = vi.fn(() => Promise.resolve())
+  getFileIcon = vi.fn(async () => ({ toDataURL: () => 'data:image/png;base64,mock' }))
 }
+
+export const app = new MockApp()
 
 export const dialog = {
   showOpenDialog: vi.fn(),

--- a/tests/main/tray.test.ts
+++ b/tests/main/tray.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import type { MockMenuItem, Tray as MockTray } from './electronMock'
+
+const showMainWindow = vi.fn()
+const quitApp = vi.fn()
+
+async function loadTrayModule({ configure = true } = {}) {
+  const trayModule = await import('../../src/main/tray')
+
+  if (configure) {
+    trayModule.configureTray({
+      getIconPath: () => 'C:/app/SimLauncher.ico',
+      showMainWindow,
+      quitApp
+    })
+  }
+
+  const { Tray, Menu } = await import('electron')
+  return {
+    trayModule,
+    TrayMock: Tray as unknown as typeof MockTray,
+    MenuMock: Menu as unknown as { buildFromTemplate: ReturnType<typeof vi.fn> }
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('createTray wires click and double-click to showing the main window', async () => {
+  const { trayModule, TrayMock } = await loadTrayModule()
+
+  trayModule.createTray()
+
+  const tray = TrayMock.instances[0]
+  expect(tray.tooltip).toBe('SimLauncher')
+
+  tray.emit('click')
+  tray.emit('double-click')
+  expect(showMainWindow).toHaveBeenCalledTimes(2)
+})
+
+test('tray menu items show the window and quit through the configured hooks', async () => {
+  const { trayModule, MenuMock } = await loadTrayModule()
+
+  trayModule.createTray()
+
+  const template = MenuMock.buildFromTemplate.mock.calls[0][0] as MockMenuItem[]
+  const showItem = template.find((item) => item.label === 'Show SimLauncher')
+  const quitItem = template.find((item) => item.label === 'Quit')
+
+  showItem!.click!()
+  expect(showMainWindow).toHaveBeenCalledTimes(1)
+
+  quitItem!.click!()
+  expect(quitApp).toHaveBeenCalledTimes(1)
+})
+
+test('createTray is a no-op when unconfigured or when a tray already exists', async () => {
+  const { trayModule, TrayMock } = await loadTrayModule({ configure: false })
+
+  // Unconfigured: nothing to wire the menu to, so no tray may be created.
+  trayModule.createTray()
+  expect(TrayMock.instances).toHaveLength(0)
+
+  trayModule.configureTray({
+    getIconPath: () => 'C:/app/SimLauncher.ico',
+    showMainWindow,
+    quitApp
+  })
+  trayModule.createTray()
+  trayModule.createTray()
+  expect(TrayMock.instances).toHaveLength(1)
+})
+
+// The #391 toggle cycle: turning the tray off must null the handle so a later
+// re-enable can build a fresh tray (a stale handle would block recreation
+// forever — the createTray guard checks it).
+test('applyTrayVisibility survives the on → off → on cycle', async () => {
+  const { trayModule, TrayMock } = await loadTrayModule()
+
+  trayModule.applyTrayVisibility(true)
+  expect(TrayMock.instances).toHaveLength(1)
+
+  trayModule.applyTrayVisibility(false)
+  expect(TrayMock.instances[0].destroy).toHaveBeenCalled()
+
+  trayModule.applyTrayVisibility(true)
+  expect(TrayMock.instances).toHaveLength(2)
+  expect(TrayMock.instances[1].isDestroyed()).toBe(false)
+})
+
+test('destroyTray tolerates being called with no tray', async () => {
+  const { trayModule, TrayMock } = await loadTrayModule()
+
+  expect(() => trayModule.destroyTray()).not.toThrow()
+  expect(TrayMock.instances).toHaveLength(0)
+})


### PR DESCRIPTION
﻿## Summary

Batch 2 of the test-coverage audit (#494): boot + tray coverage. `src/main/index.ts` and `src/main/tray.ts` were the only main-process modules never imported by any test — the app boot sequence, single-instance behavior, and the #391 tray lifecycle had zero coverage.

### Changes

- **`tests/main/electronMock.ts`**: added `Tray` (instance registry + events), `Menu.buildFromTemplate`, `nativeImage`, and made `app` event-capable (`whenReady`, `on`/`emit`, `quit`, `requestSingleInstanceLock`, `getFileIcon`). No production code changes.
- **`tests/main/boot.test.ts`** (new, 6 tests): second instance quits with nothing registered; documented boot order (CSP → migrate → handlers → configureTray → createTray → createWindow); `showTrayIcon` boot gate (#391); `second-instance` → `showMainWindow` (tray-hidden recovery path); `before-quit` and tray-Quit both set `isQuitting` before quitting (close-interceptor contract).
- **`tests/main/tray.test.ts`** (new, 5 tests): click/double-click/menu wiring to `showMainWindow`/`quitApp`; unconfigured and duplicate-create guards; the #391 on→off→on visibility cycle (stale handle would block tray recreation forever).

### Test plan

- `npm test` — 275 tests green (11 new)
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean

Part of #494 (batch 2/3 — batch 3: renderer + verifying the 4 suspected bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
