### PR TITLE
chore(deps): bump undici to patched 6.27.0 / 7.28.0 (#635)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@electron/get/node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5871,9 +5871,9 @@
       }
     },
     "node_modules/jsdom/node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7839,9 +7839,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- `npm update undici` bumps both transitive undici lines to patched versions — `node-gyp`'s **6.25.0 → 6.27.0** and `jsdom`'s **7.x → 7.28.0** — clearing all **9** dev-scope Dependabot advisories (2 high, 3 medium, 4 low).
- **Lockfile-only** change. No `overrides` entry needed: the existing `^6.25.0` / `^7.25.0` ranges already permit the patched versions, so a blanket override (which can't be both 6 and 7) is avoided entirely.
- All 9 were `scope=development` (build/test tooling — `node-gyp`, `jsdom`) and **never shipped in the installer**; `npm audit --omit=dev` (the Release gate) was already 0. This just clears the Security tab.

## Test plan
- [x] `npm audit` → **0 vulnerabilities** (was: 9 undici advisories)
- [x] `npm test` → 371 passed (53 files)
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run format:check`

Closes #635


<!-- auto-closes -->
Closes #635
<!-- auto-closes -->