### PR TITLE
chore: bump version to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump version 1.0.0 → 1.0.1 (`package.json` + `package-lock.json`) for the 1.0.1 stabilization patch.
- Shipping content: removal of the permanent `will-change` blur on `.action-hover-scale` buttons (#631).
- Code signing (#511 / #245) is **deferred** — externally blocked on Microsoft identity validation, and a fix-only patch should not wait on it. SmartScreen "not signed yet" notes stay until signing lands.

## Release steps (after merge)
- Tag `v1.0.1` on `main` → the Release workflow builds the Windows installer and publishes a **draft** GitHub release (electron-builder default). Then review/test the draft and publish it.

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (371 passed)
- [ ] Manual: install the draft `SimLauncher-Setup-1.0.1.exe`, smoke-test launch + confirm crisp button text in Settings → About

Refs #631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **1.0.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->