### PR TITLE
ci: group Dependabot updates to stop one-PR-per-dependency flood

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,20 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # Bundle updates into a few grouped PRs instead of one per dependency.
+    # Production deps are grouped separately from dev deps so runtime changes
+    # still get their own reviewable PR.
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+      development-dependencies:
+        dependency-type: 'development'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Adds `groups` to `.github/dependabot.yml` so Dependabot bundles updates instead of opening one PR per dependency (6 landed at once today: #566-#571).

Grouping:
- npm **production** deps → one PR
- npm **development** deps → one PR
- github-actions → one PR

CI-metadata only; no app or build change. Does **not** retroactively group the 6 open PRs — those are held until after v1.0.0 is tagged, then triaged.

Closes #572

<!-- auto-closes -->
Closes #572
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated dependency update automation configuration to organize npm dependency updates into separate groups for production and development dependencies, with improved organization for github-actions ecosystem updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->