### PR TITLE
a11y: route runtime feedback through a dedicated sr-only announcer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -38,7 +38,7 @@ export default function App(): ReactNode {
 function AppContent() {
   const [view, setView] = useState<'games' | 'settings'>('games')
   const { accentBgTint, syncThemeFromStore } = useTheme()
-  const { notify } = useNotify()
+  const { notify, announce } = useNotify()
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
   const [showImportWarning, setShowImportWarning] = useState(false)
   const [pendingView, setPendingView] = useState<'games' | 'settings' | null>(null)
@@ -54,6 +54,11 @@ function AppContent() {
   // would both bind global Enter/Escape and a single keypress could fire both.
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false)
   const { isAnyDirty, reportSettingsDirty, requestSaveAll, requestDiscardAll } = useAppDirty()
+
+  // Remembers the version we last announced so the live event and the
+  // getUpdateInfo() hydration (which can both deliver the same version) don't
+  // announce it twice.
+  const announcedUpdateRef = useRef<string | null>(null)
 
   // Mirror so the once-registered close-request handler reads the latest value
   // without re-subscribing.
@@ -121,7 +126,14 @@ function AppContent() {
     })
 
     const applyUpdateInfo = (info: { version?: string } | null) => {
-      if (info?.version) setUpdateInfo({ version: info.version })
+      if (!info?.version) return
+      setUpdateInfo({ version: info.version })
+      // The update pill is otherwise silent on the Games view — announce it once
+      // per version through the SR live region.
+      if (announcedUpdateRef.current !== info.version) {
+        announcedUpdateRef.current = info.version
+        announce(`Update version ${info.version} available`)
+      }
     }
 
     // Listen for auto-updates, then hydrate any update result that arrived before React mounted.
@@ -139,7 +151,7 @@ function AppContent() {
       cancelled = true
       unsubscribe()
     }
-  }, [syncThemeFromStore])
+  }, [syncThemeFromStore, announce])
 
   // Gate tab navigation behind the discard/save confirm dialog when dirty.
   // The actual view switch is deferred to handleConfirmDiscard/Save so the

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -4,6 +4,7 @@ import { getSettings } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
+import { useNotify } from './Notify'
 import { useGamesSettings } from './settings/GamesContext'
 import { EmptyState } from './EmptyState'
 import { GameRow } from './game-list/GameRow'
