### PR TITLE
ci: configure CodeRabbit (disable docstring-coverage pre-merge check)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+reviews:
+  pre_merge_checks:
+    # This codebase documents intent with inline `//` comments (the "why"),
+    # not JSDoc docstrings, so CodeRabbit's docstring-coverage metric reads
+    # artificially low and flags every PR. Turn it off to match the convention.
+    # The title / description / linked-issues / out-of-scope checks stay on.
+    docstrings:
+      mode: 'off'


### PR DESCRIPTION
## What

Adds `.coderabbit.yaml` turning off CodeRabbit's **Docstring Coverage** pre-merge check.

## Why

CodeRabbit (just installed, trialing) runs that check at an 80% default threshold. This repo documents intent with **inline `//` comments** (the "why"), not JSDoc `/** */` docstrings, so the metric reads ~25% and posts a ⚠️ warning on every PR (first seen on #548) — noise, not signal, given the code is well-commented.

The useful pre-merge checks (title / description / linked-issues / out-of-scope) stay **on**.

## Test plan

- Config-only; verified `mode: 'off'` is valid against the CodeRabbit v2 schema (`reviews.pre_merge_checks.docstrings.mode` ∈ off/warning/error).
- `'off'` is quoted so YAML doesn't coerce it to the boolean `false`.
- After merge, future PRs should show the docstring check gone from the pre-merge panel.

Closes #549


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration settings to refine code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->