### PR TITLE
a11y: document-structure + control-semantics quick-wins

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -718,9 +718,9 @@ textarea {
 }
 
 .settings-sublabel {
-  font-size: 0.625rem;
-  color: var(--text-muted);
-  line-height: 1.2;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  line-height: 1.25;
 }
 
 .settings-control {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -73,6 +73,14 @@ function AppContent() {
     runStartupMigrations()
   }, [])
 
+  // Reflect the active view in the document title and the banner heading so
+  // Narrator (and the OS task switcher) announce which screen is active — the
+  // two views were otherwise indistinguishable.
+  const viewLabel = view === 'settings' ? 'Settings' : 'Games'
+  useEffect(() => {
+    document.title = `SimLauncher — ${viewLabel}`
+  }, [viewLabel])
+
   // Surface non-React errors (async rejections, event-handler throws, errors
   // outside the render tree) as a toast — the ErrorBoundary only covers render.
   useEffect(() => subscribeGlobalErrors((message) => notify(message, 'error', 6000)), [notify])
@@ -277,7 +285,7 @@ function AppContent() {
       className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
     >
       <header className="absolute top-0 left-0 w-full z-20 header-glass">
-        <h1 className="sr-only">SimLauncher</h1>
+        <h1 className="sr-only">SimLauncher — {viewLabel}</h1>
         <WindowControls view={view} onNavigate={handleNavigate} updateInfo={updateInfo} />
       </header>
 

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -146,7 +146,7 @@ export function GameList({
   }
 
   return (
-    <div className="flex flex-col gap-3 px-1 py-2">
+    <div role="list" aria-label="Games" className="flex flex-col gap-3 px-1 py-2">
       {configuredGames
         .map((game, index) => ({ game, index }))
         .sort((firstEntry, secondEntry) => {

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -38,8 +38,11 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
 
   return (
     <div className="drag-region flex h-12 w-full items-center px-4 gap-2 shrink-0">
-      {/* Pill: branding + settings gear */}
-      <div className="no-drag glass-surface rounded-full flex items-center shrink-0 overflow-hidden">
+      {/* Pill: branding + settings gear — the app's primary navigation */}
+      <nav
+        aria-label="Primary"
+        className="no-drag glass-surface rounded-full flex items-center shrink-0 overflow-hidden"
+      >
         {/* Launcher branding */}
         <Tooltip label="SimLauncher" placement="bottom">
           <button
@@ -77,7 +80,7 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
             <SettingsIcon width={13} height={13} />
           </button>
         </Tooltip>
-      </div>
+      </nav>
 
       {/* Update Pill */}
       {updateInfo && (

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -444,6 +444,7 @@ export function GameRow({
 
   return (
     <div
+      role="listitem"
       className={`game-row-container group/row relative flex flex-col ${isActive ? '' : 'gap-2'} transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`}
       ref={rowRef}
     >

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -1,7 +1,6 @@
 import type { DragEvent, ReactNode } from 'react'
 import type { ProfileUtility, Utility } from '../../lib/config'
 import { Toggle } from '../Toggle'
-import { Tooltip } from '../Tooltip'
 
 interface ProfileUtilitiesSectionProps {
   appPaths: Record<string, string>
@@ -70,6 +69,9 @@ function renderUtilityRow(
   if (!utility) return null
 
   const label = props.appNames[utility.key] || utility.name
+  // Stable id so the visible name can be tied to the switch via <label htmlFor>
+  // (renderUtilityRow is a plain function, so useId() isn't available here).
+  const toggleId = `utility-toggle-${utility.key}`
   const iconPath = props.appPaths[utility.key]?.toLowerCase()
   const icon = iconPath ? props.appIconCache[iconPath] : null
   const dropPlacement = props.dropTarget?.id === utility.key ? props.dropTarget.placement : null
@@ -166,21 +168,23 @@ function renderUtilityRow(
             </button>
           </span>
         )}
-        <Tooltip label="Drag to reorder">
-          <div
-            className={`icon-action flex h-6 w-5 shrink-0 items-center justify-center rounded ${isEnabled ? 'cursor-grab group-active:cursor-grabbing' : ''}`}
-            aria-hidden="true"
-          >
-            <svg width="12" height="16" viewBox="0 0 12 16" fill="currentColor" aria-hidden="true">
-              <circle cx="3" cy="3" r="1.2" />
-              <circle cx="9" cy="3" r="1.2" />
-              <circle cx="3" cy="8" r="1.2" />
-              <circle cx="9" cy="8" r="1.2" />
-              <circle cx="3" cy="13" r="1.2" />
-              <circle cx="9" cy="13" r="1.2" />
-            </svg>
-          </div>
-        </Tooltip>
+        {/* Decorative drag affordance: aria-hidden + non-focusable, so a
+            Tooltip (focus/hover popover) could never surface — a native title
+            keeps the mouse hint. Keyboard users reorder via the buttons above. */}
+        <div
+          title="Drag to reorder"
+          className={`icon-action flex h-6 w-5 shrink-0 items-center justify-center rounded ${isEnabled ? 'cursor-grab group-active:cursor-grabbing' : ''}`}
+          aria-hidden="true"
+        >
+          <svg width="12" height="16" viewBox="0 0 12 16" fill="currentColor" aria-hidden="true">
+            <circle cx="3" cy="3" r="1.2" />
+            <circle cx="9" cy="3" r="1.2" />
+            <circle cx="3" cy="8" r="1.2" />
+            <circle cx="9" cy="8" r="1.2" />
+            <circle cx="3" cy="13" r="1.2" />
+            <circle cx="9" cy="13" r="1.2" />
+          </svg>
+        </div>
         <div className="relative flex h-6 w-6 shrink-0 items-center justify-center">
           {icon && !props.failedIcons[utility.key] ? (
             <img
@@ -197,13 +201,18 @@ function renderUtilityRow(
             </div>
           )}
         </div>
-        <span className="min-w-0 line-clamp-1 text-sm font-medium opacity-80">{label}</span>
+        <label
+          htmlFor={toggleId}
+          className="min-w-0 line-clamp-1 cursor-pointer text-sm font-medium opacity-80"
+        >
+          {label}
+        </label>
       </div>
       <span data-no-row-drag="true">
         <Toggle
+          id={toggleId}
           checked={isEnabled}
           onChange={() => props.onToggleUtility(utility.key)}
-          aria-label={label}
         />
       </span>
     </div>

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -115,7 +115,7 @@ export function AboutSection({
           </p>
         )}
         {updateStatus === 'error' && (
-          <p className="text-[10px] text-center text-red-400 animate-fade-slide">
+          <p className="text-[10px] text-center text-(--status-danger) animate-fade-slide">
             Update failed. Try again later.
           </p>
         )}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -53,7 +53,7 @@ export function AppearanceSection(): ReactNode {
   return (
     <>
       <div className="settings-row settings-row-responsive">
-        <label className="settings-label text-(--text-secondary)">Theme</label>
+        <span className="settings-label text-(--text-secondary)">Theme</span>
         <div className="settings-control" role="group" aria-label="Theme">
           {THEME_MODE_OPTIONS.map((option) => (
             <button
@@ -74,7 +74,7 @@ export function AppearanceSection(): ReactNode {
       </div>
 
       <div className="settings-row settings-row-responsive">
-        <label className="settings-label text-(--text-secondary)">Accent Color</label>
+        <span className="settings-label text-(--text-secondary)">Accent Color</span>
         <div className="settings-control" role="group" aria-label="Accent color">
           {ACCENT_PRESETS.map((preset) => (
             <Tooltip key={preset.hex} label={preset.name}>
@@ -97,11 +97,12 @@ export function AppearanceSection(): ReactNode {
                   setShowPicker(!showPicker)
                   if (!isCustomColor) onAccentChange('custom')
                 }}
-                aria-label="Custom accent color"
+                aria-label={
+                  isCustomColor ? 'Custom accent color (selected)' : 'Custom accent color'
+                }
                 aria-haspopup="dialog"
                 aria-expanded={showPicker}
                 aria-controls={showPicker ? 'accent-color-picker' : undefined}
-                aria-pressed={isCustomColor}
                 className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
                   isCustomColor ? 'scale-110' : ''
                 }`}
@@ -164,11 +165,12 @@ export function AppearanceSection(): ReactNode {
       </div>
 
       <div className="settings-row settings-row-responsive">
-        <label className="settings-label text-(--text-secondary)">UI Scale</label>
+        <span className="settings-label text-(--text-secondary)">UI Scale</span>
         <div className="settings-control" role="group" aria-label="UI scale">
           {ZOOM_PRESETS.map((preset) => (
             <button
               key={preset.factor}
+              type="button"
               onClick={() => onZoomFactorChange(preset.factor)}
               aria-pressed={zoomFactor === preset.factor}
               className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -93,6 +93,7 @@ export function BehaviorSection(): ReactNode {
           {DELAY_PRESETS.map((preset) => (
             <button
               key={preset.value}
+              type="button"
               onClick={() => onLaunchDelayMsChange(preset.value)}
               aria-pressed={launchDelayMs === preset.value}
               className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${


### PR DESCRIPTION
Two small a11y issues from the 2026-06-14 audit, batched into one PR since they touch the same settings components.

## #545 — view distinction + document structure

- **Per-view title + heading** — `document.title` and the banner `<h1>` now read `SimLauncher — Games` / `SimLauncher — Settings`, so Narrator and the OS task switcher announce which screen is active (both were identical before).
- **`<nav>` landmark** — the brand/gear pills are wrapped in `<nav aria-label="Primary">`.
- **List semantics** — `role="list"` on the game list + `role="listitem"` on each row, so Narrator announces "list, N items / item X of N".
- **Orphaned labels** — the Theme / Accent / UI-Scale captions had `<label>` with no `htmlFor` and no wrapped control → converted to `<span className="settings-label">` (the `role="group"` + `aria-label` already names each group).

## #546 — control-semantics + contrast polish

- **`type="button"`** on the UI-Scale and Launch-delay preset pills (they defaulted to submit — latent bug; matches the Theme/Accent buttons).
- **Custom-accent swatch** — dropped `aria-pressed` (it mixed with `aria-expanded`/`haspopup=dialog` → "pressed, collapsed" ambiguity); selection is now conveyed in the accessible name (" (selected)").
- **Drag handle** — removed the `Tooltip` wrapper on the `aria-hidden`, non-focusable handle (its label could never surface); a native `title` keeps the mouse hint. Keyboard users still reorder via the up/down buttons.
- **Utility toggle** — tied to its visible name via `<label htmlFor>` instead of `aria-label` (matches the #520 settings-row pattern).
- **Contrast** — bumped `.settings-sublabel` size/contrast (10px/muted → 11px/secondary) and replaced off-token `text-red-400` with `--status-danger`.

## Test plan

- `npm run test` (357), `typecheck`, `lint`, `format:check` — all clean.
- Pure markup/CSS semantics; verified the existing `toggleAccessibleName` test still passes (the utility toggle uses the same `htmlFor` pattern).
- Note: a couple of IDE-only `jsx-a11y` warnings appear for `role="list"`/`listitem` across the GameList↔GameRow component boundary — the project ESLint has no `jsx-a11y` plugin and the runtime parent/child relationship is correct.

Closes #545
Closes #546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced screen reader support with improved navigation labels and semantic HTML structure.
  * Fixed button behavior to prevent unintended form submissions.
  * Improved settings controls with proper label associations for assistive technologies.

* **Style**
  * Updated settings sublabel styling for improved visual consistency.
  * Enhanced error message styling to match the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->