### PR TITLE
chore(ci): run tests in CI and guard the release tag against package.json (#514)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,32 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
-      - name: Test
-        run: npm test
-
       - name: Build app
         run: npm run build
 
       - name: Audit dependencies
         run: npm audit --omit=dev
+
+  # SimLauncher only ships on Windows, and the suite exercises Windows-specific
+  # behavior (PowerShell-encoded elevated launches, taskkill/PID resolution) by
+  # reading the real process.platform rather than stubbing it. Running the tests
+  # on a Linux runner takes the non-win32 code paths and fails ~22 process tests,
+  # so the test job runs on windows-latest where the assertions are meaningful.
+  test:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Test
+        run: npm test
+
       - name: Build app
         run: npm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,17 @@ jobs:
           node-version: 24
           cache: npm
 
+      - name: Verify tag matches package.json version
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (version ${tag_version}) does not match package.json version ${pkg_version}. Bump package.json before tagging."
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} matches package.json version ${pkg_version}."
+
       - name: Install dependencies
         run: npm ci
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ npm run dev
 
 ## Code style
 
-- Run `npm run build`, `npm run typecheck`, `npm run lint`, and `npm run format:check` before submitting a PR (CI gates all four).
+- Run `npm test`, `npm run build`, `npm run typecheck`, `npm run lint`, and `npm run format:check` before submitting a PR (CI gates all five).
 - Keep changes focused, with one feature or fix per PR.
 - Keep renderer code in React and TypeScript.
 


### PR DESCRIPTION
Second of three PRs from the pre-1.0.0 readiness audit. Release-pipeline hardening — no product changes.

## Changes

### `ci.yml`: run the test suite
CI ran format / lint / typecheck / build / audit but **never** `npm test`, so the headline 1.0.0 quality investment (coverage 215→308) was local-only and could silently rot. Adds a **Test** step (after typecheck). `CONTRIBUTING.md` updated to list it as a gate (five, not four).

### `release.yml`: assert the tag matches `package.json`
The job built purely from `package.json`'s version; nothing checked it against the pushed tag. A forgotten bump would tag `v1.0.0` yet build `SimLauncher-Setup-0.9.10.exe` with a `latest.yml` advertising `0.9.10` to the entire install base. Adds an early **Verify tag matches package.json version** step (right after Node setup, before the expensive install/build) that fails fast on a mismatch:

```
tag_version="${GITHUB_REF_NAME#v}"
pkg_version="$(node -p "require('./package.json').version")"
[ "$tag_version" = "$pkg_version" ] || exit 1
```

## Test plan
- [x] `prettier --check` clean
- [x] `npm test` green locally (308)
- [ ] (validated on the next real tag) the guard passes when versions match

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #514
<!-- auto-closes -->