### PR TITLE
feat(updater): friendlier offline message for update checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Full per-release notes — including every linked issue and PR — are published
 - The app now honors the system "reduce motion" setting, Settings toggles show a keyboard focus ring, and Escape closes the import-preview and color-picker dialogs.
 - The process lookup used when closing apps now times out instead of stalling the close pipeline on a wedged system service.
 - Smaller installer: frontend libraries (React, Tailwind, etc.) are bundled by Vite into the app's own code, so their separate package copies are no longer shipped in the installer, trimming the footprint.
+- Checking for updates while offline now shows a calm "can't reach the update server — check your connection" notice instead of a generic update-failure error.
 
 ## [0.9.10] - 2026-06-12
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -16,6 +16,27 @@ let availableUpdate: UpdateAvailability | null = null
 // without consent would consume bandwidth and could interrupt a race session.
 autoUpdater.autoDownload = false
 
+// A dedicated sim rig is often offline, so the most common update "failure" is
+// simply no connectivity. Distinguish that from a real updater error (corrupt
+// download, server 4xx/5xx, signature mismatch) so the UI can show a calm
+// "can't reach the server" notice instead of a scary generic failure.
+export function isUpdateNetworkError(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code
+  if (
+    typeof code === 'string' &&
+    /^(ENOTFOUND|ETIMEDOUT|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|ENETDOWN)$/.test(
+      code
+    )
+  ) {
+    return true
+  }
+
+  const message = err instanceof Error ? err.message : String(err ?? '')
+  return /\b(ENOTFOUND|ETIMEDOUT|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|ENETDOWN)\b|getaddrinfo|net::ERR_|ERR_INTERNET_DISCONNECTED/i.test(
+    message
+  )
+}
+
 export function registerUpdaterEvents(rendererSender: SendToRenderer): void {
   sendToRenderer = rendererSender
 
@@ -49,7 +70,10 @@ export function registerUpdaterEvents(rendererSender: SendToRenderer): void {
 
   autoUpdater.on('error', (err) => {
     installAfterDownload = false
-    sendToRenderer('update-error', { message: err.message })
+    sendToRenderer('update-error', {
+      message: err.message,
+      isNetworkError: isUpdateNetworkError(err)
+    })
   })
 }
 
@@ -112,7 +136,18 @@ export function registerUpdaterHandlers(rendererSender: SendToRenderer): void {
   })
 
   ipcMain.handle('check-for-updates', async () => {
-    return await checkForUpdates()
+    try {
+      return await checkForUpdates()
+    } catch (err) {
+      // The autoUpdater 'error' event already reported this to the renderer with
+      // a categorized message. For a network failure, swallow the rejection so
+      // the manual-check flow doesn't additionally surface a generic error that
+      // would override the calmer offline notice; re-throw anything else.
+      if (isUpdateNetworkError(err)) {
+        return null
+      }
+      throw err
+    }
   })
 
   ipcMain.handle('get-update-info', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -31,8 +31,13 @@ export function isUpdateNetworkError(err: unknown): boolean {
     return true
   }
 
+  // Match only genuine connectivity failures. In particular do NOT match the
+  // broad `net::ERR_` prefix: that would also classify TLS/security errors like
+  // net::ERR_CERT_AUTHORITY_INVALID as "offline" and (via check-for-updates
+  // swallowing them) hide a real update-server/security misconfiguration behind
+  // the calm offline notice.
   const message = err instanceof Error ? err.message : String(err ?? '')
-  return /\b(ENOTFOUND|ETIMEDOUT|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|ENETDOWN)\b|getaddrinfo|net::ERR_|ERR_INTERNET_DISCONNECTED/i.test(
+  return /\b(ENOTFOUND|ETIMEDOUT|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|ENETDOWN)\b|getaddrinfo|net::ERR_(INTERNET_DISCONNECTED|NAME_NOT_RESOLVED|NAME_RESOLUTION_FAILED|NETWORK_CHANGED|CONNECTION_(REFUSED|TIMED_OUT|RESET|CLOSED|ABORTED)|ADDRESS_UNREACHABLE|PROXY_CONNECTION_FAILED|TIMED_OUT|NETWORK_ACCESS_DENIED)/i.test(
     message
   )
 }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -164,6 +164,16 @@ export interface UpdateAvailability {
 }
 
 /**
+ * Payload for the 'update-error' channel. `isNetworkError` is true when the
+ * failure is just a connectivity problem (offline rig) rather than a real
+ * updater fault, so the renderer can show a calmer message.
+ */
+export interface UpdateErrorPayload {
+  message: string
+  isNetworkError: boolean
+}
+
+/**
  * A one-shot notice the main process surfaces to the renderer on startup (e.g.
  * the persisted config was unreadable and had to be reset). Pulled once via
  * getStartupNotice and shown as a toast; the type maps to a toast variant.
@@ -210,7 +220,7 @@ export interface ElectronAPI {
   onUpdateDownloaded: (cb: (info: UpdateInfo) => void) => Unsubscribe
   onUpdateNotAvailable: (cb: (info: UpdateInfo) => void) => Unsubscribe
   onUpdateDownloadProgress: (cb: (progress: ProgressInfo) => void) => Unsubscribe
-  onUpdateError: (cb: (error: Error) => void) => Unsubscribe
+  onUpdateError: (cb: (error: UpdateErrorPayload) => void) => Unsubscribe
   installUpdate: () => Promise<unknown>
   checkForUpdates: () => Promise<unknown>
   getUpdateInfo: () => Promise<UpdateAvailability | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,7 +4,8 @@ import type {
   ElectronAPI,
   ProcessNameMismatchWarningPayload,
   RunningAppsChangedPayload,
-  StoreConfigChangePayload
+  StoreConfigChangePayload,
+  UpdateErrorPayload
 } from './api'
 
 // The channel strings used in ipcRenderer.invoke / ipcRenderer.on must match
@@ -91,8 +92,8 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.on('update-download-progress', handler)
     return () => ipcRenderer.removeListener('update-download-progress', handler)
   },
-  onUpdateError: (cb: (error: Error) => void) => {
-    const handler = (_: unknown, error: Error) => cb(error)
+  onUpdateError: (cb: (error: UpdateErrorPayload) => void) => {
+    const handler = (_: unknown, error: UpdateErrorPayload) => cb(error)
     ipcRenderer.on('update-error', handler)
     return () => ipcRenderer.removeListener('update-error', handler)
   },

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -85,6 +85,11 @@ export function AboutSection({
             Update failed. Try again later.
           </p>
         )}
+        {updateStatus === 'offline' && (
+          <p className="text-[10px] text-center text-(--text-muted) animate-fade-slide">
+            Can&apos;t reach the update server — check your connection.
+          </p>
+        )}
       </div>
     </>
   )

--- a/src/renderer/src/components/settings/types.ts
+++ b/src/renderer/src/components/settings/types.ts
@@ -1,3 +1,7 @@
 export type UpdateInfo = { version: string } | null
 
-export type UpdateStatus = 'up-to-date' | 'downloaded' | 'error' | null
+export type UpdateStatus = 'up-to-date' | 'downloaded' | 'error' | 'offline' | null
+
+// Payload from the 'update-error' channel. `isNetworkError` distinguishes a
+// connectivity problem (offline rig) from a real updater fault.
+export type UpdateErrorInfo = { message?: string; isNetworkError?: boolean }

--- a/src/renderer/src/components/settings/useUpdateStatus.ts
+++ b/src/renderer/src/components/settings/useUpdateStatus.ts
@@ -10,7 +10,7 @@ import {
   onUpdateError,
   onUpdateNotAvailable
 } from '../../lib/electron'
-import type { UpdateInfo, UpdateStatus } from './types'
+import type { UpdateErrorInfo, UpdateInfo, UpdateStatus } from './types'
 
 type Notify = (message: string, type: 'success' | 'warn' | 'error', durationMs?: number) => void
 
@@ -75,12 +75,19 @@ export function useUpdateStatus({
       setUpdateProgress(null)
       setUpdateStatus('downloaded')
     })
-    const unsubscribeError = onUpdateError((error: Error) => {
+    const unsubscribeError = onUpdateError((error: UpdateErrorInfo) => {
       setCheckingUpdate(false)
       setInstallingUpdate(false)
       setUpdateProgress(null)
-      setUpdateStatus('error')
-      notify(error?.message || 'Update check failed', 'error')
+      if (error?.isNetworkError) {
+        // Offline (common on a dedicated rig) is not a real failure — show a
+        // calm notice rather than a scary "update failed".
+        setUpdateStatus('offline')
+        notify("Can't reach the update server — check your connection.", 'warn')
+      } else {
+        setUpdateStatus('error')
+        notify(error?.message || 'Update check failed', 'error')
+      }
       clearStatusLater(4000)
     })
 

--- a/tests/main/updater.test.ts
+++ b/tests/main/updater.test.ts
@@ -159,6 +159,19 @@ test('check-for-updates swallows a network failure but rethrows other errors (#5
   await expect(handlers['check-for-updates']({})).rejects.toThrow('HTTP 500')
 })
 
+test('a TLS/cert net error is NOT downgraded to offline (#535)', async () => {
+  const { sendToRenderer, handlers } = await loadUpdaterModule()
+
+  autoUpdaterHandlers['error'](new Error('net::ERR_CERT_AUTHORITY_INVALID'))
+  const errorCall = sendToRenderer.mock.calls.find((call) => call[0] === 'update-error')
+  expect(errorCall?.[1]).toMatchObject({ isNetworkError: false })
+
+  // ...and check-for-updates must NOT swallow it — a security/config error should
+  // surface, not hide behind the calm offline notice.
+  autoUpdaterCheckForUpdates.mockRejectedValueOnce(new Error('net::ERR_CERT_AUTHORITY_INVALID'))
+  await expect(handlers['check-for-updates']({})).rejects.toThrow('ERR_CERT_AUTHORITY_INVALID')
+})
+
 test('unpackaged builds simulate the update flow without touching electron-updater', async () => {
   const { updaterModule, handlers, sendToRenderer } = await loadUpdaterModule({
     isPackaged: false

--- a/tests/main/updater.test.ts
+++ b/tests/main/updater.test.ts
@@ -127,6 +127,38 @@ test('an updater error resets the install latch', async () => {
   expect(quitAndInstall).not.toHaveBeenCalled()
 })
 
+test('a network error is flagged so the renderer can show an offline notice (#527)', async () => {
+  const { sendToRenderer } = await loadUpdaterModule()
+
+  autoUpdaterHandlers['error'](
+    Object.assign(new Error('net::ERR_INTERNET_DISCONNECTED'), { code: 'ENOTFOUND' })
+  )
+
+  const errorCall = sendToRenderer.mock.calls.find((call) => call[0] === 'update-error')
+  expect(errorCall?.[1]).toMatchObject({ isNetworkError: true })
+})
+
+test('a non-network updater error is not flagged as network (#527)', async () => {
+  const { sendToRenderer } = await loadUpdaterModule()
+
+  autoUpdaterHandlers['error'](new Error('Checksum mismatch'))
+
+  const errorCall = sendToRenderer.mock.calls.find((call) => call[0] === 'update-error')
+  expect(errorCall?.[1]).toMatchObject({ isNetworkError: false, message: 'Checksum mismatch' })
+})
+
+test('check-for-updates swallows a network failure but rethrows other errors (#527)', async () => {
+  const { handlers } = await loadUpdaterModule()
+
+  autoUpdaterCheckForUpdates.mockRejectedValueOnce(
+    Object.assign(new Error('getaddrinfo ENOTFOUND update.example.com'), { code: 'ENOTFOUND' })
+  )
+  await expect(handlers['check-for-updates']({})).resolves.toBeNull()
+
+  autoUpdaterCheckForUpdates.mockRejectedValueOnce(new Error('HTTP 500 from update server'))
+  await expect(handlers['check-for-updates']({})).rejects.toThrow('HTTP 500')
+})
+
 test('unpackaged builds simulate the update flow without touching electron-updater', async () => {
   const { updaterModule, handlers, sendToRenderer } = await loadUpdaterModule({
     isPackaged: false


### PR DESCRIPTION
On a dedicated (often offline) sim rig, the update check showed a generic "Update failed. Try again later." Now a connectivity failure reads as one.

- `updater.ts`: `isUpdateNetworkError()` detects network errors (ENOTFOUND/ETIMEDOUT/ECONNREFUSED/getaddrinfo/net::ERR_* …) by `err.code` and message; the `error` handler sends an `isNetworkError` flag, and `check-for-updates` swallows network rejections (the error event already reported them) so the manual-check flow doesn't override the offline notice.
- New `offline` update status → Settings → About shows a calm "can't reach the update server — check your connection" message (muted, not red) instead of a generic failure.
- +3 updater tests. 330 tests, typecheck, lint, format green.

Closes #527.

<!-- auto-closes -->
Closes #527
<!-- auto-closes -->