### PR TITLE
fix(games): primaryLaunch uses game-exe state; profileState init (CodeRabbit follow-ups on #588)

### DIFF
--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -340,11 +340,12 @@ export function GameRow({
       return
     }
 
-    // Capture BEFORE launching: this is a fresh game start only if the game
-    // wasn't already running. If it was (e.g. started outside SimLauncher and the
-    // user clicks Launch to start companion apps), the game exe would still be
-    // running at cooldown end and wrongly trigger the "now running" cue.
-    const wasRunning = isRunning
+    // Capture BEFORE launching: this is a fresh game start only if the GAME EXE
+    // wasn't already running. Use isGameRunning, not the aggregate isRunning — if
+    // only a companion was up (game not running), launching the game IS a primary
+    // launch and the "now running" cue should fire; the aggregate would suppress
+    // it (#587).
+    const wasRunning = isGameRunning
     let cooldownMs = 0
 
     try {
@@ -528,11 +529,13 @@ export function GameRow({
                   handleLaunchRequest.current = launcher
                 }}
                 onLaunchStart={() => onLaunchStart(game.key)}
-                // primaryLaunch only when the game wasn't already running, so the
-                // "now running" cue isn't spoken for a launch that merely
-                // (re)starts companion apps for an already-running game.
+                // primaryLaunch only when the game EXE wasn't already running
+                // (isGameRunning, not the aggregate), so the "now running" cue
+                // isn't spoken for a launch that merely (re)starts companion apps
+                // for an already-running game — but still fires when only a
+                // companion was up (#587).
                 onLaunchEnd={(cooldownMs) =>
-                  onLaunchEnd(game.key, cooldownMs, { primaryLaunch: !isRunning })
+                  onLaunchEnd(game.key, cooldownMs, { primaryLaunch: !isGameRunning })
                 }
               />
             </div>

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -46,10 +46,12 @@ export function useGameProfile(
   const [profileSet, setProfileSet] = useState<GameProfileSet>(() =>
     normalizeGameProfileSet(undefined)
   )
-  const [profileState, setProfileState] = useState<ProfileState>({
-    killControlsEnabled: false,
-    relaunchControlsEnabled: false
-  })
+  // Initialize from the same helper the load path uses (getProfileState), so the
+  // first render already reflects the default-ON opt-out semantics instead of a
+  // hardcoded false that would briefly mismatch until the store load resolves.
+  const [profileState, setProfileState] = useState<ProfileState>(() =>
+    getProfileState(normalizeGameProfileSet(undefined))
+  )
 
   const readProfileSet = useCallback(async () => {
     const profiles = await getProfiles()


### PR DESCRIPTION
Addresses the two CodeRabbit findings that were posted as **outside-diff review-body comments** on #588 (so they weren't inline and were missed before merge).

## 1. 🟠 `primaryLaunch` used aggregate state, not game-exe state

`GameRow` decided `primaryLaunch` (which gates the "now running" announcement) from the aggregate `isRunning`. If only a companion (e.g. SimHub) was running, launching the actual game exe was treated as non-primary and the cue was wrongly suppressed. Now both launch paths (row button + editor) key off `isGameRunning`, consistent with the green-dot semantics from #587.

## 2. 🟡 `profileState` initial value mismatched the default-ON semantics

`useGameProfile` initialized `profileState` to `{ killControlsEnabled: false, relaunchControlsEnabled: false }`, but the load path derives state via `getProfileState`, where absent flags are treated as **enabled** (#590). That made the first render briefly inconsistent. Now initialized from `getProfileState(normalizeGameProfileSet(undefined))`.

## Test plan

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean.
- `npm test` — 369/369 pass.

Refs #587, #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed game launch state detection to accurately track when the game executable is running
* Corrected profile editor launch-end behavior for proper state tracking
* Improved profile state initialization consistency during app startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->