### PR TITLE
fix: 1.0.0 smoke batch — restore glyph, game-running dot, comment-accuracy fixes

### DIFF
--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -1,6 +1,7 @@
 // Shared in-process flags that coordinate the window close / quit / tray flow.
-// All three can change from IPC handlers (renderer thread) and from main-thread
-// event listeners, so they must never be read inside an async gap between an
+// isQuitting can change from both IPC handlers (renderer thread) and main-thread
+// event listeners (before-quit, tray quit); the other two are written only from
+// IPC handlers. So none of them should be read across an async gap between an
 // IPC call and its response — capture synchronously at the start of a handler.
 let isQuitting = false
 let rendererDirty = false

--- a/src/main/migrator.ts
+++ b/src/main/migrator.ts
@@ -18,7 +18,7 @@ function getCustomSlotNumber(key: string) {
 // Scan every record that could reference a custom app slot and return the
 // highest slot number found. Both pre-migration (flat boolean/path keys) and
 // post-migration (utilities array) shapes are checked because the store may
-// contain a mix when this runs (e.g. gamePaths is always flat; profiles may
+// contain a mix when this runs (e.g. appPaths is always flat; profiles may
 // already be in the new shape from a partial earlier migration attempt).
 function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
   let highestSlot = 0

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -99,8 +99,12 @@ function getExternallyAdoptableGameKeys(
   return adoptableGameKeys
 }
 
-// INVARIANT: manual companion utilities are only surfaced when the owning game is
-// already launched by SimLauncher or its configured game exe is externally running.
+// A profile's tracked companion utilities are surfaced once that profile has at
+// least one app surfaced (its game OR any companion launched by SimLauncher, or
+// an unclosed / mismatch entry), or its game exe is detected running externally
+// (adoption). NOTE: this is NOT gated on the game itself running — launching only
+// a companion still surfaces that profile's companions (same aggregate-vs-game
+// distinction as the green dot, #587; the in-session-exe question is #585/#586).
 async function getTrackedRunningApps(
   processNames: Set<string>,
   adoptedOrLaunchedGameKeys: Set<string>,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -25,10 +25,12 @@ import type { AppLaunchResult, LaunchResult, ProfileLaunchEntry, ProfileLaunchIn
 import { publishRunningApps } from './running'
 
 const activeLaunches = new Set<string>()
-// After a launch completes, block further launches for this window. Apps that
-// self-relaunch under a different process name (the mismatch-warning scenario)
-// can trigger a second fast-exit within a few seconds; the block prevents a
-// race where the user clicks Launch again before the UI reflects the real state.
+// After a launch completes, block further launches process-wide (across all
+// windows — launchBlockedUntil is a single module-level scalar, not per-window)
+// for this duration. Apps that self-relaunch under a different process name (the
+// mismatch-warning scenario) can trigger a second fast-exit within a few seconds;
+// the block prevents a race where the user clicks Launch again before the UI
+// reflects the real state.
 const POST_LAUNCH_BLOCK_MS = 10000
 const PROCESS_NAME_MISMATCH_WARNING_CHANNEL = 'process-name-mismatch-warning'
 let launchBlockedUntil = 0
@@ -488,7 +490,7 @@ export async function spawnDetachedApp(
         })
       })
 
-      // The 'spawn' event fires synchronously on success for most GUI apps, but
+      // The 'spawn' event normally fires promptly (next tick) on success, but
       // some launchers (e.g. Ubisoft Connect wrapper) can delay it. The 500 ms
       // fallback ensures the caller is unblocked even if the event never fires
       // (e.g. the child is already gone by the time Node processes the queue).

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -205,7 +205,11 @@ export function getEnabledUtilityKeys(profile: StoredProfile | undefined): strin
   // Legacy path: profiles stored before the utilities-array migration keep
   // utility state as top-level boolean keys (e.g. { simhub: true }). The
   // migrator converts these on first run, but this branch handles any profile
