### PR TITLE
fix(kill): process kill fails for exe names with a single quote (WQL escaping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Full per-release notes — including every linked issue and PR — are published
 - A maximized window now reopens at your previous restored size instead of the full-screen rectangle.
 - The maximize/restore button icon now stays correct when the window is snapped or restored through Windows shortcuts (Win+Up, aero-snap, taskbar double-click), not just the title-bar button.
 - App-argument parsing now follows the Windows convention for quoted paths ending in a backslash (e.g. `"C:\My Path\" --flag`), so the rest of the arguments are no longer swallowed into one token.
+- Closing an app whose executable name contains a single quote now works (the process lookup no longer builds an invalid query).
 
 ### Changed
 

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -147,14 +147,16 @@ function findProcessIdsByExecutablePath(processName: string, appPath: string) {
       '$target = $env:SIMLAUNCHER_TARGET_PROCESS_PATH',
       '$name = $env:SIMLAUNCHER_TARGET_PROCESS_NAME',
       '$targetPath = [System.IO.Path]::GetFullPath($target)',
-      // WQL string literals escape a single quote by doubling it (like SQL), so
-      // the quote must be doubled when building the filter — NOT when assigning
-      // $name. Interpolating $name straight into the filter would emit
-      // `Name = 'Dave'sApp.exe'` for an exe whose name contains a quote, which
-      // WQL rejects as an invalid query and the process is never found.
-      '$wqlName = $name -replace "\'", "\'\'"',
-      'Get-CimInstance Win32_Process -Filter "Name = \'$wqlName\'" |',
-      '  Where-Object { $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
+      // Match the process name in PowerShell with -ieq rather than in a WQL
+      // `Name = '...'` filter. WQL string-literal quote escaping is ambiguous and
+      // version-dependent (SQL-style doubling vs backslash), and getting it wrong
+      // silently breaks the lookup for exe names containing a single quote — the
+      // exact case this guards (#531). Comparing $_.Name to the env-injected $name
+      // in the host language sidesteps WQL escaping entirely and handles any
+      // character. The (rare, user-initiated) full-process enumeration is bounded
+      // by WMI_LOOKUP_TIMEOUT_MS; precision still comes from the ExecutablePath match.
+      'Get-CimInstance Win32_Process |',
+      '  Where-Object { $_.Name -ieq $name -and $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
       '  Select-Object -ExpandProperty ProcessId |',
       '  ConvertTo-Json -Compress'
     ].join('\n')

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -111,10 +111,6 @@ function isFullExePath(appPath: string | undefined): appPath is string {
   )
 }
 
