### PR TITLE
reliability: log uncaughtException/unhandledRejection in the main process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Full per-release notes — including every linked issue and PR — are published
 
 - Each release now ships SHA-256 checksums (`SHA256SUMS.txt`) and a CycloneDX SBOM (`sbom.cdx.json`) alongside the installer, so you can verify download integrity and inspect the full dependency inventory.
 - Unexpected background errors are now surfaced as a notification instead of being swallowed silently.
+- Unexpected crashes in the app's main process are now recorded to a `main-error.log` file in the app's data folder, so issues on your machine are easier to diagnose.
 - Utilities in a profile's launch order can now be reordered with the keyboard (up/down buttons), not only by mouse drag.
 
 ### Fixed

--- a/src/main/errorLog.ts
+++ b/src/main/errorLog.ts
@@ -51,8 +51,13 @@ let installed = false
  * crash-exits on an uncaught exception or an unhandled rejection — the app logs
  * the error and keeps running. That is intentional for a desktop app that lives
  * in the tray (a silent hard-exit on a background error is worse UX than limping
- * on), but it does mean the process can continue in a degraded state. Behavior
- * beyond logging (showing a dialog, quitting) is deliberately out of scope.
+ * on), but it does mean the process can continue in a degraded state.
+ *
+ * Where continuing would be wrong — notably a failure during the boot chain,
+ * which would otherwise leave the instance holding the single-instance lock with
+ * no usable window — the call site handles termination itself (see the
+ * `whenReady().then(...).catch(...)` in index.ts) rather than relying on this
+ * log-and-continue default.
  *
  * Idempotent — safe to call more than once.
  */

--- a/src/main/errorLog.ts
+++ b/src/main/errorLog.ts
@@ -1,0 +1,74 @@
+import { app } from 'electron'
+import fs from 'fs'
+import path from 'path'
+
+// Cap the log so a tight error loop can't fill the disk. When the file exceeds
+// MAX_LOG_BYTES it is rotated to a single `.old` companion (bounding the total
+// footprint to ~2x this).
+const MAX_LOG_BYTES = 512 * 1024
+
+function logFilePath(): string {
+  return path.join(app.getPath('userData'), 'main-error.log')
+}
+
+export function formatMainError(kind: string, value: unknown): string {
+  const time = new Date().toISOString()
+
+  if (value instanceof Error) {
+    return `[${time}] ${kind}: ${value.name}: ${value.message}\n${value.stack ?? ''}\n\n`
+  }
+
+  return `[${time}] ${kind}: ${String(value)}\n\n`
+}
+
+// Best-effort append. The crash logger must NEVER throw — a failure here would
+// itself surface as an uncaught error and defeat the purpose — so every fs
+// operation is guarded and swallowed.
+export function writeMainErrorLog(kind: string, value: unknown): void {
+  try {
+    const file = logFilePath()
+
+    try {
+      if (fs.statSync(file).size > MAX_LOG_BYTES) {
+        fs.renameSync(file, `${file}.old`)
+      }
+    } catch {
+      // No existing file (ENOENT) or stat failed — nothing to rotate.
+    }
+
+    fs.appendFileSync(file, formatMainError(kind, value))
+  } catch {
+    // Disk full / file locked / permission denied — give up silently.
+  }
+}
+
+let installed = false
+
+/**
+ * Registers global main-process crash logging to `<userData>/main-error.log`.
+ *
+ * Side effect to be aware of: once these listeners exist, Node no longer
+ * crash-exits on an uncaught exception or an unhandled rejection — the app logs
+ * the error and keeps running. That is intentional for a desktop app that lives
+ * in the tray (a silent hard-exit on a background error is worse UX than limping
+ * on), but it does mean the process can continue in a degraded state. Behavior
+ * beyond logging (showing a dialog, quitting) is deliberately out of scope.
+ *
+ * Idempotent — safe to call more than once.
+ */
+export function installMainProcessErrorLogging(): void {
+  if (installed) {
+    return
+  }
+  installed = true
+
+  process.on('uncaughtException', (error) => {
+    console.error('Uncaught exception in main process:', error)
+    writeMainErrorLog('uncaughtException', error)
+  })
+
+  process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled rejection in main process:', reason)
+    writeMainErrorLog('unhandledRejection', reason)
+  })
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
-import { app } from 'electron'
+import { app, dialog } from 'electron'
 
 import { setIsQuitting } from './app-state'
