### PR TITLE
ci: enforce Conventional-Commit PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,18 +24,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # Types kept in sync with the prefixes used across this repo's history.
+          # Kept in sync with the prefixes used across this repo's history.
           types: |
             feat
             fix
-            chore
             docs
-            perf
-            refactor
-            test
-            ci
-            build
             style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
             revert
+            a11y
+            visual
             security
             reliability

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,41 @@
+name: PR title
+
+# Enforce Conventional-Commit PR titles. `main` uses squash-merge, so the PR
+# title becomes the commit subject on `main` — this guards the visible history.
+# (Feature-branch commits are squashed away, so linting individual commit
+# messages would add little; the PR title is the lever that matters here.)
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Types kept in sync with the prefixes used across this repo's history.
+          types: |
+            feat
+            fix
+            chore
+            docs
+            perf
+            refactor
+            test
+            ci
+            build
+            style
+            revert
+            security
+            reliability


### PR DESCRIPTION
Adds a PR-title lint workflow enforcing Conventional-Commit titles.

Since `main` uses squash-merge, the PR title becomes the commit subject on `main`, so the title is the right lever to keep the visible history conventional — feature-branch commit messages get squashed away. Commits here are AI-authored and already follow the convention; this is a cheap guard against the occasional drift, with zero human friction.

`amannn/action-semantic-pull-request@v5`, triggered on PR title open/edit; the `types` list mirrors this repo's prefixes (incl. `security`, `reliability`).

## Note on activation
`pull_request_target` runs the workflow from the **base** branch, so the check does not run on this PR — it first becomes active on PRs opened after this merges. (Self-check: this PR's own title, `ci: enforce Conventional-Commit PR titles`, is valid under the configured types.)

## Test plan
- No app code touched — `build` / `test` CI unaffected (workflow is additive).
- After merge, the next PR with a non-conventional title should fail the new "PR title" check; a conventional one should pass.

Refs #175
