### PR TITLE
fix(a11y): name game rows + announce launch start for Narrator (#612)

### DIFF
--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -72,7 +72,7 @@ export function GameRow({
   onCloseEditor: () => void
   cacheInitialized: boolean
 }): ReactNode {
-  const { notify } = useNotify()
+  const { notify, announce } = useNotify()
   const [profileSwitchConfirm, setProfileSwitchConfirm] = useState<{
     nextProfileId: string
     nextProfileName: string
@@ -350,6 +350,11 @@ export function GameRow({
 
     try {
       onLaunchStart(game.key)
+      // Polite SR cue that a launch has begun. The button's spinner + aria-busy
+      // are visual/verbosity-dependent; this live-region announcement is the
+      // reliable spoken "launch started" feedback, paired with the existing
+      // "X is now running" settle cue (#612).
+      announce(`Launching ${game.name}`)
       const result = await launchProfile(game.key)
       if (!result.success) {
         cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
@@ -453,6 +458,10 @@ export function GameRow({
   return (
     <div
       role="listitem"
+      // Name the list item so Narrator announces the game (e.g. "Assetto Corsa,
+      // 3 of 7") instead of synthesizing a bare list marker ("bullet") in front
+      // of each focused control in the row (#612). Keeps the list semantics.
+      aria-label={game.name}
       className={`game-row-container group/row relative flex flex-col ${isActive ? '' : 'gap-2'} transition-opacity duration-300 ${profileMenuOpen ? 'z-40' : 'z-0'} ${isDimmed ? 'opacity-45' : 'opacity-100'}`}
       ref={rowRef}
     >
@@ -528,7 +537,10 @@ export function GameRow({
                 onLaunchRequest={(launcher) => {
                   handleLaunchRequest.current = launcher
                 }}
-                onLaunchStart={() => onLaunchStart(game.key)}
+                onLaunchStart={() => {
+                  announce(`Launching ${game.name}`)
+                  onLaunchStart(game.key)
+                }}
                 // primaryLaunch only when the game EXE wasn't already running
                 // (isGameRunning, not the aggregate), so the "now running" cue
                 // isn't spoken for a launch that merely (re)starts companion apps

--- a/tests/renderer/gameRowLaunchAnnounce.test.tsx
+++ b/tests/renderer/gameRowLaunchAnnounce.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Regression test for #612 (a11y: spoken launch feedback + named list rows).
+ *
+ * Two behaviors are pinned here:
+ *   1. Clicking a row's idle Play button announces "Launching <game>" through the
+ *      screen-reader live region (useNotify().announce) before the launch IPC
+ *      runs — the spinner / aria-busy alone are visual/verbosity-dependent, so
+ *      this polite cue is the reliable spoken "launch started" feedback.
+ *   2. The row's `role="listitem"` container carries `aria-label={game.name}` so
+ *      Narrator names the row ("Assetto Corsa, 3 of 7") instead of synthesizing
+ *      a bare list marker ("bullet") before each control in the row.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const announceMock = vi.fn()
+const notifyMock = vi.fn()
+const launchProfileMock = vi.fn().mockResolvedValue({ success: true, launchedCount: 1 })
+
+// GameRow imports these directly from lib/electron. window.electronAPI is
+// undefined in jsdom, so the real module would crash at eval — stub the surface
+// GameRow touches. Only launchProfile is exercised here; the rest are inert.
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+// GameRow imports ProfileEditor, whose hook graph (useProfileEditor) pulls in
+// lib/store, which grabs window.electronAPI references at module eval — crashing
+// in jsdom. GameRow's own runtime never calls the store directly (the profile
+// hooks that do are mocked below), so no-op stubs are safe and mask nothing.
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+// Mock useNotify so announce()/notify() are observable without rendering the
+// real toast portal (jsdom lacks Element.animate, which Notify mounts).
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: announceMock }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+// Stub the profile hooks so the row doesn't reach into lib/store →
+// window.electronAPI (undefined in jsdom). A single default profile with the
+// kill/relaunch controls absent (treated as ON) is all the launch path needs.
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRow(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={false}
+          isGameRunning={false}
+          runningAppIcons={[]}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+beforeEach(() => {
+  announceMock.mockClear()
+  notifyMock.mockClear()
+  launchProfileMock.mockClear()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('GameRow launch a11y (#612)', () => {
+  test('clicking the idle Play button announces "Launching <name>" and launches', async () => {
+    await renderRow()
+
+    // The idle Play button (runningAppIcons empty AND not launching → canKill
+    // false) is named "Launch <game>".
+    const playButton = container.querySelector(
+      'button[aria-label="Launch Assetto Corsa"]'
+    ) as HTMLButtonElement | null
+    expect(playButton).not.toBeNull()
+
+    await act(async () => {
+      playButton!.click()
+    })
+
+    expect(announceMock).toHaveBeenCalledWith('Launching Assetto Corsa')
+    expect(launchProfileMock).toHaveBeenCalledWith('ac')
+  })
+
+  test('the row exposes a role="listitem" whose accessible name is the game name', async () => {
+    await renderRow()
+
+    const listItem = container.querySelector('[role="listitem"]')
+    expect(listItem).not.toBeNull()
+    expect(listItem!.getAttribute('aria-label')).toBe('Assetto Corsa')
+  })
+})

--- a/tests/renderer/gameRowLaunchAnnounce.test.tsx
+++ b/tests/renderer/gameRowLaunchAnnounce.test.tsx
@@ -162,6 +162,11 @@ describe('GameRow launch a11y (#612)', () => {
 
     expect(announceMock).toHaveBeenCalledWith('Launching Assetto Corsa')
     expect(launchProfileMock).toHaveBeenCalledWith('ac')
+    // The cue must fire BEFORE the launch IPC, not merely at some point — that
+    // is the #612 contract: the SR hears "Launching" at launch start.
+    expect(announceMock.mock.invocationCallOrder[0]).toBeLessThan(
+      launchProfileMock.mock.invocationCallOrder[0]
+    )
   })
 
   test('the row exposes a role="listitem" whose accessible name is the game name', async () => {


### PR DESCRIPTION
## Summary

Two a11y fixes found during the 1.0.0 Windows Narrator smoke (root-caused in code + adversarially verified). Renderer ARIA / live-region only — no functional or visual change.

1. **Game rows announced "bullet".** The `role="listitem"` game-row container had no accessible name, so Narrator read a synthesized list marker ("bullet") before each focused control (cog / play / reload / dropdown). Added `aria-label={game.name}` → Narrator now says e.g. "Assetto Corsa, 3 of 7". List position/count semantics preserved.
2. **Launch start had no spoken cue.** No `announce()` fired when a launch began (only the visual spinner + `aria-busy` + a verbosity-dependent button-label flip). Added a polite `announce(\`Launching ${game.name}\`)` at the two fresh-launch entry points — the row Play button and the in-editor launch button — paired with the existing "X is now running" settle cue. Profile-switch / relaunch-missing intentionally keep their own outcome cues.

### Not changed (verified working as intended during the smoke)

- Settings accordion headers already expose correct `aria-expanded` → "<name>, button, collapsed/expanded".
- "Installed Version" already carries `select-text` (selectable/copyable); static text is read by Narrator scan mode, so no focus stop was added (tabindex on static text is an anti-pattern).

Closes #612

## Test plan

- ✅ `npm run typecheck`
- ✅ `npx eslint` (clean)
- ✅ `npx prettier --check` (clean)
- ✅ `npx vitest run` — 369/369 pass
- ⏳ **Manual Narrator re-pass (Station 5) on the rebuilt 1.0.0 draft**: confirm "bullet" is gone in front of the row controls, and "Launching <game>" is spoken when Play is pressed.

## Notes

- No GameRow component test added — there is no existing GameRow render harness, and the behavior is screen-reader output best verified by the live Narrator pass. Happy to add a focused render test (mock `useNotify`, assert `announce` on launch) if preferred.
- The v1.0.0 draft tag will need to be moved to this commit + the draft rebuilt after merge (draft is not published, so safe). Pre-publish Narrator re-pass happens on that rebuilt installer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added spoken “Launching {game}” announcements before starting a game.
  * Improved screen reader support by setting clearer list semantics and ensuring the game name is read for each row.

* **Tests**
  * Added a regression test to verify launch announcements occur before the launch action and that the row exposes the expected accessibility attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->