### PR TITLE
fix(a11y): portal SR announcer out of #root so modal inert can't silence it

### DIFF
--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -268,32 +268,40 @@ export function NotifyProvider({ children }: { children: ReactNode }): ReactNode
   return (
     <NotifyContext.Provider value={value}>
       {children}
-      {/* Always-rendered visually-hidden announcer. role + aria-live are stated
-          explicitly (role=status implies polite, role=alert implies assertive)
-          for clarity and cross-AT reliability. aria-atomic so the full message
-          is re-read on every change. */}
-      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-        {politeMessage}
-      </div>
-      <div className="sr-only" role="alert" aria-live="assertive" aria-atomic="true">
-        {assertiveMessage}
-      </div>
       {createPortal(
-        // Visual-only toast stack — aria-hidden because the announcer above
-        // carries the message to assistive tech.
-        <div
-          aria-hidden="true"
-          className="fixed right-[25px] bottom-[25px] flex flex-col gap-3 z-9999"
-        >
-          {toasts.map((toast) => (
-            <ToastCard
-              key={toast.id}
-              toast={toast}
-              isDismissing={dismissingToastIds.has(toast.id)}
-              onDismiss={dismissToast}
-            />
-          ))}
-        </div>,
+        <>
+          {/* Always-rendered visually-hidden announcer. It MUST be portaled to
+              document.body (a sibling of #root) rather than rendered inline:
+              useFocusTrap marks #root `inert` while any modal is open, and
+              aria-live mutations inside an inert subtree are not announced — so
+              an inline announcer would go silent for screen-reader users for
+              every notify()/announce() fired while a dialog is up (e.g. a save
+              failure that keeps the close-confirm dialog open). role + aria-live
+              are stated explicitly (role=status implies polite, role=alert
+              implies assertive) for cross-AT reliability; aria-atomic so the
+              full message is re-read on every change. */}
+          <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+            {politeMessage}
+          </div>
+          <div className="sr-only" role="alert" aria-live="assertive" aria-atomic="true">
+            {assertiveMessage}
+          </div>
+          {/* Visual-only toast stack — aria-hidden because the announcer above
+              carries the message to assistive tech. */}
+          <div
+            aria-hidden="true"
+            className="fixed right-[25px] bottom-[25px] flex flex-col gap-3 z-9999"
+          >
+            {toasts.map((toast) => (
+              <ToastCard
+                key={toast.id}
+                toast={toast}
+                isDismissing={dismissingToastIds.has(toast.id)}
+                onDismiss={dismissToast}
+              />
+            ))}
+          </div>
+        </>,
         document.body
       )}
     </NotifyContext.Provider>

--- a/tests/renderer/announcer.test.tsx
+++ b/tests/renderer/announcer.test.tsx
@@ -59,8 +59,11 @@ async function renderProvider(): Promise<{
       </NotifyProvider>
     )
   })
-  const polite = container.querySelector('[aria-live="polite"]')
-  const assertive = container.querySelector('[aria-live="assertive"]')
+  // The announcer is portaled to document.body (so it escapes the `inert` that
+  // useFocusTrap sets on #root while a modal is open), not rendered inside the
+  // provider's subtree — query the body, not the container.
+  const polite = document.body.querySelector('[aria-live="polite"]')
+  const assertive = document.body.querySelector('[aria-live="assertive"]')
   if (!polite || !assertive) throw new Error('announcer live regions not found')
   return {
     container,
@@ -118,5 +121,43 @@ describe('Notify announcer (#541)', () => {
     expect(card!.closest('[aria-hidden="true"]')).not.toBeNull()
 
     unmount()
+  })
+
+  // Regression: useFocusTrap marks #root `inert` while a modal is open, and
+  // aria-live mutations inside an inert subtree are not announced. The announcer
+  // therefore MUST live outside #root (portaled to document.body) so a
+  // notification fired while a dialog is up still reaches assistive tech — the
+  // exact failure mode of the close-confirm save error.
+  test('announcer escapes the modal `inert` on #root', async () => {
+    // Mimic the real app shell: NotifyProvider mounts inside #root.
+    const root = document.createElement('div')
+    root.id = 'root'
+    document.body.appendChild(root)
+    let appRoot: Root | null = null
+    await act(async () => {
+      appRoot = createRoot(root)
+      appRoot.render(
+        <NotifyProvider>
+          <Capture />
+        </NotifyProvider>
+      )
+    })
+
+    // The live regions must NOT be inside #root...
+    expect(root.querySelector('[aria-live]')).toBeNull()
+    // ...they live in document.body, a sibling of #root.
+    const assertive = document.body.querySelector('[aria-live="assertive"]') as HTMLElement | null
+    expect(assertive).not.toBeNull()
+    expect(assertive!.closest('#root')).toBeNull()
+
+    // A modal opening inerts #root. The announcement must stay reachable (no
+    // inert ancestor) and carry the message.
+    root.setAttribute('inert', '')
+    act(() => api!.notify('Failed to save changes. Window not closed.', 'error'))
+    expect(assertive!.closest('[inert]')).toBeNull()
+    expect(assertive!.textContent).toContain('Failed to save changes')
+
+    act(() => appRoot?.unmount())
+    root.remove()
   })
 })


### PR DESCRIPTION
## Summary

The dedicated screen-reader announcer added in #541 rendered its two `aria-live` regions inline inside `#root`. `useFocusTrap` marks `#root` `inert` while any modal is open (ConfirmDialog, ImportPreviewDialog, ColorPickerPopover), and `aria-live` mutations inside an inert subtree are **not announced** in Chromium/Electron. So every `notify()` / `announce()` fired while a dialog was open was dropped for screen-reader users — most notably the close-confirm save-failure error, which keeps the dialog open and fires an assertive `notify`.

This regressed 0.9.10, where the announcement rode the toast container that is portaled to `document.body` and therefore escaped inert.

## Fix

Portal the two announcer divs to `document.body` alongside the existing toast stack — exactly what `useFocusTrap`'s own JSDoc prescribes (*the container MUST be rendered outside #root … so it is not itself inerted*). The announcer now lives as a sibling of `#root`, beyond the reach of the modal `inert`.

Found by the pre-1.0.0 multi-agent code audit (adversarially verified: real, user-reachable, diff-introduced).

## Test plan

- New regression test `announcer escapes the modal inert on #root`: mounts the provider inside a real `#root`, asserts the live regions are not inside `#root`, then sets `#root` `inert`, fires `notify(…, 'error')`, and asserts the assertive region has no `[inert]` ancestor and carries the message. Fails on the old inline code.
- Existing announcer tests updated to query `document.body` (the new portal home).
- Full suite green: 353 tests pass; lint, typecheck, format clean.

Closes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen reader announcements to function correctly when modals are displayed
  * Enhanced notification accessibility across different UI contexts
* **Tests**
  * Added regression test ensuring announcements remain accessible with modal interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->