### PR TITLE
ci(release): verify installer signature + timestamp on release (#245)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,17 +60,19 @@ jobs:
       - name: Verify the installer is signed and timestamped
         shell: pwsh
         run: |
-          $exe = Get-ChildItem dist -Filter *.exe | Select-Object -First 1
-          if (-not $exe) { throw 'No installer found in dist/.' }
-          $sig = Get-AuthenticodeSignature $exe.FullName
-          Write-Host "File:      $($exe.Name)"
-          Write-Host "Status:    $($sig.Status)"
-          Write-Host "Signer:    $($sig.SignerCertificate.Subject)"
-          Write-Host "Timestamp: $($sig.TimeStamperCertificate.Subject)"
-          if (-not $sig.SignerCertificate) { throw 'Installer is NOT signed.' }
-          if ($sig.SignerCertificate.Subject -notlike '*CN=David Kohout*') { throw "Unexpected signer: $($sig.SignerCertificate.Subject)" }
-          if (-not $sig.TimeStamperCertificate) { throw 'Installer is signed but NOT timestamped.' }
-          Write-Host 'OK: signed by David Kohout and timestamped.'
+          $exes = Get-ChildItem dist -Filter *.exe
+          if (-not $exes) { throw 'No installer (.exe) found in dist/.' }
+          foreach ($exe in $exes) {
+            $sig = Get-AuthenticodeSignature $exe.FullName
+            Write-Host "File:      $($exe.Name)"
+            Write-Host "Status:    $($sig.Status)"
+            Write-Host "Signer:    $($sig.SignerCertificate.Subject)"
+            Write-Host "Timestamp: $($sig.TimeStamperCertificate.Subject)"
+            if ($sig.Status -ne 'Valid') { throw "Invalid Authenticode status for $($exe.Name): $($sig.Status)" }
+            if ($sig.SignerCertificate.Subject -notlike '*CN=David Kohout*') { throw "Unexpected signer for $($exe.Name): $($sig.SignerCertificate.Subject)" }
+            if (-not $sig.TimeStamperCertificate) { throw "$($exe.Name) is signed but NOT timestamped." }
+            Write-Host "OK: $($exe.Name) signed by David Kohout and timestamped."
+          }
 
       - name: Generate SHA-256 checksums
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,27 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        # forceCodeSigning is enforced here (release-only) instead of in
-        # electron-builder.yml so contributors can still build unsigned from
-        # source (npm run dist:win) without Azure creds. On a release, a signing
-        # failure now fails the build instead of silently shipping unsigned.
-        run: npx electron-builder --win --publish always -c.win.forceCodeSigning=true
+        run: npx electron-builder --win --publish always
+
+      # Enforce signing on releases without putting forceCodeSigning in
+      # electron-builder.yml (which would break unsigned `npm run dist:win`
+      # builds from source). This also asserts the signature is TIMESTAMPED —
+      # without a timestamp the signature would expire with the short-lived
+      # Trusted Signing cert (~3 days). A failure here fails the release.
+      - name: Verify the installer is signed and timestamped
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem dist -Filter *.exe | Select-Object -First 1
+          if (-not $exe) { throw 'No installer found in dist/.' }
+          $sig = Get-AuthenticodeSignature $exe.FullName
+          Write-Host "File:      $($exe.Name)"
+          Write-Host "Status:    $($sig.Status)"
+          Write-Host "Signer:    $($sig.SignerCertificate.Subject)"
+          Write-Host "Timestamp: $($sig.TimeStamperCertificate.Subject)"
+          if (-not $sig.SignerCertificate) { throw 'Installer is NOT signed.' }
+          if ($sig.SignerCertificate.Subject -notlike '*CN=David Kohout*') { throw "Unexpected signer: $($sig.SignerCertificate.Subject)" }
+          if (-not $sig.TimeStamperCertificate) { throw 'Installer is signed but NOT timestamped.' }
+          Write-Host 'OK: signed by David Kohout and timestamped.'
 
       - name: Generate SHA-256 checksums
         shell: bash


### PR DESCRIPTION
## Summary

- The `-c.win.forceCodeSigning=true` override added in #511 was malformed — electron-builder read it as a config-file path (`ENOENT … .win.forceCodeSigning=true`) and the `v1.0.2` release failed **before signing even ran** (so nothing was published — the draft mechanism + this failure meant zero exposure).
- Revert that flag and instead verify the built installer with `Get-AuthenticodeSignature` after the build: the release **fails unless** the installer is signed by `CN=David Kohout` **and timestamped**.
- This is stronger than `forceCodeSigning` (it also asserts the **timestamp**, without which the signature would expire with the short-lived Trusted Signing cert) and keeps `electron-builder.yml` clean so `npm run dist:win` still builds unsigned from source (the build-from-source trust pillar).

## Test plan

- [x] `npm run format:check` / `lint` / `build` / `test` — CI
- [ ] Re-tag `v1.0.2` → release builds + signs, the new verify step passes → **signed + timestamped** draft installer

Closes #245