-import { installMainProcessErrorLogging } from './errorLog'
+import { installMainProcessErrorLogging, writeMainErrorLog } from './errorLog'
 import { registerHandlers } from './ipc'
 import { migrateProfilesToNamedSets } from './migrator'
 import { registerContentSecurityPolicy } from './security'
@@ -35,34 +35,51 @@ if (!gotTheLock) {
     setIsQuitting(true)
   })
 
-  app.whenReady().then(() => {
-    registerContentSecurityPolicy()
-    try {
-      migrateProfilesToNamedSets()
-    } catch (error) {
-      // A malformed legacy profile must not brick boot. migrateProfilesToNamedSets
-      // throws so config import can roll back, but at startup there is no snapshot
-      // to restore: every store write lands only after the migrated shape is fully
-      // built, so a throw leaves the original profiles untouched and the migrated
-      // flags unset, and a future launch retries against the original data.
-      console.error('Profile migration failed; leaving stored profiles unchanged.', error)
-    }
-    registerHandlers()
-    configureTray({
-      getIconPath: getAppIconPath,
-      showMainWindow,
-      quitApp: () => {
-        // Set isQuitting before app.quit() so the window 'close' interceptor
-        // does not cancel the quit triggered from the tray menu. The
-        // 'before-quit' event fires after app.quit() is called, which would be
-        // too late if the interceptor runs first.
-        setIsQuitting(true)
-        app.quit()
+  app
+    .whenReady()
+    .then(() => {
+      registerContentSecurityPolicy()
+      try {
+        migrateProfilesToNamedSets()
+      } catch (error) {
+        // A malformed legacy profile must not brick boot. migrateProfilesToNamedSets
+        // throws so config import can roll back, but at startup there is no snapshot
+        // to restore: every store write lands only after the migrated shape is fully
+        // built, so a throw leaves the original profiles untouched and the migrated
+        // flags unset, and a future launch retries against the original data.
+        console.error('Profile migration failed; leaving stored profiles unchanged.', error)
       }
+      registerHandlers()
+      configureTray({
+        getIconPath: getAppIconPath,
+        showMainWindow,
+        quitApp: () => {
+          // Set isQuitting before app.quit() so the window 'close' interceptor
+          // does not cancel the quit triggered from the tray menu. The
+          // 'before-quit' event fires after app.quit() is called, which would be
+          // too late if the interceptor runs first.
+          setIsQuitting(true)
+          app.quit()
+        }
+      })
+      if (store.get('showTrayIcon') !== false) {
+        createTray()
+      }
+      createWindow()
     })
-    if (store.get('showTrayIcon') !== false) {
-      createTray()
-    }
-    createWindow()
-  })
+    .catch((error) => {
+      // A rejection while bringing up handlers/tray/window must NOT be left to the
+      // global unhandledRejection logger, which logs and keeps the process alive:
+      // that would leave this first instance holding the single-instance lock with
+      // no usable window, and later launches would be routed to the broken process
+      // (the user would have to kill it manually). Log, tell the user, and exit so
+      // the lock is released and a relaunch can start cleanly.
+      writeMainErrorLog('bootFailure', error)
+      console.error('SimLauncher failed to start:', error)
+      dialog.showErrorBox(
+        'SimLauncher failed to start',
+        error instanceof Error ? error.message : String(error)
+      )
+      app.exit(1)
+    })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,12 +1,17 @@
 import { app } from 'electron'
 
 import { setIsQuitting } from './app-state'
+import { installMainProcessErrorLogging } from './errorLog'
 import { registerHandlers } from './ipc'
 import { migrateProfilesToNamedSets } from './migrator'
 import { registerContentSecurityPolicy } from './security'
 import { store } from './store'
 import { configureTray, createTray } from './tray'
 import { createWindow, getAppIconPath, showMainWindow } from './window'
+
+// Register crash logging first, before any other main-process work, so an early
+// failure (lock acquisition, store build, boot) still leaves a diagnostic trail.
+installMainProcessErrorLogging()
 
 // Prevent multiple instances: the first instance acquires the lock; any
 // subsequent launch is redirected to focus the already-running window.

--- a/tests/main/boot.test.ts
+++ b/tests/main/boot.test.ts
@@ -23,6 +23,16 @@ async function bootApp(opts: BootOptions = {}) {
   vi.doMock('../../src/main/security', () => securityMock)
   vi.doMock('../../src/main/security.ts', () => securityMock)
 
+  // Mock crash logging so importing index doesn't register real process-level
+  // uncaughtException/unhandledRejection handlers across the whole test run.
+  const errorLogMock = {
+    installMainProcessErrorLogging: vi.fn()
+  }
+  vi.doMock('./errorLog', () => errorLogMock)
+  vi.doMock('/src/main/errorLog.ts', () => errorLogMock)
+  vi.doMock('../../src/main/errorLog', () => errorLogMock)
+  vi.doMock('../../src/main/errorLog.ts', () => errorLogMock)
+
   const migratorMock = {
     migrateProfilesToNamedSets: vi.fn(() => {
       if (opts.migrateThrows) {
@@ -83,7 +93,15 @@ async function bootApp(opts: BootOptions = {}) {
   await new Promise((resolve) => setTimeout(resolve, 0))
 
   const appState = await import('../../src/main/app-state')
-  return { app: app as typeof mockApp, appState, callLog, trayMock, windowMock, ipcMock }
+  return {
+    app: app as typeof mockApp,
+    appState,
+    callLog,
+    trayMock,
+    windowMock,
+    ipcMock,
+    errorLogMock
+  }
 }
 
 beforeEach(() => {
@@ -113,6 +131,13 @@ test('first instance boots in the documented order', async () => {
     'createTray',
     'createWindow'
   ])
+})
+
+// Crash logging is registered at module load (before the single-instance lock),
+// so even a second instance that quits immediately still has a diagnostic trail.
+test('boot registers main-process crash logging before anything else (#522)', async () => {
+  const { errorLogMock } = await bootApp()
+  expect(errorLogMock.installMainProcessErrorLogging).toHaveBeenCalledTimes(1)
 })
 
 // migrateProfilesToNamedSets throws on a failed store write so config import can

--- a/tests/main/boot.test.ts
+++ b/tests/main/boot.test.ts
@@ -6,6 +6,7 @@ interface BootOptions {
   lockAcquired?: boolean
   showTrayIcon?: boolean
   migrateThrows?: boolean
+  windowThrows?: boolean
 }
 
 // Imports src/main/index for its side effects with every collaborator module
@@ -26,7 +27,8 @@ async function bootApp(opts: BootOptions = {}) {
   // Mock crash logging so importing index doesn't register real process-level
   // uncaughtException/unhandledRejection handlers across the whole test run.
   const errorLogMock = {
-    installMainProcessErrorLogging: vi.fn()
+    installMainProcessErrorLogging: vi.fn(),
+    writeMainErrorLog: vi.fn()
   }
   vi.doMock('./errorLog', () => errorLogMock)
   vi.doMock('/src/main/errorLog.ts', () => errorLogMock)
@@ -67,7 +69,12 @@ async function bootApp(opts: BootOptions = {}) {
   vi.doMock('../../src/main/tray.ts', () => trayMock)
 
   const windowMock = {
-    createWindow: vi.fn(() => callLog.push('createWindow')),
+    createWindow: vi.fn(() => {
+      if (opts.windowThrows) {
+        throw new Error('mock window creation failure')
+      }
+      callLog.push('createWindow')
+    }),
     getAppIconPath: vi.fn(() => 'C:/app/SimLauncher.ico'),
     showMainWindow: vi.fn()
   }
@@ -150,6 +157,21 @@ test('boot survives a profile migration failure and still finishes booting (#513
   // 'migrate' is absent (the mock threw before recording), but boot continued.
   expect(callLog).toEqual(['csp', 'handlers', 'configureTray', 'createTray', 'createWindow'])
   expect(consoleError).toHaveBeenCalled()
+  consoleError.mockRestore()
+})
+
+// A failure bringing up handlers/tray/window must not be swallowed by the global
+// unhandledRejection logger — that would leave this instance holding the
+// single-instance lock with no window. The boot chain's own .catch logs, warns
+// the user, and exits so the lock is released and a relaunch can start (#522).
+test('boot failure logs, shows an error box, and exits so the lock is released (#522)', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const { app, errorLogMock } = await bootApp({ windowThrows: true })
+  const { dialog } = await import('electron')
+
+  expect(errorLogMock.writeMainErrorLog).toHaveBeenCalledWith('bootFailure', expect.any(Error))
+  expect(dialog.showErrorBox).toHaveBeenCalled()
+  expect(app.exit).toHaveBeenCalledWith(1)
   consoleError.mockRestore()
 })
 

--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -168,7 +168,8 @@ export const app = new MockApp()
 
 export const dialog = {
   showOpenDialog: vi.fn(),
-  showSaveDialog: vi.fn()
+  showSaveDialog: vi.fn(),
+  showErrorBox: vi.fn()
 }
 
 export const ipcMain = {

--- a/tests/main/errorLog.test.ts
+++ b/tests/main/errorLog.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+interface FsMock {
+  statSync: ReturnType<typeof vi.fn>
+  renameSync: ReturnType<typeof vi.fn>
+  appendFileSync: ReturnType<typeof vi.fn>
+}
+
+async function loadModule() {
+  vi.resetModules()
+  const appMock = { getPath: vi.fn(() => 'C:/userData') }
+  vi.doMock('electron', () => ({ app: appMock }))
+  const fsMock: FsMock = {
+    statSync: vi.fn(() => ({ size: 0 })),
+    renameSync: vi.fn(),
+    appendFileSync: vi.fn()
+  }
+  vi.doMock('fs', () => ({ default: fsMock }))
+  const mod = await import('../../src/main/errorLog')
+  return { mod, fsMock, appMock }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.doUnmock('electron')
+  vi.doUnmock('fs')
+})
+
+test('formatMainError renders an Error with kind, name, message, stack and an ISO timestamp', async () => {
+  const { mod } = await loadModule()
+
+  const out = mod.formatMainError('uncaughtException', new Error('boom'))
+
+  expect(out).toMatch(/^\[\d{4}-\d\d-\d\dT[\d:.]+Z\] uncaughtException: Error: boom/)
+  expect(out).toContain('at ') // stack frame
+})
+
+test('formatMainError stringifies a non-Error rejection reason', async () => {
+  const { mod } = await loadModule()
+
+  expect(mod.formatMainError('unhandledRejection', 'just a string')).toContain(
+    'unhandledRejection: just a string'
+  )
+  expect(mod.formatMainError('unhandledRejection', { code: 42 })).toContain('[object Object]')
+})
+
+test('writeMainErrorLog appends to <userData>/main-error.log without rotating a small file', async () => {
+  const { mod, fsMock } = await loadModule()
+  fsMock.statSync.mockReturnValue({ size: 100 })
+
+  mod.writeMainErrorLog('uncaughtException', new Error('x'))
+
+  expect(fsMock.renameSync).not.toHaveBeenCalled()
+  expect(fsMock.appendFileSync).toHaveBeenCalledWith(
+    expect.stringContaining('main-error.log'),
+    expect.stringContaining('uncaughtException')
+  )
+})
+
+test('writeMainErrorLog rotates to a .old companion once the file exceeds the cap', async () => {
+  const { mod, fsMock } = await loadModule()
+  fsMock.statSync.mockReturnValue({ size: 600 * 1024 })
+
+  mod.writeMainErrorLog('uncaughtException', new Error('x'))
+
+  expect(fsMock.renameSync).toHaveBeenCalledWith(
+    expect.stringContaining('main-error.log'),
+    expect.stringContaining('main-error.log.old')
+  )
+  expect(fsMock.appendFileSync).toHaveBeenCalled()
+})
+
+test('writeMainErrorLog does not rotate when there is no existing file (stat throws)', async () => {
+  const { mod, fsMock } = await loadModule()
+  fsMock.statSync.mockImplementation(() => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+  })
+
+  mod.writeMainErrorLog('uncaughtException', new Error('x'))
+
+  expect(fsMock.renameSync).not.toHaveBeenCalled()
+  expect(fsMock.appendFileSync).toHaveBeenCalled()
+})
+
+test('writeMainErrorLog never throws even when the disk write fails', async () => {
+  const { mod, fsMock } = await loadModule()
+  fsMock.appendFileSync.mockImplementation(() => {
+    throw new Error('ENOSPC: no space left on device')
+  })
+
+  expect(() => mod.writeMainErrorLog('uncaughtException', new Error('x'))).not.toThrow()
+})
+
+test('installMainProcessErrorLogging registers both handlers exactly once (idempotent)', async () => {
+  const { mod } = await loadModule()
+  const onSpy = vi.spyOn(process, 'on').mockImplementation(() => process)
+
+  mod.installMainProcessErrorLogging()
+  mod.installMainProcessErrorLogging() // second call must be a no-op
+
+  const events = onSpy.mock.calls.map((call) => call[0])
+  expect(events.filter((e) => e === 'uncaughtException')).toHaveLength(1)
+  expect(events.filter((e) => e === 'unhandledRejection')).toHaveLength(1)
+})
+
+test('the registered uncaughtException handler writes the error to the log', async () => {
+  const { mod, fsMock } = await loadModule()
+  const handlers: Record<string, (value: unknown) => void> = {}
+  vi.spyOn(process, 'on').mockImplementation((event: string, handler: (value: unknown) => void) => {
+    handlers[event] = handler
+    return process
+  })
+
+  mod.installMainProcessErrorLogging()
+  handlers.uncaughtException(new Error('kaboom'))
+
+  expect(fsMock.appendFileSync).toHaveBeenCalledWith(
+    expect.stringContaining('main-error.log'),
+    expect.stringContaining('kaboom')
+  )
+})


### PR DESCRIPTION
## What

Adds a global crash-logging net for the **main** process. The renderer already has `ErrorBoundary` + global `error`/`unhandledrejection` handlers; the main process had nothing — an uncaught exception or unhandled rejection in main (tray creation, window-state listeners, updater, etc.) just dumped to stderr and could vanish without a trace on a user's machine.

New `src/main/errorLog.ts` → `installMainProcessErrorLogging()`, registered **first** in `index.ts` (before the single-instance lock) so even an early failure leaves a trail. It:

- logs to `console.error` **and** appends a timestamped entry to `<userData>/main-error.log`;
- rotates to a single `.old` companion once the file passes 512 KB (bounds disk use so an error loop can't fill it);
- **never throws** — every fs op is guarded, so the crash logger can't itself become a crash.

## Design decisions (agreed with @Shieldxx)

- **Log only, no behavior change** beyond logging — no dialog, no forced quit. That's deliberately out of scope.
- ⚠️ Registering these listeners has a side effect: Node no longer crash-exits on an uncaught exception / unhandled rejection in main, so the tray app **logs and keeps running** instead of silently disappearing. For a desktop app that lives in the tray that's the better default (a silent hard-exit is worse UX), but it does mean the process can continue in a degraded state.
- **Redaction:** logs `name` / `message` / `stack` (and the rejection reason); no config or secret dumps.

## Tests

9 new (`errorLog.test.ts` + a boot-wiring assertion): format for Error vs non-Error, append, rotation past the cap, no-rotate when the file is absent, the writer swallowing a failed disk write, idempotent registration of both handlers, the registered handler actually writing, and `index.ts` installing it on boot. Full suite 326 green; typecheck / lint / format clean.

## Note

The actual `main-error.log` write path is best verified on a packaged build (smoke), since the userData folder differs from dev. Logic is unit-covered with mocked fs.

Closes #522.
