### PR TITLE
docs(readme): add Discord badge and community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/Stashpeak/SimLauncher/ci.yml?branch=main&label=CI)](../../actions/workflows/ci.yml)
 [![License: GPL-3.0](https://img.shields.io/github/license/Stashpeak/SimLauncher)](LICENSE)
 ![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D6)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/37BPprjazF)
 
 One-click startup for your entire sim racing setup.
 
@@ -165,6 +166,8 @@ Please **don't** open a public issue for security vulnerabilities. Report them p
 ---
 
 ## Support
+
+Questions, setup help, or want to show your rig? Join the [SimLauncher Discord](https://discord.gg/37BPprjazF). For bugs and feature requests, open a [GitHub issue](../../issues).
 
 If SimLauncher saves you time on race day, a small tip is appreciated: [paypal.me/shieldxx](https://paypal.me/shieldxx)
 


### PR DESCRIPTION
## What
- Adds a **Discord** badge to the README badge row, linking to the invite (`discord.gg/37BPprjazF`).
- Expands the **Support** section: questions / setup help -> Discord, bugs / feature requests -> GitHub Issues, tip -> PayPal.

## Why
The README half of the Discord community launch (the website already links it in the header + footer). The README is where the ~470 downloaders pass through, so it is the highest-leverage discovery spot.

## Notes
- The badge is **static** (`Discord | Join`) on purpose, so it does not surface the brand-new server's member count. Swap to a live-count shields badge later once the community has grown.
- Matches the existing shields.io badge style; no other content changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project README with a Discord invite badge near the top.
  * Added a note in the Support section inviting users to join the project’s Discord community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->