### PR TITLE
feat(release): SHA-256 checksums + CycloneDX SBOM per release (refs #245)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
 
       - name: Generate SBOM (CycloneDX)
         uses: anchore/sbom-action@v0
+        env:
+          # Electron is a devDependency but electron-builder embeds its
+          # Chromium runtime into the installer, so dev deps must be included
+          # or the shipped, security-critical Electron component is omitted.
+          SYFT_JAVASCRIPT_INCLUDE_DEV_DEPENDENCIES: 'true'
         with:
           file: package-lock.json
           format: cyclonedx-json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,30 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
         run: npx electron-builder --win --publish always
 
+      - name: Generate SHA-256 checksums
+        shell: bash
+        run: |
+          cd dist
+          sha256sum *.exe | tee SHA256SUMS.txt
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          file: package-lock.json
+          format: cyclonedx-json
+          output-file: dist/sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attach checksums and SBOM to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            dist/SHA256SUMS.txt dist/sbom.cdx.json \
+            --repo Stashpeak/SimLauncher --clobber
+
       - name: Generate release notes
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Full per-release notes — including every linked issue and PR — are published
 
 ## [Unreleased]
 
+### Added
+
+- Each release now ships SHA-256 checksums (`SHA256SUMS.txt`) and a CycloneDX SBOM (`sbom.cdx.json`) alongside the installer, so you can verify download integrity and inspect the full dependency inventory.
+
 ### Fixed
 
 - The maximize/restore button icon now stays correct when the window is snapped or restored through Windows shortcuts (Win+Up, aero-snap, taskbar double-click), not just the title-bar button.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ For the full development workflow — running in dev mode, the test/lint/typeche
 - **The source is public** and licensed under **GPL-3.0** — you can read every line, the full commit history, issues, pull requests, and CI runs before trusting a binary.
 - **You can build it yourself** from source (see above) instead of running the published installer.
 - **Releases are built in CI** from tagged commits, and each release's notes link the issues and PRs behind every change.
+- **Every release is verifiable**: each one ships `SHA256SUMS.txt` to confirm the installer's integrity and a CycloneDX `sbom.cdx.json` listing the full dependency inventory.
 - **Development is AI-assisted** (Claude Code, Codex & Gemini) with human review on every change, disclosed openly in the commit history.
 - **Security issues** should be reported privately — see [Security](#security).
 


### PR DESCRIPTION
## What

Adds two verifiable artifacts to every tagged release, covering the **checksums + SBOM** scope of #245 (code signing is the remaining, separately-tracked part):

- **`SHA256SUMS.txt`** — SHA-256 of the installer `.exe`, so anyone can verify their download wasn't tampered with.
- **`sbom.cdx.json`** — a CycloneDX SBOM of the full dependency inventory.

Both are generated after the build and attached to the GitHub release.

## How

Three new steps in `release.yml`, after the existing publish step (which creates the release):

1. `sha256sum *.exe | tee SHA256SUMS.txt`
2. SBOM via `anchore/sbom-action` (syft) reading `package-lock.json`
3. `gh release upload ... --clobber` to attach both

### Why syft and not cyclonedx-npm

`@cyclonedx/cyclonedx-npm` runs `npm ls` under the hood and **hard-crashes** on this repo's tree because `vite@8` violates `electron-vite@5`'s peer range (`ELSPROBLEMS` — the #475 situation). `--ignore-npm-errors` just trades the exit-1 for a `TypeError`. syft parses the lockfile directly and is unaffected, so the SBOM step stays green regardless of the e-vite/vite peer state. No source or dependency changes — this PR is purely CI workflow + docs.

## Docs

- `CHANGELOG.md` → Unreleased / Added
- `README.md` → "Trust & transparency" now states releases are verifiable

## Test plan

- [x] `prettier --check` clean on all changed files
- [x] No source/dependency changes (working tree diff is workflow + 2 docs files only)
- [ ] Verified on the next tagged release: both assets appear on the release and `sha256sum -c SHA256SUMS.txt` validates the installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)