@@ -31,7 +32,15 @@ export function GameList({
   const [appIconCache, setAppIconCache] = useState<Record<string, string>>({})
   const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
   const [focusActiveTitle, setFocusActiveTitle] = useState(true)
-  const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock()
+  const { announce } = useNotify()
+  // Announce a launch as "now running" once its cooldown settles. Resolved from
+  // the static GAMES config (never stale) so the timer closure stays correct.
+  const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock({
+    onLaunchSettled: (gameKey) => {
+      const name = GAMES.find((game) => game.key === gameKey)?.name
+      if (name) announce(`${name} is now running`)
+    }
+  })
   const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
   const { gameIcons } = useGamesSettings()
 

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -33,15 +33,22 @@ export function GameList({
   const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
   const [focusActiveTitle, setFocusActiveTitle] = useState(true)
   const { announce } = useNotify()
-  // Announce a launch as "now running" once its cooldown settles. Resolved from
-  // the static GAMES config (never stale) so the timer closure stays correct.
+  const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
+  // Announce "X is now running" once a launch cooldown settles — but only if the
+  // game is actually running by then. The cooldown also runs on partial failures
+  // (a companion app started while the game exe failed), where the user has
+  // already heard the assertive error; gating on the live runningStatus avoids a
+  // contradictory "now running" follow-up. useLaunchBlock always invokes the
+  // latest callback, so this reads the freshest running state (the 10s cooldown
+  // is exactly the window for process detection to catch up). The name comes
+  // from the static GAMES config so the timer closure can't go stale.
   const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock({
     onLaunchSettled: (gameKey) => {
+      if (!runningStatus[gameKey]) return
       const name = GAMES.find((game) => game.key === gameKey)?.name
       if (name) announce(`${name} is now running`)
     }
   })
-  const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
   const { gameIcons } = useGamesSettings()
 
   useEffect(() => {

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -35,16 +35,25 @@ export function GameList({
   const { announce } = useNotify()
   const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
   // Announce "X is now running" once a launch cooldown settles — but only if the
-  // game is actually running by then. The cooldown also runs on partial failures
-  // (a companion app started while the game exe failed), where the user has
-  // already heard the assertive error; gating on the live runningStatus avoids a
-  // contradictory "now running" follow-up. useLaunchBlock always invokes the
-  // latest callback, so this reads the freshest running state (the 10s cooldown
-  // is exactly the window for process detection to catch up). The name comes
-  // from the static GAMES config so the timer closure can't go stale.
+  // game EXECUTABLE itself is detected running by then. The cooldown also runs on
+  // partial failures (a companion app started while the game exe failed), and
+  // runningStatus[key] is an aggregate that's true for any app under the key
+  // (companions included), so it would still fire there after the user already
+  // heard the assertive error. Match a running app against the configured game
+  // path instead (same game-vs-companion split used for the running strip), so a
+  // failed game launch stays silent. useLaunchBlock always invokes the latest
+  // callback, so this reads the freshest snapshot (the 10s cooldown is the window
+  // for process detection to catch up). Name comes from the static GAMES config
+  // so the timer closure can't go stale.
   const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock({
     onLaunchSettled: (gameKey) => {
-      if (!runningStatus[gameKey]) return
+      const gamePath = gamePaths[gameKey]
+      if (!gamePath) return
+      const gamePathLower = normalizePath(gamePath)
+      const gameExeRunning = runningApps.some(
+        (app) => app.gameKey === gameKey && normalizePath(app.path) === gamePathLower
+      )
+      if (!gameExeRunning) return
       const name = GAMES.find((game) => game.key === gameKey)?.name
       if (name) announce(`${name} is now running`)
     }

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -16,6 +16,8 @@ import { CheckIcon, WarningTriangleIcon, ErrorIcon } from './icons'
 
 type ToastType = 'success' | 'warn' | 'error'
 
+type Politeness = 'polite' | 'assertive'
+
 interface Toast {
   id: number
   message: string
@@ -24,10 +26,23 @@ interface Toast {
 }
 
 interface NotifyContextValue {
+  /** Show a visual toast AND announce its message to screen readers. */
   notify: (message: string, type: ToastType, durationMs?: number) => void
+  /**
+   * Announce a message to screen readers only (no visual toast) — for state
+   * changes that already have their own visible indicator (update pill, a row
+   * going green). Errors should pass 'assertive' so they interrupt.
+   */
+  announce: (message: string, politeness?: Politeness) => void
 }
 
 export const NotifyContext = createContext<NotifyContextValue | null>(null)
+
+// Appended to alternating announcements so two identical consecutive messages
+// still register as a DOM text change (otherwise a screen reader stays silent on
+// the repeat). U+200B is zero-width and not spoken, so it is invisible to both
+// sighted and AT users.
+const ANNOUNCE_SEPARATOR = '​'
 
 const TOAST_PROGRESS_CLASSES: Record<ToastType, string> = {
   success: 'toast-progress-success',
@@ -119,9 +134,17 @@ function ToastCard({
   }, [toast.duration, toast.id])
 
   return (
+    // The toast is a purely visual echo: the message is spoken through the
+    // dedicated live-region announcer (see NotifyProvider), so the whole card is
+    // aria-hidden to avoid double-announcement and the old "— dismiss
+    // notification" pollution. tabIndex={-1} keeps this focusable control out of
+    // the Tab order so it isn't a focusable node inside an aria-hidden subtree;
+    // keyboard/AT users rely on the auto-dismiss timer, mouse users can click.
     <button
       type="button"
-      aria-label={`${toast.message} — dismiss notification`}
+      aria-hidden="true"
+      tabIndex={-1}
+      title="Dismiss"
       className={`toast-card glass-surface overflow-hidden relative rounded-[18px] text-left px-[16px] py-[14px] min-w-[280px] max-w-[400px] shadow-[0_8px_30px_#00000050] transition-all duration-250 ease-out ${TOAST_STYLES[toast.type]} ${isDismissing ? 'toast-card-dismissing opacity-0 translate-x-5 scale-95' : 'opacity-100 translate-x-0 scale-100'}`}
       onClick={() => onDismiss(toast.id)}
     >
@@ -144,6 +167,26 @@ export function NotifyProvider({ children }: { children: ReactNode }): ReactNode
   const [toasts, setToasts] = useState<Toast[]>([])
   const [dismissingToastIds, setDismissingToastIds] = useState<Set<number>>(() => new Set())
   const dismissTimersRef = useRef<Map<number, number>>(new Map())
+
+  // Dedicated screen-reader announcer: two always-rendered visually-hidden live
+  // regions. Keeping them mounted (rather than conditionally rendering on a
+  // message) is what makes the announcement reliable — the region exists before
+  // its text changes. Errors go to the assertive region so they interrupt;
+  // everything else is polite.
+  const [politeMessage, setPoliteMessage] = useState('')
+  const [assertiveMessage, setAssertiveMessage] = useState('')
+  const politeAltRef = useRef(false)
+  const assertiveAltRef = useRef(false)
+
+  const announce = useCallback<NotifyContextValue['announce']>((message, politeness = 'polite') => {
+    if (politeness === 'assertive') {
+      assertiveAltRef.current = !assertiveAltRef.current
+      setAssertiveMessage(assertiveAltRef.current ? message : message + ANNOUNCE_SEPARATOR)
+    } else {
+      politeAltRef.current = !politeAltRef.current
+      setPoliteMessage(politeAltRef.current ? message : message + ANNOUNCE_SEPARATOR)
+    }
+  }, [])
 
   const removeToast = useCallback((id: number) => {
     const dismissTimer = dismissTimersRef.current.get(id)
@@ -191,16 +234,22 @@ export function NotifyProvider({ children }: { children: ReactNode }): ReactNode
     }
   }, [])
 
-  const notify = useCallback<NotifyContextValue['notify']>((message, type, durationMs = 3000) => {
-    const toast: Toast = {
-      id: ++toastId,
-      message,
-      type,
-      duration: durationMs
-    }
+  const notify = useCallback<NotifyContextValue['notify']>(
+    (message, type, durationMs = 3000) => {
+      const toast: Toast = {
+        id: ++toastId,
+        message,
+        type,
+        duration: durationMs
+      }
 
-    setToasts((current) => [...current, toast])
-  }, [])
+      setToasts((current) => [...current, toast])
+      // Speak the same message through the live-region announcer; errors
+      // interrupt (assertive), success/warn wait their turn (polite).
+      announce(message, type === 'error' ? 'assertive' : 'polite')
+    },
+    [announce]
+  )
 
   useEffect(() => {
     return onAppLaunchError((data: unknown) => {
@@ -214,16 +263,26 @@ export function NotifyProvider({ children }: { children: ReactNode }): ReactNode
     })
   }, [notify])
 
-  const value = useMemo(() => ({ notify }), [notify])
+  const value = useMemo(() => ({ notify, announce }), [notify, announce])
 
   return (
     <NotifyContext.Provider value={value}>
       {children}
+      {/* Always-rendered visually-hidden announcer. role + aria-live are stated
+          explicitly (role=status implies polite, role=alert implies assertive)
+          for clarity and cross-AT reliability. aria-atomic so the full message
+          is re-read on every change. */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {politeMessage}
+      </div>
+      <div className="sr-only" role="alert" aria-live="assertive" aria-atomic="true">
+        {assertiveMessage}
+      </div>
       {createPortal(
+        // Visual-only toast stack — aria-hidden because the announcer above
+        // carries the message to assistive tech.
         <div
-          role="status"
-          aria-live="polite"
-          aria-atomic="false"
+          aria-hidden="true"
           className="fixed right-[25px] bottom-[25px] flex flex-col gap-3 z-9999"
         >
           {toasts.map((toast) => (

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -53,7 +53,10 @@ export function GameRow({
   isLaunching: boolean
   isLaunchBlocked: boolean
   onLaunchStart: (gameKey: string) => void
-  onLaunchEnd: (gameKey: string, cooldownMs?: number) => void
+  // `primaryLaunch` marks a fresh game launch (vs a profile switch / relaunch-
+  // missing) so the launch-block only speaks the "now running" cue after a real
+  // launch.
+  onLaunchEnd: (gameKey: string, cooldownMs?: number, options?: { primaryLaunch?: boolean }) => void
   onRunningStateRefresh: () => Promise<void>
   onToggleEditor: () => void
   // Explicit close for this row's editor (key-guarded functional update) so the
@@ -351,7 +354,7 @@ export function GameRow({
       notify('Failed to launch profile', 'error')
       console.error(err)
     } finally {
-      onLaunchEnd(game.key, cooldownMs)
+      onLaunchEnd(game.key, cooldownMs, { primaryLaunch: true })
     }
   }
 
@@ -512,7 +515,9 @@ export function GameRow({
                   handleLaunchRequest.current = launcher
                 }}
                 onLaunchStart={() => onLaunchStart(game.key)}
-                onLaunchEnd={(cooldownMs) => onLaunchEnd(game.key, cooldownMs)}
+                onLaunchEnd={(cooldownMs) =>
+                  onLaunchEnd(game.key, cooldownMs, { primaryLaunch: true })
+                }
               />
             </div>
           )}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -333,6 +333,11 @@ export function GameRow({
       return
     }
 
+    // Capture BEFORE launching: this is a fresh game start only if the game
+    // wasn't already running. If it was (e.g. started outside SimLauncher and the
+    // user clicks Launch to start companion apps), the game exe would still be
+    // running at cooldown end and wrongly trigger the "now running" cue.
+    const wasRunning = isRunning
     let cooldownMs = 0
 
     try {
@@ -354,7 +359,7 @@ export function GameRow({
       notify('Failed to launch profile', 'error')
       console.error(err)
     } finally {
-      onLaunchEnd(game.key, cooldownMs, { primaryLaunch: true })
+      onLaunchEnd(game.key, cooldownMs, { primaryLaunch: !wasRunning })
     }
   }
 
@@ -515,8 +520,11 @@ export function GameRow({
                   handleLaunchRequest.current = launcher
                 }}
                 onLaunchStart={() => onLaunchStart(game.key)}
+                // primaryLaunch only when the game wasn't already running, so the
+                // "now running" cue isn't spoken for a launch that merely
+                // (re)starts companion apps for an already-running game.
                 onLaunchEnd={(cooldownMs) =>
-                  onLaunchEnd(game.key, cooldownMs, { primaryLaunch: true })
+                  onLaunchEnd(game.key, cooldownMs, { primaryLaunch: !isRunning })
                 }
               />
             </div>

--- a/src/renderer/src/hooks/useLaunchBlock.ts
+++ b/src/renderer/src/hooks/useLaunchBlock.ts
@@ -1,5 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
 
+export interface UseLaunchBlockOptions {
+  /**
+   * Called once the post-launch cooldown for a game lapses — i.e. the launch
+   * sequence has fully settled. Only fires when a cooldown actually ran (apps
+   * were started), so it is a reliable "now running" signal. Not called if a new
+   * launch pre-empts the cooldown or the component unmounts first.
+   */
+  onLaunchSettled?: (gameKey: string) => void
+}
+
 export interface UseLaunchBlockResult {
   /** The game currently in its launch sequence, or null when idle. */
   launchingGameKey: string | null
@@ -14,9 +24,15 @@ export interface UseLaunchBlockResult {
   handleLaunchEnd: (finishedGameKey: string, cooldownMs?: number) => void
 }
 
-export function useLaunchBlock(): UseLaunchBlockResult {
+export function useLaunchBlock(options: UseLaunchBlockOptions = {}): UseLaunchBlockResult {
+  const { onLaunchSettled } = options
   const [launchingGameKey, setLaunchingGameKey] = useState<string | null>(null)
   const launchBlockTimeoutRef = useRef<number | null>(null)
+
+  // Read the latest callback from the cooldown timer without re-subscribing or
+  // baking a stale closure into the scheduled timeout.
+  const onLaunchSettledRef = useRef(onLaunchSettled)
+  onLaunchSettledRef.current = onLaunchSettled
 
   useEffect(() => {
     return () => {
@@ -48,10 +64,13 @@ export function useLaunchBlock(): UseLaunchBlockResult {
       }
 
       launchBlockTimeoutRef.current = window.setTimeout(() => {
+        launchBlockTimeoutRef.current = null
+        // A new launch would have cleared this timeout in handleLaunchStart, so
+        // reaching here means this game's sequence settled uninterrupted.
         setLaunchingGameKey((latestGameKey) =>
           latestGameKey === finishedGameKey ? null : latestGameKey
         )
-        launchBlockTimeoutRef.current = null
+        onLaunchSettledRef.current?.(finishedGameKey)
       }, cooldownMs)
 
       return currentGameKey

--- a/src/renderer/src/hooks/useLaunchBlock.ts
+++ b/src/renderer/src/hooks/useLaunchBlock.ts
@@ -1,11 +1,22 @@
 import { useEffect, useRef, useState } from 'react'
 
+export interface LaunchEndOptions {
+  /**
+   * Marks this as a fresh game launch (not a profile switch or relaunch-missing,
+   * which reuse the same cooldown while the game is already running). Only a
+   * primary launch fires `onLaunchSettled`, so the "now running" cue isn't spoken
+   * after a switch/relaunch.
+   */
+  primaryLaunch?: boolean
+}
+
 export interface UseLaunchBlockOptions {
   /**
-   * Called once the post-launch cooldown for a game lapses — i.e. the launch
-   * sequence has fully settled. Only fires when a cooldown actually ran (apps
-   * were started), so it is a reliable "now running" signal. Not called if a new
-   * launch pre-empts the cooldown or the component unmounts first.
+   * Called once the post-launch cooldown for a PRIMARY launch lapses — i.e. a
+   * fresh game launch has fully settled. Only fires when a cooldown actually ran
+   * (apps were started) AND the launch was flagged `primaryLaunch`. Not called
+   * for profile switches / relaunch-missing, if a new launch pre-empts the
+   * cooldown, or if the component unmounts first.
    */
   onLaunchSettled?: (gameKey: string) => void
 }
@@ -19,9 +30,14 @@ export interface UseLaunchBlockResult {
    * If `cooldownMs` > 0 the block stays active for that duration after the
    * launch so that the UI remains locked during process-startup time (prevents
    * accidental double-launches). The cooldown is cancelled if a new launch
-   * starts before it expires.
+   * starts before it expires. Pass `{ primaryLaunch: true }` for a fresh launch
+   * so the settled cue fires (omit it for switches / relaunch-missing).
    */
-  handleLaunchEnd: (finishedGameKey: string, cooldownMs?: number) => void
+  handleLaunchEnd: (
+    finishedGameKey: string,
+    cooldownMs?: number,
+    options?: LaunchEndOptions
+  ) => void
 }
 
 export function useLaunchBlock(options: UseLaunchBlockOptions = {}): UseLaunchBlockResult {
@@ -51,7 +67,15 @@ export function useLaunchBlock(options: UseLaunchBlockOptions = {}): UseLaunchBl
     setLaunchingGameKey(gameKey)
   }
 
-  const handleLaunchEnd = (finishedGameKey: string, cooldownMs = 0) => {
+  const handleLaunchEnd = (
+    finishedGameKey: string,
+    cooldownMs = 0,
+    options: LaunchEndOptions = {}
+  ) => {
+    // Captured per-launch so the scheduled timer fires the settled cue only for a
+    // fresh launch — never after a profile switch / relaunch-missing.
+    const isPrimaryLaunch = options.primaryLaunch === true
+
     setLaunchingGameKey((currentGameKey) => {
       // Guard: a new launch for a different game may have started while this
       // one was in flight — leave that key untouched.
@@ -70,7 +94,9 @@ export function useLaunchBlock(options: UseLaunchBlockOptions = {}): UseLaunchBl
         setLaunchingGameKey((latestGameKey) =>
           latestGameKey === finishedGameKey ? null : latestGameKey
         )
-        onLaunchSettledRef.current?.(finishedGameKey)
+        if (isPrimaryLaunch) {
+          onLaunchSettledRef.current?.(finishedGameKey)
+        }
       }, cooldownMs)
 
       return currentGameKey

--- a/tests/renderer/announcer.test.tsx
+++ b/tests/renderer/announcer.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Regression test for #541 (a11y: dedicated sr-only announcer).
+ *
+ * Runtime feedback used to ride on a single polite toast whose live-region
+ * child was an `aria-label`led `<button>` — Narrator announced it unreliably and
+ * appended "— dismiss notification" to every status, and errors shared the
+ * polite channel so they never interrupted.
+ *
+ * Contract pinned here:
+ *   1. notify() routes by type — success/warn to the polite region, error to the
+ *      assertive region.
+ *   2. announce() speaks without a toast and honours the politeness argument.
+ *   3. The visual toast is aria-hidden, not in the tab order, and carries no
+ *      "dismiss notification" text into the a11y tree.
+ */
+
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  // The toast progress bar is WAAPI-driven; jsdom doesn't implement
+  // Element.animate, so stub it to a no-op animation when a real toast renders.
+  Element.prototype.animate = vi.fn(() => ({ cancel: vi.fn() })) as never
+})
+
+// Notify subscribes to two main-process push channels at mount. Stub the
+// electron bridge so the module doesn't touch window.electronAPI (undefined in
+// jsdom); each subscriber just returns its no-op unsubscribe.
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  onAppLaunchError: () => () => {},
+  onProcessNameMismatchWarning: () => () => {}
+}))
+
+import { NotifyProvider, useNotify } from '../../src/renderer/src/components/Notify'
+
+let api: ReturnType<typeof useNotify> | null = null
+
+function Capture(): null {
+  api = useNotify()
+  return null
+}
+
+async function renderProvider(): Promise<{
+  container: HTMLDivElement
+  polite: HTMLElement
+  assertive: HTMLElement
+  unmount: () => void
+}> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root: Root | null = null
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <NotifyProvider>
+        <Capture />
+      </NotifyProvider>
+    )
+  })
+  const polite = container.querySelector('[aria-live="polite"]')
+  const assertive = container.querySelector('[aria-live="assertive"]')
+  if (!polite || !assertive) throw new Error('announcer live regions not found')
+  return {
+    container,
+    polite: polite as HTMLElement,
+    assertive: assertive as HTMLElement,
+    unmount: () => {
+      act(() => root?.unmount())
+      container.remove()
+    }
+  }
+}
+
+describe('Notify announcer (#541)', () => {
+  test('notify routes success to polite and error to assertive, with no dismiss pollution', async () => {
+    const { polite, assertive, unmount } = await renderProvider()
+
+    act(() => api!.notify('Launching iRacing', 'success'))
+    expect(polite.textContent).toContain('Launching iRacing')
+    expect(assertive.textContent ?? '').not.toContain('Launching iRacing')
+
+    act(() => api!.notify('iRacing failed to launch', 'error'))
+    expect(assertive.textContent).toContain('iRacing failed to launch')
+    expect(polite.textContent ?? '').not.toContain('iRacing failed to launch')
+
+    expect(polite.textContent ?? '').not.toMatch(/dismiss/i)
+    expect(assertive.textContent ?? '').not.toMatch(/dismiss/i)
+
+    unmount()
+  })
+
+  test('announce speaks without a toast and honours politeness', async () => {
+    const { container, polite, assertive, unmount } = await renderProvider()
+
+    act(() => api!.announce('Update version 1.2.3 available'))
+    expect(polite.textContent).toContain('Update version 1.2.3 available')
+    // No visual toast for a plain announce().
+    expect(document.body.querySelector('.toast-card')).toBeNull()
+    expect(container.querySelector('.toast-card')).toBeNull()
+
+    act(() => api!.announce('Save failed', 'assertive'))
+    expect(assertive.textContent).toContain('Save failed')
+
+    unmount()
+  })
+
+  test('the visual toast is aria-hidden, unfocusable, and carries no accessible name', async () => {
+    const { unmount } = await renderProvider()
+
+    act(() => api!.notify('Switched to Wet Setup', 'success'))
+    const card = document.body.querySelector('.toast-card') as HTMLButtonElement | null
+    expect(card).not.toBeNull()
+    expect(card!.tabIndex).toBe(-1)
+    expect(card!.hasAttribute('aria-label')).toBe(false)
+    // The card sits inside an aria-hidden subtree so it is not double-announced.
+    expect(card!.closest('[aria-hidden="true"]')).not.toBeNull()
+
+    unmount()
+  })
+})

--- a/tests/renderer/useLaunchBlock.test.tsx
+++ b/tests/renderer/useLaunchBlock.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Contract for the launch-block cooldown's settled cue (#541).
+ *
+ * onLaunchSettled drives the screen-reader "X is now running" announcement, so
+ * it must fire ONLY for a fresh primary launch that actually held a cooldown —
+ * never for a profile switch / relaunch-missing (which reuse the same cooldown
+ * while the game is already running), never when no apps started, and never once
+ * a newer launch has pre-empted the cooldown.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import {
+  useLaunchBlock,
+  type UseLaunchBlockResult
+} from '../../src/renderer/src/hooks/useLaunchBlock'
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+let api: UseLaunchBlockResult | null = null
+const onLaunchSettled = vi.fn()
+
+function Harness(): null {
+  api = useLaunchBlock({ onLaunchSettled })
+  return null
+}
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  onLaunchSettled.mockClear()
+  api = null
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Harness />)
+  })
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('useLaunchBlock onLaunchSettled (#541)', () => {
+  test('fires once, with the game key, after a primary launch cooldown lapses', () => {
+    act(() => api!.handleLaunchStart('iracing'))
+    act(() => api!.handleLaunchEnd('iracing', 10000, { primaryLaunch: true }))
+    expect(onLaunchSettled).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(10000))
+    expect(onLaunchSettled).toHaveBeenCalledTimes(1)
+    expect(onLaunchSettled).toHaveBeenCalledWith('iracing')
+  })
+
+  test('does not fire when no cooldown ran (no apps started)', () => {
+    act(() => api!.handleLaunchStart('iracing'))
+    act(() => api!.handleLaunchEnd('iracing', 0, { primaryLaunch: true }))
+    act(() => vi.advanceTimersByTime(60000))
+    expect(onLaunchSettled).not.toHaveBeenCalled()
+  })
+
+  test('does not fire for non-primary flows (profile switch / relaunch-missing)', () => {
+    act(() => api!.handleLaunchStart('iracing'))
+    act(() => api!.handleLaunchEnd('iracing', 10000))
+    act(() => vi.advanceTimersByTime(10000))
+    expect(onLaunchSettled).not.toHaveBeenCalled()
+  })
+
+  test('does not fire when a newer launch pre-empts the cooldown', () => {
+    act(() => api!.handleLaunchStart('iracing'))
+    act(() => api!.handleLaunchEnd('iracing', 10000, { primaryLaunch: true }))
+    act(() => vi.advanceTimersByTime(5000))
+    act(() => api!.handleLaunchStart('acc'))
+    act(() => vi.advanceTimersByTime(10000))
+    expect(onLaunchSettled).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

Runtime feedback (launch / failure / close-apps / profile switch / update / "now running") used to ride on a single **polite toast whose live-region child was an `aria-label`led `<button>`**. Narrator announced that inconsistently, appended "— dismiss notification" to every status, and errors shared the polite channel so they never interrupted.

This adds a dedicated screen-reader announcer and routes feedback through it.

## Changes

- **`Notify.tsx`** — two always-rendered visually-hidden live regions: polite `role="status"` + assertive `role="alert"`. `notify()` now also speaks its message (errors → assertive, success/warn → polite). The visual toast stack is `aria-hidden` and each card is `tabIndex={-1}`, so it's a mouse-only visual echo that no longer double-announces. New `announce()` is exposed for SR-only cues. Identical consecutive messages re-announce via a zero-width separator.
- **`App.tsx`** — announces `Update version N available` once per version (the Games-view update pill was otherwise silent), deduped across the live event + `getUpdateInfo()` hydration.
- **`useLaunchBlock.ts`** — new optional `onLaunchSettled` callback fired when a launch cooldown lapses (only runs when apps actually started → a reliable "now running" signal).
- **`GameList.tsx`** — wires `onLaunchSettled` to announce `X is now running`, resolving the name from the static `GAMES` config (never stale).

## Acceptance (from #541)

- ✅ Launch announces "Launching X" + a completion cue ("X is now running")
- ✅ A failure interrupts (assertive)
- ✅ An update is announced on the Games view
- ✅ No "dismiss notification" pollution

## Test plan

- New `tests/renderer/announcer.test.tsx` (3 cases): notify routing by type, `announce()` without a toast + politeness, and the toast being aria-hidden/unfocusable/unnamed.
- `npm run test` → 353 passing · `typecheck` · `lint` · `format:check` all clean.
- Manual Narrator pass deferred to the batched pre-release a11y smoke (forced-colors #542 lands first).

Closes #541


<!-- auto-closes -->
Closes #541
<!-- auto-closes -->