### PR TITLE
fix(theme): align accent fallbacks to the teal brand, drop dead purple tokens

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -1,11 +1,6 @@
 @import 'tailwindcss' source('./');
 
 :root {
-  --purple-primary: #ad46ff;
-  --purple-solid-hover: #c06cff;
-  --purple-accent: rgba(173, 70, 255, 0.2);
-  --purple-accent-strong: rgba(173, 70, 255, 0.34);
-  --purple-button-text: #e9d4ff;
   --glass-bg: rgba(255, 255, 255, 0.02);
   --glass-bg-elevated: rgba(255, 255, 255, 0.05);
   --glass-border: rgba(255, 255, 255, 0.4);
@@ -14,12 +9,14 @@
   --text-secondary: rgba(255, 255, 255, 0.7);
   --text-muted: rgba(255, 255, 255, 0.5);
   --text-subtle: rgba(255, 255, 255, 0.3);
-  --accent: var(--purple-primary);
+  --accent: #008c99;
   --accent-foreground: #000000;
   --accent-action-foreground: var(--text-primary);
   --accent-glow-opacity: 0.25;
-  --accent-glow: rgba(173, 70, 255, var(--accent-glow-opacity));
-  --focus-ring: rgba(173, 70, 255, 0.25);
+  --accent-glow: rgba(0, 140, 153, var(--accent-glow-opacity));
+  /* Derived from --accent so the keyboard focus ring tracks the live accent
+     (theme.ts sets --accent at runtime); default resolves to the teal brand. */
+  --focus-ring: color-mix(in srgb, var(--accent) 25%, transparent);
   --danger-surface: rgba(244, 63, 94, 0.14);
   --danger-border: rgba(251, 113, 133, 0.28);
   --danger-text: rgba(254, 205, 211, 0.95);
@@ -79,12 +76,12 @@
   --text-secondary: rgba(20, 20, 24, 0.7);
   --text-muted: rgba(20, 20, 24, 0.5);
   --text-subtle: rgba(20, 20, 24, 0.5);
-  --accent: var(--purple-primary);
+  --accent: #008c99;
   --accent-foreground: #000000;
   --accent-action-foreground: var(--text-primary);
   --accent-glow-opacity: 0.22;
-  --accent-glow: rgba(173, 70, 255, var(--accent-glow-opacity));
-  --focus-ring: rgba(173, 70, 255, 0.45);
+  --accent-glow: rgba(0, 140, 153, var(--accent-glow-opacity));
+  --focus-ring: color-mix(in srgb, var(--accent) 45%, transparent);
   --danger-surface: rgba(244, 63, 94, 0.1);
   --danger-border: rgba(200, 35, 60, 0.35);
   --danger-text: rgba(145, 25, 45, 0.95);

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -112,7 +112,7 @@ export function AppearanceSection(): ReactNode {
                   className="absolute inset-0 rounded-full"
                   style={{
                     background: isCustomColor
-                      ? accentCustom || '#ad46ff'
+                      ? accentCustom || DEFAULT_ACCENT_COLOR
                       : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
                   }}
                 />
@@ -135,7 +135,7 @@ export function AppearanceSection(): ReactNode {
 
             {showPicker && (
               <ColorPickerPopover
-                color={accentCustom || '#ad46ff'}
+                color={accentCustom || DEFAULT_ACCENT_COLOR}
                 onChange={onCustomColorChange}
                 onClose={() => setShowPicker(false)}
                 anchorRef={customSwatchRef}


### PR DESCRIPTION
Brand alignment David asked for: make the teal accent consistent and remove leftover purple.

The runtime default accent is already teal (`DEFAULT_ACCENT_COLOR = #008c99`, applied by `theme.ts` on boot), but several purple remnants survived in `App.css`:

- **Static `--accent` / `--accent-glow` fallbacks** (the values used for the first pre-theme frame) were purple → recoloured to teal, removing a possible one-frame purple flash on cold boot.
- **`--focus-ring` was hardcoded purple** and `theme.ts` never overrides it, so the keyboard focus ring rendered **purple at runtime** regardless of the accent → now `color-mix(in srgb, var(--accent) …)`, so it tracks the live accent (teal by default, follows a custom accent too).
- **Dead legacy tokens removed**: `--purple-primary` / `-solid-hover` / `-accent` / `-accent-strong` / `-button-text` (no references anywhere).
- Custom-colour-picker fallback `'#ad46ff'` → `DEFAULT_ACCENT_COLOR`.

Purple stays available only as the user-selectable "Pit Night" accent preset, which is intended.

## Test plan
- `npm run format` / `lint` / `typecheck` — clean
- `npm test` — 350/350
- Pure visual/brand alignment; no behaviour change. (Manual: focus ring + accent glow render teal by default and follow a custom accent.)

Refs #175
