### PR TITLE
ci: switch Dependabot to a monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     # Bundle updates into a few grouped PRs instead of one per dependency.
     # Production deps are grouped separately from dev deps so runtime changes
     # still get their own reviewable PR.
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Follow-up to #573 (grouping). Drops the npm + github-actions schedules from `weekly` to `monthly` so dependency PRs land in one predictable monthly sweep.

No `ignore` rules — majors (incl. Electron) still surface as PRs so we learn about new versions, just less often. Security alerts fire immediately regardless of schedule. CI-metadata only.

Closes #577

<!-- auto-closes -->
Closes #577
<!-- auto-closes -->