### PR TITLE
security(deps): bump js-yaml override to ^4.2.0 (GHSA-h67p-54hq-rp68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,14 @@ Full per-release notes — including every linked issue and PR — are published
 - The app now honors the system "reduce motion" setting, Settings toggles show a keyboard focus ring, and Escape closes the import-preview and color-picker dialogs.
 - The process lookup used when closing apps now times out instead of stalling the close pipeline on a wedged system service.
 - Smaller installer: frontend libraries (React, Tailwind, etc.) are bundled by Vite into the app's own code, so their separate package copies are no longer shipped in the installer, trimming the footprint.
-- Checking for updates while offline now shows a calm "can't reach the update server — check your connection" notice instead of a generic update-failure error.
+- Checking for or installing an update while offline now shows a single calm "can't reach the update server — check your connection" notice instead of a generic or duplicated update-failure error.
 - A broad screen-reader and keyboard accessibility pass: launch progress, launch failures, "now running", companion-apps-closed and update-available status are now spoken through a dedicated live region (errors interrupt); the games and settings screens expose proper headings, landmarks, list semantics and a per-screen window title; switching screens or pressing Escape moves keyboard focus into the visible screen instead of stranding it; and every control shows a visible focus ring, with idle icon buttons brightened to meet contrast.
 - The accent colour is now the SimLauncher teal everywhere — the keyboard focus ring and a brief startup flash that could still show the old purple are gone.
 - Updated the application icon to the current SimLauncher branding.
+
+### Security
+
+- Updated the bundled `js-yaml` dependency to 4.2.0, resolving a moderate denial-of-service advisory (GHSA-h67p-54hq-rp68) in the library that parses the auto-update manifest.
 
 ## [0.9.10] - 2026-06-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,9 +5798,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "overrides": {
     "@electron/asar": "4.2.0",
-    "js-yaml": "4.1.1",
+    "js-yaml": "^4.2.0",
     "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
## Why

A freshly-published advisory **GHSA-h67p-54hq-rp68** (moderate: quadratic-complexity DoS in js-yaml merge-key handling) covers **js-yaml ≤ 4.1.1**. Our `overrides` pinned js-yaml to exactly `4.1.1`, and it reaches the **production** tree via `electron-updater` (parses `latest.yml`). The CI `build` job's `npm audit --omit=dev` now **fails on every PR** (it's what failed #578; #565/#573 passed earlier today on the same code — the advisory is new).

## Fix

Override `js-yaml: 4.1.1 → ^4.2.0` (resolves to 4.2.0, the fixed release).

## Verification

- `npm audit --omit=dev` → **0 vulnerabilities**
- **359 tests** pass; typecheck, lint, format clean
- Diff is just the override + lockfile + CHANGELOG (Security note; offline-install wording folded in)

Landing in 1.0.0 — moderate security advisory on a prod dep, blocking CI, trivial fix.

Closes #579

<!-- auto-closes -->
Closes #579
<!-- auto-closes -->