### PR TITLE
a11y: add Windows High Contrast / forced-colors support

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -796,3 +796,72 @@ textarea {
     scroll-behavior: auto !important;
   }
 }
+
+/* Windows High Contrast / forced-colors: the OS swaps author colours for a small
+   system palette and strips most backgrounds, gradients and box-shadows. Our UI
+   leans on accent-tinted surfaces, glass borders and glow shadows, so without
+   these overrides the focus ring, button boundaries, the toggle on/off cue and
+   the status dots all collapse into one flat colour. Restore them with system
+   colour keywords (CanvasText = foreground, ButtonText = control outline,
+   Highlight = active selection). !important is needed to beat the Tailwind
+   utility / runtime custom-property colours at equal specificity, mirroring the
+   reduced-motion block above. */
+@media (forced-colors: active) {
+  /* Keyboard focus must stay visible — the accent color-mix ring resolves to a
+     non-system colour and is dropped here. */
+  *:focus-visible {
+    outline: 2px solid CanvasText !important;
+    outline-offset: 2px;
+  }
+
+  /* The toggle's real focus target is the sr-only checkbox, so its visible ring
+     lives on the sibling track. */
+  .peer:focus-visible ~ .toggle-track {
+    outline: 2px solid CanvasText !important;
+  }
+
+  /* Interactive surfaces lose their tinted/glass fill — give them a real edge. */
+  .accent-action,
+  .accent-surface-action,
+  .neutral-action,
+  .danger-action,
+  .icon-action,
+  .dropdown-trigger-surface,
+  .settings-control-pill {
+    border: 1px solid ButtonText !important;
+  }
+
+  /* Selected / checked controls stand out via the system Highlight. */
+  .selected-surface,
+  .dropdown-item[aria-checked='true'] {
+    border: 1px solid Highlight !important;
+  }
+
+  /* Toggle switch: outline the track, fill the checked track with Highlight, and
+     keep a solid system-colour thumb so on vs off is unmistakable (position is a
+     second cue). */
+  .toggle-track {
+    border: 1px solid CanvasText !important;
+  }
+
+  .toggle-track::after {
+    background: CanvasText !important;
+    border-color: CanvasText !important;
+  }
+
+  .peer:checked ~ .toggle-track {
+    background: Highlight !important;
+  }
+
+  /* Status dots (running / unsaved / selected): their accent/green fills and glow
+     shadows vanish — render a solid system-colour disc instead. */
+  .status-dot {
+    background: CanvasText !important;
+    box-shadow: none !important;
+  }
+
+  /* Don't dim inactive game rows below contrast — keep every title fully legible. */
+  .game-row-container {
+    opacity: 1 !important;
+  }
+}

--- a/src/renderer/src/components/StickySaveBar.tsx
+++ b/src/renderer/src/components/StickySaveBar.tsx
@@ -67,7 +67,7 @@ export function StickySaveBar({ onRequestDiscard }: { onRequestDiscard: () => vo
           className="relative flex h-2 w-2 shrink-0 items-center justify-center"
         >
           <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-(--accent) opacity-75" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
+          <span className="status-dot relative inline-flex h-2 w-2 rounded-full bg-(--accent)" />
         </span>
         <span className="min-w-0 flex-1 text-xs font-medium text-(--text-secondary)">
           You have unsaved changes.

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -37,7 +37,7 @@ export function GameIcon({ game, isRunning, iconUrl }: GameIconProps): ReactNode
       }
       {isRunning && (
         <Tooltip label="Running">
-          <div className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]">
+          <div className="status-dot absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]">
             <span className="sr-only">{game.name} is running</span>
           </div>
         </Tooltip>

--- a/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
@@ -100,7 +100,7 @@ export function GameRowProfileMenu({
                 }`}
               >
                 <span
-                  className={`h-1.5 w-1.5 shrink-0 rounded-full ${selected ? 'bg-(--accent)' : 'bg-(--text-subtle)'}`}
+                  className={`status-dot h-1.5 w-1.5 shrink-0 rounded-full ${selected ? 'bg-(--accent)' : 'bg-(--text-subtle)'}`}
                 />
                 <span className="min-w-0 flex-1 truncate">{profile.name}</span>
               </button>

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -36,7 +36,7 @@ export function SettingsSection({
             {title}
             {dirty && (
               <span
-                className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)"
+                className="status-dot h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)"
                 title="Unsaved changes"
                 aria-label="Unsaved changes in this section"
               />


### PR DESCRIPTION
## What

In Windows High Contrast Mode the OS replaces author colours with a small system palette and strips most backgrounds, gradients and box-shadows. The UI leans on accent-tinted surfaces, glass borders and glow shadows, so without `forced-colors` handling the **focus ring, button boundaries, the toggle on/off cue and the status dots all collapse** into one flat colour — a blind-spot for low-vision keyboard users.

## Changes

A single `@media (forced-colors: active)` block in `App.css` (plus a shared `status-dot` class), using system colour keywords (`CanvasText` = foreground, `ButtonText` = control outline, `Highlight` = active selection):

- **Focus** — `:focus-visible` → `outline: 2px solid CanvasText` (the accent `color-mix` ring resolves to a non-system colour and is dropped), including the toggle's sibling-track ring.
- **Buttons** — `.accent-action / .accent-surface-action / .neutral-action / .danger-action / .icon-action / .dropdown-trigger-surface / .settings-control-pill` get a `ButtonText` border; `.selected-surface` / checked dropdown items use a `Highlight` border.
- **Toggle** — bordered track, `Highlight` checked fill, solid `CanvasText` thumb (position is a second on/off cue).
- **Status dots** — running / unsaved / selected dots render as a solid `CanvasText` disc via a new `status-dot` class added to `GameIcon`, `StickySaveBar`, `SettingsSection`, `GameRowProfileMenu`.
- **Row dimming** — inactive game rows no longer drop to `opacity: 0.45`, so titles stay full-contrast.

`!important` is used to beat Tailwind utility / runtime custom-property colours at equal specificity, mirroring the existing reduced-motion block.

## Test plan

- `npm run test` (357), `typecheck`, `lint`, `format:check` — all clean. (No unit test: forced-colors is a visual/OS-level mode jsdom can't assert.)
- **Manual smoke (batched pre-release a11y pass):** Windows Settings → enable **Contrast themes** (e.g. "Aquatic") and verify: keyboard focus ring visible on every control; buttons have outlines; toggle on vs off distinguishable; running/unsaved/selected dots visible; inactive rows legible.

Closes #542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows High Contrast and forced-colors mode support with restored focus outlines, improved toggle and button styling, and enhanced status indicator visibility.

* **Style**
  * Updated status indicator styling across components for improved visual consistency and accessibility in high contrast environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #542
<!-- auto-closes -->