### PR TITLE
a11y: make the running-app warning Dismiss keyboard reachable

### DIFF
--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -9,6 +9,7 @@ import {
   FloatingPortal,
   offset,
   shift,
+  useClick,
   useDismiss,
   useFloating,
   useInteractions,
@@ -55,9 +56,13 @@ function RunningAppIconItem({
     whileElementsMounted: autoUpdate
   })
 
+  // useClick makes the trigger keyboard-operable (Enter/Space) and opens on a
+  // plain left-click, alongside the existing right-click — only when there's a
+  // warning, so non-warning icons stay inert.
+  const click = useClick(context, { enabled: !!app.warning })
   const dismiss = useDismiss(context)
   const role = useRole(context, { role: 'menu' })
-  const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, role])
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role])
 
   // Only show the context menu when there is a warning (e.g. process-name
   // mismatch). Apps without warnings get no right-click menu so the native
@@ -93,38 +98,68 @@ function RunningAppIconItem({
     name: app.name
   })
 
+  // Icon still loading (cache not yet populated) and nothing actionable to
+  // surface: show a skeleton so the strip doesn't collapse then jump when icons
+  // arrive. Once the cache is initialized, a null icon means "no icon found" and
+  // falls through to the initial. A warning always renders the button below.
+  if (app.icon === null && !isFailed && !cacheInitialized && !app.warning) {
+    return <div aria-hidden="true" className="h-4 w-4 skeleton-icon animate-pulse" />
+  }
+
+  const initials = app.name
+    .replace(/\.exe$/i, '')
+    .slice(0, 2)
+    .toUpperCase()
+
   let content: ReactElement<Record<string, unknown>>
 
