### PR TITLE
perf(game-list): memoize rows to cut re-renders on status change

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-18 - React.memo on List Components
+**Learning:** GameRow and its child components (GameRowActions, GameRowProfileMenu, RunningAppsStrip) inside GameList re-rendered whenever any game's running status updated, since the parent re-rendered the whole list.
+**Action:** Wrapped list components with React.memo() to ensure that only the components with updated props re-render, preventing unnecessary reconciliation across the entire game list.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2024-10-18 - React.memo on List Components
+
 **Learning:** GameRow and its child components (GameRowActions, GameRowProfileMenu, RunningAppsStrip) inside GameList re-rendered whenever any game's running status updated, since the parent re-rendered the whole list.
 **Action:** Wrapped list components with React.memo() to ensure that only the components with updated props re-render, preventing unnecessary reconciliation across the entire game list.

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react'
+import React, { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react'
 import {
   createProfileId,
   getActiveGameProfile,
@@ -28,7 +28,7 @@ import { useAppDirty } from '../../contexts/AppDirtyContext'
 // Cooldown is skipped (0 ms) when no apps were actually launched.
 const POST_LAUNCH_BLOCK_MS = 10000
 
-export function GameRow({
+export const GameRow = React.memo(function GameRow({
   game,
   isActive,
   isRunning,
@@ -567,4 +567,4 @@ export function GameRow({
       />
     </div>
   )
-}
+})

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 
 import { GameRowProfileMenu, type GameRowProfileMenuProps } from './GameRowProfileMenu'
 import { RefreshIcon, KillIcon, PlayMarkIcon, SettingsIcon } from '../icons'
@@ -19,7 +19,7 @@ export interface GameRowActionsProps {
   profileMenuProps: GameRowProfileMenuProps
 }
 
-export function GameRowActions({
+export const GameRowActions = React.memo(function GameRowActions({
   isActive,
   isLaunching,
   isLaunchBlocked,
@@ -129,4 +129,4 @@ export function GameRowActions({
       </Tooltip>
     </div>
   )
-}
+})

--- a/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
+++ b/src/renderer/src/components/game-list/GameRowProfileMenu.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import React, { useId } from 'react'
 import type { Dispatch, KeyboardEvent, MutableRefObject, ReactNode, SetStateAction } from 'react'
 import type { GameProfileSet, NamedGameProfile } from '../../lib/config'
 import { ChevronDownIcon, CheckIcon, PlusIcon } from '../icons'
@@ -24,7 +24,7 @@ export interface GameRowProfileMenuProps {
   onNewProfileSubmit: () => void
 }
 
-export function GameRowProfileMenu({
+export const GameRowProfileMenu = React.memo(function GameRowProfileMenu({
   profileSet,
   activeProfile,
   profileMenuOpen,
@@ -158,4 +158,4 @@ export function GameRowProfileMenu({
       )}
     </div>
   )
-}
+})

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode, type ReactElement } from 'react'
+import React, { useState, type ReactNode, type ReactElement } from 'react'
 import { dismissAppIcon } from '../../lib/electron'
 import { Tooltip } from '../Tooltip'
 import { buildDismissLabel } from '../../lib/contextMenuLabel'
@@ -197,7 +197,7 @@ function RunningAppIconItem({
   )
 }
 
-export function RunningAppsStrip({
+export const RunningAppsStrip = React.memo(function RunningAppsStrip({
   runningAppIcons,
   cacheInitialized
 }: RunningAppsStripProps): ReactNode {
@@ -253,4 +253,4 @@ export function RunningAppsStrip({
       )}
     </div>
   )
-}
+})


### PR DESCRIPTION
💡 What: Wrapped `GameRow`, `GameRowActions`, `RunningAppsStrip`, and `GameRowProfileMenu` with `React.memo()`.

🎯 Why: The `GameList` component loops over `configuredGames` and renders a `GameRow` for each. When a single game's status changes (e.g., launching an app), the parent state updates, causing the entire list to re-render.

📊 Impact: Reduces unnecessary re-renders of list items whose props haven't changed. This should significantly reduce main thread blocking during game running state transitions.

🔬 Measurement: Verify with React DevTools Profiler by toggling app launch states and observing that only the affected row component re-renders.

---
*PR created automatically by Jules for task [7375463328990914395](https://jules.google.com/task/7375463328990914395) started by @Shieldxx*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness in the game list by reducing unnecessary re-renders when a game’s running status changes.
  * Made several game list row and status components render more efficiently, which should help the interface feel smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->