### PR TITLE
fix(subsystem): retry once on a transient file lock before failing open (#505)

### DIFF
--- a/src/main/processes/subsystem.ts
+++ b/src/main/processes/subsystem.ts
@@ -12,16 +12,28 @@ const PE_SIGNATURE = 0x00004550 // 'PE\0\0'
 const SUBSYSTEM_OFFSET = 4 + 20 + 68
 const PE_HEADERS_READ_SIZE = SUBSYSTEM_OFFSET + 2
 
+// Errno codes for a file that exists but is momentarily held by another process
+// (a sharing violation surfaces as EBUSY/EPERM/EACCES on Windows; EMFILE/ENFILE
+// are transient descriptor exhaustion). These warrant one short retry; anything
+// else — a missing file, a malformed PE — is a settled answer that fails open
+// immediately.
+const TRANSIENT_LOCK_CODES = new Set(['EBUSY', 'EACCES', 'EPERM', 'EMFILE', 'ENFILE'])
+const LOCK_RETRY_DELAY_MS = 50
+
+function isTransientLockError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    TRANSIENT_LOCK_CODES.has((error as NodeJS.ErrnoException).code ?? '')
+  )
+}
+
 /**
- * Read the PE optional header's Subsystem field to detect console-subsystem
- * executables. Spawning those with `detached: true` gives them
- * DETACHED_PROCESS — no console is ever created and tools like powershell.exe
- * exit without executing anything (#486), so the spawner needs to know.
- *
- * Fails open: any unreadable/odd file reports `false` (treated as GUI), which
- * preserves the long-standing detached spawn behavior.
+ * Read the PE optional header's Subsystem field. Throws on an I/O failure (so
+ * the caller can decide whether the failure is worth retrying) and returns
+ * `false` for any file that opens cleanly but isn't a console-subsystem PE.
  */
-export async function isConsoleExecutable(exePath: string): Promise<boolean> {
+async function readSubsystemIsConsole(exePath: string): Promise<boolean> {
   let file: fs.promises.FileHandle | undefined
   try {
     file = await fs.promises.open(exePath, 'r')
@@ -40,9 +52,35 @@ export async function isConsoleExecutable(exePath: string): Promise<boolean> {
     }
 
     return peHeaders.readUInt16LE(SUBSYSTEM_OFFSET) === SUBSYSTEM_WINDOWS_CUI
-  } catch {
-    return false
   } finally {
     await file?.close().catch(() => {})
+  }
+}
+
+/**
+ * Read the PE optional header's Subsystem field to detect console-subsystem
+ * executables. Spawning those with `detached: true` gives them
+ * DETACHED_PROCESS — no console is ever created and tools like powershell.exe
+ * exit without executing anything (#486), so the spawner needs to know.
+ *
+ * Fails open: any unreadable/odd file reports `false` (treated as GUI), which
+ * preserves the long-standing detached spawn behavior. A transient sharing
+ * violation (another process briefly holding the file) is retried once after a
+ * short delay before failing open, so a console app isn't misclassified merely
+ * because its file was momentarily locked (#505).
+ */
+export async function isConsoleExecutable(exePath: string): Promise<boolean> {
+  try {
+    return await readSubsystemIsConsole(exePath)
+  } catch (error) {
+    if (!isTransientLockError(error)) {
+      return false
+    }
+    await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_DELAY_MS))
+    try {
+      return await readSubsystemIsConsole(exePath)
+    } catch {
+      return false
+    }
   }
 }

--- a/tests/main/subsystem.test.ts
+++ b/tests/main/subsystem.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, test } from 'vitest'
+import { afterAll, afterEach, expect, test, vi } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -45,6 +45,14 @@ afterAll(() => {
   })
 })
 
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function lockError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`mock ${code}`), { code })
+}
+
 test('detects a console-subsystem PE (#486)', async () => {
   const file = writeFixture('console', buildPeFixture({ subsystem: SUBSYSTEM_CONSOLE }))
   await expect(isConsoleExecutable(file)).resolves.toBe(true)
@@ -72,6 +80,36 @@ test('fails open (non-console) on a truncated file (#486)', async () => {
 
 test('fails open (non-console) on a nonexistent path (#486)', async () => {
   await expect(isConsoleExecutable('C:/does/not/exist.exe')).resolves.toBe(false)
+})
+
+test('retries once on a transient lock and then succeeds (#505)', async () => {
+  const file = writeFixture('lock-retry', buildPeFixture({ subsystem: SUBSYSTEM_CONSOLE }))
+  const realOpen = fs.promises.open
+  const openSpy = vi
+    .spyOn(fs.promises, 'open')
+    .mockRejectedValueOnce(lockError('EBUSY'))
+    .mockImplementation((...args: Parameters<typeof fs.promises.open>) =>
+      realOpen.apply(fs.promises, args)
+    )
+
+  await expect(isConsoleExecutable(file)).resolves.toBe(true)
+  expect(openSpy).toHaveBeenCalledTimes(2)
+})
+
+test('does not retry on a non-transient error (#505)', async () => {
+  const file = writeFixture('no-retry', buildPeFixture({ subsystem: SUBSYSTEM_CONSOLE }))
+  const openSpy = vi.spyOn(fs.promises, 'open').mockRejectedValue(lockError('ENOENT'))
+
+  await expect(isConsoleExecutable(file)).resolves.toBe(false)
+  expect(openSpy).toHaveBeenCalledTimes(1)
+})
+
+test('fails open after the retry still hits the lock (#505)', async () => {
+  const file = writeFixture('lock-persist', buildPeFixture({ subsystem: SUBSYSTEM_CONSOLE }))
+  const openSpy = vi.spyOn(fs.promises, 'open').mockRejectedValue(lockError('EBUSY'))
+
+  await expect(isConsoleExecutable(file)).resolves.toBe(false)
+  expect(openSpy).toHaveBeenCalledTimes(2)
 })
 
 // Real-world sanity against actual Windows system binaries (skipped on the


### PR DESCRIPTION
## What

`isConsoleExecutable` (`src/main/processes/subsystem.ts`) fails open to GUI/detached when the exe can't be read. For a **console** app that misclassification silently restores the pre-#486 detached behavior for that launch — and a transient sharing violation (another process briefly holding the file) shouldn't be enough to trigger it.

## How

- Split the PE-header read into a helper (`readSubsystemIsConsole`) that **throws** on an I/O failure and returns `false` only for files that open cleanly but aren't console PEs.
- `isConsoleExecutable` retries that helper **once after ~50 ms** when the failure is a transient lock (`EBUSY`/`EACCES`/`EPERM`/`EMFILE`/`ENFILE`).
- Settled answers — missing file (`ENOENT`), malformed PE, truncation — still fail open immediately with **no** retry.

Pulled into 1.0.0 from Future as a cheap, no-downside robustness fix for the "stable" milestone (per triage). No real-world repro, low risk.

## Test plan

- [x] 3 new tests: retries once then succeeds; no retry on a non-transient error (`ENOENT`, opened once); fails open after the retry still hits the lock (opened twice)
- [x] Existing #486 subsystem tests unchanged and green
- [x] Full suite 300 passed · typecheck · lint · format all clean

Closes #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #505
<!-- auto-closes -->