### PR TITLE
feat: Settings deep-link opens + scrolls to target section (#642)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -322,10 +322,6 @@ function AppContent() {
     setShowImportWarning(true)
   }
 
-  // Clear the deep-link target once SettingsView has opened + scrolled to it, so
-  // re-clicking the same CTA fires the effect again.
-  const handleTargetConsumed = useCallback(() => setSettingsTarget(null), [])
-
   return (
     <div
       className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
@@ -404,7 +400,6 @@ function AppContent() {
                 onClose={() => handleNavigate('games')}
                 updateInfo={updateInfo}
                 targetSection={settingsTarget}
-                onTargetConsumed={handleTargetConsumed}
               />
             </div>
           </div>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { NotifyProvider, useNotify } from './components/Notify'
 import { WindowControls } from './components/WindowControls'
 import { GameList } from './components/GameList'
 import { SettingsView } from './components/SettingsView'
+import type { SettingsSectionKey } from './components/settings/types'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { StickySaveBar } from './components/StickySaveBar'
 import { WarningTriangleIcon, CloseIcon } from './components/icons'
@@ -42,6 +43,11 @@ function AppContent() {
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
   const [showImportWarning, setShowImportWarning] = useState(false)
   const [pendingView, setPendingView] = useState<'games' | 'settings' | null>(null)
+  // Deep-link target: which Settings section to open + scroll to when Settings
+  // becomes the active view. `pendingTarget` mirrors `pendingView` so a target
+  // requested while there are unsaved changes survives the save/discard confirm.
+  const [settingsTarget, setSettingsTarget] = useState<SettingsSectionKey | null>(null)
+  const [pendingTarget, setPendingTarget] = useState<SettingsSectionKey | null>(null)
   const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
   // When true, the close dialog's actions minimize to tray instead of fully
   // quitting. Set from the `close-requested` payload so the dialog labels and
@@ -185,14 +191,24 @@ function AppContent() {
   // Gate tab navigation behind the discard/save confirm dialog when dirty.
   // The actual view switch is deferred to handleConfirmDiscard/Save so the
   // user's choice (save vs discard) determines the transition.
-  const handleNavigate = (nextView: 'games' | 'settings') => {
-    if (view === nextView) return
+  const handleNavigate = (
+    nextView: 'games' | 'settings',
+    target: SettingsSectionKey | null = null
+  ) => {
+    if (view === nextView) {
+      // Already on this view; still surface a requested section (e.g. clicking
+      // a deep-link CTA again) so it re-opens + scrolls.
+      if (nextView === 'settings' && target) setSettingsTarget(target)
+      return
+    }
 
     if (isAnyDirty) {
       setPendingView(nextView)
+      setPendingTarget(target)
       return
     }
     setView(nextView)
+    setSettingsTarget(target)
   }
 
   const handleDiscardAll = useCallback(async () => {
@@ -216,12 +232,15 @@ function AppContent() {
     await handleDiscardAll()
     if (pendingView) {
       setView(pendingView)
+      setSettingsTarget(pendingTarget)
       setPendingView(null)
+      setPendingTarget(null)
     }
-  }, [handleDiscardAll, pendingView])
+  }, [handleDiscardAll, pendingView, pendingTarget])
 
   const handleConfirmCancel = () => {
     setPendingView(null)
+    setPendingTarget(null)
   }
 
   const handleConfirmSave = useCallback(async () => {
@@ -242,9 +261,11 @@ function AppContent() {
     setRefreshKey((k) => k + 1)
     if (pendingView) {
       setView(pendingView)
+      setSettingsTarget(pendingTarget)
       setPendingView(null)
+      setPendingTarget(null)
     }
-  }, [pendingView, requestSaveAll])
+  }, [pendingView, pendingTarget, requestSaveAll])
 
   const handleCloseConfirmSave = useCallback(async () => {
     let success: boolean
@@ -300,6 +321,10 @@ function AppContent() {
     setRefreshKey((k) => k + 1)
     setShowImportWarning(true)
   }
+
+  // Clear the deep-link target once SettingsView has opened + scrolled to it, so
+  // re-clicking the same CTA fires the effect again.
+  const handleTargetConsumed = useCallback(() => setSettingsTarget(null), [])
 
   return (
     <div
@@ -375,7 +400,12 @@ function AppContent() {
               aria-label="Settings"
               className={`view-focus-region flex-1 overflow-y-auto pt-16 px-4 ${isAnyDirty ? 'pb-24' : ''} custom-scrollbar`}
             >
-              <SettingsView onClose={() => handleNavigate('games')} updateInfo={updateInfo} />
+              <SettingsView
+                onClose={() => handleNavigate('games')}
+                updateInfo={updateInfo}
+                targetSection={settingsTarget}
+                onTargetConsumed={handleTargetConsumed}
+              />
             </div>
           </div>
         </main>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -322,6 +322,11 @@ function AppContent() {
     setShowImportWarning(true)
   }
 
+  // SettingsView clears the deep-link target once it has opened + scrolled to
+  // it, so re-requesting the SAME section produces a real state change and
+  // re-fires the open/scroll effect.
+  const handleTargetConsumed = useCallback(() => setSettingsTarget(null), [])
+
   return (
     <div
       className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
@@ -400,6 +405,7 @@ function AppContent() {
                 onClose={() => handleNavigate('games')}
                 updateInfo={updateInfo}
                 targetSection={settingsTarget}
+                onTargetConsumed={handleTargetConsumed}
               />
             </div>
           </div>

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -10,6 +10,7 @@ import { useGamesSettings } from './settings/GamesContext'
 import { EmptyState } from './EmptyState'
 import { GameRow } from './game-list/GameRow'
 import { GamepadIcon } from './icons'
+import type { SettingsSectionKey } from './settings/types'
 
 // Derive the payload type from the store binding (same approach as
 // useSettingsLoad) so the reason gate below stays in sync with
@@ -30,7 +31,7 @@ const normalizePath = (path: string) => path.toLowerCase()
 export function GameList({
   onNavigate
 }: {
-  onNavigate: (view: 'games' | 'settings') => void
+  onNavigate: (view: 'games' | 'settings', target?: SettingsSectionKey) => void
 }): ReactNode {
   const [configuredGames, setConfiguredGames] = useState<Game[]>([])
   const [settingsLoaded, setSettingsLoaded] = useState(false)
@@ -173,7 +174,9 @@ export function GameList({
         description="Configure your simulation game paths in settings to manage their companion apps and profiles here."
         action={{
           label: 'Configure Games',
-          onClick: () => onNavigate('settings')
+          // Deep-link straight to the Games section, opened + scrolled into
+          // view, rather than the top of Settings (#583 / #642).
+          onClick: () => onNavigate('settings', 'games')
         }}
       />
     )

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -20,34 +20,25 @@ import { useAppDirty } from '../contexts/AppDirtyContext'
 export function SettingsView({
   onClose,
   updateInfo,
-  targetSection,
-  onTargetConsumed
+  targetSection
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
   targetSection: SettingsSectionKey | null
-  onTargetConsumed: () => void
 }): ReactNode {
   return (
-    <SettingsViewContent
-      onClose={onClose}
-      updateInfo={updateInfo}
-      targetSection={targetSection}
-      onTargetConsumed={onTargetConsumed}
-    />
+    <SettingsViewContent onClose={onClose} updateInfo={updateInfo} targetSection={targetSection} />
   )
 }
 
 function SettingsViewContent({
   onClose,
   updateInfo,
-  targetSection,
-  onTargetConsumed
+  targetSection
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
   targetSection: SettingsSectionKey | null
-  onTargetConsumed: () => void
 }) {
   const { notify, announce } = useNotify()
   const { loading, isDirty, dirtySections, saveSettings } = useSettingsMeta()
@@ -68,19 +59,24 @@ function SettingsViewContent({
   }, [])
 
   // Deep-link arrival (the "Configure Games" CTA, later onboarding): open the
-  // requested section and scroll it into view, then clear the request so the
-  // same CTA can re-trigger. Gated on `loading` because the sections (and their
-  // scroll anchors) aren't in the DOM until the config has loaded.
+  // requested section and scroll it to the top. Gated on `loading` because the
+  // sections (and their scroll anchors) aren't in the DOM until the config has
+  // loaded. The scroll is deferred ~one expand-transition: a previously
+  // collapsed section has no height yet, so scrolling immediately would clamp it
+  // partway down before its content exists. Navigating back to Games resets the
+  // target to null, so the same CTA re-fires without an explicit consume hop.
   useEffect(() => {
     if (loading || !targetSection) return
     setSectionOpen(targetSection, true)
-    const node = rootRef.current?.querySelector<HTMLElement>(`[data-section="${targetSection}"]`)
-    if (node) {
-      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      node.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' })
-    }
-    onTargetConsumed()
-  }, [targetSection, loading, setSectionOpen, onTargetConsumed])
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    // Keep the delay in sync with SettingsSection's duration-300 grid-rows
+    // transition so the section has reached full height before we scroll.
+    const timer = window.setTimeout(() => {
+      const node = rootRef.current?.querySelector<HTMLElement>(`[data-section="${targetSection}"]`)
+      node?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' })
+    }, 320)
+    return () => window.clearTimeout(timer)
+  }, [targetSection, loading, setSectionOpen])
 
   // Escape navigates back to the games view from anywhere inside Settings.
   // This listener is on the bubble phase (not capture), so ConfirmDialog's

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useNotify } from './Notify'
 import { AboutSection } from './settings/AboutSection'
 import { AppearanceSection } from './settings/AppearanceSection'
@@ -8,7 +8,7 @@ import { ConfigSection } from './settings/ConfigSection'
 import { GamesSection } from './settings/GamesSection'
 import { SettingsSection } from './settings/SettingsSection'
 import { useSettingsMeta } from './settings/SettingsMetaContext'
-import type { UpdateInfo } from './settings/types'
+import type { SettingsSectionKey, UpdateInfo } from './settings/types'
 import { useUpdateStatus } from './settings/useUpdateStatus'
 import { useAppDirty } from '../contexts/AppDirtyContext'
 
@@ -19,20 +19,35 @@ import { useAppDirty } from '../contexts/AppDirtyContext'
 
 export function SettingsView({
   onClose,
-  updateInfo
+  updateInfo,
+  targetSection,
+  onTargetConsumed
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
+  targetSection: SettingsSectionKey | null
+  onTargetConsumed: () => void
 }): ReactNode {
-  return <SettingsViewContent onClose={onClose} updateInfo={updateInfo} />
+  return (
+    <SettingsViewContent
+      onClose={onClose}
+      updateInfo={updateInfo}
+      targetSection={targetSection}
+      onTargetConsumed={onTargetConsumed}
+    />
+  )
 }
 
 function SettingsViewContent({
   onClose,
-  updateInfo
+  updateInfo,
+  targetSection,
+  onTargetConsumed
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
+  targetSection: SettingsSectionKey | null
+  onTargetConsumed: () => void
 }) {
   const { notify, announce } = useNotify()
   const { loading, isDirty, dirtySections, saveSettings } = useSettingsMeta()
@@ -46,10 +61,26 @@ function SettingsViewContent({
     apps: false
   })
   const updateStatus = useUpdateStatus({ updateInfo, notify, announce })
+  const rootRef = useRef<HTMLDivElement>(null)
 
-  const setSectionOpen = (section: keyof typeof expandedSections, open: boolean) => {
+  const setSectionOpen = useCallback((section: keyof typeof expandedSections, open: boolean) => {
     setExpandedSections((current) => ({ ...current, [section]: open }))
-  }
+  }, [])
+
+  // Deep-link arrival (the "Configure Games" CTA, later onboarding): open the
+  // requested section and scroll it into view, then clear the request so the
+  // same CTA can re-trigger. Gated on `loading` because the sections (and their
+  // scroll anchors) aren't in the DOM until the config has loaded.
+  useEffect(() => {
+    if (loading || !targetSection) return
+    setSectionOpen(targetSection, true)
+    const node = rootRef.current?.querySelector<HTMLElement>(`[data-section="${targetSection}"]`)
+    if (node) {
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      node.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' })
+    }
+    onTargetConsumed()
+  }, [targetSection, loading, setSectionOpen, onTargetConsumed])
 
   // Escape navigates back to the games view from anywhere inside Settings.
   // This listener is on the bubble phase (not capture), so ConfirmDialog's
@@ -85,9 +116,10 @@ function SettingsViewContent({
   if (loading) return null
 
   return (
-    <div className="animate-fade-slide relative space-y-8 pb-2">
+    <div ref={rootRef} className="animate-fade-slide relative space-y-8 pb-2">
       <SettingsSection
         title="About"
+        sectionKey="about"
         open={expandedSections.about}
         onOpenChange={(open) => setSectionOpen('about', open)}
         dirty={dirtySections.about}
@@ -106,6 +138,7 @@ function SettingsViewContent({
 
       <SettingsSection
         title="Appearance"
+        sectionKey="appearance"
         open={expandedSections.appearance}
         onOpenChange={(open) => setSectionOpen('appearance', open)}
         dirty={dirtySections.appearance}
@@ -115,6 +148,7 @@ function SettingsViewContent({
 
       <SettingsSection
         title="Behavior"
+        sectionKey="behavior"
         open={expandedSections.behavior}
         onOpenChange={(open) => setSectionOpen('behavior', open)}
         dirty={dirtySections.behavior}
@@ -124,6 +158,7 @@ function SettingsViewContent({
 
       <SettingsSection
         title="Config"
+        sectionKey="config"
         open={expandedSections.config}
         onOpenChange={(open) => setSectionOpen('config', open)}
       >
@@ -132,6 +167,7 @@ function SettingsViewContent({
 
       <SettingsSection
         title="Games"
+        sectionKey="games"
         open={expandedSections.games}
         onOpenChange={(open) => setSectionOpen('games', open)}
         dirty={dirtySections.games}
@@ -141,6 +177,7 @@ function SettingsViewContent({
 
       <SettingsSection
         title="Utility Apps"
+        sectionKey="apps"
         open={expandedSections.apps}
         onOpenChange={(open) => setSectionOpen('apps', open)}
         dirty={dirtySections.apps}

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -20,25 +20,34 @@ import { useAppDirty } from '../contexts/AppDirtyContext'
 export function SettingsView({
   onClose,
   updateInfo,
-  targetSection
+  targetSection,
+  onTargetConsumed
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
   targetSection: SettingsSectionKey | null
+  onTargetConsumed: () => void
 }): ReactNode {
   return (
-    <SettingsViewContent onClose={onClose} updateInfo={updateInfo} targetSection={targetSection} />
+    <SettingsViewContent
+      onClose={onClose}
+      updateInfo={updateInfo}
+      targetSection={targetSection}
+      onTargetConsumed={onTargetConsumed}
+    />
   )
 }
 
 function SettingsViewContent({
   onClose,
   updateInfo,
-  targetSection
+  targetSection,
+  onTargetConsumed
 }: {
   onClose: () => void
   updateInfo: UpdateInfo
   targetSection: SettingsSectionKey | null
+  onTargetConsumed: () => void
 }) {
   const { notify, announce } = useNotify()
   const { loading, isDirty, dirtySections, saveSettings } = useSettingsMeta()
@@ -63,8 +72,7 @@ function SettingsViewContent({
   // sections (and their scroll anchors) aren't in the DOM until the config has
   // loaded. The scroll is deferred ~one expand-transition: a previously
   // collapsed section has no height yet, so scrolling immediately would clamp it
-  // partway down before its content exists. Navigating back to Games resets the
-  // target to null, so the same CTA re-fires without an explicit consume hop.
+  // partway down before its content exists.
   useEffect(() => {
     if (loading || !targetSection) return
     setSectionOpen(targetSection, true)
@@ -74,9 +82,14 @@ function SettingsViewContent({
     const timer = window.setTimeout(() => {
       const node = rootRef.current?.querySelector<HTMLElement>(`[data-section="${targetSection}"]`)
       node?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' })
+      // Clear the target only AFTER it's handled, so re-requesting the SAME
+      // section (e.g. onboarding while Settings is already open) is a real state
+      // change that re-fires this effect. Clearing earlier would also cancel
+      // this scroll via the cleanup below.
+      onTargetConsumed()
     }, 320)
     return () => window.clearTimeout(timer)
-  }, [targetSection, loading, setSectionOpen])
+  }, [targetSection, loading, setSectionOpen, onTargetConsumed])
 
   // Escape navigates back to the games view from anywhere inside Settings.
   // This listener is on the bubble phase (not capture), so ConfirmDialog's

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -1,7 +1,10 @@
 import { useId, type ReactNode } from 'react'
+import type { SettingsSectionKey } from './types'
 
 interface SettingsSectionProps {
   title: string
+  // Stable key used to deep-link/scroll to this section (data-section anchor).
+  sectionKey: SettingsSectionKey
   open: boolean
   onOpenChange: (open: boolean) => void
   children: ReactNode
@@ -10,6 +13,7 @@ interface SettingsSectionProps {
 
 export function SettingsSection({
   title,
+  sectionKey,
   open,
   onOpenChange,
   children,
@@ -17,7 +21,9 @@ export function SettingsSection({
 }: SettingsSectionProps): ReactNode {
   const regionId = useId()
   return (
-    <section className="space-y-4">
+    // scroll-mt-16 leaves room for the absolute header so a scrolled-to section
+    // heading isn't tucked behind it (#642 deep-link auto-scroll).
+    <section data-section={sectionKey} className="scroll-mt-16 space-y-4">
       {/* Heading WRAPS the button (WAI-ARIA accordion pattern). A button has
           presentational children, so a heading placed *inside* it is stripped
           from the accessibility tree — wrapping keeps the section title in the

--- a/src/renderer/src/components/settings/types.ts
+++ b/src/renderer/src/components/settings/types.ts
@@ -5,3 +5,8 @@ export type UpdateStatus = 'up-to-date' | 'downloaded' | 'error' | 'offline' | n
 // Payload from the 'update-error' channel. `isNetworkError` distinguishes a
 // connectivity problem (offline rig) from a real updater fault.
 export type UpdateErrorInfo = { message?: string; isNetworkError?: boolean }
+
+// The collapsible Settings sections, in render order. Used to deep-link a
+// navigation straight into one section (e.g. the "Configure Games" CTA, or
+// onboarding) so it opens expanded and scrolled into view (#642 / #583).
+export type SettingsSectionKey = 'about' | 'appearance' | 'behavior' | 'config' | 'games' | 'apps'

--- a/tests/renderer/settingsDeepLink.test.tsx
+++ b/tests/renderer/settingsDeepLink.test.tsx
@@ -2,11 +2,12 @@
  * #642 / #583 — Settings deep-link auto-expand.
  *
  * When SettingsView receives a `targetSection` (e.g. from the "Configure Games"
- * CTA, or later onboarding), that section must open (aria-expanded=true) and
- * scroll into view, then the consume callback fires so the same CTA can
- * re-trigger. A null target must leave the default collapse state untouched
- * (no regression for a plain gear-icon open). Games is collapsed by default, so
- * it is the meaningful section to assert against.
+ * CTA, or later onboarding), that section opens (aria-expanded=true) and, once
+ * its expand transition has settled, scrolls to the top. A null target leaves
+ * the default collapse state untouched (no regression for a plain gear-icon
+ * open). Games is collapsed by default, so it is the meaningful section to
+ * assert against. The scroll is deferred ~one expand-transition (a previously
+ * collapsed section has no height yet), so it is asserted after a short wait.
  */
 import { describe, expect, test, vi, beforeEach } from 'vitest'
 import { act, type ReactNode } from 'react'
@@ -78,8 +79,7 @@ const metaValue: SettingsMetaContextValue = {
 }
 
 async function renderSettings(
-  targetSection: SettingsSectionKey | null,
-  onConsumed: () => void
+  targetSection: SettingsSectionKey | null
 ): Promise<{ container: HTMLElement; unmount: () => void }> {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -89,12 +89,7 @@ async function renderSettings(
     root.render(
       <AppDirtyProvider>
         <SettingsMetaContext.Provider value={metaValue}>
-          <SettingsView
-            onClose={() => {}}
-            updateInfo={null}
-            targetSection={targetSection}
-            onTargetConsumed={onConsumed}
-          />
+          <SettingsView onClose={() => {}} updateInfo={null} targetSection={targetSection} />
         </SettingsMetaContext.Provider>
       </AppDirtyProvider>
     )
@@ -116,6 +111,13 @@ function sectionButton(container: HTMLElement, key: SettingsSectionKey): HTMLBut
   return button as HTMLButtonElement
 }
 
+// Wait out the deferred scroll (SettingsView delays it ~one 300ms transition).
+async function flushDeferredScroll() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 360))
+  })
+}
+
 describe('Settings deep-link auto-expand (#642 / #583)', () => {
   beforeEach(() => {
     notifyMock.mockClear()
@@ -126,26 +128,26 @@ describe('Settings deep-link auto-expand (#642 / #583)', () => {
       .mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia
   })
 
-  test('a targetSection opens that section, scrolls it into view, and consumes the target', async () => {
-    const onConsumed = vi.fn()
-    const harness = await renderSettings('games', onConsumed)
+  test('a targetSection opens that section immediately, then scrolls it into view', async () => {
+    const harness = await renderSettings('games')
     try {
-      // Games is collapsed by default — the deep-link must open it.
+      // Games is collapsed by default — the deep-link opens it right away.
       expect(sectionButton(harness.container, 'games').getAttribute('aria-expanded')).toBe('true')
+      // The scroll is deferred until the expand transition has settled.
+      expect(scrollIntoViewMock).not.toHaveBeenCalled()
+      await flushDeferredScroll()
       expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
-      expect(onConsumed).toHaveBeenCalledTimes(1)
     } finally {
       harness.unmount()
     }
   })
 
-  test('no target leaves Games collapsed and does not scroll (direct gear open)', async () => {
-    const onConsumed = vi.fn()
-    const harness = await renderSettings(null, onConsumed)
+  test('no target leaves Games collapsed and never scrolls (direct gear open)', async () => {
+    const harness = await renderSettings(null)
     try {
       expect(sectionButton(harness.container, 'games').getAttribute('aria-expanded')).toBe('false')
+      await flushDeferredScroll()
       expect(scrollIntoViewMock).not.toHaveBeenCalled()
-      expect(onConsumed).not.toHaveBeenCalled()
     } finally {
       harness.unmount()
     }

--- a/tests/renderer/settingsDeepLink.test.tsx
+++ b/tests/renderer/settingsDeepLink.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * #642 / #583 — Settings deep-link auto-expand.
+ *
+ * When SettingsView receives a `targetSection` (e.g. from the "Configure Games"
+ * CTA, or later onboarding), that section must open (aria-expanded=true) and
+ * scroll into view, then the consume callback fires so the same CTA can
+ * re-trigger. A null target must leave the default collapse state untouched
+ * (no regression for a plain gear-icon open). Games is collapsed by default, so
+ * it is the meaningful section to assert against.
+ */
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const notifyMock = vi.fn()
+const announceMock = vi.fn()
+const scrollIntoViewMock = vi.fn()
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: announceMock }),
+  NotifyProvider: ({ children }: { children: ReactNode }) => children
+}))
+
+// The update hook touches electron IPC on mount; stub it to a static shape so
+// the test renders SettingsView without a real preload bridge.
+vi.mock('../../src/renderer/src/components/settings/useUpdateStatus', () => ({
+  useUpdateStatus: () => ({
+    appVersion: '1.0.1',
+    checkingUpdate: false,
+    installingUpdate: false,
+    updateProgress: null,
+    updateStatus: null,
+    handleManualCheck: vi.fn(),
+    handleInstallUpdate: vi.fn()
+  })
+}))
+
+// The section bodies pull in their own contexts/electron. We only exercise the
+// accordion shells (the real SettingsSection), so render the bodies as null.
+vi.mock('../../src/renderer/src/components/settings/AboutSection', () => ({
+  AboutSection: () => null
+}))
+vi.mock('../../src/renderer/src/components/settings/AppearanceSection', () => ({
+  AppearanceSection: () => null
+}))
+vi.mock('../../src/renderer/src/components/settings/AppsSection', () => ({
+  AppsSection: () => null
+}))
+vi.mock('../../src/renderer/src/components/settings/BehaviorSection', () => ({
+  BehaviorSection: () => null
+}))
+vi.mock('../../src/renderer/src/components/settings/ConfigSection', () => ({
+  ConfigSection: () => null
+}))
+vi.mock('../../src/renderer/src/components/settings/GamesSection', () => ({
+  GamesSection: () => null
+}))
+
+import { SettingsView } from '../../src/renderer/src/components/SettingsView'
+import {
+  SettingsMetaContext,
+  type SettingsMetaContextValue
+} from '../../src/renderer/src/components/settings/SettingsMetaContext'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { SettingsSectionKey } from '../../src/renderer/src/components/settings/types'
+
+const metaValue: SettingsMetaContextValue = {
+  loading: false,
+  isDirty: false,
+  dirtySections: { appearance: false, behavior: false, games: false, apps: false, about: false },
+  saveSettings: vi.fn(async () => true),
+  exportingConfig: false,
+  importingConfig: false,
+  autoCheckUpdates: false,
+  onExportConfig: vi.fn(),
+  onImportConfig: vi.fn(),
+  onAutoCheckUpdatesChange: vi.fn()
+}
+
+async function renderSettings(
+  targetSection: SettingsSectionKey | null,
+  onConsumed: () => void
+): Promise<{ container: HTMLElement; unmount: () => void }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root: Root | null = null
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <SettingsMetaContext.Provider value={metaValue}>
+          <SettingsView
+            onClose={() => {}}
+            updateInfo={null}
+            targetSection={targetSection}
+            onTargetConsumed={onConsumed}
+          />
+        </SettingsMetaContext.Provider>
+      </AppDirtyProvider>
+    )
+  })
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    }
+  }
+}
+
+function sectionButton(container: HTMLElement, key: SettingsSectionKey): HTMLButtonElement {
+  const button = container.querySelector(`[data-section="${key}"] button`)
+  if (!button) throw new Error(`No disclosure button for section "${key}"`)
+  return button as HTMLButtonElement
+}
+
+describe('Settings deep-link auto-expand (#642 / #583)', () => {
+  beforeEach(() => {
+    notifyMock.mockClear()
+    scrollIntoViewMock.mockClear()
+    Element.prototype.scrollIntoView = scrollIntoViewMock
+    window.matchMedia = vi
+      .fn()
+      .mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia
+  })
+
+  test('a targetSection opens that section, scrolls it into view, and consumes the target', async () => {
+    const onConsumed = vi.fn()
+    const harness = await renderSettings('games', onConsumed)
+    try {
+      // Games is collapsed by default — the deep-link must open it.
+      expect(sectionButton(harness.container, 'games').getAttribute('aria-expanded')).toBe('true')
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
+      expect(onConsumed).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('no target leaves Games collapsed and does not scroll (direct gear open)', async () => {
+    const onConsumed = vi.fn()
+    const harness = await renderSettings(null, onConsumed)
+    try {
+      expect(sectionButton(harness.container, 'games').getAttribute('aria-expanded')).toBe('false')
+      expect(scrollIntoViewMock).not.toHaveBeenCalled()
+      expect(onConsumed).not.toHaveBeenCalled()
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/settingsDeepLink.test.tsx
+++ b/tests/renderer/settingsDeepLink.test.tsx
@@ -3,19 +3,24 @@
  *
  * When SettingsView receives a `targetSection` (e.g. from the "Configure Games"
  * CTA, or later onboarding), that section opens (aria-expanded=true) and, once
- * its expand transition has settled, scrolls to the top. A null target leaves
- * the default collapse state untouched (no regression for a plain gear-icon
- * open). Games is collapsed by default, so it is the meaningful section to
- * assert against. The scroll is deferred ~one expand-transition (a previously
- * collapsed section has no height yet), so it is asserted after a short wait.
+ * its expand transition has settled, scrolls to the top, then the target is
+ * consumed so re-requesting the same section re-fires. A null target leaves the
+ * default collapse state untouched (no regression for a plain gear-icon open).
+ * Games is collapsed by default, so it is the meaningful section to assert
+ * against. The scroll is deferred ~one expand-transition (a previously collapsed
+ * section has no height yet), so it is asserted after a short wait.
  */
-import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 
 const notifyMock = vi.fn()
 const announceMock = vi.fn()
 const scrollIntoViewMock = vi.fn()
+
+// Capture the originals so each test can restore the shared DOM globals it stubs.
+const originalScrollIntoView = Element.prototype.scrollIntoView
+const originalMatchMedia = window.matchMedia
 
 vi.mock('../../src/renderer/src/components/Notify', () => ({
   useNotify: () => ({ notify: notifyMock, announce: announceMock }),
@@ -79,7 +84,8 @@ const metaValue: SettingsMetaContextValue = {
 }
 
 async function renderSettings(
-  targetSection: SettingsSectionKey | null
+  targetSection: SettingsSectionKey | null,
+  onTargetConsumed: () => void = vi.fn()
 ): Promise<{ container: HTMLElement; unmount: () => void }> {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -89,7 +95,12 @@ async function renderSettings(
     root.render(
       <AppDirtyProvider>
         <SettingsMetaContext.Provider value={metaValue}>
-          <SettingsView onClose={() => {}} updateInfo={null} targetSection={targetSection} />
+          <SettingsView
+            onClose={() => {}}
+            updateInfo={null}
+            targetSection={targetSection}
+            onTargetConsumed={onTargetConsumed}
+          />
         </SettingsMetaContext.Provider>
       </AppDirtyProvider>
     )
@@ -118,18 +129,29 @@ async function flushDeferredScroll() {
   })
 }
 
+function stubMatchMedia(reduceMotion: boolean) {
+  window.matchMedia = vi
+    .fn()
+    .mockReturnValue({ matches: reduceMotion }) as unknown as typeof window.matchMedia
+}
+
 describe('Settings deep-link auto-expand (#642 / #583)', () => {
   beforeEach(() => {
     notifyMock.mockClear()
     scrollIntoViewMock.mockClear()
     Element.prototype.scrollIntoView = scrollIntoViewMock
-    window.matchMedia = vi
-      .fn()
-      .mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia
+    stubMatchMedia(false)
   })
 
-  test('a targetSection opens that section immediately, then scrolls it into view', async () => {
-    const harness = await renderSettings('games')
+  afterEach(() => {
+    // Restore the shared DOM globals so these stubs don't leak into other specs.
+    Element.prototype.scrollIntoView = originalScrollIntoView
+    window.matchMedia = originalMatchMedia
+  })
+
+  test('a targetSection opens that section, smooth-scrolls it in, then consumes the target', async () => {
+    const onConsumed = vi.fn()
+    const harness = await renderSettings('games', onConsumed)
     try {
       // Games is collapsed by default — the deep-link opens it right away.
       expect(sectionButton(harness.container, 'games').getAttribute('aria-expanded')).toBe('true')
@@ -137,17 +159,32 @@ describe('Settings deep-link auto-expand (#642 / #583)', () => {
       expect(scrollIntoViewMock).not.toHaveBeenCalled()
       await flushDeferredScroll()
       expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
+      expect(onConsumed).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('prefers-reduced-motion uses an instant (auto) scroll', async () => {
+    stubMatchMedia(true)
+    const harness = await renderSettings('games')
+    try {
+      await flushDeferredScroll()
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' })
     } finally {
       harness.unmount()
     }
   })
 
   test('no target leaves Games collapsed and never scrolls (direct gear open)', async () => {
-    const harness = await renderSettings(null)
+    const onConsumed = vi.fn()
+    const harness = await renderSettings(null, onConsumed)
     try {
       expect(sectionButton(harness.container, 'games').getAttribute('aria-expanded')).toBe('false')
       await flushDeferredScroll()
       expect(scrollIntoViewMock).not.toHaveBeenCalled()
+      expect(onConsumed).not.toHaveBeenCalled()
     } finally {
       harness.unmount()
     }


### PR DESCRIPTION
## Summary
- Navigation gains an optional **target section**. The "Configure Games" CTA now deep-links to the **Games** section, opened and scrolled to the top, instead of the top of a collapsed Settings list (#583).
- The target survives the unsaved-changes confirm (`pendingTarget` mirrors `pendingView`) and respects `prefers-reduced-motion`. The scroll is **deferred ~one expand transition** so a previously collapsed section reaches full height first — otherwise the document is too short and the browser clamps it partway down.
- **Scope note:** the section *reorder* originally proposed in #642 was intentionally **dropped** (maintainer's call). The existing order stays and Games/Apps remain collapsed by default (they're the longest sections); only a deep-link/onboarding arrival auto-opens its target. The `targetSection` plumbing is reused by onboarding (#641) later.

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test` (373 passed; +2 new deep-link tests in `tests/renderer/settingsDeepLink.test.tsx`)
- [x] Manual: "Configure Games" from the empty state → Settings opens with **Games expanded and scrolled to the top**; unsaved-changes deferral path verified (Save/Discard still lands on the open Games section).

Closes #642
Closes #583


<!-- auto-closes -->
Closes #583
Closes #642
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deep-linking to specific Settings sections, including opening the requested section and scrolling it into view.
  * The empty-state button in the game list now takes users directly to the Settings → Games section.

* **Bug Fixes**
  * Preserved the intended Settings section when navigating through unsaved-changes save, discard, and close flows.
  * Improved section anchoring so scrolled-to content is easier to view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->