### PR TITLE
feat(a11y): reduced-motion, toggle focus, modal Escape, keyboard reorder, restore bounds (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,17 @@ Full per-release notes — including every linked issue and PR — are published
 ### Added
 
 - Each release now ships SHA-256 checksums (`SHA256SUMS.txt`) and a CycloneDX SBOM (`sbom.cdx.json`) alongside the installer, so you can verify download integrity and inspect the full dependency inventory.
+- Utilities in a profile's launch order can now be reordered with the keyboard (up/down buttons), not only by mouse drag.
 
 ### Fixed
 
+- A maximized window now reopens at your previous restored size instead of the full-screen rectangle.
 - The maximize/restore button icon now stays correct when the window is snapped or restored through Windows shortcuts (Win+Up, aero-snap, taskbar double-click), not just the title-bar button.
 - App-argument parsing now follows the Windows convention for quoted paths ending in a backslash (e.g. `"C:\My Path\" --flag`), so the rest of the arguments are no longer swallowed into one token.
 
 ### Changed
 
+- The app now honors the system "reduce motion" setting, Settings toggles show a keyboard focus ring, and Escape closes the import-preview and color-picker dialogs.
 - The process lookup used when closing apps now times out instead of stalling the close pipeline on a wedged system service.
 
 ## [0.9.10] - 2026-06-12

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -175,7 +175,10 @@ export function createWindow(): void {
       return
     }
 
-    store.set('windowBounds', mainWindow.getBounds())
+    // getNormalBounds (not getBounds) so a maximized window persists its
+    // pre-maximize size; otherwise the next launch reopens un-maximized at the
+    // full work-area rectangle and the user's restored size is lost.
+    store.set('windowBounds', mainWindow.getNormalBounds())
 
     const action = decideCloseAction({
       isQuitting: getIsQuitting(),

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -770,3 +770,32 @@ textarea {
 .settings-control-preset {
   width: 4.75rem;
 }
+
+/* Keyboard focus for the Settings toggle switches: the real checkbox is
+   sr-only, so the focus ring goes on the visual track when the peer input is
+   focus-visible. Matches the outline treatment used elsewhere. */
+.peer:focus-visible ~ .toggle-track {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Keyboard reorder buttons (launch order) — visible focus consistent with the
+   app's outline treatment. */
+.reorder-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+/* Respect the OS "reduce motion" preference: neutralize transitions and stop
+   the infinite loops (ping/pulse/spin, toast progress) for vestibular safety.
+   Mirrors the marketing site's reduced-motion support. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -35,7 +35,7 @@ export function ColorPickerPopover({
   // Focus is trapped here rather than via aria-modal because the popover is
   // portalled to document.body and positioned absolutely — a real modal focus
   // trap keeps keyboard users from tabbing into the background settings form.
-  useFocusTrap(true, popoverRef)
+  useFocusTrap(true, popoverRef, undefined, onClose)
 
   useLayoutEffect(() => {
     const updatePosition = () => {

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -101,6 +101,14 @@ function ToastCard({
       return undefined
     }
 
+    // Honor reduced-motion: this progress bar is WAAPI-driven, so the CSS
+    // reduced-motion rules don't cover it. The toast still auto-dismisses on its
+    // own timer; we just skip the shrinking animation. (Optional chaining keeps
+    // it safe in jsdom, which doesn't implement matchMedia.)
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) {
+      return undefined
+    }
+
     const animation = progressElement.animate([{ width: '100%' }, { width: '0%' }], {
       duration: toast.duration,
       easing: 'linear',

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -121,6 +121,51 @@ function renderUtilityRow(
             {orderIndex + 1}
           </span>
         )}
+        {/* Keyboard path for reordering — the drag handle is mouse-only (#515). */}
+        {isEnabled && typeof orderIndex === 'number' && props.enabledUtilityEntries.length > 1 && (
+          <span data-no-row-drag="true" className="flex shrink-0 flex-col gap-0.5">
+            <button
+              type="button"
+              aria-label={`Move ${label} up in launch order`}
+              disabled={orderIndex === 0}
+              onClick={() => {
+                const previous = props.enabledUtilityEntries[orderIndex - 1]
+                if (previous) props.onMoveEnabledUtility(entry.id, previous.id, 'before')
+              }}
+              className="reorder-btn icon-action flex h-3.5 w-5 cursor-pointer items-center justify-center rounded disabled:cursor-default disabled:opacity-30"
+            >
+              <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+                <path
+                  d="M1 5L5 1L9 5"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              aria-label={`Move ${label} down in launch order`}
+              disabled={orderIndex === props.enabledUtilityEntries.length - 1}
+              onClick={() => {
+                const next = props.enabledUtilityEntries[orderIndex + 1]
+                if (next) props.onMoveEnabledUtility(entry.id, next.id, 'after')
+              }}
+              className="reorder-btn icon-action flex h-3.5 w-5 cursor-pointer items-center justify-center rounded disabled:cursor-default disabled:opacity-30"
+            >
+              <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+                <path
+                  d="M1 1L5 5L9 1"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </span>
+        )}
         <Tooltip label="Drag to reorder">
           <div
             className={`icon-action flex h-6 w-5 shrink-0 items-center justify-center rounded ${isEnabled ? 'cursor-grab group-active:cursor-grabbing' : ''}`}

--- a/src/renderer/src/components/settings/ImportPreviewDialog.tsx
+++ b/src/renderer/src/components/settings/ImportPreviewDialog.tsx
@@ -67,7 +67,7 @@ export function ImportPreviewDialog({
   // The trap is conditional on `summary` being present because the dialog may
   // briefly be `isOpen: true` while the summary is still loading — activating
   // the trap on an empty container would immediately focus the wrong element.
-  useFocusTrap(isOpen && !!summary, dialogRef)
+  useFocusTrap(isOpen && !!summary, dialogRef, undefined, onCancel)
 
   if (!isOpen || !summary) return null
 

--- a/src/renderer/src/hooks/useFocusTrap.ts
+++ b/src/renderer/src/hooks/useFocusTrap.ts
@@ -1,4 +1,4 @@
-import { useEffect, type RefObject } from 'react'
+import { useEffect, useRef, type RefObject } from 'react'
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -32,12 +32,25 @@ function setBackgroundInert(inert: boolean): void {
  *
  * The container MUST be rendered OUTSIDE #root (e.g. portaled to document.body)
  * so it is not itself inerted.
+ *
+ * When `onEscape` is provided, Escape closes the dialog. It is handled on the
+ * document in the capture phase with stopImmediatePropagation so it dismisses
+ * this dialog before any background keydown handler (Settings, profile editor)
+ * can see the key — matching ConfirmDialog's own Escape behaviour.
  */
 export function useFocusTrap(
   active: boolean,
   containerRef: RefObject<HTMLElement | null>,
-  initialFocusRef?: RefObject<HTMLElement | null>
+  initialFocusRef?: RefObject<HTMLElement | null>,
+  onEscape?: () => void
 ): void {
+  // Stable ref so passing a fresh onEscape each render does not re-run the trap
+  // (which would re-inert the background and steal focus).
+  const onEscapeRef = useRef(onEscape)
+  useEffect(() => {
+    onEscapeRef.current = onEscape
+  }, [onEscape])
+
   useEffect(() => {
     if (!active) return
     const container = containerRef.current
@@ -86,8 +99,21 @@ export function useFocusTrap(
 
     container.addEventListener('keydown', handleKeyDown)
 
+    // Escape-to-dismiss (when a handler was supplied). Capture phase so it wins
+    // over background document listeners; a no-op when no onEscape was passed.
+    const handleEscape = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      const onEscape = onEscapeRef.current
+      if (!onEscape) return
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      onEscape()
+    }
+    document.addEventListener('keydown', handleEscape, true)
+
     return () => {
       container.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('keydown', handleEscape, true)
       trapDepth = Math.max(0, trapDepth - 1)
       if (trapDepth === 0) setBackgroundInert(false)
       // Restore focus only AFTER un-inerting; focusing an element inside an inert

--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -98,6 +98,7 @@ export class BrowserWindow extends MockEventTarget {
   isDestroyed = vi.fn(() => this.destroyed)
   isMaximized = vi.fn(() => false)
   getBounds = vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 }))
+  getNormalBounds = vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 }))
   loadFile = vi.fn()
   loadURL = vi.fn()
 }

--- a/tests/main/window.test.ts
+++ b/tests/main/window.test.ts
@@ -81,6 +81,8 @@ async function getCreatedWindow() {
     show: ReturnType<typeof vi.fn>
     hide: ReturnType<typeof vi.fn>
     close: ReturnType<typeof vi.fn>
+    getBounds: ReturnType<typeof vi.fn>
+    getNormalBounds: ReturnType<typeof vi.fn>
     webContents: {
       emit: (event: string, ...args: unknown[]) => void
       send: ReturnType<typeof vi.fn>
@@ -165,6 +167,26 @@ test('close quits by default and persists the window bounds first', async () => 
   // Bounds are saved on every close path so the next start restores them.
   expect(storeSet).toHaveBeenCalledWith('windowBounds', { x: 0, y: 0, width: 800, height: 600 })
   expect(closeEvent.preventDefault).not.toHaveBeenCalled()
+})
+
+test('close persists the pre-maximize (normal) bounds, not the maximized rect (#515)', async () => {
+  const { createWindow, storeSet } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+  // A maximized window: getBounds() is the full work-area rect, getNormalBounds()
+  // is the size to restore to. We must persist the latter.
+  win.getBounds.mockReturnValue({ x: 0, y: 0, width: 1920, height: 1040 })
+  win.getNormalBounds.mockReturnValue({ x: 120, y: 90, width: 900, height: 650 })
+
+  win.emit('close', { preventDefault: vi.fn() })
+
+  expect(storeSet).toHaveBeenCalledWith('windowBounds', { x: 120, y: 90, width: 900, height: 650 })
+  expect(storeSet).not.toHaveBeenCalledWith('windowBounds', {
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1040
+  })
 })
 
 test('close hides to tray when minimize-to-tray is enabled', async () => {

--- a/tests/renderer/useFocusTrapEscape.test.tsx
+++ b/tests/renderer/useFocusTrapEscape.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Covers the Escape-to-dismiss support added to useFocusTrap (#515). Two of the
+ * three modal surfaces (ImportPreviewDialog, ColorPickerPopover) had no Escape
+ * handler; they now pass onEscape through the shared hook, which closes on
+ * Escape in the capture phase + stopImmediatePropagation so the key can't leak
+ * to background keydown handlers.
+ */
+
+import { afterEach, expect, test, vi } from 'vitest'
+import { useRef } from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { useFocusTrap } from '../../src/renderer/src/hooks/useFocusTrap'
+
+function Harness({ onEscape }: { onEscape?: () => void }): React.ReactElement {
+  const ref = useRef<HTMLDivElement>(null)
+  useFocusTrap(true, ref, undefined, onEscape)
+  return (
+    <div ref={ref}>
+      <button type="button">inside</button>
+    </div>
+  )
+}
+
+let activeRoot: Root | null = null
+let activeContainer: HTMLDivElement | null = null
+
+async function render(onEscape?: () => void): Promise<HTMLButtonElement> {
+  activeContainer = document.createElement('div')
+  document.body.appendChild(activeContainer)
+  await act(async () => {
+    activeRoot = createRoot(activeContainer!)
+    activeRoot.render(<Harness onEscape={onEscape} />)
+  })
+  return activeContainer.querySelector('button')!
+}
+
+function pressEscape(target: Element): void {
+  act(() => {
+    target.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    )
+  })
+}
+
+afterEach(() => {
+  if (activeRoot) act(() => activeRoot!.unmount())
+  activeContainer?.remove()
+  activeRoot = null
+  activeContainer = null
+})
+
+test('Escape invokes onEscape when provided', async () => {
+  const onEscape = vi.fn()
+  const button = await render(onEscape)
+
+  pressEscape(button)
+
+  expect(onEscape).toHaveBeenCalledTimes(1)
+})
+
+test('Escape is stopped in the capture phase so background handlers do not also fire', async () => {
+  const onEscape = vi.fn()
+  const background = vi.fn()
+  document.addEventListener('keydown', background)
+  const button = await render(onEscape)
+
+  pressEscape(button)
+
+  expect(onEscape).toHaveBeenCalledTimes(1)
+  expect(background).not.toHaveBeenCalled()
+  document.removeEventListener('keydown', background)
+})
+
+test('Escape with no onEscape is a no-op and lets the event reach background handlers', async () => {
+  const background = vi.fn()
+  document.addEventListener('keydown', background)
+  const button = await render(undefined)
+
+  pressEscape(button)
+
+  expect(background).toHaveBeenCalledTimes(1)
+  document.removeEventListener('keydown', background)
+})


### PR DESCRIPTION
Third of three PRs from the pre-1.0.0 readiness audit — the polish/a11y cluster. No new features; all close papercuts that contradict the 0.9.8/0.9.9 a11y investment.

## Changes (all from #515)

| # | Fix | Where |
|---|---|---|
| 1 | **`prefers-reduced-motion`** support — neutralize transitions, stop the infinite ping/pulse/spin loops | `App.css` (one `@media` block) |
| 2 | **Settings toggles get a keyboard focus ring** (the sr-only checkbox left the track with no visible focus — WCAG 2.4.7 regression of the 0.9.9 pass) | `App.css` (`.peer:focus-visible ~ .toggle-track`) |
| 3 | **Escape closes the import-preview & color-picker dialogs** (they had none; `ConfirmDialog` already did) | `useFocusTrap` gains an optional `onEscape` (capture-phase + `stopImmediatePropagation` so it can't leak to background handlers) → wired into both |
| 4 | **Maximized window reopens at the restored size**, not the maximized rect | `window.ts`: `getNormalBounds()` instead of `getBounds()` on close |
| 5 | **Keyboard reorder for launch order** — up/down buttons (drag was mouse-only, a WCAG 2.1.1 failure of an advertised feature) | `ProfileUtilitiesSection` (reuses the existing `moveEnabledUtility`) |

## Notes
- The toggle focus ring is a plain CSS rule (not a Tailwind utility) to match the app's existing `outline: 2px solid var(--focus-ring)` treatment and avoid v4 `outline-style` ambiguity.
- `ConfirmDialog` keeps its own Escape handler (passes no `onEscape`), so there's no double-handling.
- Maximized-**state** restore (re-maximizing on launch) was deliberately left out — it needs renderer icon-sync work and risks desync; the size restore is the load-bearing fix.

## Tests (+4 → 304)
- `window.test.ts`: a maximized close persists `getNormalBounds`, not the maximized rect
- `useFocusTrapEscape.test.tsx`: Escape invokes `onEscape`; capture-phase stop blocks background handlers; no-op (event passes through) when no handler

## Gates
- [x] 304 tests · typecheck · lint · format · build all clean

Closes #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- auto-closes -->
Closes #515
<!-- auto-closes -->