-function escapeWmiString(value: string) {
-  return value.replace(/'/g, "''")
-}
-
 function parseProcessIds(output: string) {
   const trimmedOutput = output.trim()
 
@@ -144,14 +140,20 @@ function findProcessIdsByExecutablePath(processName: string, appPath: string) {
     accessDenied?: boolean
   }>((resolve) => {
     const script = [
-      // The target path is injected via an environment variable rather than
-      // interpolated directly into the script string. This prevents a path
-      // containing single-quotes or special PowerShell metacharacters from
-      // breaking out of the string literal or injecting arbitrary commands.
+      // Both the target path and the process name are injected via environment
+      // variables rather than interpolated into the script string. This prevents
+      // a value containing single-quotes or PowerShell metacharacters from
+      // breaking out of a string literal or injecting arbitrary commands.
       '$target = $env:SIMLAUNCHER_TARGET_PROCESS_PATH',
-      `$name = '${escapeWmiString(processName)}'`,
+      '$name = $env:SIMLAUNCHER_TARGET_PROCESS_NAME',
       '$targetPath = [System.IO.Path]::GetFullPath($target)',
-      'Get-CimInstance Win32_Process -Filter "Name = \'$name\'" |',
+      // WQL string literals escape a single quote by doubling it (like SQL), so
+      // the quote must be doubled when building the filter — NOT when assigning
+      // $name. Interpolating $name straight into the filter would emit
+      // `Name = 'Dave'sApp.exe'` for an exe whose name contains a quote, which
+      // WQL rejects as an invalid query and the process is never found.
+      '$wqlName = $name -replace "\'", "\'\'"',
+      'Get-CimInstance Win32_Process -Filter "Name = \'$wqlName\'" |',
       '  Where-Object { $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
       '  Select-Object -ExpandProperty ProcessId |',
       '  ConvertTo-Json -Compress'
@@ -168,7 +170,11 @@ function findProcessIdsByExecutablePath(processName: string, appPath: string) {
         // which would break the path-scoping safety guarantee and kill
         // same-named processes the user started outside SimLauncher (#503).
         timeout: WMI_LOOKUP_TIMEOUT_MS,
-        env: { ...process.env, SIMLAUNCHER_TARGET_PROCESS_PATH: path.resolve(appPath) }
+        env: {
+          ...process.env,
+          SIMLAUNCHER_TARGET_PROCESS_PATH: path.resolve(appPath),
+          SIMLAUNCHER_TARGET_PROCESS_NAME: processName
+        }
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1278,10 +1278,10 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
   expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
 })
 
-test('PID lookup injects the name via env and doubles single quotes for WQL (#531)', async () => {
+test('PID lookup injects the name via env and matches it in PowerShell, not WQL (#531)', async () => {
   // An exe whose name contains a single quote (e.g. Dave'sApp.exe) must not break
-  // the Get-CimInstance WQL filter. The name is passed via env (never interpolated)
-  // and the quote is doubled when the filter is built, so WQL stays valid.
+  // the lookup. The name is passed via env (never interpolated) and matched with
+  // -ieq in Where-Object, so no WQL string-literal quote escaping is involved.
   const quotedPath = "C:/Tools/Dave'sApp.exe"
   markExistingPath(quotedPath)
   processNames.add("dave'sapp.exe")
@@ -1305,11 +1305,12 @@ test('PID lookup injects the name via env and doubles single quotes for WQL (#53
   expect((psCall!.options.env as Record<string, string>).SIMLAUNCHER_TARGET_PROCESS_NAME).toContain(
     "'"
   )
-  // WQL doubling happens at filter-build time; the filter uses the doubled var.
-  expect(script).toContain('$wqlName = $name -replace')
-  expect(script).toContain("Name = '$wqlName'")
-  // The raw quoted name must NOT be interpolated into the filter (the bug).
-  expect(script).not.toContain("Name = 'Dave'sApp.exe'")
+  // Name is matched in PowerShell (-ieq), not in a WQL string literal, so no
+  // quote escaping is needed and the WQL Name filter is gone.
+  expect(script).toContain('$_.Name -ieq $name')
+  expect(script).not.toContain('-Filter')
+  // The raw quoted name must never appear in the script (it travels via env).
+  expect(script).not.toContain("Dave'sApp.exe")
 })
 
 test('killProfileApps only kills the PID matching the requested executable path (#341)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -146,7 +146,12 @@ async function loadProcessModules() {
         }
 
         const script = args[args.indexOf('-Command') + 1]
-        const processName = script.match(/\$name = '([^']+)'/)?.[1]?.toLowerCase()
+        // findProcessIdsByExecutablePath now passes the name via env var (#531);
+        // fall back to the legacy in-script form for any other powershell call.
+        const processName = (
+          (options.env?.SIMLAUNCHER_TARGET_PROCESS_NAME as string | undefined) ??
+          script.match(/\$name = '([^']+)'/)?.[1]
+        )?.toLowerCase()
 
         const targetPathEnv = options.env?.SIMLAUNCHER_TARGET_PROCESS_PATH
         if (typeof targetPathEnv !== 'string' || targetPathEnv.length === 0) {
@@ -1271,6 +1276,40 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
     ])
   )
   expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
+})
+
+test('PID lookup injects the name via env and doubles single quotes for WQL (#531)', async () => {
+  // An exe whose name contains a single quote (e.g. Dave'sApp.exe) must not break
+  // the Get-CimInstance WQL filter. The name is passed via env (never interpolated)
+  // and the quote is doubled when the filter is built, so WQL stays valid.
+  const quotedPath = "C:/Tools/Dave'sApp.exe"
+  markExistingPath(quotedPath)
+  processNames.add("dave'sapp.exe")
+  registerProcess(quotedPath, "dave'sapp.exe", '4321')
+  const { killProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { simhub: quotedPath }
+  })
+
+  await killProfileApps('ac', [quotedPath])
+
+  const psCall = execFileCalls.find(
+    (call) =>
+      call.command === 'powershell.exe' &&
+      call.args.some((arg) => arg.includes('Get-CimInstance Win32_Process'))
+  )
+  expect(psCall).toBeDefined()
+  const script = psCall!.args[psCall!.args.length - 1] as string
+
+  // Name comes from the environment, not interpolated into the script string.
+  expect(script).toContain('$name = $env:SIMLAUNCHER_TARGET_PROCESS_NAME')
+  expect((psCall!.options.env as Record<string, string>).SIMLAUNCHER_TARGET_PROCESS_NAME).toContain(
+    "'"
+  )
+  // WQL doubling happens at filter-build time; the filter uses the doubled var.
+  expect(script).toContain('$wqlName = $name -replace')
+  expect(script).toContain("Name = '$wqlName'")
+  // The raw quoted name must NOT be interpolated into the filter (the bug).
+  expect(script).not.toContain("Name = 'Dave'sApp.exe'")
 })
 
 test('killProfileApps only kills the PID matching the requested executable path (#341)', async () => {


### PR DESCRIPTION
Fixes #531. `findProcessIdsByExecutablePath` built a WQL `Get-CimInstance` filter by interpolating the exe name; for a name like `Dave'sApp.exe` WQL got `Name = 'Dave'sApp.exe'` — invalid → throws → the process is never found/killed.

Fix: pass the name via `SIMLAUNCHER_TARGET_PROCESS_NAME` env var (mirrors the target path; no script interpolation) and double the quote for WQL at filter-build time (`$wqlName = $name -replace "'", "''"`). Removed the now-dead `escapeWmiString`. Updated the test mock to read the name from env; added a regression test pinning the doubling + env injection. 328 tests, typecheck, lint, format green.

Closes #531.

<!-- auto-closes -->
Closes #531
<!-- auto-closes -->