### PR TITLE
chore: community-health files, CHANGELOG backfill, README polish (refs #175)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig baseline for editors that don't read Prettier/ESLint config.
+# https://editorconfig.org — Prettier still owns formatting for the file types
+# it handles; this just keeps non-Prettier files (configs, scripts, markdown)
+# consistent.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Markdown: trailing whitespace can be a meaningful line break, so don't strip it.
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewer for the whole repository.
+# Formalizes the human-review gate: every PR requests review from @Shieldxx.
+* @Shieldxx

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Shows a "Sponsor" button on the repo. The README already invites tips;
+# this wires up the button to the same PayPal link.
+custom: ['https://paypal.me/shieldxx']

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Force new issues through the bug/feature templates so reports arrive
+# structured; the contact links below route everything else off the issue
+# tracker.
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Questions & setup help
+    url: https://simlauncher.com/#faq
+    about: How-to and "how do I configure X" questions — check the FAQ first.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/Stashpeak/SimLauncher/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.
+  # Uncomment after enabling GitHub Discussions on the repo (Settings → Features):
+  # - name: 💬 Discussions
+  #   url: https://github.com/Stashpeak/SimLauncher/discussions
+  #   about: Ideas, questions, and general conversation belong here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ All notable changes to SimLauncher are documented here. The format is based on
 Full per-release notes — including every linked issue and PR — are published on the
 [GitHub Releases page](https://github.com/Stashpeak/SimLauncher/releases).
 
+## [Unreleased]
+
+### Fixed
+
+- The maximize/restore button icon now stays correct when the window is snapped or restored through Windows shortcuts (Win+Up, aero-snap, taskbar double-click), not just the title-bar button.
+- App-argument parsing now follows the Windows convention for quoted paths ending in a backslash (e.g. `"C:\My Path\" --flag`), so the rest of the arguments are no longer swallowed into one token.
+
+### Changed
+
+- The process lookup used when closing apps now times out instead of stalling the close pipeline on a wedged system service.
+
+## [0.9.10] - 2026-06-12
+
+### Fixed
+
+- Launched apps now start in their own folder (working directory). Apps that load files relative to it — like iOverlay's overlay graphics — could previously fail in a loop and leak memory until an out-of-memory freeze when launched through SimLauncher. Elevated launches pass the working directory as well.
+
+## [0.9.9] - 2026-06-02
+
+### Added
+
+- A separate "Show tray icon" toggle, decoupled from minimize-to-tray — hide the tray icon entirely, and the close button then quits.
+- Single-instance lock: launching SimLauncher again focuses the running window (including restore from tray) instead of starting a second copy.
+- Custom tooltips and a styled context menu replacing the native OS ones, with tracked-aware dismiss labels on running-app icons.
+- A Discard button on the sticky unsaved-changes bar, behind a modal confirm.
+- Per-section dirty indicators in Settings, a direct New profile button in the editor header, and an honored launch delay up to 30 s (previously capped silently at 5 s).
+
+### Changed
+
+- Accessibility pass across the app: named icon-only buttons, dialog roles and labels, real modal focus trapping and restore, live regions for toasts, and hidden tab views removed from the focus order and accessibility tree.
+- Reverting an edit back to its saved value now clears the unsaved-changes bar automatically.
+- Unified frosted-glass treatment across the save bar and profile dropdown.
+
+### Fixed
+
+- Profiles created via the editor "+" are removed on discard — no more orphan "New Profile" entries.
+- Ghost "unsaved changes" indicator on Utility Apps after a profile save.
+- The brand wordmark renders crisp at every zoom level.
+- Enter on a focused dialog button no longer also fires the default Save action.
+
 ## [0.9.8] - 2026-06-01
 
 ### Added
@@ -52,3 +92,9 @@ per-sim profile system, config export/import, dynamic custom app slots, the
 auto-updater and tray UX, and the 2026 design overhaul. See the
 [GitHub Releases page](https://github.com/Stashpeak/SimLauncher/releases) for the
 complete history and detailed notes.
+
+[Unreleased]: https://github.com/Stashpeak/SimLauncher/compare/v0.9.10...HEAD
+[0.9.10]: https://github.com/Stashpeak/SimLauncher/compare/v0.9.9...v0.9.10
+[0.9.9]: https://github.com/Stashpeak/SimLauncher/compare/v0.9.8...v0.9.9
+[0.9.8]: https://github.com/Stashpeak/SimLauncher/compare/v0.9.7...v0.9.8
+[0.9.7]: https://github.com/Stashpeak/SimLauncher/compare/v0.9.6...v0.9.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,9 @@ npm run dev
    { key: 'myutil', name: 'My Utility' }
    ```
 
-   `UTILITIES` is a computed export that concatenates `BUILT_IN_UTILITIES` with the
-   user's custom slots, so built-in utilities go in `BUILT_IN_UTILITIES` — not in
-   `UTILITIES`. User-renameable slots are generated automatically as `customapp<N>`
-   keys and must not be authored by hand.
+   Built-in utilities go in `BUILT_IN_UTILITIES`. The user's custom slots are
+   generated automatically as `customapp<N>` keys by `getUtilities(customSlots)`
+   and must not be authored by hand.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ One-click startup for your entire sim racing setup.
 
 Launch iRacing, Assetto Corsa, ACC and other sims on Windows, together with SimHub, Crew Chief, Trading Paints, overlays, telemetry tools and wheelbase software — automatically.
 
-<!-- DEMO_VIDEO: drag-drop assets-source demo.mp4 into the PR conversation to mint the
-     user-attachments URL, then replace this comment with the rendered video link. -->
+https://github.com/user-attachments/assets/0befc41c-ad71-4d75-930c-9bfa680c3ece
 
 **➡️ [Download SimLauncher for Windows](../../releases/latest)**
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ One-click startup for your entire sim racing setup.
 
 Launch iRacing, Assetto Corsa, ACC and other sims on Windows, together with SimHub, Crew Chief, Trading Paints, overlays, telemetry tools and wheelbase software — automatically.
 
+<!-- DEMO_VIDEO: drag-drop assets-source demo.mp4 into the PR conversation to mint the
+     user-attachments URL, then replace this comment with the rendered video link. -->
+
+**➡️ [Download SimLauncher for Windows](../../releases/latest)**
+
+> On first launch Windows SmartScreen may warn that the publisher is unrecognized — the installer isn't code-signed yet. Click **More info → Run anyway**.
+
 <table>
   <tr>
     <td><img alt="Launcher Tab" src="docs/screenshots/Launcher%20Tab.png" /></td>
@@ -24,6 +31,8 @@ Launch iRacing, Assetto Corsa, ACC and other sims on Windows, together with SimH
     <td><img alt="No Games Configured" src="docs/screenshots/Launcher%20Tab%20-%20No%20Games%20Configured.png" /></td>
   </tr>
 </table>
+
+**Jump to:** [Who it's for](#who-is-this-for) · [Features](#features) · [Supported games](#supported-games) · [Installation](#installation) · [Troubleshooting](#troubleshooting) · [Build from source](#building-from-source) · [Security](#security) · [Support](#support)
 
 ---
 
@@ -65,6 +74,8 @@ In that case, your current setup is already simple enough.
 - Start with Windows, start minimized, and minimize to tray options
 - Toast notifications for launch status and errors
 
+---
+
 ## Planned Features
 
 - **Optional auto-close**: Automatically terminate companion apps and utilities when the sim game session ends.
@@ -73,13 +84,17 @@ In that case, your current setup is already simple enough.
 - **Enhanced session management**: Session-state-aware app launching and advanced restart triggers.
 - **Global profile actions**: Explicit "Close Full Profile" and "Close Game" actions for better control.
 
+---
+
 ## Supported Games
 
 Assetto Corsa, Assetto Corsa Competizione, Assetto Corsa Evo, Assetto Corsa Rally, Aerofly FS 4, Automobilista, Automobilista 2, BeamNG, DCS World, Dirt Rally, Dirt Rally 2.0, EA WRC, F1 24, F1 25, IL-2 Sturmovik: Great Battles, iRacing, Le Mans Ultimate, Microsoft Flight Simulator 2020, Microsoft Flight Simulator 2024, Prepar3D, Project Motor Racing, RaceRoom Racing Experience, Richard Burns Rally, Rennsport, rFactor, rFactor 2, X-Plane 12
 
+---
+
 ## Supported Utilities
 
-SimHub, Crew Chief, Trading Paints, Garage 61, Second Monitor, plus up to 20 user-added custom app slots
+**Built-in:** SimHub, Crew Chief, Trading Paints, Garage 61, Second Monitor. **Anything else** — overlays, telemetry tools, wheelbase software — goes in up to 20 user-added custom app slots, each launched the same way.
 
 ---
 
@@ -119,17 +134,17 @@ The installer isn't code-signed yet, so SmartScreen may warn on first launch. Cl
 
 ## Building from source
 
-SimLauncher is a standard Electron + electron-vite project. You need [Node.js](https://nodejs.org/) 24 or newer and npm.
+You can build the installer yourself instead of trusting the published binary. It's a standard Electron + electron-vite project; you need [Node.js](https://nodejs.org/) 24 or newer.
 
 ```bash
-git clone https://github.com/Stashpeak/SimLauncher.git
+git clone https://github.com/Stashpeak/SimLauncher
 cd SimLauncher
 npm install
-npm run dev        # run in development
-npm run dist:win   # build a Windows installer into dist/
+npx install-electron   # Electron >=42 no longer downloads its binary via postinstall
+npm run dist:win       # build a Windows installer into dist/
 ```
 
-Other useful scripts: `npm test` (unit tests), `npm run lint`, and `npm run typecheck`.
+For the full development workflow — running in dev mode, the test/lint/typecheck gates, and how to add a game or utility — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Community-health / open-source readiness pass for 1.0.0 (#175). Docs and repo-meta only — no source code touched.

### Repo-meta files
- `.github/CODEOWNERS` — `* @Shieldxx`, formalizes the human-review gate
- `.editorconfig` — baseline for non-Prettier editors (Prettier still owns the file types it handles)
- `.github/FUNDING.yml` — wires the Sponsor button to the PayPal link the README already mentions
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues off, contact links to the FAQ and the security-advisory form. The Discussions entry is committed **commented-out** — uncomment it after you enable Discussions (Settings → Features).

### Labels
- Created `good first issue`. The rest of #175's list (`chore`, `help wanted`, `wontfix`, `duplicate`, `invalid`) already existed.

### CHANGELOG
- Added `[Unreleased]`, backfilled the missing **0.9.10** and **0.9.9** entries (the changelog had drifted two releases behind), and added the Keep-a-Changelog compare-link chain so each version heading is clickable.

### README
- Leads with a **Download for Windows** callout + an inline SmartScreen one-liner
- Added a **Jump to:** nav line (the doc has 13 H2 sections)
- Normalized the `---` separator rhythm (the Features→Supported Utilities run had 4 back-to-back H2s)
- Slimmed **Building from source** to delegate the full dev workflow to CONTRIBUTING — fixes the `.git` clone-URL drift **and** the missing `npx install-electron` step (README would have failed on Electron ≥42)
- Clarified that overlays/telemetry/wheelbase software are generic custom slots, not dedicated integrations (at the Supported Utilities section; the marketing tagline is untouched)
- Dropped the stale `UTILITIES`-export reference in CONTRIBUTING (that export was removed in #501)

## ⚠️ One manual step from you (demo video)

The README has a `<!-- DEMO_VIDEO -->` placeholder where the launch-flow demo should lead. GitHub only renders an inline video player for files uploaded through its attachment system (a repo-relative `<video>` tag gets stripped, and the GIF version of the 10 s clip is 4–9 MB — too heavy to commit). So:

1. **Drag-drop `simlauncher-web/assets/demo.mp4` into this PR's conversation box.** GitHub uploads it and gives a `https://github.com/user-attachments/assets/…` URL.
2. Paste that URL here (or ping me) and I'll wire it into the README in place of the placeholder before merge.

This keeps the binary out of git history and gives the best quality (same MP4 as the landing page).

## Deliberately left for you (repo settings / assets, not code)
- Enable GitHub Discussions, then uncomment the Discussions contact link
- Custom social/OpenGraph image (repo Settings)
- Pin 1–3 orienting issues
- Decide on commitlint / a dedicated `/docs` surface

## Test plan
- `npm run format:check` clean; no source changed, so test/lint/typecheck are unaffected (CI confirms)

Refs #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
