### PR TITLE
fix: pre-1.0.0 a11y + updater polish batch (#560, #562, #563, #564)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "0.9.10",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "0.9.10",
+      "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -136,6 +136,15 @@ export function registerUpdaterHandlers(rendererSender: SendToRenderer): void {
       return { success: true }
     } catch (err) {
       installAfterDownload = false
+      // downloadUpdate() both emits the 'error' event AND rejects. The event
+      // already surfaced a categorized message to the renderer, so for a network
+      // failure swallow the rejection here — otherwise the renderer's install
+      // catch fires a second, generic "Failed to install update" error that
+      // overrides the calmer offline notice (mirrors the check-for-updates
+      // handler). Re-throw anything else so genuine failures still surface.
+      if (isUpdateNetworkError(err)) {
+        return { success: false, offline: true }
+      }
       throw err
     }
   })

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -11,6 +11,11 @@
   --text-subtle: rgba(255, 255, 255, 0.3);
   --accent: #008c99;
   --accent-foreground: #000000;
+  /* Readable accent for accent-colored TEXT (section headings, update pill,
+     launch-order badge): the raw accent is ~3.5-4.2:1 on these surfaces, below
+     WCAG AA 4.5:1. theme.ts recomputes a contrast-tuned variant at runtime for
+     the live/custom accent; this is the static default for the brand teal. */
+  --accent-text: #33a3ad;
   --accent-action-foreground: var(--text-primary);
   --accent-glow-opacity: 0.25;
   --accent-glow: rgba(0, 140, 153, var(--accent-glow-opacity));
@@ -78,6 +83,9 @@
   --text-subtle: rgba(20, 20, 24, 0.5);
   --accent: #008c99;
   --accent-foreground: #000000;
+  /* Darker readable accent for accent-colored text on the light background
+     (theme.ts recomputes at runtime; static default for the brand teal). */
+  --accent-text: #00707a;
   --accent-action-foreground: var(--text-primary);
   --accent-glow-opacity: 0.22;
   --accent-glow: rgba(0, 140, 153, var(--accent-glow-opacity));

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -15,7 +15,7 @@
      launch-order badge): the raw accent is ~3.5-4.2:1 on these surfaces, below
      WCAG AA 4.5:1. theme.ts recomputes a contrast-tuned variant at runtime for
      the live/custom accent; this is the static default for the brand teal. */
-  --accent-text: #33a3ad;
+  --accent-text: #66bac2;
   --accent-action-foreground: var(--text-primary);
   --accent-glow-opacity: 0.25;
   --accent-glow: rgba(0, 140, 153, var(--accent-glow-opacity));
@@ -85,7 +85,7 @@
   --accent-foreground: #000000;
   /* Darker readable accent for accent-colored text on the light background
      (theme.ts recomputes at runtime; static default for the brand teal). */
-  --accent-text: #00707a;
+  --accent-text: #00626b;
   --accent-action-foreground: var(--text-primary);
   --accent-glow-opacity: 0.22;
   --accent-glow: rgba(0, 140, 153, var(--accent-glow-opacity));

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -36,6 +36,10 @@ interface NotifyContextValue {
   announce: (message: string, politeness?: Politeness) => void
 }
 