-  // that somehow missed migration (manual store edit, partial import, etc.).
+  // that missed migration (manual store edit, partial import, etc.). NOTE: this
+  // returns ALL top-level keys set to `true`, so non-utility booleans like
+  // launchAutomatically / trackingEnabled are included too; the only caller
+  // (getProfileTrackablePaths) tolerates this because those keys have no matching
+  // appPaths entry and are dropped by the isValidExePath filter.
   return Object.entries(profile)
     .filter(([, value]) => value === true)
     .map(([key]) => key)

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -4,6 +4,7 @@ import { getSettings } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
+import { isGameExeRunning } from '../lib/runningGame'
 import { useNotify } from './Notify'
 import { useGamesSettings } from './settings/GamesContext'
 import { EmptyState } from './EmptyState'
@@ -47,13 +48,7 @@ export function GameList({
   // so the timer closure can't go stale.
   const { launchingGameKey, handleLaunchStart, handleLaunchEnd } = useLaunchBlock({
     onLaunchSettled: (gameKey) => {
-      const gamePath = gamePaths[gameKey]
-      if (!gamePath) return
-      const gamePathLower = normalizePath(gamePath)
-      const gameExeRunning = runningApps.some(
-        (app) => app.gameKey === gameKey && normalizePath(app.path) === gamePathLower
-      )
-      if (!gameExeRunning) return
+      if (!isGameExeRunning(runningApps, gameKey, gamePaths[gameKey])) return
       const name = GAMES.find((game) => game.key === gameKey)?.name
       if (name) announce(`${name} is now running`)
     }
@@ -162,9 +157,13 @@ export function GameList({
         .map(({ game }) => {
           const hasActiveTitle = focusActiveTitle && Object.values(runningStatus).some(Boolean)
           const gamePathLower = gamePaths[game.key] ? normalizePath(gamePaths[game.key]) : undefined
+          // The green dot means the game's own exe is running — NOT the
+          // runningStatus[key] aggregate, which is also true when only a
+          // companion (e.g. SimHub) is up (#587). See isGameExeRunning.
+          const gameExeRunning = isGameExeRunning(runningApps, game.key, gamePaths[game.key])
           // Exclude the game's own executable so it doesn't appear as a
-          // companion app in the running strip — the green dot on GameIcon
-          // already communicates that the game itself is running.
+          // companion app in the running strip — the dot above already
+          // represents the game itself.
           const appsForGame = runningApps.filter(
             (a) => a.gameKey === game.key && normalizePath(a.path) !== gamePathLower
           )
@@ -185,6 +184,7 @@ export function GameList({
               gameIconUrl={gameIcons[game.key]}
               isActive={activeEditorKey === game.key}
               isRunning={!!runningStatus[game.key]}
+              isGameRunning={gameExeRunning}
               runningAppIcons={runningAppIcons}
               isDimmed={hasActiveTitle && !runningStatus[game.key]}
               isLaunching={launchingGameKey === game.key}

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -5,6 +5,7 @@ import {
   SettingsIcon,
   MinimizeIcon,
   MaximizeIcon,
+  RestoreIcon,
   CloseWindowIcon
 } from './icons'
 import { Tooltip } from './Tooltip'
@@ -121,7 +122,11 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
             className="icon-action cursor-pointer rounded-full p-2"
             aria-label={isMaximized ? 'Restore' : 'Maximize'}
           >
-            <MaximizeIcon width={14} height={14} />
+            {isMaximized ? (
+              <RestoreIcon width={14} height={14} />
+            ) : (
+              <MaximizeIcon width={14} height={14} />
+            )}
           </button>
         </Tooltip>
         <Tooltip label="Close" placement="bottom">

--- a/src/renderer/src/components/WindowControls.tsx
+++ b/src/renderer/src/components/WindowControls.tsx
@@ -42,7 +42,7 @@ export function WindowControls({ view, onNavigate, updateInfo }: WindowControlsP
       {/* Pill: branding + settings gear — the app's primary navigation */}
       <nav
         aria-label="Primary"
-        className="no-drag glass-surface rounded-full flex items-center shrink-0 overflow-hidden"
+        className="no-drag glass-surface rounded-full flex items-center shrink-0"
       >
         {/* Launcher branding */}
         <Tooltip label="SimLauncher" placement="bottom">

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -32,6 +32,7 @@ export function GameRow({
   game,
   isActive,
   isRunning,
+  isGameRunning,
   runningAppIcons,
   gameIconUrl,
   isDimmed,
@@ -46,7 +47,13 @@ export function GameRow({
 }: {
   game: Game
   isActive: boolean
+  // Aggregate: any tracked app under this game's key is running (game exe OR a
+  // companion). Drives sorting, dimming, relaunch-missing and the switch
+  // confirm — all of which mean "this profile has something running".
   isRunning: boolean
+  // Narrow: the game's OWN executable is running. Drives only the green status
+  // dot, whose tooltip/label assert the game itself is running (#587).
+  isGameRunning: boolean
   runningAppIcons: RunningAppIcon[]
   gameIconUrl?: string
   isDimmed: boolean
@@ -452,7 +459,7 @@ export function GameRow({
         className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? 'isolation-auto! z-20' : 'z-0'}`}
       >
         <div className="flex items-center gap-5">
-          <GameIcon game={game} isRunning={isRunning} iconUrl={gameIconUrl} />
+          <GameIcon game={game} isRunning={isGameRunning} iconUrl={gameIconUrl} />
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
               <h2 className="game-title font-normal text-(--text-primary)">{game.name}</h2>

--- a/src/renderer/src/components/icons/index.tsx
+++ b/src/renderer/src/components/icons/index.tsx
@@ -118,6 +118,27 @@ export function MaximizeIcon(props: IconProps): ReactNode {
   )
 }
 
+export function RestoreIcon(props: IconProps): ReactNode {
+  return (
+    <Icon
+      width={props.width ?? 16}
+      height={props.height ?? 16}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+      strokeLinecap="round"
+      {...props}
+    >
+      {/* Front window (bottom-left) */}
+      <rect x="2" y="5" width="9" height="9" rx="1.5" />
+      {/* Back window (offset up-right) — only the edges not hidden by the front */}
+      <path d="M5 5V3.5A1.5 1.5 0 0 1 6.5 2H12.5A1.5 1.5 0 0 1 14 3.5V9.5A1.5 1.5 0 0 1 12.5 11H11" />
+    </Icon>
+  )
+}
+
 export function CloseWindowIcon(props: IconProps): ReactNode {
   return (
     <Icon

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -34,8 +34,9 @@ export function SettingsProvider({
   const { notify } = useNotify()
   const theme = useTheme()
   // Ref keeps themeRef.current always pointing at the latest theme object so
-  // that useSettingsLoad's loadSettingsFromStore callback (memoized with an
-  // empty dep array) can call theme.setThemeMode without becoming stale.
+  // that useSettingsLoad's loadSettingsFromStore callback (whose dependency
+  // array deliberately omits `theme`) can call theme.setThemeMode without
+  // closing over a stale theme.
   const themeRef = useRef(theme)
   themeRef.current = theme
 

--- a/src/renderer/src/components/settings/saveRace.ts
+++ b/src/renderer/src/components/settings/saveRace.ts
@@ -1,6 +1,8 @@
 // These four fields are dictionary-typed (Record<string, string>) and can be
-// edited concurrently while a save is in flight. All other settings fields are
-// scalars whose last-writer-wins behaviour is acceptable, so they are not tracked.
+// edited concurrently while a save is in flight, so they carry per-field edit
+// versions to detect mid-save edits. Other dictionary-typed state such as
+// `profiles` is intentionally NOT version-tracked (its last-writer-wins
+// behaviour is accepted); the remaining settings are scalars.
 export const SETTINGS_OBJECT_FIELDS = ['appPaths', 'appNames', 'appArgs', 'gamePaths'] as const
 
 export type SettingsObjectField = (typeof SETTINGS_OBJECT_FIELDS)[number]

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -1,16 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
-import {
-  getActiveGameProfile,
-  normalizeGameProfileSet,
-  type GameProfileSet,
-  type Profiles
-} from '../lib/config'
+import { normalizeGameProfileSet, type GameProfileSet, type Profiles } from '../lib/config'
 import { getProfiles, saveProfile } from '../lib/store'
-
-type ProfileState = {
-  killControlsEnabled: boolean
-  relaunchControlsEnabled: boolean
-}
+import { getProfileState, type ProfileState } from '../lib/profileControls'
 
 const FOCUS_DEBOUNCE_MS = 300
 const PROFILE_FOCUS_EVENT = 'simlauncher:profile-focus-reload'
@@ -37,15 +28,6 @@ function ensureFocusListener() {
       window.dispatchEvent(new Event(PROFILE_FOCUS_EVENT))
     }, FOCUS_DEBOUNCE_MS)
   })
-}
-
-const getProfileState = (profileSet: GameProfileSet): ProfileState => {
-  const profile = getActiveGameProfile(profileSet)
-
-  return {
-    killControlsEnabled: profile.killControlsEnabled === true,
-    relaunchControlsEnabled: profile.relaunchControlsEnabled === true
-  }
 }
 
 export interface UseGameProfileResult {

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -15,10 +15,11 @@ type ProfileState = {
 const FOCUS_DEBOUNCE_MS = 300
 const PROFILE_FOCUS_EVENT = 'simlauncher:profile-focus-reload'
 
-// Module-level singleton: the focus listener is registered once for the entire
-// renderer lifetime. Multiple useGameProfile instances share it through the
-// custom event, so the store is read at most once per focus regain regardless
-// of how many game rows are mounted.
+// Module-level singleton: the OS 'focus' listener is registered once for the
+// entire renderer lifetime and debounced, so each focus regain produces exactly
+// one PROFILE_FOCUS_EVENT dispatch. NOTE: this does NOT dedupe store reads —
+// every mounted useGameProfile registers its own PROFILE_FOCUS_EVENT handler, so
+// the store is read once per mounted game row per focus regain.
 let focusListenerActive = false
 let focusDebounceTimer: ReturnType<typeof setTimeout> | undefined
 

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -133,8 +133,10 @@ export function useProfileEditor({
   const [launchAutomatically, setLaunchAutomatically] = useState(true)
   const [gamePosition, setGamePosition] = useState<GamePosition>('first')
   const [trackingEnabled, setTrackingEnabled] = useState(true)
-  const [killControlsEnabled, setKillControlsEnabled] = useState(false)
-  const [relaunchControlsEnabled, setRelaunchControlsEnabled] = useState(false)
+  // Default ON (see useGameProfile getProfileState / #590); the load below uses
+  // the same `!== false` rule so only an explicit opt-out reads as off.
+  const [killControlsEnabled, setKillControlsEnabled] = useState(true)
+  const [relaunchControlsEnabled, setRelaunchControlsEnabled] = useState(true)
   const [trackedProcessPaths, setTrackedProcessPaths] = useState<string[]>([])
   const [appIconCache, setAppIconCache] = useState<Record<string, string>>({})
   const [failedIcons, setFailedIcons] = useState<Record<string, boolean>>({})
@@ -181,8 +183,8 @@ export function useProfileEditor({
       // Anything other than an explicit 'last' means game-first (#471)
       setGamePosition(profile.gamePosition === 'last' ? 'last' : 'first')
       setTrackingEnabled(profile.trackingEnabled !== false)
-      setKillControlsEnabled(profile.killControlsEnabled === true)
-      setRelaunchControlsEnabled(profile.relaunchControlsEnabled === true)
+      setKillControlsEnabled(profile.killControlsEnabled !== false)
+      setRelaunchControlsEnabled(profile.relaunchControlsEnabled !== false)
       setTrackedProcessPaths(
         Array.isArray(profile.trackedProcessPaths) ? profile.trackedProcessPaths : []
       )

--- a/src/renderer/src/lib/migrations.ts
+++ b/src/renderer/src/lib/migrations.ts
@@ -76,9 +76,11 @@ function getStringRecord(value: unknown) {
  * atomically at the end (after all store writes succeed), so a crash mid-migration
  * will retry on next launch rather than silently leaving data half-migrated.
  *
- * Ordering matters: settings are saved before profiles so that the resolved
- * custom-slot count (derived from the migrated appPaths/appNames) is available
- * when the profile store is read back on the next load.
+ * The custom-slot count is resolved in-memory (getHighestCustomSlot over
+ * appPaths/appNames/profiles) and baked into the migrated profiles before any
+ * store write, so the relative order of saveSettings vs saveProfiles is not
+ * significant. Both writes happen at the very end so a crash before the
+ * `migrated` flag is set retries cleanly on the next launch.
  */
 export async function migrateFromLocalStorage(): Promise<void> {
   const flags = await getMigrationFlags()

--- a/src/renderer/src/lib/profileControls.ts
+++ b/src/renderer/src/lib/profileControls.ts
@@ -1,0 +1,19 @@
+import { getActiveGameProfile, type GameProfileSet } from './config'
+
+export type ProfileState = {
+  killControlsEnabled: boolean
+  relaunchControlsEnabled: boolean
+}
+
+// Default ON: managing companion apps is the core use case, so the Close Apps
+// and Relaunch controls are surfaced unless a profile explicitly opts out with
+// `false`. Profiles from before these toggles existed (field absent) therefore
+// get the controls too; users can still disable them per-profile (#590).
+export function getProfileState(profileSet: GameProfileSet): ProfileState {
+  const profile = getActiveGameProfile(profileSet)
+
+  return {
+    killControlsEnabled: profile.killControlsEnabled !== false,
+    relaunchControlsEnabled: profile.relaunchControlsEnabled !== false
+  }
+}

--- a/src/renderer/src/lib/runningGame.ts
+++ b/src/renderer/src/lib/runningGame.ts
@@ -1,0 +1,29 @@
+import type { RunningApp } from '../hooks/useRunningApps'
+
+// Windows paths are case-insensitive, but the main process may return them in
+// any case (process snapshots vs. settings-stored paths), so compare lowercased.
+const normalize = (path: string): string => path.toLowerCase()
+
+/**
+ * True when the game's OWN executable (its configured path) is among the running
+ * apps for this game key — i.e. the game itself is running, as opposed to only
+ * companion apps being up.
+ *
+ * This is deliberately narrower than `runningStatus[key]`, which is an aggregate
+ * that is also true when only a companion (e.g. SimHub) is running. The green
+ * status dot and the "now running" announcement both mean "the game is running",
+ * so both derive from this — keeping them in agreement (#587).
+ *
+ * Note: launcher / secondary-watch games where the in-session executable is not
+ * `gamePaths[key]` (iRacing via its UI, AC via Content Manager) are out of scope
+ * here and handled by the running-state pass (#585/#586).
+ */
+export function isGameExeRunning(
+  runningApps: Pick<RunningApp, 'path' | 'gameKey'>[],
+  gameKey: string,
+  gamePath: string | undefined
+): boolean {
+  if (!gamePath) return false
+  const target = normalize(gamePath)
+  return runningApps.some((app) => app.gameKey === gameKey && normalize(app.path) === target)
+}

--- a/tests/renderer/profileControlsDefault.test.ts
+++ b/tests/renderer/profileControlsDefault.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The per-profile "Allow close apps controls" / "Allow relaunch controls" flags
+ * default ON: managing companion apps is the core use case, so the row's Close
+ * Apps (X) and Relaunch buttons appear unless a profile explicitly opts out with
+ * `false`. Profiles saved before these toggles existed (field absent) get them
+ * too. Only a deliberate `false` hides the controls (#590).
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { getProfileState } from '../../src/renderer/src/lib/profileControls'
+import type { GameProfileSet } from '../../src/renderer/src/lib/config'
+
+const makeSet = (flags: {
+  killControlsEnabled?: boolean
+  relaunchControlsEnabled?: boolean
+}): GameProfileSet => ({
+  activeProfileId: 'p1',
+  profiles: [{ id: 'p1', name: 'Test', utilities: [], ...flags }]
+})
+
+describe('getProfileState — close/relaunch controls default ON (#590)', () => {
+  test('enabled when the fields are absent (new / pre-toggle profiles)', () => {
+    const state = getProfileState(makeSet({}))
+    expect(state.killControlsEnabled).toBe(true)
+    expect(state.relaunchControlsEnabled).toBe(true)
+  })
+
+  test('disabled only when explicitly false', () => {
+    const state = getProfileState(
+      makeSet({ killControlsEnabled: false, relaunchControlsEnabled: false })
+    )
+    expect(state.killControlsEnabled).toBe(false)
+    expect(state.relaunchControlsEnabled).toBe(false)
+  })
+
+  test('enabled when explicitly true', () => {
+    const state = getProfileState(
+      makeSet({ killControlsEnabled: true, relaunchControlsEnabled: true })
+    )
+    expect(state.killControlsEnabled).toBe(true)
+    expect(state.relaunchControlsEnabled).toBe(true)
+  })
+
+  test('each flag is independent', () => {
+    const state = getProfileState(makeSet({ killControlsEnabled: false }))
+    expect(state.killControlsEnabled).toBe(false)
+    expect(state.relaunchControlsEnabled).toBe(true)
+  })
+})

--- a/tests/renderer/runningGame.test.ts
+++ b/tests/renderer/runningGame.test.ts
@@ -34,6 +34,8 @@ describe('isGameExeRunning', () => {
   })
 
   test('matches case-insensitively (Windows paths)', () => {
-    expect(isGameExeRunning([{ path: acGame.path.toUpperCase(), gameKey: 'ac' }], 'ac', acGame.path)).toBe(true)
+    expect(
+      isGameExeRunning([{ path: acGame.path.toUpperCase(), gameKey: 'ac' }], 'ac', acGame.path)
+    ).toBe(true)
   })
 })

--- a/tests/renderer/runningGame.test.ts
+++ b/tests/renderer/runningGame.test.ts
@@ -1,0 +1,39 @@
+/**
+ * isGameExeRunning decides whether the green "Running" dot on a game and the
+ * "<game> is now running" announcement fire. Both must mean the GAME ITSELF is
+ * running — not merely that a companion (e.g. SimHub) under the same profile is
+ * up, which is what the runningStatus[key] aggregate would wrongly report (#587).
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { isGameExeRunning } from '../../src/renderer/src/lib/runningGame'
+
+const acGame = { path: 'C:\\Games\\AssettoCorsa\\acs.exe', gameKey: 'ac' }
+const simhub = { path: 'C:\\Program Files\\SimHub\\SimHubWPF.exe', gameKey: 'ac' }
+
+describe('isGameExeRunning', () => {
+  test('true when the game exe is among the running apps for its key', () => {
+    expect(isGameExeRunning([acGame, simhub], 'ac', acGame.path)).toBe(true)
+  })
+
+  test('false when only a companion under the same key is running (#587)', () => {
+    expect(isGameExeRunning([simhub], 'ac', acGame.path)).toBe(false)
+  })
+
+  test('false when nothing for the game is running', () => {
+    expect(isGameExeRunning([], 'ac', acGame.path)).toBe(false)
+  })
+
+  test('false when the game path is not configured', () => {
+    expect(isGameExeRunning([acGame], 'ac', undefined)).toBe(false)
+  })
+
+  test('requires the gameKey to match, not just the path', () => {
+    expect(isGameExeRunning([{ path: acGame.path, gameKey: 'acc' }], 'ac', acGame.path)).toBe(false)
+  })
+
+  test('matches case-insensitively (Windows paths)', () => {
+    expect(isGameExeRunning([{ path: acGame.path.toUpperCase(), gameKey: 'ac' }], 'ac', acGame.path)).toBe(true)
+  })
+})


### PR DESCRIPTION
Pre-1.0.0 smoke-test fix batch.

## 1. Maximize/restore glyph (Closes #584)

The title-bar button always rendered the maximize square even when maximized — only the tooltip and aria-label switched to "Restore". Adds a `RestoreIcon` and picks the glyph from `isMaximized`, so it stays correct under the button and the OS paths that drive it (Win+Up, aero-snap, taskbar double-click).

## 2. Game-running dot reflects the game exe (Closes #587)

The green "Running" dot lit up whenever **any** tracked app under a profile was running (companions included), so a left-open SimHub kept the game marked "running" after the game closed. The dot now derives from a new `isGameExeRunning` helper that matches the configured game path; the `runningStatus` aggregate is kept for sorting/dimming/relaunch/switch-confirm. The launch "now running" announcement shares the helper, so the dot and the announcement always agree. Launcher / secondary-watch games (iRacing UI, AC via Content Manager) are deferred to the running-state pass (#585 / #586).

## 3. Branding/settings pill focus ring (Closes #589)

The top-left nav pill had `overflow-hidden`, which clipped its child buttons' focus outline at the rounded edge — tabbing to the wordmark or gear showed only the inner divider. Removes `overflow-hidden` so the standard focus ring shows, with no hover-corner bleed.

## 4. Default the close-apps / relaunch controls to ON (Closes #590)

The per-profile "Allow close apps controls" / "Allow relaunch controls" flags defaulted to false, so the row's Close Apps (X) and Relaunch buttons stayed hidden until enabled. Managing companion apps is the core use case, so default them ON: the flags read as `!== false`, so new and pre-toggle profiles get the controls; an explicit `false` opt-out is respected. `getProfileState` is extracted to a pure `lib/profileControls` module and unit-tested.

## 5. Comment-accuracy audit cleanup (docs)

A multi-agent audit of all 97 source files (~367 substantive comments) flagged 11 comments whose stated behavior contradicted the code — **0 high severity, none hid a live bug**. One was the #587 dot comment (fixed in part 2); this corrects the other 10 (process-global cooldown, focus-singleton dedup scope, `appPaths` vs `gamePaths`, `isQuitting`-only mutation, etc.).

## Test plan

- `npm run typecheck`, `npm run lint`, `npm run format:check` — all clean.
- `npm test` — 369/369 pass, incl. new tests for `isGameExeRunning` and the `getProfileState` default-ON rule.
- Manual smoke (final rebuild): maximize/restore glyph swaps; running dot clears when the game closes but SimHub stays up; focus ring visible on the nav pill; new profiles show Close Apps / Relaunch controls by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Window maximize button now shows the correct restore icon when maximized.
  * Game status indicator now more precisely separates whether the game executable is running from whether companion apps are running.

* **Bug Fixes**
  * Profile editor “close apps” and “relaunch” controls now default to enabled, and existing profiles follow an explicit opt-out rule.

* **Tests**
  * Added coverage for game executable running detection, including companion-only, key mismatch, and case-insensitive path scenarios.

* **Documentation**
  * Improved clarity of internal comments around process tracking and settings/state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->