### PR TITLE
fix(games): refresh the Games list reactively on store changes (#601)

### DIFF
--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { GAMES, type Game } from '../lib/config'
-import { getSettings } from '../lib/store'
+import { getSettings, onStoreConfigChanged } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
@@ -55,29 +55,42 @@ export function GameList({
   })
   const { gameIcons } = useGamesSettings()
 
-  useEffect(() => {
-    let mounted = true
+  // Read the configured-games list (+ derived UI state) from the store. Kept in
+  // a callback so it can run on mount AND on every store config change: the
+  // Games view stays mounted (#479), so without a reactive re-read it would hold
+  // its mount-time snapshot. The normal save paths (sticky bar, in-Settings
+  // footer) persist without bumping App's refreshKey, so a newly-configured game
+  // stayed hidden and a removed one lingered until the next app restart (#601).
+  const loadSettings = useCallback(async (alive: { current: boolean }) => {
+    try {
+      const settings = await getSettings()
+      if (!alive.current) return
 
-    async function loadInitialSettings() {
-      try {
-        const settings = await getSettings()
-        if (!mounted) return
-
-        setGamePaths(settings.gamePaths)
-        setFocusActiveTitle(settings.focusActiveTitle !== false)
-        setConfiguredGames(GAMES.filter((game) => !!settings.gamePaths[game.key]))
-        setSettingsLoaded(true)
-      } catch (err) {
-        console.error('Failed to load game settings', err)
-      }
-    }
-
-    loadInitialSettings()
-
-    return () => {
-      mounted = false
+      setGamePaths(settings.gamePaths)
+      setFocusActiveTitle(settings.focusActiveTitle !== false)
+      setConfiguredGames(GAMES.filter((game) => !!settings.gamePaths[game.key]))
+      setSettingsLoaded(true)
+    } catch (err) {
+      console.error('Failed to load game settings', err)
     }
   }, [])
+
+  useEffect(() => {
+    const alive = { current: true }
+    void loadSettings(alive)
+    // GameList is a pure reader with no dirty baseline, so — unlike
+    // useSettingsLoad — it must NOT skip the 'save-settings' reason: that's the
+    // write that carries gamePaths. The event fires after the store write, and
+    // GameList never writes the store, so there is no feedback loop.
+    const unsubscribe = onStoreConfigChanged(() => {
+      void loadSettings(alive)
+    })
+
+    return () => {
+      alive.current = false
+      unsubscribe()
+    }
+  }, [loadSettings])
 
   // Lazy-load Windows shell icons for newly-seen running app paths. Uses the
   // undefined sentinel (vs '' for "loaded but no icon") so re-fetching on


### PR DESCRIPTION
## What

Fixes #601: the Games list does not reflect added / removed games until the app is restarted.

## Root cause

`GameList` read the configured-games list exactly once in a mount-only `useEffect([])` and never subscribed to store changes. The Games view is kept mounted (CSS `inert`+opacity, #479), so that effect never re-fires on a tab switch. The only in-process refresh path is a full remount via `<GameList key={refreshKey}>` — and the **normal** save buttons don't bump `refreshKey`:

- StickySaveBar "Save Changes" → `requestSaveAll()` only
- in-Settings footer "Save Changes" → `useSettingsSave.handleSave` (persists + resetDirty, no refreshKey)
- a clean (non-dirty) navigate back to Games → `setView` directly

Only the unsaved-changes / close dialogs and config import bump `refreshKey`. So after a normal save, `GameList` kept its mount-time snapshot:

- a **newly-configured** game was absent from the snapshot → stayed hidden
- a **removed** game was present in the snapshot → lingered

Persistence was always correct (`getSettings` is uncached end-to-end), which is why a restart fixed it.

This is **not** a dependency bump. The latent defect is original to `GameList`, but it became the everyday user-visible regression with the unified dirty-state UX (#404, `5848d61`), which first shipped in **v0.9.8** — so v0.9.8 / v0.9.9 / v0.9.10 are all affected.

Verified by a multi-agent root-cause pass (8 agents; two independent skeptics refuted nothing; HIGH confidence).

## Fix

Make `GameList` reactive: subscribe to `onStoreConfigChanged` and re-read settings on every store mutation. Unlike `useSettingsLoad` (the *writer*, which skips its own `save-settings` / `save-profiles` bulk writes to avoid clobbering its dirty baseline), `GameList` is a pure *reader* with no dirty baseline, so it must act on `save-settings` — that's the reason carrying `gamePaths`. No feedback loop: GameList never writes the store and the event fires after the write.

The existing `refreshKey` choreography is left in place — it remains valid for `<SettingsProvider key={refreshKey}>` re-baselining on import/discard, and is now harmless belt-and-suspenders for GameList.

## Test plan

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm test` — 369/369 pass
- Manual smoke (batched into the 1.0.0 pre-release run):
  - add a game → Save via sticky bar → appears without restart
  - delete a game → Save → disappears without restart
  - both repeated via "Back to Games" after saving (the clean-navigate path)
  - config import still refreshes; no EmptyState flash on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced GameList component to actively respond to store configuration changes, improving real-time settings synchronization and preventing potential state updates after component unmount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->