### PR TITLE
docs(readme): harden release badge against shields rate-limit caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SimLauncher
 
-[![Latest release](https://img.shields.io/github/v/release/Stashpeak/SimLauncher)](../../releases)
+[![Latest release](https://img.shields.io/github/v/release/Stashpeak/SimLauncher?sort=semver&cacheSeconds=3600)](../../releases)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/37BPprjazF)
 [![Downloads](https://img.shields.io/github/downloads/Stashpeak/SimLauncher/total)](../../releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/Stashpeak/SimLauncher/ci.yml?branch=main&label=CI)](../../actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary

The `release` badge in the README intermittently rendered **`invalid`** (red) even though the latest release (v1.0.1) is published, non-draft, non-prerelease.

**Root cause:** the live `github/v/release` badge relies on shields.io querying the GitHub API with its shared *unauthenticated* token pool, which gets rate-limited. When that happens shields returns `invalid`, and GitHub's **camo image proxy caches that transient failure** — so every viewer keeps seeing the broken badge until the cache expires (a hard refresh only fixes the local browser, not other users).

**Fix:** `?sort=semver&cacheSeconds=3600`
- The URL change generates a **new camo image** → busts the stale cached "invalid" for **all** viewers, not just one browser.
- `cacheSeconds=3600` makes shields serve its cached value longer → far fewer hits on the rate-limited GitHub API → far fewer transient `invalid` going forward.
- `sort=semver` makes the displayed version deterministic (highest semver).

Verified the endpoint returns `{"message":"v1.0.1","color":"blue"}` with these params.

## Test plan
- [x] `npm run format:check`
- [ ] Visual: badge renders `release v1.0.1` (blue) after merge — confirm in an incognito window / different account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Latest release” badge in the README to improve version sorting and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->