### PR TITLE
fix: sharpen blurry text on action-hover-scale buttons (#631)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -399,10 +399,6 @@ textarea {
   transform: scale(1.04);
 }
 
-.action-hover-scale {
-  will-change: transform;
-}
-
 .icon-action {
   background: transparent;
   /* --text-muted (not --text-subtle) so resting icon glyphs clear the 3:1


### PR DESCRIPTION
## Summary
- Remove the permanent `will-change: transform` on `.action-hover-scale` (~20 buttons app-wide: Settings → About, Save Changes, Browse, Back to Games, dialog actions, error-screen buttons).
- It permanently promoted each button to its own GPU compositing layer; combined with the app zoom factor and fractional display scaling, Chromium rasterised the layer text at a sub-pixel offset, which read as blurry. The hover scale still animates smoothly via the existing `transition` (the browser composites on demand during the transform), so the permanent hint was both wrong and a waste of GPU memory.

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test` (371 passed)
- [x] Manual: Settings → About buttons render crisp text at non-default zoom; hover scale still animates smoothly (verified by David)

Closes #631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up hover-related styling for interactive elements.  
  * No visible behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->