### PR TITLE
build: hyphenate installer artifactName so checksum verify matches (#614)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,11 @@ nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
   perMachine: false
+  # Hyphenated, space-free name so the local artifact, the published GitHub
+  # asset, latest.yml and SHA256SUMS.txt all agree — otherwise the default
+  # "${productName} Setup ${version}" (with spaces) is sanitized to hyphens on
+  # upload and `sha256sum -c SHA256SUMS.txt` fails on the downloaded asset (#614).
+  artifactName: ${productName}-Setup-${version}.${ext}
 publish:
   provider: github
   owner: Stashpeak


### PR DESCRIPTION
## Summary

Fixes #614: the v1.0.0 draft's `SHA256SUMS.txt` lists the installer with spaces (`SimLauncher Setup 1.0.0.exe`) while the published GitHub asset uses hyphens (`SimLauncher-Setup-1.0.0.exe`), so the standard `sha256sum -c SHA256SUMS.txt` fails on the downloaded file even though the hash value is correct — breaking the #564 integrity-verify UX.

Sets a hyphenated NSIS `artifactName` so the local artifact, the published asset, `latest.yml`, and `SHA256SUMS.txt` are all consistent.

```yaml
nsis:
  artifactName: ${productName}-Setup-${version}.${ext}
```

Auto-update is unaffected — electron-builder keeps `latest.yml` and the asset name in sync. Bonus: cleaner, space-free download filename.

Closes #614

## Test plan

- ✅ `npx prettier --check electron-builder.yml` (clean)
- ⏳ **Verified on the re-tag release build**: after merge + re-tag, the produced asset is `SimLauncher-Setup-1.0.0.exe`, `SHA256SUMS.txt` lists the same name, and `sha256sum -c SHA256SUMS.txt` passes on the downloaded file.

> Note: regular PR CI runs lint/test/`electron-vite build` only; `electron-builder` (which consumes `artifactName`) runs in `release.yml` on the tag, so this is verified at re-tag time, not in PR CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure consistent artifact naming across downloads, verification files, and release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->