+/** Standalone screen-reader announcement (no toast) — shared so consumers like
+ *  useUpdateStatus don't redefine (and risk drifting from) this signature. */
+export type Announce = NotifyContextValue['announce']
+
 export const NotifyContext = createContext<NotifyContextValue | null>(null)
 
 // Appended to alternating announcements so two identical consecutive messages

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -34,7 +34,7 @@ function SettingsViewContent({
   onClose: () => void
   updateInfo: UpdateInfo
 }) {
-  const { notify } = useNotify()
+  const { notify, announce } = useNotify()
   const { loading, isDirty, dirtySections, saveSettings } = useSettingsMeta()
   const { registerSaveHandler, registerDiscardHandler } = useAppDirty()
   const [expandedSections, setExpandedSections] = useState({
@@ -45,7 +45,7 @@ function SettingsViewContent({
     games: false,
     apps: false
   })
-  const updateStatus = useUpdateStatus({ updateInfo, notify })
+  const updateStatus = useUpdateStatus({ updateInfo, notify, announce })
 
   const setSectionOpen = (section: keyof typeof expandedSections, open: boolean) => {
     setExpandedSections((current) => ({ ...current, [section]: open }))

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -93,7 +93,7 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
             aria-hidden="true"
             className="h-2 w-2 rounded-full bg-(--accent) animate-pulse shadow-[0_0_8px_var(--accent)]"
           />
-          <span className="text-[10px] font-medium uppercase tracking-wider text-(--accent)">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-(--accent-text)">
             Update v{updateInfo.version} Available
           </span>
         </button>

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -119,7 +119,7 @@ function renderUtilityRow(
       )}
       <div className="flex min-w-0 items-center gap-3">
         {isEnabled && typeof orderIndex === 'number' && (
-          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-(--accent)/15 text-[11px] font-black tabular-nums text-(--accent)">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-(--accent)/15 text-[11px] font-black tabular-nums text-(--accent-text)">
             {orderIndex + 1}
           </span>
         )}

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -32,7 +32,7 @@ export function SettingsSection({
           aria-expanded={open}
           aria-controls={regionId}
         >
-          <span className="flex flex-1 items-center gap-2 text-left text-sm font-semibold uppercase tracking-wider text-(--accent)">
+          <span className="flex flex-1 items-center gap-2 text-left text-sm font-semibold uppercase tracking-wider text-(--accent-text)">
             {title}
             {dirty && (
               <span

--- a/src/renderer/src/components/settings/useUpdateStatus.ts
+++ b/src/renderer/src/components/settings/useUpdateStatus.ts
@@ -10,10 +10,10 @@ import {
   onUpdateError,
   onUpdateNotAvailable
 } from '../../lib/electron'
+import type { Announce } from '../Notify'
 import type { UpdateErrorInfo, UpdateInfo, UpdateStatus } from './types'
 
 type Notify = (message: string, type: 'success' | 'warn' | 'error', durationMs?: number) => void
-type Announce = (message: string, politeness?: 'polite' | 'assertive') => void
 
 export interface UseUpdateStatusResult {
   appVersion: string

--- a/src/renderer/src/components/settings/useUpdateStatus.ts
+++ b/src/renderer/src/components/settings/useUpdateStatus.ts
@@ -13,6 +13,7 @@ import {
 import type { UpdateErrorInfo, UpdateInfo, UpdateStatus } from './types'
 
 type Notify = (message: string, type: 'success' | 'warn' | 'error', durationMs?: number) => void
+type Announce = (message: string, politeness?: 'polite' | 'assertive') => void
 
 export interface UseUpdateStatusResult {
   appVersion: string
@@ -26,10 +27,12 @@ export interface UseUpdateStatusResult {
 
 export function useUpdateStatus({
   updateInfo,
-  notify
+  notify,
+  announce
 }: {
   updateInfo: UpdateInfo
   notify: Notify
+  announce: Announce
 }): UseUpdateStatusResult {
   const [appVersion, setAppVersion] = useState<string>('')
   const [checkingUpdate, setCheckingUpdate] = useState(false)
@@ -128,6 +131,11 @@ export function useUpdateStatus({
       setInstallingUpdate(true)
       setUpdateProgress(null)
       setUpdateStatus(null)
+      // The download has no screen-reader-visible text (the button is
+      // aria-live=off so it doesn't announce every percent), so announce that
+      // the install started. Success ends in an app restart; failures are
+      // announced via notify().
+      announce('Downloading update…')
 
       try {
         await installUpdate()
@@ -139,7 +147,7 @@ export function useUpdateStatus({
         console.error(err)
       }
     }
-  }, [notify, updateInfo])
+  }, [announce, notify, updateInfo])
 
   return {
     appVersion,

--- a/src/renderer/src/lib/theme.ts
+++ b/src/renderer/src/lib/theme.ts
@@ -44,6 +44,12 @@ const DARK_TEXT_BG_REF = '#322d3a'
 const LIGHT_TEXT_BG_REF = '#f4f4f8'
 // Slightly above the 4.5:1 AA floor for normal text, for margin across surfaces.
 const ACCENT_TEXT_TARGET_CONTRAST = 4.6
+// Accent fraction blended into the reference surface to model the accent-TINTED
+// backgrounds the text actually sits on (launch-order badge ~15% over glass,
+// update pill ~12-18%; in light theme the glass itself is accent-tinted). The
+// tint pulls the background toward the text's own hue and lowers contrast below
+// a plain surface, so the readable variant must be derived against it.
+const TEXT_BG_TINT = 0.2
 
 function clampChannel(value: number) {
   return Math.max(0, Math.min(255, Math.round(value)))
@@ -55,6 +61,16 @@ function channelToHex(value: number) {
 
 function rgbToHex(r: number, g: number, b: number) {
   return `#${channelToHex(r)}${channelToHex(g)}${channelToHex(b)}`
+}
+
+// Alpha-composite fgHex over bgHex at the given alpha (src-over). Used to model
+// an accent-tinted surface as a flat reference color for contrast derivation.
+function compositeOver(fgHex: string, bgHex: string, alpha: number): string {
+  return rgbToHex(
+    getChannel(fgHex, 1) * alpha + getChannel(bgHex, 1) * (1 - alpha),
+    getChannel(fgHex, 3) * alpha + getChannel(bgHex, 3) * (1 - alpha),
+    getChannel(fgHex, 5) * alpha + getChannel(bgHex, 5) * (1 - alpha)
+  )
 }
 
 function contrastBetween(hexA: string, hexB: string) {
@@ -96,11 +112,15 @@ function deriveAccentText(accentHex: string, bgHex: string, toward: string): str
  */
 function applyAccentTextToken(): void {
   const isLight = document.documentElement.dataset.theme === 'light'
-  const accentText = deriveAccentText(
+  // Derive against the worst case: the accent composited over the plain surface,
+  // modeling the accent-tinted badge/pill backgrounds. Plain-surface text (the
+  // section headings) then clears AA with extra margin.
+  const tintedRef = compositeOver(
     currentAccentHex,
     isLight ? LIGHT_TEXT_BG_REF : DARK_TEXT_BG_REF,
-    isLight ? '#000000' : '#ffffff'
+    TEXT_BG_TINT
   )
+  const accentText = deriveAccentText(currentAccentHex, tintedRef, isLight ? '#000000' : '#ffffff')
   document.documentElement.style.setProperty('--accent-text', accentText)
 }
 

--- a/src/renderer/src/lib/theme.ts
+++ b/src/renderer/src/lib/theme.ts
@@ -8,6 +8,11 @@ export const DEFAULT_THEME_MODE: ThemeMode = 'dark'
 // the previous one before registering a new one.
 let themeMediaCleanup: (() => void) | null = null
 
+// The live accent hex, remembered so the derived --accent-text token can be
+// recomputed whenever EITHER the accent or the resolved theme changes (the
+// readable variant depends on both). Mirrors the App.css default brand teal.
+let currentAccentHex = '#008c99'
+
 function getChannel(hex: string, start: number) {
   return parseInt(hex.slice(start, start + 2), 16)
 }
@@ -30,6 +35,75 @@ function getContrastRatio(lighterLuminance: number, darkerLuminance: number) {
   return (lighterLuminance + 0.05) / (darkerLuminance + 0.05)
 }
 
+// Representative background surfaces the accent-colored TEXT labels (section
+// headings, update pill, launch-order badge) sit on, used to derive a readable
+// --accent-text. Dark = a panel/glass surface over the app gradient; light =
+// the near-white app background. Chosen toward the lighter end of each so the
+// derived text still clears AA on the lightest surface a label can land on.
+const DARK_TEXT_BG_REF = '#322d3a'
+const LIGHT_TEXT_BG_REF = '#f4f4f8'
+// Slightly above the 4.5:1 AA floor for normal text, for margin across surfaces.
+const ACCENT_TEXT_TARGET_CONTRAST = 4.6
+
+function clampChannel(value: number) {
+  return Math.max(0, Math.min(255, Math.round(value)))
+}
+
+function channelToHex(value: number) {
+  return clampChannel(value).toString(16).padStart(2, '0')
+}
+
+function rgbToHex(r: number, g: number, b: number) {
+  return `#${channelToHex(r)}${channelToHex(g)}${channelToHex(b)}`
+}
+
+function contrastBetween(hexA: string, hexB: string) {
+  const a = getRelativeLuminance(hexA)
+  const b = getRelativeLuminance(hexB)
+  return a >= b ? getContrastRatio(a, b) : getContrastRatio(b, a)
+}
+
+/**
+ * Derives a readable text color from the accent by blending it toward `toward`
+ * (white on dark surfaces, black on light) just far enough to meet
+ * ACCENT_TEXT_TARGET_CONTRAST against bgHex. Returns the accent unchanged when
+ * it already passes, and `toward` as the guaranteed-legible fallback. Keeps the
+ * accent's hue while making it AA-legible as text, including for custom accents
+ * that fail at full saturation.
+ */
+function deriveAccentText(accentHex: string, bgHex: string, toward: string): string {
+  const ar = getChannel(accentHex, 1)
+  const ag = getChannel(accentHex, 3)
+  const ab = getChannel(accentHex, 5)
+  const tr = getChannel(toward, 1)
+  const tg = getChannel(toward, 3)
+  const tb = getChannel(toward, 5)
+
+  for (let t = 0; t <= 1.0001; t += 0.05) {
+    const candidate = rgbToHex(ar + (tr - ar) * t, ag + (tg - ag) * t, ab + (tb - ab) * t)
+    if (contrastBetween(candidate, bgHex) >= ACCENT_TEXT_TARGET_CONTRAST) {
+      return candidate
+    }
+  }
+
+  return toward
+}
+
+/**
+ * (Re)computes --accent-text from the live accent and the resolved theme.
+ * Invoked whenever the accent changes (applyAccentTheme) or the theme flips
+ * (applyThemeMode), since the readable variant depends on both.
+ */
+function applyAccentTextToken(): void {
+  const isLight = document.documentElement.dataset.theme === 'light'
+  const accentText = deriveAccentText(
+    currentAccentHex,
+    isLight ? LIGHT_TEXT_BG_REF : DARK_TEXT_BG_REF,
+    isLight ? '#000000' : '#ffffff'
+  )
+  document.documentElement.style.setProperty('--accent-text', accentText)
+}
+
 /**
  * Returns the foreground color (#000 or #fff) that maximises contrast against
  * the given accent hex color, using the WCAG 2.x relative-luminance formula.
@@ -48,9 +122,11 @@ export function getAccentForeground(hex: string): '#000000' | '#ffffff' {
  * custom properties. Silently no-ops for invalid hex strings so callers can
  * pass raw user input without pre-validation.
  *
- * Three tokens are set: --accent (the raw hex), --accent-foreground (the
- * accessible foreground from getAccentForeground), and --accent-glow (an rgba
- * that composes the opacity from --accent-glow-opacity defined in the stylesheet).
+ * Four tokens are set: --accent (the raw hex), --accent-foreground (the
+ * accessible foreground from getAccentForeground), --accent-glow (an rgba that
+ * composes the opacity from --accent-glow-opacity defined in the stylesheet),
+ * and --accent-text (a contrast-tuned variant for accent-colored text, derived
+ * for the current theme so it stays AA-legible even for custom accents).
  */
 export function applyAccentTheme(hex: string): void {
   const normalizedHex = hex.trim()
@@ -63,6 +139,7 @@ export function applyAccentTheme(hex: string): void {
   const g = getChannel(normalizedHex, 3)
   const b = getChannel(normalizedHex, 5)
 
+  currentAccentHex = normalizedHex
   document.documentElement.style.setProperty('--accent', normalizedHex)
   document.documentElement.style.setProperty(
     '--accent-foreground',
@@ -72,6 +149,7 @@ export function applyAccentTheme(hex: string): void {
     '--accent-glow',
     `rgba(${r}, ${g}, ${b}, var(--accent-glow-opacity))`
   )
+  applyAccentTextToken()
 }
 
 export function normalizeThemeMode(value: unknown): ThemeMode {
@@ -93,6 +171,9 @@ export function applyThemeMode(mode: ThemeMode): void {
 
   const applyResolvedTheme = (theme: 'light' | 'dark') => {
     document.documentElement.dataset.theme = theme
+    // The readable --accent-text depends on the resolved theme, so recompute it
+    // whenever the theme changes (including live system-preference changes).
+    applyAccentTextToken()
   }
 
   if (mode !== 'system') {

--- a/tests/main/updater.test.ts
+++ b/tests/main/updater.test.ts
@@ -113,6 +113,22 @@ test('a failed download resets the install latch', async () => {
   expect(quitAndInstall).not.toHaveBeenCalled()
 })
 
+test('install-update swallows a network failure instead of double-surfacing it (#560)', async () => {
+  const { handlers } = await loadUpdaterModule()
+  downloadUpdate.mockRejectedValueOnce(
+    Object.assign(new Error('getaddrinfo ENOTFOUND github.com'), { code: 'ENOTFOUND' })
+  )
+
+  // The 'error' event already showed the calm offline notice; the install IPC
+  // must resolve (not reject), otherwise the renderer fires a second generic
+  // "Failed to install update" that overrides the offline message.
+  await expect(handlers['install-update']({})).resolves.toMatchObject({ offline: true })
+
+  // The latch is still cleared, so a later stray download won't auto-install.
+  autoUpdaterHandlers['update-downloaded']({ version: '1.2.3' })
+  expect(quitAndInstall).not.toHaveBeenCalled()
+})
+
 test('an updater error resets the install latch', async () => {
   const { handlers } = await loadUpdaterModule()
   let resolveDownload: () => void = () => {}

--- a/tests/renderer/accentText.test.ts
+++ b/tests/renderer/accentText.test.ts
@@ -10,9 +10,15 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 import { applyAccentTheme } from '../../src/renderer/src/lib/theme'
 
-// The reference surfaces theme.ts derives the readable accent against.
+// The plain reference surfaces theme.ts derives the readable accent against.
 const DARK_BG = '#322d3a'
 const LIGHT_BG = '#f4f4f8'
+// The accent-TINTED surfaces the token actually renders on (launch-order badge =
+// accent ~/15 over glass; in light theme the glass is itself accent-tinted).
+// Modeled independently of theme.ts so these assertions are not circular; these
+// are LOWER-contrast than the plain references and are the binding constraint.
+const LIGHT_TINTED_BADGE_BG = '#c0e1e5'
+const DARK_TINTED_BADGE_BG = '#2f3a47'
 const AA_NORMAL_TEXT = 4.5
 
 function channel(hex: string, start: number): number {
@@ -68,6 +74,16 @@ describe('accent-text contrast (#562)', () => {
     applyAccentTheme('#008c99')
 
     expect(contrast(accentText(), LIGHT_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
+  })
+
+  test('default accent text clears AA on the accent-tinted badge surfaces (both themes)', () => {
+    document.documentElement.dataset.theme = 'light'
+    applyAccentTheme('#008c99')
+    expect(contrast(accentText(), LIGHT_TINTED_BADGE_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
+
+    document.documentElement.dataset.theme = 'dark'
+    applyAccentTheme('#008c99')
+    expect(contrast(accentText(), DARK_TINTED_BADGE_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
   })
 
   test('a dark custom accent unreadable at full saturation is lightened until it passes (dark)', () => {

--- a/tests/renderer/accentText.test.ts
+++ b/tests/renderer/accentText.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression for #562 (a11y: accent color used as text fails WCAG AA).
+ *
+ * applyAccentTheme derives an --accent-text token tuned for the resolved theme,
+ * so accent-colored text (Settings section headings, the update pill, the
+ * launch-order badge) stays AA-legible (>=4.5:1) for the default teal AND for
+ * custom accents that are unreadable at full saturation.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { applyAccentTheme } from '../../src/renderer/src/lib/theme'
+
+// The reference surfaces theme.ts derives the readable accent against.
+const DARK_BG = '#322d3a'
+const LIGHT_BG = '#f4f4f8'
+const AA_NORMAL_TEXT = 4.5
+
+function channel(hex: string, start: number): number {
+  return parseInt(hex.slice(start, start + 2), 16)
+}
+
+function linearize(c: number): number {
+  const n = c / 255
+  return n <= 0.03928 ? n / 12.92 : Math.pow((n + 0.055) / 1.055, 2.4)
+}
+
+function luminance(hex: string): number {
+  return (
+    0.2126 * linearize(channel(hex, 1)) +
+    0.7152 * linearize(channel(hex, 3)) +
+    0.0722 * linearize(channel(hex, 5))
+  )
+}
+
+function contrast(a: string, b: string): number {
+  const la = luminance(a)
+  const lb = luminance(b)
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+function accentText(): string {
+  return document.documentElement.style.getPropertyValue('--accent-text').trim()
+}
+
+beforeEach(() => {
+  document.documentElement.removeAttribute('style')
+  delete document.documentElement.dataset.theme
+})
+
+afterEach(() => {
+  document.documentElement.removeAttribute('style')
+  delete document.documentElement.dataset.theme
+})
+
+describe('accent-text contrast (#562)', () => {
+  test('default teal accent yields AA-legible text on the dark surface', () => {
+    document.documentElement.dataset.theme = 'dark'
+    applyAccentTheme('#008c99')
+
+    const text = accentText()
+    expect(text).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(contrast(text, DARK_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
+  })
+
+  test('default teal accent yields AA-legible text on the light surface', () => {
+    document.documentElement.dataset.theme = 'light'
+    applyAccentTheme('#008c99')
+
+    expect(contrast(accentText(), LIGHT_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
+  })
+
+  test('a dark custom accent unreadable at full saturation is lightened until it passes (dark)', () => {
+    document.documentElement.dataset.theme = 'dark'
+    applyAccentTheme('#7a0010') // very dark red, ~2:1 as raw text on dark
+
+    expect(contrast(accentText(), DARK_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
+  })
+
+  test('a too-light custom accent is darkened until it passes (light)', () => {
+    document.documentElement.dataset.theme = 'light'
+    applyAccentTheme('#ffe14d') // light yellow, fails on the near-white surface
+
+    expect(contrast(accentText(), LIGHT_BG)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT)
+  })
+})


### PR DESCRIPTION
Pre-tag polish batch from the whole-app analysis (0 release-blockers found; these are the fix-soon items pulled into 1.0.0) plus the offline-install fix. Each was adversarially reviewed before this PR.

## Changes

**#562 — accent color as text failed WCAG AA.** The raw accent (~3.5-4.2:1 on app surfaces) was used as foreground text for Settings section headings, the update pill and the launch-order badge. Added an `--accent-text` token derived at runtime in `theme.ts`: it blends the live accent toward white (dark) / black (light) until it clears AA, derived against the **accent-tinted worst-case surface** (the pill/badge sit on accent tints, which lower contrast below a plain surface). Recomputed on both accent and theme changes; `App.css` carries static brand-teal defaults. The three text sites use `--accent-text`; accent stays for fills/borders/icons (3:1 non-text bar). Default teal now scores 5.1-6.5:1 across plain and tinted surfaces, both themes.

**#560 — offline Download & Install showed two contradictory toasts** (calm offline notice + scary "Failed to install") and ended in error state. `downloadUpdate()` both emits the `error` event and rejects; the install-update handler now swallows network-categorized rejections (mirroring `check-for-updates`), so only the calm offline notice shows. Genuine failures still surface.

**#563 — update download was silent to screen readers** (button is `aria-live=off` to avoid announcing every percent). Announce "Downloading update…" on install start; failures announce via `notify()`, success ends in a restart.

**#564 — `package-lock.json` was still 0.9.10** after the 1.0.0 bump, so the release SBOM would misreport the product version. Re-synced (version fields only, no dependency changes).

## Test plan

- New `tests/renderer/accentText.test.ts` (5): assert the derived `--accent-text` clears AA against the plain refs AND the accent-tinted badge surfaces, in both themes, including a custom accent that fails at full saturation.
- New `tests/main/updater.test.ts` case: install-update resolves (does not double-surface) on a network failure.
- Full suite green: **359 tests**; typecheck, lint, format clean.
- Manual smoke pending: Narrator hears "Downloading update"; light/dark High-Contrast-off visual check of headings/pill/badge.

Closes #560
Closes #562
Closes #563
Closes #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation handling for network-related failures by returning a graceful offline result instead of surfacing a secondary “failed to install” error.
* **New Features**
  * Added screen-reader announcements during the “install update” flow for improved accessibility.
* **Style**
  * Introduced a dedicated, contrast-tuned `--accent-text` color token for more readable accent-colored text across light/dark themes and accent-tinted surfaces (including settings headers and profile reorder badges).
* **Tests**
  * Added regression coverage for offline update behavior and WCAG AA contrast validation for computed accent text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #560
Closes #562
Closes #563
Closes #564
<!-- auto-closes -->