### PR TITLE
fix: 1.0.1 stabilization batch (CI SHA-pinning #610, store-change reason gate #603, warning-icon border #576)

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           sha256sum *.exe | tee SHA256SUMS.txt
 
       - name: Generate SBOM (CycloneDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         env:
           # Electron is a devDependency but electron-builder embeds its
           # Chromium runtime into the installer, so dev deps must be included

--- a/.github/workflows/sync-pr-closes.yml
+++ b/.github/workflows/sync-pr-closes.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
       - main
 
+# Restrictive default so any future job inherits least privilege; the existing
+# job below explicitly grants the narrow scope it needs (pull-requests: write).
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -11,6 +11,15 @@ import { EmptyState } from './EmptyState'
 import { GameRow } from './game-list/GameRow'
 import { GamepadIcon } from './icons'
 
+// Derive the payload type from the store binding (same approach as
+// useSettingsLoad) so the reason gate below stays in sync with
+// StoreConfigChangeReason without a second import.
+type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] extends (
+  payload: infer Payload
+) => void
+  ? Payload
+  : never
+
 // Case-insensitive path comparison — Windows paths are case-insensitive but
 // the main process may return them in any case (e.g. from process snapshots
 // vs. settings-stored paths). Without normalization, `C:\foo` and `c:\foo`
@@ -78,11 +87,18 @@ export function GameList({
   useEffect(() => {
     const alive = { current: true }
     void loadSettings(alive)
-    // GameList is a pure reader with no dirty baseline, so — unlike
-    // useSettingsLoad — it must NOT skip the 'save-settings' reason: that's the
-    // write that carries gamePaths. The event fires after the store write, and
-    // GameList never writes the store, so there is no feedback loop.
-    const unsubscribe = onStoreConfigChanged(() => {
+    // GameList only reads gamePaths + focusActiveTitle, both written by
+    // 'save-settings'. So — unlike useSettingsLoad — it must NOT skip
+    // 'save-settings' (that's the write that carries gamePaths), but it CAN
+    // skip reasons that never touch gamePaths: 'save-profile' / 'save-profiles'
+    // (profiles only) and 'set-migration-flags' (boolean flags only). Gating
+    // here stops an unrelated save (theme, tray, a profile save) from giving
+    // configuredGames a new reference and needlessly re-subscribing the
+    // running-apps IPC/monitor (#603). 'import-config' replaces the whole store
+    // (keys ['*']) and can carry gamePaths, so it must reload. GameList never
+    // writes the store, so there is no feedback loop.
+    const unsubscribe = onStoreConfigChanged((payload: StoreConfigChangePayload) => {
+      if (payload.reason !== 'import-config' && payload.reason !== 'save-settings') return
       void loadSettings(alive)
     })
 

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -77,7 +77,18 @@ export function GameList({
 
       setGamePaths(settings.gamePaths)
       setFocusActiveTitle(settings.focusActiveTitle !== false)
-      setConfiguredGames(GAMES.filter((game) => !!settings.gamePaths[game.key]))
+      // Keep the previous configuredGames array reference when the game SET is
+      // unchanged. Every Settings save sends the full settings object, so
+      // 'save-settings' carries gamePaths in its changed keys even when gamePaths
+      // didn't actually change (theme/tray/accent saves). Without this guard a
+      // fresh array would churn useRunningApps' effect, re-subscribing the
+      // running-apps IPC/monitor on every unrelated save (#603).
+      setConfiguredGames((prev) => {
+        const next = GAMES.filter((game) => !!settings.gamePaths[game.key])
+        const unchanged =
+          prev.length === next.length && prev.every((game, index) => game.key === next[index].key)
+        return unchanged ? prev : next
+      })
       setSettingsLoaded(true)
     } catch (err) {
       console.error('Failed to load game settings', err)
@@ -87,15 +98,14 @@ export function GameList({
   useEffect(() => {
     const alive = { current: true }
     void loadSettings(alive)
-    // GameList only reads gamePaths + focusActiveTitle, both written by
-    // 'save-settings'. So — unlike useSettingsLoad — it must NOT skip
-    // 'save-settings' (that's the write that carries gamePaths), but it CAN
-    // skip reasons that never touch gamePaths: 'save-profile' / 'save-profiles'
-    // (profiles only) and 'set-migration-flags' (boolean flags only). Gating
-    // here stops an unrelated save (theme, tray, a profile save) from giving
-    // configuredGames a new reference and needlessly re-subscribing the
-    // running-apps IPC/monitor (#603). 'import-config' replaces the whole store
-    // (keys ['*']) and can carry gamePaths, so it must reload. GameList never
+    // Reload only for reasons that can carry gamePaths: 'import-config' (full
+    // store replace, keys ['*']) and 'save-settings'. Skip 'save-profile' /
+    // 'save-profiles' (profiles only) and 'set-migration-flags' (boolean flags)
+    // so those writes don't trigger a needless getSettings round-trip. Every
+    // Settings save sends the FULL settings object, so 'save-settings' also fires
+    // on theme/tray/accent changes — loadSettings absorbs that cheaply by keeping
+    // the configuredGames reference stable when the game set is unchanged (see the
+    // guard above), so useRunningApps doesn't re-subscribe (#603). GameList never
     // writes the store, so there is no feedback loop.
     const unsubscribe = onStoreConfigChanged((payload: StoreConfigChangePayload) => {
       if (payload.reason !== 'import-config' && payload.reason !== 'save-settings') return

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -124,7 +124,7 @@ function RunningAppIconItem({
         ref={refs.setReference}
         type="button"
         aria-label={`${app.name}: ${app.warning}`}
-        className="flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-sm ring-1 ring-(--warning-text)"
+        className="flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-(--warning-border)"
         {...triggerProps}
       >
         {isAvailable ? (


### PR DESCRIPTION
## Summary
Dávka A of the **1.0.1 stabilization** milestone — three low-risk, fully disjoint quick wins. No user-facing behaviour change: CI hardening + a render perf gate + a 1px UI artifact fix.

## Changes
- **CI supply-chain (#610):** pin the two third-party actions to immutable commit SHAs with a trailing version comment — `amannn/action-semantic-pull-request@e32d7e6 # v5`, `anchore/sbom-action@e22c389 # v0.24.0` — and add a top-level `permissions: {}` default to `sync-pr-closes.yml` (the existing job keeps its narrow `pull-requests: write`). First-party `actions/*` left as-is (the issue marks SHA-pinning them optional).
- **GameList over-fire (#603):** gate the `onStoreConfigChanged` re-read on `payload.reason`, reloading only for the reasons that can carry `gamePaths` (`import-config`, `save-settings`). Stops unrelated store writes (theme/tray/profile saves) from churning `configuredGames` and re-subscribing the running-apps IPC/monitor. Positive allowlist, so any future `StoreConfigChangeReason` defaults to no-reload.
- **Warning icon leftover line (#576):** swap the warning running-app icon's box-shadow `ring` (paints 1px outside the layout box → compositor residual during unmount reflow) for a real `border border-(--warning-border)` that paints inside the box and is removed atomically. Also aligns the lone `ring` outlier with the app-wide warning convention.

## Test plan
- `npm run format:check` ✓
- `npm run lint` ✓
- `npm run typecheck` (tsc + preload types) ✓
- `npm run build` ✓ (vite 8.0.16)
- `npm test` ✓ — **371 passed (53 files)**

Closes #610
Closes #603
Closes #576


<!-- auto-closes -->
Closes #576
Closes #603
Closes #610
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned commit SHAs instead of mutable version tags for PR title checks and release SBOM generation.
  * Tightened workflow permissions for the pull request synchronization workflow to follow least-privilege defaults.
* **Improvements**
  * Refined game settings reload behavior to trigger only for configuration import and settings saves, reducing unnecessary refreshes.
* **Style**
  * Adjusted the warning icon trigger styling in the running apps display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->