### PR TITLE
fix: WMI lookup timeout + Windows-convention arg parsing (closes #503, #504)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -27,6 +27,10 @@ import { publishRunningApps } from './running'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { KillFailure, KillFailureReason, KillResult } from './types'
 
+// Generous for a healthy system (the query usually returns in tens of ms) but
+// bounded so a wedged WMI service cannot hang a kill request forever.
+const WMI_LOOKUP_TIMEOUT_MS = 3000
+
 export interface KillAttemptResult {
   processName: string
   success: boolean
@@ -158,11 +162,21 @@ function findProcessIdsByExecutablePath(processName: string, appPath: string) {
       ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
       {
         windowsHide: true,
+        // A hung or slow WMI query (slow disk, process-heavy system) must not
+        // stall the kill pipeline indefinitely. On timeout this surfaces as a
+        // clean kill failure — deliberately NOT a `taskkill /IM` fallback,
+        // which would break the path-scoping safety guarantee and kill
+        // same-named processes the user started outside SimLauncher (#503).
+        timeout: WMI_LOOKUP_TIMEOUT_MS,
         env: { ...process.env, SIMLAUNCHER_TARGET_PROCESS_PATH: path.resolve(appPath) }
       },
       (error, stdout, stderr) => {
         if (error) {
-          const detail = stderr.trim() || stdout.trim() || error.message
+          // execFile sets `killed` when it terminated the child itself —
+          // with a plain timeout option that means the deadline elapsed.
+          const detail = error.killed
+            ? `Process lookup timed out after ${WMI_LOOKUP_TIMEOUT_MS / 1000} seconds.`
+            : stderr.trim() || stdout.trim() || error.message
           console.error(`Failed to find process IDs for ${appPath}: ${detail}`)
           resolve({ processIds: [], detail, accessDenied: isAccessDeniedMessage(detail) })
           return

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -219,10 +219,13 @@ export function parseCommandLineArgs(input: string): string[] {
 
       const charAfterQuote = input[index + backslashCount + 1]
       const quoteEndsToken = charAfterQuote === undefined || /\s/.test(charAfterQuote)
-      // Drive-letter or UNC prefix anywhere in the token so far — quotes are
-      // invalid characters in Windows paths, so a path-looking token cannot
+      // The token itself must BE a path (optionally as a --key=value payload):
+      // drive-letter or UNC prefix at the token start. Anchoring matters — a
+      // sentence merely containing a path (e.g. "Saved under C:\Logs\" today")
+      // must keep the strict literal-quote behaviour. Quotes are invalid
+      // characters in Windows paths, so an actual path token cannot
       // legitimately want a literal quote here.
-      const looksLikeWindowsPath = /[A-Za-z]:[\\/]|^\\\\/.test(current)
+      const looksLikeWindowsPath = /^(?:[^\s"]*=)?(?:[A-Za-z]:[\\/]|\\\\)/.test(current)
 
       if (inQuotes && quoteEndsToken && looksLikeWindowsPath) {
         // The path-friendly deviation described above: `...\" ` closes the

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -173,22 +173,58 @@ export function isRunningExePath(processNames: Set<string>, appPath: string): bo
  * We do not delegate to the shell (`shell: true`) because that would spawn an
  * intermediate cmd.exe and break `detached` process-tree ownership — the child
  * would become a grandchild of cmd.exe rather than a direct child, preventing
- * reliable PID-based kill.  This parser handles the subset of quoting rules
- * that users realistically enter in the Settings UI (double-quoted groups,
- * backslash-escaped quotes).
+ * reliable PID-based kill.
+ *
+ * Backslashes follow the Windows argv convention (CommandLineToArgvW): they
+ * are literal unless they precede a double quote, in which case each pair
+ * collapses to one backslash and an odd remainder escapes the quote. One
+ * deliberate deviation: inside a quoted group, an odd trailing backslash whose
+ * quote is followed by whitespace/end closes the group instead of producing a
+ * literal quote — so `"C:\My Path\" --flag` parses the way users mean it
+ * (a path plus a flag) rather than swallowing the rest of the line (#504).
+ *
+ * Exported for unit tests only — not part of the processes barrel surface.
  */
-function parseCommandLineArgs(input: string) {
+export function parseCommandLineArgs(input: string): string[] {
   const args: string[] = []
   let current = ''
   let inQuotes = false
 
   for (let index = 0; index < input.length; index += 1) {
     const char = input[index]
-    const nextChar = input[index + 1]
 
-    if (char === '\\' && nextChar === '"') {
-      current += nextChar
-      index += 1
+    if (char === '\\') {
+      let backslashCount = 0
+      while (input[index + backslashCount] === '\\') {
+        backslashCount += 1
+      }
+
+      if (input[index + backslashCount] !== '"') {
+        current += '\\'.repeat(backslashCount)
+        index += backslashCount - 1
+        continue
+      }
+
+      current += '\\'.repeat(Math.floor(backslashCount / 2))
+
+      if (backslashCount % 2 === 0) {
+        // Even run: backslashes consumed, the quote toggles on the next pass.
+        index += backslashCount - 1
+        continue
+      }
+
+      const charAfterQuote = input[index + backslashCount + 1]
+      const quoteEndsToken = charAfterQuote === undefined || /\s/.test(charAfterQuote)
+
+      if (inQuotes && quoteEndsToken) {
+        // The path-friendly deviation described above: `...\" ` closes the
+        // quoted group and keeps the backslash.
+        current += '\\'
+        inQuotes = false
+      } else {
+        current += '"'
+      }
+      index += backslashCount // also consumes the quote
       continue
     }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -178,10 +178,14 @@ export function isRunningExePath(processNames: Set<string>, appPath: string): bo
  * Backslashes follow the Windows argv convention (CommandLineToArgvW): they
  * are literal unless they precede a double quote, in which case each pair
  * collapses to one backslash and an odd remainder escapes the quote. One
- * deliberate deviation: inside a quoted group, an odd trailing backslash whose
- * quote is followed by whitespace/end closes the group instead of producing a
- * literal quote — so `"C:\My Path\" --flag` parses the way users mean it
- * (a path plus a flag) rather than swallowing the rest of the line (#504).
+ * deliberate deviation: inside a quoted group whose accumulated content looks
+ * like a Windows path, an odd trailing backslash whose quote is followed by
+ * whitespace/end closes the group instead of producing a literal quote — so
+ * `"C:\My Path\" --flag` parses the way users mean it (a path plus a flag)
+ * rather than swallowing the rest of the line (#504). The path test is what
+ * keeps escaped quotes in non-path arguments (e.g. `"Lap \" time"`) on the
+ * strict Windows behaviour — a literal `"` cannot occur in a Windows path, so
+ * the two intents never genuinely collide.
  *
  * Exported for unit tests only — not part of the processes barrel surface.
  */
@@ -215,8 +219,12 @@ export function parseCommandLineArgs(input: string): string[] {
 
       const charAfterQuote = input[index + backslashCount + 1]
       const quoteEndsToken = charAfterQuote === undefined || /\s/.test(charAfterQuote)
+      // Drive-letter or UNC prefix anywhere in the token so far — quotes are
+      // invalid characters in Windows paths, so a path-looking token cannot
+      // legitimately want a literal quote here.
+      const looksLikeWindowsPath = /[A-Za-z]:[\\/]|^\\\\/.test(current)
 
-      if (inQuotes && quoteEndsToken) {
+      if (inQuotes && quoteEndsToken && looksLikeWindowsPath) {
         // The path-friendly deviation described above: `...\" ` closes the
         // quoted group and keeps the backslash.
         current += '\\'

--- a/tests/main/spawnHelpers.test.ts
+++ b/tests/main/spawnHelpers.test.ts
@@ -95,6 +95,16 @@ test('parseCommandLineArgs handles quoted paths ending in a backslash (#504)', a
   expect(parseCommandLineArgs('--out "D:\\Logs\\"')).toEqual(['--out', 'D:\\Logs\\'])
 })
 
+// Codex P2 on #508: an escaped quote before whitespace inside a NON-path
+// quoted value keeps the strict Windows behaviour (one argument containing a
+// literal quote) — only path-looking tokens get the closing deviation.
+test('parseCommandLineArgs keeps escaped quotes in non-path quoted values', async () => {
+  const { parseCommandLineArgs } = await loadSpawnModule()
+
+  expect(parseCommandLineArgs('--title "Lap \\" time"')).toEqual(['--title', 'Lap " time'])
+  expect(parseCommandLineArgs('"say \\" loudly \\" twice"')).toEqual(['say " loudly " twice'])
+})
+
 test('parseCommandLineArgs keeps backslash runs not followed by a quote literal', async () => {
   const { parseCommandLineArgs } = await loadSpawnModule()
 

--- a/tests/main/spawnHelpers.test.ts
+++ b/tests/main/spawnHelpers.test.ts
@@ -103,6 +103,18 @@ test('parseCommandLineArgs keeps escaped quotes in non-path quoted values', asyn
 
   expect(parseCommandLineArgs('--title "Lap \\" time"')).toEqual(['--title', 'Lap " time'])
   expect(parseCommandLineArgs('"say \\" loudly \\" twice"')).toEqual(['say " loudly " twice'])
+  // A sentence merely CONTAINING a path is not a path token — the heuristic
+  // is anchored to the token start, so the literal quote survives here.
+  expect(parseCommandLineArgs('--title "Saved under C:\\Logs\\" today"')).toEqual([
+    '--title',
+    'Saved under C:\\Logs" today'
+  ])
+})
+
+test('parseCommandLineArgs closes path tokens supplied as --key=value payloads (#504)', async () => {
+  const { parseCommandLineArgs } = await loadSpawnModule()
+
+  expect(parseCommandLineArgs('"--log=C:\\Temp\\" -v')).toEqual(['--log=C:\\Temp\\', '-v'])
 })
 
 test('parseCommandLineArgs keeps backslash runs not followed by a quote literal', async () => {

--- a/tests/main/spawnHelpers.test.ts
+++ b/tests/main/spawnHelpers.test.ts
@@ -72,6 +72,38 @@ test('normalizeLaunchInput resolves a plain game path to the game key', async ()
   })
 })
 
+test('parseCommandLineArgs splits plain and double-quoted arguments', async () => {
+  const { parseCommandLineArgs } = await loadSpawnModule()
+
+  expect(parseCommandLineArgs('--fullscreen -w 1920')).toEqual(['--fullscreen', '-w', '1920'])
+  expect(parseCommandLineArgs('--config "C:\\My Path\\settings.ini"')).toEqual([
+    '--config',
+    'C:\\My Path\\settings.ini'
+  ])
+  expect(parseCommandLineArgs('--title \\"quoted\\"')).toEqual(['--title', '"quoted"'])
+})
+
+// The #504 edge: a quoted path with a trailing backslash must close the quote
+// instead of swallowing the rest of the line into one argument.
+test('parseCommandLineArgs handles quoted paths ending in a backslash (#504)', async () => {
+  const { parseCommandLineArgs } = await loadSpawnModule()
+
+  expect(parseCommandLineArgs('"C:\\My Path\\" --flag')).toEqual(['C:\\My Path\\', '--flag'])
+  // The strict Windows-convention spelling of the same intent.
+  expect(parseCommandLineArgs('"C:\\My Path\\\\" --flag')).toEqual(['C:\\My Path\\', '--flag'])
+  // A trailing-backslash path as the final token.
+  expect(parseCommandLineArgs('--out "D:\\Logs\\"')).toEqual(['--out', 'D:\\Logs\\'])
+})
+
+test('parseCommandLineArgs keeps backslash runs not followed by a quote literal', async () => {
+  const { parseCommandLineArgs } = await loadSpawnModule()
+
+  expect(parseCommandLineArgs('\\\\server\\share\\file.cfg')).toEqual([
+    '\\\\server\\share\\file.cfg'
+  ])
+  expect(parseCommandLineArgs('"a\\\\b c"')).toEqual(['a\\\\b c'])
+})
+
 test('normalizeLaunchInput resolves a plain utility path via appPaths reverse lookup', async () => {
   const { normalizeLaunchInput } = await loadSpawnModule()
   storeData.gamePaths = { iracing: 'C:/Games/iRacingUI.exe' }


### PR DESCRIPTION
﻿## Summary

Two robustness fixes from the Gemini handoff audit.

### #503 — WMI lookup timeout (`kill.ts`)

The PowerShell WMI PID lookup (`findProcessIdsByExecutablePath`) now runs with a 3 s `execFile` timeout, so a wedged WMI service or pathologically slow machine cannot stall the kill pipeline indefinitely. A timeout surfaces as a clean kill failure (unclosed-process warning with a clear message).

**Deliberate deviation from the issue suggestion:** no `taskkill /IM` fallback. The WMI lookup exists precisely to scope kills by executable *path*; falling back to image-name on timeout would kill same-named processes the user started outside SimLauncher — a safety regression worse than the failure it papers over. Noted in #503.

### #504 — Windows-convention arg parsing (`spawn.ts`)

`parseCommandLineArgs` previously treated every `\"` as an escaped quote, so `"C:\My Path\" --flag` swallowed the rest of the line into one argument. It now follows the Windows argv backslash convention (CommandLineToArgvW): backslash pairs before a quote collapse, an odd remainder escapes. Plus one path-friendly deviation, documented in the code: an odd trailing backslash at a token boundary closes the quoted group — so both `"C:\My Path\" --flag` and the strict `"C:\My Path\\" --flag` spelling parse as a path plus a flag. Escaped quotes elsewhere (`\"quoted\"`) behave exactly as before.

### Test plan

- `npm test` — 293 green (6 new parser tests: basic splitting, the #504 trailing-backslash cases incl. strict spelling and final-token form, literal backslash runs/UNC paths)
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- The WMI timeout is a declarative `execFile` option + message branch; the failure path it feeds is covered by the existing kill-pipeline suites

Closes #503, closes #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
