### PR TITLE
feat(settings): 'Open logs folder' button in About

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Full per-release notes — including every linked issue and PR — are published
 - Each release now ships SHA-256 checksums (`SHA256SUMS.txt`) and a CycloneDX SBOM (`sbom.cdx.json`) alongside the installer, so you can verify download integrity and inspect the full dependency inventory.
 - Unexpected background errors are now surfaced as a notification instead of being swallowed silently.
 - Unexpected crashes in the app's main process are now recorded to a `main-error.log` file in the app's data folder, so issues on your machine are easier to diagnose.
+- An "Open logs folder" button in Settings → About opens the folder with that crash log and your settings file, so it's easy to find when reporting an issue.
 - Utilities in a profile's launch order can now be reordered with the keyboard (up/down buttons), not only by mouse drag.
 
 ### Fixed

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4,6 +4,7 @@ import { registerConfigHandlers } from './config'
 import { registerContextMenuHandlers } from './context-menu'
 import { registerIconHandlers } from './icons'
 import { registerLaunchHandlers } from './launch'
+import { registerSystemHandlers } from './system'
 
 /**
  * Registers all ipcMain handlers for the application. Must be called once
@@ -21,5 +22,6 @@ export function registerHandlers(): void {
   registerIconHandlers()
   registerContextMenuHandlers()
   registerWindowHandlers()
+  registerSystemHandlers()
   registerUpdaterHandlers(sendToRenderer)
 }

--- a/src/main/ipc/system.ts
+++ b/src/main/ipc/system.ts
@@ -1,0 +1,15 @@
+import { app, ipcMain, shell } from 'electron'
+
+/**
+ * System/OS integration handlers that don't belong to a more specific domain.
+ */
+export function registerSystemHandlers(): void {
+  // Open the app's data folder (where main-error.log and config.json live) in the
+  // OS file manager, so a user can find the crash log to attach to a bug report
+  // without hunting through a hidden %APPDATA% path. The path is fixed and
+  // app-owned — the renderer cannot pass an arbitrary path to open.
+  ipcMain.handle('open-logs-folder', async () => {
+    // shell.openPath resolves to '' on success or an error string on failure.
+    return shell.openPath(app.getPath('userData'))
+  })
+}

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -232,6 +232,7 @@ export interface ElectronAPI {
   getFileIcon: (filePath: string) => Promise<string | null>
   getVersion: () => Promise<string>
   getStartupNotice: () => Promise<StartupNotice | null>
+  openLogsFolder: () => Promise<string>
   dismissAppIcon: (
     appPath: string,
     gameKey: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -126,6 +126,7 @@ const electronAPI: ElectronAPI = {
   getFileIcon: (filePath: string) => ipcRenderer.invoke('get-file-icon', filePath),
   getVersion: () => ipcRenderer.invoke('get-version'),
   getStartupNotice: () => ipcRenderer.invoke('get-startup-notice'),
+  openLogsFolder: () => ipcRenderer.invoke('open-logs-folder'),
   dismissAppIcon: (appPath: string, gameKey: string) =>
     ipcRenderer.invoke('dismiss-app-icon', appPath, gameKey)
 }

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { openLogsFolder } from '../../lib/electron'
+import { useNotify } from '../Notify'
 import { Toggle } from '../Toggle'
 import { useSettingsMeta } from './SettingsMetaContext'
 import type { UpdateInfo, UpdateStatus } from './types'
@@ -27,6 +28,17 @@ export function AboutSection({
   onInstallUpdate
 }: AboutSectionProps): ReactNode {
   const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettingsMeta()
+  const { notify } = useNotify()
+
+  const handleOpenLogsFolder = async () => {
+    // shell.openPath resolves to '' on success or a non-empty error string on
+    // failure (e.g. no file-manager association). Surface that so the click
+    // never looks like it silently did nothing.
+    const error = await openLogsFolder()
+    if (error) {
+      notify('Could not open the logs folder.', 'error')
+    }
+  }
 
   return (
     <>
@@ -45,7 +57,7 @@ export function AboutSection({
         <button
           type="button"
           onClick={() => {
-            void openLogsFolder()
+            void handleOpenLogsFolder()
           }}
           className="action-hover-scale cursor-pointer rounded-lg border border-(--glass-border) px-3 py-1.5 text-xs font-medium text-(--text-secondary)"
         >

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 
+import { openLogsFolder } from '../../lib/electron'
 import { Toggle } from '../Toggle'
 import { useSettingsMeta } from './SettingsMetaContext'
 import type { UpdateInfo, UpdateStatus } from './types'
@@ -32,6 +33,24 @@ export function AboutSection({
       <div className="settings-row">
         <span className="settings-label text-(--text-secondary)">Installed Version</span>
         <span className="select-text text-xs font-mono text-(--text-muted)">v{appVersion}</span>
+      </div>
+
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <span className="settings-label">Diagnostics</span>
+          <span className="settings-sublabel">
+            Open the folder with the crash log and settings file
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void openLogsFolder()
+          }}
+          className="action-hover-scale cursor-pointer rounded-lg border border-(--glass-border) px-3 py-1.5 text-xs font-medium text-(--text-secondary)"
+        >
+          Open logs folder
+        </button>
       </div>
 
       <div className="settings-row">

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -35,4 +35,5 @@ export const getAssetData = window.electronAPI.getAssetData
 export const getFileIcon = window.electronAPI.getFileIcon
 export const getVersion = () => window.electronAPI.getVersion()
 export const getStartupNotice = () => window.electronAPI.getStartupNotice()
+export const openLogsFolder = () => window.electronAPI.openLogsFolder()
 export const dismissAppIcon = window.electronAPI.dismissAppIcon

--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -172,6 +172,11 @@ export const dialog = {
   showErrorBox: vi.fn()
 }
 
+export const shell = {
+  openPath: vi.fn().mockResolvedValue(''),
+  showItemInFolder: vi.fn()
+}
+
 export const ipcMain = {
   handle: vi.fn((channel: string, handler: MockIpcHandler) => {
     __ipcHandlers[channel] = handler

--- a/tests/main/system.test.ts
+++ b/tests/main/system.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import { __ipcHandlers, app, clearIpcHandlers, shell } from './electronMock'
+
+async function loadSystemHandlers() {
+  // No vi.resetModules() here: it would create a fresh electron mock instance
+  // whose __ipcHandlers diverges from the one imported at the top of this file.
+  // system.ts has no module-level state, so re-registering into the shared mock
+  // (cleared first) is sufficient and keeps app/shell mocks shared.
+  clearIpcHandlers()
+  const mod = await import('../../src/main/ipc/system')
+  mod.registerSystemHandlers()
+  return __ipcHandlers
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test('open-logs-folder opens the app userData folder', async () => {
+  ;(app.getPath as ReturnType<typeof vi.fn>).mockReturnValue('C:/userData')
+  const handlers = await loadSystemHandlers()
+
+  expect(handlers['open-logs-folder']).toBeTypeOf('function')
+
+  await handlers['open-logs-folder']()
+
+  expect(app.getPath).toHaveBeenCalledWith('userData')
+  expect(shell.openPath).toHaveBeenCalledWith('C:/userData')
+})
+
+test('open-logs-folder surfaces shell.openPath result (error string on failure)', async () => {
+  ;(shell.openPath as ReturnType<typeof vi.fn>).mockResolvedValueOnce('Failed to open path')
+  const handlers = await loadSystemHandlers()
+
+  await expect(handlers['open-logs-folder']()).resolves.toBe('Failed to open path')
+})


### PR DESCRIPTION
Completes the #522 crash-logging work: gives users a one-click way to open `<userData>` (where `main-error.log` and `config.json` live) so they can attach the log to a bug report instead of hunting through a hidden %APPDATA% path.

- New `src/main/ipc/system.ts` → `registerSystemHandlers()` with an `open-logs-folder` handler (`shell.openPath(app.getPath('userData'))`; fixed app-owned path — the renderer can't pass an arbitrary path to open).
- Wired through preload (`api.ts` + `index.ts`) and `lib/electron.ts`.
- "Open logs folder" button added under Settings → About (new Diagnostics row).
- +2 tests (`system.test.ts`); `shell` added to the electron mock. 329 tests, typecheck, lint, format, build green.

Closes #526.

<!-- auto-closes -->
Closes #526
<!-- auto-closes -->