### PR TITLE
docs: README installer is code-signed now (#664)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://github.com/user-attachments/assets/0befc41c-ad71-4d75-930c-9bfa680c3ece
 
 **➡️ [Download SimLauncher for Windows](../../releases/latest)** · 💬 **[Join the Discord](https://discord.gg/37BPprjazF)**
 
-> On first launch Windows SmartScreen may warn that the publisher is unrecognized — the installer isn't code-signed yet. Click **More info → Run anyway**.
+> The installer is **code-signed** — Windows SmartScreen now shows the verified publisher (**David Kohout**). It may still warn on first launch until the new signature builds reputation; click **More info → Run anyway**.
 
 ## Screenshots
 
@@ -134,7 +134,7 @@ Assetto Corsa, Assetto Corsa Competizione, Assetto Corsa Evo, Assetto Corsa Rall
 
 ### "Windows protected your PC" (SmartScreen)
 
-The installer isn't code-signed yet, so SmartScreen may warn on first launch. Click **More info → Run anyway**.
+The installer **is** code-signed (verified publisher: David Kohout), but Windows SmartScreen reputation builds up over downloads and time — so it may still warn on first launch until then. Click **More info → Run anyway**. You can confirm the signature yourself in the installer's **Properties → Digital Signatures** tab.
 
 ### A game won't launch
 


### PR DESCRIPTION
## Summary

- `v1.0.2` ships a **code-signed** installer (Azure Trusted Signing, verified publisher **David Kohout**, timestamped — verified in CI). The README still said the installer "isn't code-signed yet" in two spots, which is now false.
- Updated the **hero blockquote** and the **Troubleshooting → SmartScreen** entry to: the installer **is** signed (verified publisher), but SmartScreen reputation still builds over downloads + time, so it may warn temporarily → **More info → Run anyway**.
- Added a pointer to verify the signature via **Properties → Digital Signatures**.

The same copy on the website (`simlauncher-web`) and the Overtake mirror upload are handled separately.

## Test plan

- [x] `npm run format:check` (prettier — the only gate a markdown-only change can break)
- [ ] Build/lint/test unaffected (no source touched)
- [ ] Manual: README renders correctly on GitHub

Closes #664


<!-- auto-closes -->
Closes #664
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows installation guidance to reflect that the installer is now code-signed.
  * Clarified that SmartScreen reputation may still take time to build.
  * Added instructions for checking the installer’s digital signature in the file properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->