### PR TITLE
test: renderer coverage for subscriptions, migrations, profile editing (audit batch 3, refs #494)

### DIFF
--- a/tests/renderer/migrations.test.ts
+++ b/tests/renderer/migrations.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Startup localStorage→store migration. The one-shot guard is the critical
+ * behavior: if the migrated flag is ever ignored, every boot re-imports the
+ * stale localStorage copy and silently overwrites the user's current config.
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  migrateFromLocalStorage,
+  runStartupMigrations
+} from '../../src/renderer/src/lib/migrations'
+
+const getMigrationFlagsMock = vi.fn()
+const saveSettingsMock = vi.fn()
+const saveProfilesMock = vi.fn()
+const setMigrationFlagsMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getMigrationFlags: (...args: unknown[]) => getMigrationFlagsMock(...args),
+  saveSettings: (...args: unknown[]) => saveSettingsMock(...args),
+  saveProfiles: (...args: unknown[]) => saveProfilesMock(...args),
+  setMigrationFlags: (...args: unknown[]) => setMigrationFlagsMock(...args)
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  getMigrationFlagsMock.mockResolvedValue({ migrated: false })
+  saveSettingsMock.mockResolvedValue(undefined)
+  saveProfilesMock.mockResolvedValue(undefined)
+  setMigrationFlagsMock.mockResolvedValue(undefined)
+})
+
+describe('migrateFromLocalStorage', () => {
+  test('the migrated flag makes the migration a strict no-op (one-shot guard)', async () => {
+    getMigrationFlagsMock.mockResolvedValue({ migrated: true })
+    localStorage.setItem('simLauncherAppPaths', JSON.stringify({ simhub: 'C:/Old/SimHub.exe' }))
+
+    await migrateFromLocalStorage()
+
+    expect(saveSettingsMock).not.toHaveBeenCalled()
+    expect(saveProfilesMock).not.toHaveBeenCalled()
+    expect(setMigrationFlagsMock).not.toHaveBeenCalled()
+  })
+
+  test('migrates legacy paths, names, and profiles into named profile sets', async () => {
+    localStorage.setItem(
+      'simLauncherAppPaths',
+      JSON.stringify({ simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' })
+    )
+    localStorage.setItem(
+      'simLauncherGamePaths',
+      JSON.stringify({ iracing: 'C:/Games/iRacingUI.exe' })
+    )
+    localStorage.setItem('simLauncherAppName_customapp2', 'Overlay')
+    localStorage.setItem(
+      'profile_iracing',
+      JSON.stringify({ simhub: true, launchAutomatically: false })
+    )
+
+    await migrateFromLocalStorage()
+
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appPaths: { simhub: 'C:/Tools/SimHub.exe', customapp2: 'C:/Tools/Overlay.exe' },
+        gamePaths: { iracing: 'C:/Games/iRacingUI.exe' },
+        appNames: { customapp2: 'Overlay' },
+        // Inferred from the highest legacy customapp slot in use.
+        customSlots: 2
+      })
+    )
+
+    const migratedProfiles = saveProfilesMock.mock.calls[0][0] as {
+      iracing: {
+        activeProfileId: string
+        profiles: Array<Record<string, unknown>>
+      }
+    }
+    expect(migratedProfiles.iracing.activeProfileId).toBe('default')
+    const [defaultProfile] = migratedProfiles.iracing.profiles
+    expect(defaultProfile.id).toBe('default')
+    expect(defaultProfile.launchAutomatically).toBe(false)
+    // Legacy boolean flags become the ordered utilities array...
+    expect(defaultProfile.utilities).toContainEqual({ id: 'simhub', enabled: true })
+    // ...and must not survive as raw boolean keys alongside it.
+    expect(defaultProfile).not.toHaveProperty('simhub')
+
+    expect(setMigrationFlagsMock).toHaveBeenCalledWith({
+      profileUtilityOrderMigrated: true,
+      migrated: true
+    })
+  })
+
+  test('an empty localStorage still sets the migrated flag so the scan never reruns', async () => {
+    await migrateFromLocalStorage()
+
+    expect(saveSettingsMock).not.toHaveBeenCalled()
+    expect(saveProfilesMock).not.toHaveBeenCalled()
+    expect(setMigrationFlagsMock).toHaveBeenCalledWith({
+      profileUtilityOrderMigrated: true,
+      migrated: true
+    })
+  })
+})
+
+describe('runStartupMigrations', () => {
+  test('swallows migration failures so a corrupt legacy value cannot block boot', async () => {
+    localStorage.setItem('simLauncherAppPaths', '{not json')
+
+    await expect(runStartupMigrations()).resolves.toBeUndefined()
+    expect(saveSettingsMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/renderer/profileEditorSaveDelete.test.tsx
+++ b/tests/renderer/profileEditorSaveDelete.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * useProfileEditor save assembly and delete safety. The save path re-reads the
+ * profile set from the store and surgically replaces only the edited profile —
+ * sibling profiles must come through byte-identical (clobbering them is silent
+ * multi-profile data loss). Delete must refuse to remove the last profile and
+ * re-point activeProfileId when the active profile is removed.
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import {
+  useProfileEditor,
+  type UseProfileEditorResult
+} from '../../src/renderer/src/hooks/useProfileEditor'
+
+const getSettingsMock = vi.fn()
+const getProfilesMock = vi.fn()
+const saveProfileMock = vi.fn()
+const notifyMock = vi.fn()
+const onCloseMock = vi.fn()
+const onProfilesChangedMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: (...args: unknown[]) => getSettingsMock(...args),
+  getProfiles: (...args: unknown[]) => getProfilesMock(...args),
+  saveProfile: (...args: unknown[]) => saveProfileMock(...args)
+}))
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  getFileIcon: vi.fn(async () => ''),
+  browsePath: vi.fn(),
+  launchProfile: vi.fn(async () => ({ success: true, launchedCount: 1 }))
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock })
+}))
+
+const APP_PATHS = { simhub: 'C:/Tools/SimHub.exe', crewchief: 'C:/Tools/CrewChief.exe' }
+// Referentially stable across renders: useProfileEditor's settings-sync effect
+// depends on these objects, and a fresh {} per render would loop it forever.
+const APP_NAMES = {}
+
+vi.mock('../../src/renderer/src/components/settings/AppsContext', () => ({
+  useAppsSettings: () => ({ appPaths: APP_PATHS, appNames: APP_NAMES, customSlots: 1 })
+}))
+
+const SIBLING_PROFILE = {
+  id: 'p2',
+  name: 'Endurance',
+  utilities: [{ id: 'crewchief', enabled: true }],
+  trackingEnabled: false,
+  trackedProcessPaths: ['C:/Tools/Telemetry.exe']
+}
+
+function twoProfileSet() {
+  return {
+    iracing: {
+      activeProfileId: 'p1',
+      profiles: [
+        {
+          id: 'p1',
+          name: 'Race Day',
+          utilities: [{ id: 'simhub', enabled: true }],
+          launchAutomatically: true
+        },
+        { ...SIBLING_PROFILE, utilities: [...SIBLING_PROFILE.utilities] }
+      ]
+    }
+  }
+}
+
+function singleProfileSet() {
+  return {
+    iracing: {
+      activeProfileId: 'p1',
+      profiles: [{ id: 'p1', name: 'Race Day', utilities: [{ id: 'simhub', enabled: true }] }]
+    }
+  }
+}
+
+function Probe({ onCapture }: { onCapture: (api: UseProfileEditorResult) => void }) {
+  onCapture(
+    useProfileEditor({
+      gameKey: 'iracing',
+      activeProfileId: 'p1',
+      onProfilesChanged: onProfilesChangedMock,
+      onClose: onCloseMock
+    })
+  )
+  return null
+}
+
+async function mountEditor() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: UseProfileEditorResult | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Probe onCapture={(api) => (captured = api)} />)
+  })
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getApi: () => {
+      if (!captured) throw new Error('Probe did not capture state')
+      return captured
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSettingsMock.mockResolvedValue({ appPaths: APP_PATHS, appNames: {}, customSlots: 1 })
+  getProfilesMock.mockResolvedValue(twoProfileSet())
+  saveProfileMock.mockResolvedValue(undefined)
+  onProfilesChangedMock.mockResolvedValue(undefined)
+})
+
+describe('useProfileEditor save assembly', () => {
+  test('save replaces only the edited profile and preserves siblings verbatim', async () => {
+    const harness = await mountEditor()
+    try {
+      let saved = false
+      await act(async () => {
+        saved = await harness.getApi().handleSave()
+      })
+
+      expect(saved).toBe(true)
+      const [gameKey, savedSet] = saveProfileMock.mock.calls[0] as [
+        string,
+        { activeProfileId: string; profiles: Array<Record<string, unknown>> }
+      ]
+      expect(gameKey).toBe('iracing')
+      expect(savedSet.activeProfileId).toBe('p1')
+      expect(savedSet.profiles).toHaveLength(2)
+      // The sibling must come through exactly as stored — including fields the
+      // editor never touches (trackingEnabled, trackedProcessPaths).
+      expect(savedSet.profiles[1]).toEqual(SIBLING_PROFILE)
+      expect(onCloseMock).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('a blank profile name falls back to the stored name instead of saving ""', async () => {
+    const harness = await mountEditor()
+    try {
+      await act(async () => {
+        harness.getApi().setProfileName('   ')
+      })
+      await act(async () => {
+        await harness.getApi().handleSave()
+      })
+
+      const [, savedSet] = saveProfileMock.mock.calls[0] as [
+        string,
+        { profiles: Array<{ id: string; name: string }> }
+      ]
+      expect(savedSet.profiles[0].name).toBe('Race Day')
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('a failed save reports false, notifies, and keeps the editor open', async () => {
+    const harness = await mountEditor()
+    try {
+      saveProfileMock.mockRejectedValueOnce(new Error('store write failed'))
+
+      let saved = true
+      await act(async () => {
+        saved = await harness.getApi().handleSave()
+      })
+
+      expect(saved).toBe(false)
+      expect(onCloseMock).not.toHaveBeenCalled()
+      expect(notifyMock).toHaveBeenCalledWith('Failed to save profile', 'error')
+    } finally {
+      harness.unmount()
+    }
+  })
+})
+
+describe('useProfileEditor delete safety', () => {
+  test('refuses to delete the last remaining profile', async () => {
+    getProfilesMock.mockResolvedValue(singleProfileSet())
+    const harness = await mountEditor()
+    try {
+      await act(async () => {
+        await harness.getApi().handleDeleteProfile()
+      })
+
+      expect(notifyMock).toHaveBeenCalledWith('At least one profile is required', 'warn')
+      expect(harness.getApi().profileDeleteConfirm).toBeNull()
+      expect(saveProfileMock).not.toHaveBeenCalled()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('deleting the active profile re-points activeProfileId to a survivor', async () => {
+    const harness = await mountEditor()
+    try {
+      await act(async () => {
+        await harness.getApi().handleDeleteProfile()
+      })
+      expect(harness.getApi().profileDeleteConfirm).toEqual({
+        profileId: 'p1',
+        profileName: 'Race Day'
+      })
+
+      await act(async () => {
+        await harness.getApi().confirmDeleteProfile()
+      })
+
+      const [, savedSet] = saveProfileMock.mock.calls[0] as [
+        string,
+        { activeProfileId: string; profiles: Array<{ id: string }> }
+      ]
+      // A dangling activeProfileId would make every reader fall back
+      // unpredictably; it must point at a profile that still exists.
+      expect(savedSet.activeProfileId).toBe('p2')
+      expect(savedSet.profiles.map((profile) => profile.id)).toEqual(['p2'])
+      expect(onCloseMock).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/settingsSnapshotKeyOrder.test.tsx
+++ b/tests/renderer/settingsSnapshotKeyOrder.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * #480 key-order contract: the dirty baseline is a JSON string compare, so the
+ * snapshot built by useSettingsLoad must carry the exact same keys in the exact
+ * same order as the currentSettingsState memo in useSettingsState. A reordered
+ * or missing key reads as permanently dirty (or permanently clean) — this test
+ * fails as soon as one side adds a key without the other.
+ */
+
+import { beforeEach, expect, test, vi } from 'vitest'
+import { act, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { useSettingsLoad } from '../../src/renderer/src/components/settings/useSettingsLoad'
+import {
+  useSettingsState,
+  type SettingsStateSnapshot
+} from '../../src/renderer/src/components/settings/useSettingsState'
+
+const getSettingsMock = vi.fn()
+const getProfilesMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: (...args: unknown[]) => getSettingsMock(...args),
+  getProfiles: (...args: unknown[]) => getProfilesMock(...args),
+  onStoreConfigChanged: () => () => {}
+}))
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  getFileIcon: vi.fn(async () => ''),
+  getAssetData: vi.fn(async () => '')
+}))
+
+interface ProbeApi {
+  loadSettingsFromStore: () => Promise<SettingsStateSnapshot>
+  currentSettingsState: SettingsStateSnapshot
+}
+
+function Probe({ onCapture }: { onCapture: (api: ProbeApi) => void }) {
+  const bundle = useSettingsState()
+  const themeRef = useRef({ setThemeMode: () => {} })
+  const { loadSettingsFromStore } = useSettingsLoad({
+    themeRef,
+    latestSettingsObjects: bundle.latestSettingsObjects,
+    resetDirty: () => {},
+    ...bundle.setters
+  })
+
+  onCapture({ loadSettingsFromStore, currentSettingsState: bundle.currentSettingsState })
+  return null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSettingsMock.mockResolvedValue({
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    appNames: { simhub: 'SimHub' },
+    appArgs: {},
+    gamePaths: { iracing: 'C:/Games/iRacingUI.exe' },
+    customSlots: 1,
+    accentPreset: 'teal',
+    accentCustom: '',
+    accentBgTint: false,
+    themeMode: 'dark',
+    focusActiveTitle: true,
+    launchDelayMs: 1000,
+    startWithWindows: false,
+    startMinimized: false,
+    minimizeToTray: false,
+    showTrayIcon: true,
+    autoCheckUpdates: true,
+    zoomFactor: 1
+  })
+  getProfilesMock.mockResolvedValue({})
+})
+
+test('useSettingsLoad snapshot and currentSettingsState agree on keys AND order (#480)', async () => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: ProbeApi | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Probe onCapture={(api) => (captured = api)} />)
+  })
+
+  try {
+    if (!captured) throw new Error('Probe did not capture state')
+    let snapshot: SettingsStateSnapshot | null = null
+    await act(async () => {
+      snapshot = await captured!.loadSettingsFromStore()
+    })
+
+    const snapshotKeys = Object.keys(snapshot!)
+    const stateKeys = Object.keys(captured!.currentSettingsState)
+
+    // toEqual on arrays is order-sensitive — exactly what the JSON string
+    // compare in useDirtyTracking needs.
+    expect(snapshotKeys).toEqual(stateKeys)
+
+    // After a load, the freshly rendered state must serialize identically to
+    // the snapshot the loader returned — this is the resetDirty(snapshot)
+    // contract: baseline === live state ⇒ clean.
+    expect(JSON.stringify(captured!.currentSettingsState)).toBe(JSON.stringify(snapshot))
+  } finally {
+    act(() => {
+      root?.unmount()
+    })
+    container.remove()
+  }
+})

--- a/tests/renderer/useRunningApps.test.tsx
+++ b/tests/renderer/useRunningApps.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Push-subscription lifecycle of useRunningApps: the hook drives the entire
+ * "what is running" UI (status dots, kill/relaunch controls), so a broken
+ * subscribe/unsubscribe cycle either freezes the UI on stale data or leaks
+ * main-process subscribers after unmount.
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import type { Game } from '../../src/renderer/src/lib/config'
+import {
+  useRunningApps,
+  type RunningAppsChangedPayload,
+  type UseRunningAppsResult
+} from '../../src/renderer/src/hooks/useRunningApps'
+
+const getRunningAppsMock = vi.fn()
+const subscribeRunningAppsMock = vi.fn()
+const unsubscribeRunningAppsMock = vi.fn()
+const removeChangeListenerMock = vi.fn()
+let changeListener: ((payload: RunningAppsChangedPayload) => void) | null = null
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  getRunningApps: (...args: unknown[]) => getRunningAppsMock(...args),
+  subscribeRunningApps: (...args: unknown[]) => subscribeRunningAppsMock(...args),
+  unsubscribeRunningApps: (...args: unknown[]) => unsubscribeRunningAppsMock(...args),
+  onRunningAppsChanged: (listener: (payload: RunningAppsChangedPayload) => void) => {
+    changeListener = listener
+    return removeChangeListenerMock
+  }
+}))
+
+const GAMES: Game[] = [
+  { key: 'iracing', name: 'iRacing', icon: 'assets/iracing.png' },
+  { key: 'acc', name: 'ACC', icon: 'assets/acc.png' }
+]
+
+const IRACING_APP = {
+  path: 'C:/Games/iRacingUI.exe',
+  name: 'iRacingUI.exe',
+  gameKey: 'iracing',
+  tracked: false
+}
+
+function payload(
+  apps: RunningAppsChangedPayload['apps'],
+  reason: RunningAppsChangedPayload['reason'] = 'scan'
+): RunningAppsChangedPayload {
+  return { apps, reason, updatedAt: 1 }
+}
+
+function Probe({
+  games,
+  onCapture
+}: {
+  games: Game[]
+  onCapture: (result: UseRunningAppsResult) => void
+}) {
+  onCapture(useRunningApps(games))
+  return null
+}
+
+async function mountProbe(games: Game[]) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: UseRunningAppsResult | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Probe games={games} onCapture={(result) => (captured = result)} />)
+  })
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getResult: () => {
+      if (!captured) throw new Error('Probe did not capture state')
+      return captured
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  changeListener = null
+  subscribeRunningAppsMock.mockResolvedValue(payload([], 'initial'))
+  unsubscribeRunningAppsMock.mockResolvedValue(undefined)
+  getRunningAppsMock.mockResolvedValue([])
+})
+
+describe('useRunningApps push-subscription lifecycle', () => {
+  test('applies the initial subscription snapshot to apps and per-game status', async () => {
+    subscribeRunningAppsMock.mockResolvedValue(payload([IRACING_APP], 'initial'))
+    const harness = await mountProbe(GAMES)
+    try {
+      expect(harness.getResult().runningApps).toEqual([IRACING_APP])
+      expect(harness.getResult().runningStatus).toEqual({ iracing: true, acc: false })
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('push events update the running state without polling', async () => {
+    const harness = await mountProbe(GAMES)
+    try {
+      expect(harness.getResult().runningStatus).toEqual({ iracing: false, acc: false })
+
+      await act(async () => {
+        changeListener?.(payload([IRACING_APP], 'launch'))
+      })
+      expect(harness.getResult().runningStatus).toEqual({ iracing: true, acc: false })
+
+      await act(async () => {
+        changeListener?.(payload([], 'exit'))
+      })
+      expect(harness.getResult().runningApps).toEqual([])
+      expect(harness.getResult().runningStatus).toEqual({ iracing: false, acc: false })
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('falls back to a one-shot poll when the subscription fails', async () => {
+    subscribeRunningAppsMock.mockRejectedValue(new Error('ipc broken'))
+    getRunningAppsMock.mockResolvedValue([IRACING_APP])
+
+    const harness = await mountProbe(GAMES)
+    try {
+      expect(harness.getResult().runningStatus).toEqual({ iracing: true, acc: false })
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('unmount tears down both the renderer listener and the main-process subscription', async () => {
+    const harness = await mountProbe(GAMES)
+
+    harness.unmount()
+
+    expect(removeChangeListenerMock).toHaveBeenCalledTimes(1)
+    expect(unsubscribeRunningAppsMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('with no configured games it never subscribes and reports empty state', async () => {
+    const harness = await mountProbe([])
+    try {
+      expect(subscribeRunningAppsMock).not.toHaveBeenCalled()
+      expect(harness.getResult().runningApps).toEqual([])
+      expect(harness.getResult().runningStatus).toEqual({})
+    } finally {
+      harness.unmount()
+    }
+  })
+})


### PR DESCRIPTION
﻿## Summary

Batch 3 (final) of the test-coverage audit (#494): 15 renderer tests. No production code changes.

### What is covered

- **`useRunningApps`** (5): initial subscription snapshot → apps + per-game status; push events update without polling; subscribe failure falls back to a one-shot poll; unmount tears down both the renderer listener and the main-process subscription; no configured games ⇒ no subscription.
- **`migrations`** (4): the `migrated` flag makes the scan a strict no-op (recurring-data-loss guard); legacy localStorage → named-profile-set conversion (paths, names, inferred customSlots, boolean flags → utilities array); empty storage still latches the flag; `runStartupMigrations` swallows corrupt legacy values so boot can't be blocked.
- **#480 key-order contract** (1): the `useSettingsLoad` snapshot and the `useSettingsState` memo must agree on keys and order — the dirty baseline is a JSON string compare, so drift on either side = phantom dirty. Fails as soon as one side adds a key without the other.
- **`useProfileEditor`** (5): save replaces only the edited profile and preserves siblings verbatim (multi-profile data-loss guard); blank-name fallback; failed save → `false` + editor stays open; last-profile delete refusal; deleting the active profile re-points `activeProfileId` to a survivor.

### Suspected-bug verdicts (from the #494 critic list)

| Suspect | Verdict |
| --- | --- |
| `saveRace.ts` ignores `latestObjects` | **Not a bug.** Returning `savedObjects` is correct — the dirty baseline must reflect what's on disk, so an edit made during save correctly stays dirty. The unused params are vestigial; cleanup candidate for the docs/health phases. |
| `theme.ts` media-listener leak | **Not a bug.** `applyThemeMode` runs `themeMediaCleanup?.()` before registering a new listener. |
| Import preview token leak | **Real but minor.** Cancel button releases the token; only unmount-with-open-dialog leaks it, and it's bounded by the 5-min TTL + clear-on-next-preview (both covered by batch 1 tests). Noted in #494. |
| `useSettingsLoad` save-profile reload race | **Not reachable.** `App.handleNavigate` blocks leaving Settings while dirty, so a GameRow profile save can't fire against in-flight settings edits. |

### Deliberately deferred

GameRow `finally`-guards and App dialog-stacking are integration-heavy (full component tree + provider stack); adjacent flows are already covered by `appDirtyAggregator`/`closeConfirmSave`/`discardPipeline` suites. Documented in #494.

### Test plan

- `npm test` — 279 tests green (15 new)
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean

Part of #494 (batch 3/3). With #496 and this PR merged, phase 1 of the audit trilogy is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
