### PR TITLE
feat(a11y): semantic HTML pass - h1/h2 headings, label-linked toggles, header landmark (#520)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -264,9 +264,10 @@ function AppContent() {
     <div
       className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
     >
-      <div className="absolute top-0 left-0 w-full z-20 header-glass">
+      <header className="absolute top-0 left-0 w-full z-20 header-glass">
+        <h1 className="sr-only">SimLauncher</h1>
         <WindowControls view={view} onNavigate={handleNavigate} updateInfo={updateInfo} />
-      </div>
+      </header>
 
       {showImportWarning && (
         <div

--- a/src/renderer/src/components/Toggle.tsx
+++ b/src/renderer/src/components/Toggle.tsx
@@ -29,7 +29,13 @@ export function Toggle({
     >
       <input
         id={id}
-        aria-label={ariaLabel || id}
+        // Only set aria-label when one is explicitly passed. The previous
+        // `ariaLabel || id` fallback injected the raw React useId() string as
+        // the accessible name, which OVERRIDES an associated <label htmlFor={id}>
+        // — a labelled switch would then announce as ":r0:" instead of its text
+        // (#520). No caller relied on the fallback (they all pass aria-label or
+        // a real <label>), so dropping it only removes the bug.
+        aria-label={ariaLabel}
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -446,7 +446,7 @@ export function GameRow({
           <GameIcon game={game} isRunning={isRunning} iconUrl={gameIconUrl} />
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
-              <h3 className="game-title font-normal text-(--text-primary)">{game.name}</h3>
+              <h2 className="game-title font-normal text-(--text-primary)">{game.name}</h2>
             </div>
             <RunningAppsStrip
               runningAppIcons={runningAppIcons}

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useId, type ReactNode } from 'react'
 
 import { openLogsFolder } from '../../lib/electron'
 import { useNotify } from '../Notify'
@@ -27,6 +27,7 @@ export function AboutSection({
   onManualCheck,
   onInstallUpdate
 }: AboutSectionProps): ReactNode {
+  const autoCheckUpdatesId = useId()
   const { autoCheckUpdates, onAutoCheckUpdatesChange } = useSettingsMeta()
   const { notify } = useNotify()
 
@@ -67,13 +68,15 @@ export function AboutSection({
 
       <div className="settings-row">
         <div className="settings-label-group">
-          <span className="settings-label">Automatically check for updates</span>
+          <label htmlFor={autoCheckUpdatesId} className="settings-label">
+            Automatically check for updates
+          </label>
           <span className="settings-sublabel">Check on startup when enabled</span>
         </div>
         <Toggle
+          id={autoCheckUpdatesId}
           checked={autoCheckUpdates}
           onChange={onAutoCheckUpdatesChange}
-          aria-label="Automatically check for updates"
         />
       </div>
 

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { useId, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { DEFAULT_ACCENT_COLOR } from '../../lib/config'
 import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
@@ -30,6 +30,8 @@ const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
 ]
 
 export function AppearanceSection(): ReactNode {
+  const accentBgTintId = useId()
+  const focusActiveTitleId = useId()
   const [showPicker, setShowPicker] = useState(false)
   const customSwatchRef = useRef<HTMLButtonElement>(null)
   const {
@@ -144,20 +146,20 @@ export function AppearanceSection(): ReactNode {
       </div>
 
       <div className="settings-row">
-        <label className="settings-label text-(--text-secondary)">Accent Glow Background</label>
-        <Toggle
-          checked={accentBgTint}
-          onChange={onAccentBgTintChange}
-          aria-label="Toggle accent glow background"
-        />
+        <label htmlFor={accentBgTintId} className="settings-label text-(--text-secondary)">
+          Accent Glow Background
+        </label>
+        <Toggle id={accentBgTintId} checked={accentBgTint} onChange={onAccentBgTintChange} />
       </div>
 
       <div className="settings-row">
-        <label className="settings-label text-(--text-secondary)">Focus active title</label>
+        <label htmlFor={focusActiveTitleId} className="settings-label text-(--text-secondary)">
+          Focus active title
+        </label>
         <Toggle
+          id={focusActiveTitleId}
           checked={focusActiveTitle}
           onChange={onFocusActiveTitleChange}
-          aria-label="Focus active title"
         />
       </div>
 

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useId, type ReactNode } from 'react'
 
 import { Toggle } from '../Toggle'
 import { useBehaviorSettings } from './BehaviorContext'
@@ -11,6 +11,11 @@ const DELAY_PRESETS = [
 ]
 
 export function BehaviorSection(): ReactNode {
+  const startWithWindowsId = useId()
+  const showTrayIconId = useId()
+  const startMinimizedId = useId()
+  const minimizeToTrayId = useId()
+
   const {
     startWithWindows,
     startMinimized,
@@ -29,49 +34,53 @@ export function BehaviorSection(): ReactNode {
     <>
       <div className="settings-row">
         <div className="settings-label-group">
-          <span className="settings-label">Start with Windows</span>
+          <label htmlFor={startWithWindowsId} className="settings-label">
+            Start with Windows
+          </label>
           <span className="settings-sublabel">Launch SimLauncher automatically at login</span>
         </div>
         <Toggle
+          id={startWithWindowsId}
           checked={startWithWindows}
           onChange={onStartWithWindowsChange}
-          aria-label="Start with Windows"
         />
       </div>
       <div className="settings-row">
         <div className="settings-label-group">
-          <span className="settings-label">Show tray icon</span>
+          <label htmlFor={showTrayIconId} className="settings-label">
+            Show tray icon
+          </label>
           <span className="settings-sublabel">Keep a SimLauncher icon in the system tray</span>
         </div>
-        <Toggle
-          checked={showTrayIcon}
-          onChange={onShowTrayIconChange}
-          aria-label="Show tray icon"
-        />
+        <Toggle id={showTrayIconId} checked={showTrayIcon} onChange={onShowTrayIconChange} />
       </div>
       <div className="settings-row">
         <div className="settings-label-group">
-          <span className="settings-label">Start minimized</span>
+          <label htmlFor={startMinimizedId} className="settings-label">
+            Start minimized
+          </label>
           <span className="settings-sublabel">Start hidden in the system tray</span>
         </div>
         <Toggle
+          id={startMinimizedId}
           checked={startMinimized}
           onChange={onStartMinimizedChange}
-          aria-label="Start minimized"
           disabled={!showTrayIcon}
         />
       </div>
       <div className="settings-row">
         <div className="settings-label-group">
-          <span className="settings-label">Minimize to tray on close</span>
+          <label htmlFor={minimizeToTrayId} className="settings-label">
+            Minimize to tray on close
+          </label>
           <span className="settings-sublabel">
             Keep SimLauncher running when the window is closed
           </span>
         </div>
         <Toggle
+          id={minimizeToTrayId}
           checked={minimizeToTray}
           onChange={onMinimizeToTrayChange}
-          aria-label="Minimize to tray on close"
           disabled={!showTrayIcon}
         />
       </div>

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -25,7 +25,7 @@ export function SettingsSection({
         aria-expanded={open}
         aria-controls={regionId}
       >
-        <h3 className="flex flex-1 items-center gap-2 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
+        <h2 className="flex flex-1 items-center gap-2 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
           {title}
           {dirty && (
             <span
@@ -34,7 +34,7 @@ export function SettingsSection({
               aria-label="Unsaved changes in this section"
             />
           )}
-        </h3>
+        </h2>
         <svg
           width="14"
           height="14"

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -18,38 +18,46 @@ export function SettingsSection({
   const regionId = useId()
   return (
     <section className="space-y-4">
-      <button
-        type="button"
-        onClick={() => onOpenChange(!open)}
-        className="flex w-full cursor-pointer items-center gap-2 px-1"
-        aria-expanded={open}
-        aria-controls={regionId}
-      >
-        <h2 className="flex flex-1 items-center gap-2 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
-          {title}
-          {dirty && (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)"
-              title="Unsaved changes"
-              aria-label="Unsaved changes in this section"
-            />
-          )}
-        </h2>
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={`text-(--text-subtle) transition-transform duration-300 ${open ? 'rotate-0' : '-rotate-90'}`}
-          aria-hidden="true"
+      {/* Heading WRAPS the button (WAI-ARIA accordion pattern). A button has
+          presentational children, so a heading placed *inside* it is stripped
+          from the accessibility tree — wrapping keeps the section title in the
+          heading outline while the button stays the disclosure control. The h2
+          is bare: Tailwind preflight zeroes heading margin/font, so this is
+          visually neutral; the visual styling lives on the inner <span>. */}
+      <h2>
+        <button
+          type="button"
+          onClick={() => onOpenChange(!open)}
+          className="flex w-full cursor-pointer items-center gap-2 px-1"
+          aria-expanded={open}
+          aria-controls={regionId}
         >
-          <path d="M3 6l5 5 5-5" />
-        </svg>
-      </button>
+          <span className="flex flex-1 items-center gap-2 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
+            {title}
+            {dirty && (
+              <span
+                className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)"
+                title="Unsaved changes"
+                aria-label="Unsaved changes in this section"
+              />
+            )}
+          </span>
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={`text-(--text-subtle) transition-transform duration-300 ${open ? 'rotate-0' : '-rotate-90'}`}
+            aria-hidden="true"
+          >
+            <path d="M3 6l5 5 5-5" />
+          </svg>
+        </button>
+      </h2>
       <div
         id={regionId}
         role="region"

--- a/tests/renderer/toggleAccessibleName.test.tsx
+++ b/tests/renderer/toggleAccessibleName.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Regression test for #520 (a11y semantic pass).
+ *
+ * Toggle's `<input>` used to set `aria-label={ariaLabel || id}`. That fallback
+ * was unreached until the settings rows started linking a real
+ * `<label htmlFor={id}>` and passing `id` WITHOUT an `aria-label` — at which
+ * point the fallback injected the raw React `useId()` string (e.g. ":r0:") as
+ * the input's aria-label, which OVERRIDES the associated label. A labelled
+ * switch would then announce as ":r0:" instead of its visible text.
+ *
+ * Contract pinned here:
+ *   1. With an `id` and no `aria-label`, the input has NO aria-label attribute,
+ *      so an external <label htmlFor> provides the accessible name.
+ *   2. An explicit `aria-label` is still honoured (used by presentational /
+ *      label-less toggles).
+ */
+
+import { describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { Toggle } from '../../src/renderer/src/components/Toggle'
+
+async function render(ui: React.ReactNode): Promise<{
+  container: HTMLDivElement
+  unmount: () => void
+}> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root: Root | null = null
+  await act(async () => {
+    root = createRoot(container)
+    root.render(ui)
+  })
+  return {
+    container,
+    unmount: () => {
+      act(() => root?.unmount())
+      container.remove()
+    }
+  }
+}
+
+function getCheckbox(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector('input[type="checkbox"]')
+  if (!input) throw new Error('toggle checkbox not found')
+  return input as HTMLInputElement
+}
+
+describe('Toggle accessible name (#520)', () => {
+  test('with an id and no aria-label, the input has no aria-label so a <label htmlFor> can name it', async () => {
+    const { container, unmount } = await render(
+      <>
+        <label htmlFor="demo-toggle">Start with Windows</label>
+        <Toggle id="demo-toggle" checked={false} onChange={vi.fn()} />
+      </>
+    )
+    const input = getCheckbox(container)
+    expect(input.id).toBe('demo-toggle')
+    // The core regression assertion: must NOT fall back to aria-label={id}.
+    expect(input.hasAttribute('aria-label')).toBe(false)
+    unmount()
+  })
+
+  test('an explicit aria-label is still applied (presentational / label-less use)', async () => {
+    const { container, unmount } = await render(
+      <Toggle checked onChange={vi.fn()} aria-label="Mute notifications" />
+    )
+    expect(getCheckbox(container).getAttribute('aria-label')).toBe('Mute notifications')
+    unmount()
+  })
+})


### PR DESCRIPTION
Pre-1.0.0 a11y semantic-HTML pass on the renderer DOM (Gemini implementation + Claude review/fix). Purely semantic — no visual change intended.

## Changes
- **Top-level `<h1>`** — visually-hidden (`sr-only`) app title in the titlebar banner (the normal flow had no `<h1>`; the only one was crash-only in `ErrorBoundary`).
- **Section titles `<h3>` → `<h2>`** (`SettingsSection`, `GameRow`) so headings nest under the `<h1>` without skipping a level.
- **Accordion heading fix** — the settings section title was an `<h2>` *inside* the disclosure `<button>`; a button has presentational children (WAI-ARIA), so the heading was stripped from the a11y tree. Inverted to the WAI-ARIA accordion pattern (`<h2>` wraps the `<button>`) so the title is a real, exposed heading. Bare `<h2>` (Tailwind preflight zeroes margin/font) → visually neutral; title styling moved to an inner `<span>`.
- **Label-linked toggles** — each settings toggle now links its visible text via `<label htmlFor>` + `useId()` and a forwarded `Toggle` `id`; the redundant `aria-label` is dropped on those rows. Clicking the label now toggles the switch.
- **`<header>` landmark** for the titlebar wrapper.

## Review fix (not in the original Gemini batch)
`Toggle`'s input set `aria-label={ariaLabel || id}`. Once rows began passing an `id` without an `aria-label`, the raw React `useId()` string became the input's `aria-label` and **overrode** the associated `<label>` (a labelled switch would announce as ":r0:"). The fallback was previously unreached, so it's dropped; pinned with a regression test (`toggleAccessibleName.test.tsx`).

## Out of scope
- No behavior, styling, or main-process changes.
- Group/segmented controls (UI Scale, Launch delay, Theme, Accent Color) keep their `role="group"` + `aria-label` pattern, untouched.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — 0 warnings
- `npm run format` — clean
- `npm test` — 350/350 pass (incl. 2 new toggle accessible-name regression tests)
- Manual a11y smoke (recommended on packaged build): Tab through Settings → focus ring lands on each switch; clicking a label flips its switch; a11y inspector shows one `<h1>` "SimLauncher", `<h2>` section + game titles exposed under it, and a `banner` landmark for the header.

Closes #520
