### PR TITLE
build(deps): pin vite and electron-vite to exact versions (#561)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "electron": "^42.4.0",
         "electron-builder": "^26.8.1",
-        "electron-vite": "^5.0.0",
+        "electron-vite": "5.0.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -34,7 +34,7 @@
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
-        "vite": "^8.0.16",
+        "vite": "8.0.16",
         "vitest": "^4.1.5"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "electron": "^42.4.0",
     "electron-builder": "^26.8.1",
-    "electron-vite": "^5.0.0",
+    "electron-vite": "5.0.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -69,7 +69,7 @@
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
-    "vite": "^8.0.16",
+    "vite": "8.0.16",
     "vitest": "^4.1.5"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
Resolves #561 via the **pin** path: vite `^8.0.16` and electron-vite `^5.0.0` are pinned to exact versions so a transitive `npm install` cannot silently swap the build toolchain and break `electron-vite build`.

## Why pin, not upgrade
- **electron-vite 6** is the only release whose peer range accepts vite 8 — but it is a stale **beta** (6.0.0-beta.1, no stable in 2+ months). Shipping a beta build tool in a stabilization patch is the wrong risk.
- **Pinning vite back to 7** would break the build: vite 7 carries esbuild as a hard `^0.27.0` dep, which collides with the load-bearing `esbuild ^0.28.1` security override (#532, GHSA-gv7w-rqvm-qjhr); no patched 0.27.x exists.
- vite reached 8 via an incidental Dependabot bump, not deliberate feature adoption — nothing uses vite-8-only APIs.

## Known / by design
- The `electron-vite ↔ vite` peer-mismatch warning **persists** (`npm ls` still reports vite invalid against electron-vite's `^5||^6||^7`, ELSPROBLEMS exit). Unchanged from before; the pin only removes the silent-caret-swap hazard. Resolving the mismatch outright needs the electron-vite 6 **stable** upgrade — deferred past 1.0.1 (recommend a follow-up issue).
- The `esbuild ^0.28.1` override is untouched and still resolves esbuild to 0.28.1 under both vite and electron-vite.

## Test plan
- `npm install` → lockfile diff is 4 lines (the two spec strings only; no transitive churn)
- `npm run build` ✓ (vite 8.0.16)
- `npm test` ✓ — 371 passed (53 files)
- `npm run format:check` ✓
- `npm ls vite electron-vite esbuild` → vite 8.0.16 / electron-vite 5.0.0 / esbuild 0.28.1 (override intact)

Closes #561


<!-- auto-closes -->
Closes #561
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest compatible versions for improved build tooling stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->