-  if (isAvailable) {
+  if (app.warning) {
+    // A warning icon is actionable (it opens a Dismiss menu), so the trigger is
+    // a real focusable <button>: keyboard/Narrator users can reach it, hear that
+    // it's actionable (aria-haspopup) and open the menu via Enter/Space or click
+    // (useClick) — not just right-click (WCAG 2.1.1). The inner icon/initial is
+    // decorative; the button's aria-label carries the name + warning.
+    content = (
+      <button
+        ref={refs.setReference}
+        type="button"
+        aria-label={`${app.name}: ${app.warning}`}
+        className="flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-sm ring-1 ring-(--warning-text)"
+        {...triggerProps}
+      >
+        {isAvailable ? (
+          <img
+            src={app.icon ?? undefined}
+            alt=""
+            className="h-4 w-4 object-contain opacity-80"
+            onError={onError}
+          />
+        ) : (
+          <span aria-hidden="true" className="text-[6px] font-black">
+            {initials}
+          </span>
+        )}
+      </button>
+    )
+  } else if (isAvailable) {
     content = (
       <img
         ref={refs.setReference}
         src={app.icon ?? undefined}
-        alt={app.warning ? `${app.name}: ${app.warning}` : ''}
-        className={`h-4 w-4 object-contain opacity-80 ${app.warning ? 'cursor-pointer rounded-sm ring-1 ring-(--warning-text)' : ''}`}
+        alt=""
+        className="h-4 w-4 object-contain opacity-80"
         onError={onError}
-        {...triggerProps}
       />
     )
-  } else if (app.icon === null && !isFailed && !cacheInitialized) {
-    // Icon is still loading (cache not yet populated): show a skeleton so
-    // the strip does not collapse and then jump when icons arrive. Once the
-    // cache is initialized, a null icon means "no icon found" — fall through
-    // to the fallback initial so there's no empty hole.
-    return <div aria-hidden="true" className="h-4 w-4 skeleton-icon animate-pulse" />
   } else {
     content = (
       <div
         ref={refs.setReference}
         role="img"
-        aria-label={app.warning ? `${app.name}: ${app.warning}` : app.name}
-        className={`fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0 ${app.warning ? 'cursor-pointer ring-1 ring-(--warning-text)' : ''}`}
-        {...triggerProps}
+        aria-label={app.name}
+        className="fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0"
       >
-        {app.name
-          .replace(/\.exe$/i, '')
-          .slice(0, 2)
-          .toUpperCase()}
+        {initials}
       </div>
     )
   }

--- a/tests/renderer/runningAppsStripWarning.test.tsx
+++ b/tests/renderer/runningAppsStripWarning.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Regression test for #543 — the running-app warning trigger must be reachable
+ * and operable by keyboard / Narrator, not mouse-only.
+ *
+ * Previously the warning icon was an <img>/role="img" whose Dismiss menu opened
+ * only via onContextMenu (right-click), so keyboard and screen-reader users hit
+ * a WCAG 2.1.1 dead end. The trigger is now a real <button> (aria-haspopup) that
+ * opens the menu on click / Enter / Space; non-warning icons stay inert.
+ */
+
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const dismissAppIconMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  dismissAppIcon: (...args: unknown[]) => dismissAppIconMock(...args)
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import {
+  RunningAppsStrip,
+  type RunningAppIcon
+} from '../../src/renderer/src/components/game-list/RunningAppsStrip'
+
+const WARNING_APP: RunningAppIcon = {
+  icon: 'data:image/png;base64,AAAA',
+  name: 'obs64.exe',
+  path: 'C:/Apps/obs64.exe',
+  gameKey: 'iracing',
+  warning: 'Running under a different process name'
+}
+
+const NORMAL_APP: RunningAppIcon = {
+  icon: 'data:image/png;base64,BBBB',
+  name: 'discord.exe',
+  path: 'C:/Apps/discord.exe',
+  gameKey: 'iracing'
+}
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function render(apps: RunningAppIcon[]): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<RunningAppsStrip runningAppIcons={apps} cacheInitialized={true} />)
+  })
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  dismissAppIconMock.mockClear()
+})
+
+describe('RunningAppsStrip warning trigger (#543)', () => {
+  test('a warning icon is a focusable button that advertises its menu; a normal icon is not', async () => {
+    await render([WARNING_APP, NORMAL_APP])
+
+    const buttons = container.querySelectorAll('button')
+    // Exactly one trigger button (the warning); the menu's Dismiss button only
+    // exists once opened.
+    expect(buttons.length).toBe(1)
+
+    const trigger = buttons[0]
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu')
+    expect(trigger.getAttribute('aria-label')).toContain('obs64.exe')
+    expect(trigger.getAttribute('aria-label')).toContain('Running under a different process name')
+    // Native buttons are in the tab order (not tabIndex=-1).
+    expect(trigger.tabIndex).toBe(0)
+
+    // The non-warning icon is an inert <img>, never a button.
+    expect(container.querySelector('img[alt=""]')).not.toBeNull()
+  })
+
+  test('clicking the warning trigger opens the Dismiss menu (no mouse-only dead end)', async () => {
+    await render([WARNING_APP])
+
+    const trigger = container.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement
+    expect(trigger).not.toBeNull()
+    expect(document.body.querySelector('[role="menuitem"]')).toBeNull()
+
+    await act(async () => {
+      trigger.click()
+    })
+
+    const menuItem = document.body.querySelector('[role="menuitem"]')
+    expect(menuItem).not.toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  })
+})


### PR DESCRIPTION
## What

The running-app **warning icon** carries a Dismiss menu that opened **only via right-click** on a non-focusable `<img>`/`role="img"`, with `aria-haspopup`/`aria-expanded` sitting on an unfocusable element — a WCAG **2.1.1** keyboard/Narrator dead end (a keyboard user couldn't reach it, learn it was actionable, or dismiss the warning).

## Changes (`RunningAppsStrip.tsx`)

- When `app.warning` is present, the trigger is now a real **`<button type="button">`** (focusable, in the tab order) with `aria-haspopup="menu"` and an `aria-label` carrying the app name + warning. The icon/initial inside is decorative.
- Added `@floating-ui` **`useClick`** (enabled only for warnings) so the menu opens via **click / Enter / Space** as well as the existing `onContextMenu` (right-click still works for mouse users).
- Non-warning icons stay inert (`<img alt="">` / `role="img"`), exactly as before.
- Because the trigger is now focusable, `FloatingFocusManager` can also return focus to it on close.

## Test plan

- New `tests/renderer/runningAppsStripWarning.test.tsx` (2 cases): a warning icon renders as a focusable button advertising its menu (a normal icon doesn't); clicking the trigger opens the Dismiss menu and sets `aria-expanded`.
- `npm run test` (359), `typecheck`, `lint`, `format:check` — all clean.

Closes #543


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Running app warning indicators are now keyboard-accessible and can be focused and operated via keyboard navigation (Tab, Enter/Space)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->