### PR TITLE
a11y: focus management + focus-visibility (view switch, Escape, dark-glass controls)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -397,7 +397,9 @@ textarea {
 
 .icon-action {
   background: transparent;
-  color: var(--text-subtle);
+  /* --text-muted (not --text-subtle) so resting icon glyphs clear the 3:1
+     non-text contrast minimum; --text-subtle (~2.3:1) was below it. */
+  color: var(--text-muted);
 }
 
 .icon-action.icon-action-active {
@@ -422,7 +424,7 @@ textarea {
 .icon-action.danger-action {
   background: transparent;
   box-shadow: none;
-  color: var(--text-subtle);
+  color: var(--text-muted);
 }
 
 .icon-action.danger-action:hover {
@@ -781,6 +783,24 @@ textarea {
 .reorder-btn:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
+}
+
+/* Fallback keyboard focus ring for any button / role=button that doesn't carry
+   one of the dedicated .accent-action/.icon-action/etc. rules above — e.g. the
+   wordmark, the profile-menu trigger, the accent swatches and the section
+   disclosure headers, which otherwise showed only the faint UA outline on dark
+   glass. outline-offset keeps it clear of round swatches. */
+button:focus-visible,
+[role='button']:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* View re-homing focus target (App.tsx) — focused programmatically on a view
+   switch to keep keyboard focus inside the visible view. It's not user-tabbable
+   (tabIndex=-1), so it must not paint a ring around the whole scroll region. */
+.view-focus-region:focus {
+  outline: none;
 }
 
 /* Respect the OS "reduce motion" preference: neutralize transitions and stop

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -60,6 +60,12 @@ function AppContent() {
   // announce it twice.
   const announcedUpdateRef = useRef<string | null>(null)
 
+  // Focus targets for re-homing keyboard focus into the visible view on a view
+  // switch (see the effect below). viewFocusReadyRef skips the initial mount.
+  const gamesRegionRef = useRef<HTMLDivElement>(null)
+  const settingsRegionRef = useRef<HTMLDivElement>(null)
+  const viewFocusReadyRef = useRef(false)
+
   // Mirror so the once-registered close-request handler reads the latest value
   // without re-subscribing.
   const discardConfirmOpenRef = useRef(false)
@@ -80,6 +86,21 @@ function AppContent() {
   useEffect(() => {
     document.title = `SimLauncher — ${viewLabel}`
   }, [viewLabel])
+
+  // Re-home keyboard focus into the now-visible view whenever the view changes
+  // (tab switch, Escape-from-Settings). Otherwise focus stays on the control
+  // that triggered the switch — which is about to become `inert` — and drops to
+  // <body>, so the next Tab restarts at the titlebar. Skip the first run so the
+  // app doesn't steal focus on initial load. preventScroll keeps the viewport
+  // from jumping.
+  useEffect(() => {
+    if (!viewFocusReadyRef.current) {
+      viewFocusReadyRef.current = true
+      return
+    }
+    const region = view === 'settings' ? settingsRegionRef.current : gamesRegionRef.current
+    region?.focus({ preventScroll: true })
+  }, [view])
 
   // Surface non-React errors (async rejections, event-handler throws, errors
   // outside the render tree) as a toast — the ErrorBoundary only covers render.
@@ -330,7 +351,10 @@ function AppContent() {
             }`}
           >
             <div
-              className={`flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
+              ref={gamesRegionRef}
+              tabIndex={-1}
+              aria-label="Games"
+              className={`view-focus-region flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
             >
               <GameList key={refreshKey} onNavigate={handleNavigate} />
             </div>
@@ -346,7 +370,10 @@ function AppContent() {
             }`}
           >
             <div
-              className={`flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
+              ref={settingsRegionRef}
+              tabIndex={-1}
+              aria-label="Settings"
+              className={`view-focus-region flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
             >
               <SettingsView onClose={() => handleNavigate('games')} updateInfo={updateInfo} />
             </div>

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -112,7 +112,7 @@ export function GameRowActions({
           className={`flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-full transition-all duration-300 ${
             isActive
               ? 'icon-action-active'
-              : 'icon-action opacity-40 group-hover/row:opacity-100 group-hover/row:bg-(--glass-bg)'
+              : 'icon-action opacity-60 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 group-hover/row:bg-(--glass-bg)'
           }`}
           aria-label={
             isActive ? `Close profile settings for ${gameName}` : `Profile settings for ${gameName}`


### PR DESCRIPTION
Last of the 1.0.0 a11y audit items (P2, effort M).

## Problems

- **Focus dead-end** — Escape from Settings (and the games↔settings switch) left focus on the now-`inert` subtree, so it dropped to `<body>` and the next Tab restarted at the titlebar.
- **Invisible focus on dark glass** — the wordmark, profile-menu trigger, accent swatches and section disclosure headers had no focus-ring class, showing only the faint UA outline.
- **Low-contrast idle icons** — `.icon-action` rested on `--text-subtle` (~2.3:1, below the 3:1 non-text minimum); the per-row gear was hover-only (no `focus-within`).

## Changes

- **Re-home focus** (`App.tsx`) — a `useEffect` keyed on `view` moves focus into the now-visible view via a `tabIndex={-1}` focus-catcher region (one per view, `aria-label` "Games"/"Settings"), skipping the initial mount and using `preventScroll`. Fixes both the view-switch and Escape-from-Settings dead-ends.
- **Global focus-ring fallback** (`App.css`) — `button` / `[role="button"]` `:focus-visible` now always paints the accent ring; dedicated rules still win where present. Covers the wordmark/trigger/swatches/headers without per-component edits.
- **Contrast** — `.icon-action` resting colour → `--text-muted` (≥3:1); the per-row gear gets a visible resting opacity + `group-focus-within`/`focus-visible:opacity-100`.
- The focus-catcher region suppresses its own outline (it's not user-tabbable).

## Test plan

- `npm run test` (357), `typecheck`, `lint`, `format:check` — all clean.
- This change is focus/visual behaviour across the inert view boundary (hard to assert meaningfully in jsdom), so it's verified in the **batched pre-release a11y smoke**: keyboard-only — Escape/view-switch lands focus in the visible view (next Tab continues there, not the titlebar); every control shows a focus ring; window controls + gear are visible at rest and on focus.

Closes #544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default icon colors and added consistent focus ring styling for buttons
  * Adjusted button opacity styling in game row actions

* **Bug Fixes**
  * Enhanced keyboard focus management when switching between games and settings views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #544
<!-- auto-closes -->