### PR TITLE
feat: first-run onboarding (one-click loop + optional accent/zoom step) (#641)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -526,4 +526,18 @@ export function registerConfigHandlers(): void {
       notifyStoreConfigChanged({ reason: 'set-migration-flags', keys: changedKeys })
     }
   })
+
+  // onboardingSeen is a LOCAL-only UX flag: the first-run onboarding modal is
+  // shown once, then this is set so it never reappears. Kept out of the config
+  // export/import surface (not in EXPECTED_CONFIG_KEYS) so it never travels
+  // between machines. No store-config-changed broadcast is needed: the modal
+  // manages its own dismissal via renderer state. #641
+  ipcMain.handle('get-onboarding-seen', () => {
+    return store.get('onboardingSeen')
+  })
+
+  ipcMain.handle('set-onboarding-seen', (_event, seen: unknown) => {
+    if (typeof seen !== 'boolean') return
+    store.set('onboardingSeen', seen)
+  })
 }

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -7,6 +7,7 @@ import { isStoredProfileSet, type StoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
+  LOCAL_ONLY_STORE_KEYS,
   MAX_CONFIG_IMPORT_BYTES,
   MAX_CUSTOM_SLOTS,
   consumeConfigRecoveryNotice,
@@ -211,6 +212,11 @@ function applySanitizedConfig(supportedConfig: Record<string, unknown>) {
   try {
     store.clear()
     setStoreEntries(supportedConfig)
+    // Import replaces the whole store; carry local-only UX flags (e.g.
+    // onboardingSeen) over from the snapshot so they don't reset on import. #641
+    for (const key of LOCAL_ONLY_STORE_KEYS) {
+      if (key in snapshot) store.set(key, snapshot[key])
+    }
     migrateProfilesToNamedSets()
     applyRuntimeConfigSettings()
     applyTrayVisibility(store.get('showTrayIcon') !== false)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -85,7 +85,12 @@ const STORE_OPTIONS = {
     windowBounds: { type: 'object', default: {} },
     profileUtilityOrderMigrated: { type: 'boolean', default: false },
     profileSetsMigrated: { type: 'boolean', default: false },
-    migrated: { type: 'boolean', default: false }
+    migrated: { type: 'boolean', default: false },
+    // Internal, LOCAL-only first-run flag (onboarding shown once). Deliberately
+    // NOT added to EXPECTED_CONFIG_KEYS so it is excluded from config
+    // export/import - it is a local UX flag and must not travel between
+    // machines. #641
+    onboardingSeen: { type: 'boolean', default: false }
   }
 } as ConstructorParameters<typeof StoreConstructor>[0] & { projectName: string }
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -312,6 +312,10 @@ export const EXPECTED_CONFIG_KEYS = new Set([
 ])
 const LEGACY_CONFIG_KEYS = new Set(['killOnClose'])
 const IMPORTABLE_CONFIG_KEYS = new Set([...EXPECTED_CONFIG_KEYS, ...LEGACY_CONFIG_KEYS])
+// Keys that live in the store but are deliberately NOT in EXPECTED_CONFIG_KEYS
+// (excluded from config export/import). A config import clears the store, so
+// these local-only UX flags must be preserved across it or they silently reset. #641
+export const LOCAL_ONLY_STORE_KEYS = ['onboardingSeen'] as const
 const BOOLEAN_CONFIG_KEYS = new Set([
   'accentBgTint',
   'focusActiveTitle',

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -231,6 +231,8 @@ export interface ElectronAPI {
   saveProfiles: (profiles: unknown) => Promise<void>
   getMigrationFlags: () => Promise<MigrationFlags>
   setMigrationFlags: (patch: Partial<MigrationFlags>) => Promise<void>
+  getOnboardingSeen: () => Promise<boolean>
+  setOnboardingSeen: (seen: boolean) => Promise<void>
   onStoreConfigChanged: (cb: (payload: StoreConfigChangePayload) => void) => Unsubscribe
   exportConfig: () => Promise<ConfigFileResult>
   previewImportConfig: () => Promise<ConfigImportPreviewResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -114,6 +114,8 @@ const electronAPI: ElectronAPI = {
   saveProfiles: (profiles: unknown) => ipcRenderer.invoke('save-profiles', profiles),
   getMigrationFlags: () => ipcRenderer.invoke('get-migration-flags'),
   setMigrationFlags: (patch: unknown) => ipcRenderer.invoke('set-migration-flags', patch),
+  getOnboardingSeen: () => ipcRenderer.invoke('get-onboarding-seen'),
+  setOnboardingSeen: (seen: boolean) => ipcRenderer.invoke('set-onboarding-seen', seen),
   onStoreConfigChanged: (cb: (payload: StoreConfigChangePayload) => void) => {
     const handler = (_: unknown, payload: StoreConfigChangePayload) => cb(payload)
     ipcRenderer.on('store-config-changed', handler)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -383,22 +383,27 @@ function AppContent() {
   // resolved (non-null) so the modal never flashes during the initial reads.
   const showOnboarding = onboardingSeen === false && hasConfiguredGame === false
 
-  const persistOnboardingSeenFlag = () => {
+  const finishOnboarding = () => {
+    setOnboardingSeen(true)
     void persistOnboardingSeen(true).catch((err: unknown) => {
       console.error('Failed to persist onboarding-seen flag', err)
     })
+    // The modal may have persisted accent/zoom directly via saveSettings, which
+    // the already-mounted SettingsProvider ignores (it skips its own
+    // save-settings broadcasts). Remount it (refreshKey) so its in-memory copy
+    // reflects the persisted values — otherwise the next full Settings save
+    // would overwrite the onboarding choices with stale defaults. #641
+    setRefreshKey((key) => key + 1)
   }
 
   const handleOnboardingSetup = () => {
-    setOnboardingSeen(true)
-    persistOnboardingSeenFlag()
+    finishOnboarding()
     // Hand off to the Games section, opened + scrolled via the #648 deep-link.
     handleNavigate('settings', 'games')
   }
 
   const handleOnboardingSkip = () => {
-    setOnboardingSeen(true)
-    persistOnboardingSeenFlag()
+    finishOnboarding()
   }
 
   return (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -105,9 +105,13 @@ function AppContent() {
   // configured (mirrors GameList's getSettings + onStoreConfigChanged read).
   useEffect(() => {
     let cancelled = false
-    void getOnboardingSeen().then((seen: boolean) => {
-      if (!cancelled) setOnboardingSeen(seen)
-    })
+    void getOnboardingSeen()
+      .then((seen: boolean) => {
+        if (!cancelled) setOnboardingSeen(seen)
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to read onboarding-seen flag', err)
+      })
 
     const readConfiguredGames = () => {
       void getSettings()
@@ -379,16 +383,22 @@ function AppContent() {
   // resolved (non-null) so the modal never flashes during the initial reads.
   const showOnboarding = onboardingSeen === false && hasConfiguredGame === false
 
+  const persistOnboardingSeenFlag = () => {
+    void persistOnboardingSeen(true).catch((err: unknown) => {
+      console.error('Failed to persist onboarding-seen flag', err)
+    })
+  }
+
   const handleOnboardingSetup = () => {
     setOnboardingSeen(true)
-    void persistOnboardingSeen(true)
+    persistOnboardingSeenFlag()
     // Hand off to the Games section, opened + scrolled via the #648 deep-link.
     handleNavigate('settings', 'games')
   }
 
   const handleOnboardingSkip = () => {
     setOnboardingSeen(true)
-    void persistOnboardingSeen(true)
+    persistOnboardingSeenFlag()
   }
 
   return (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { SettingsView } from './components/SettingsView'
 import type { SettingsSectionKey } from './components/settings/types'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { StickySaveBar } from './components/StickySaveBar'
+import { OnboardingModal } from './components/OnboardingModal'
 import { WarningTriangleIcon, CloseIcon } from './components/icons'
 import {
   forceClose,
@@ -19,6 +20,13 @@ import {
 } from './lib/electron'
 import { subscribeGlobalErrors } from './lib/globalErrors'
 import { runStartupMigrations } from './lib/migrations'
+import { GAMES } from './lib/config'
+import {
+  getOnboardingSeen,
+  getSettings,
+  onStoreConfigChanged,
+  setOnboardingSeen as persistOnboardingSeen
+} from './lib/store'
 import { useTheme } from './contexts/ThemeContext'
 import { SettingsProvider } from './components/settings/SettingsContext'
 import { AppDirtyProvider, useAppDirty } from './contexts/AppDirtyContext'
@@ -61,6 +69,14 @@ function AppContent() {
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false)
   const { isAnyDirty, reportSettingsDirty, requestSaveAll, requestDiscardAll } = useAppDirty()
 
+  // First-run onboarding gate. Both start null (loading) so the modal never
+  // flashes before the real values are known. Shown only for a brand-new user:
+  // onboarding not yet seen AND no game configured yet. Existing users have a
+  // game, so the zero-games half is false and they are never onboarded - no
+  // backfill migration needed. #641
+  const [onboardingSeen, setOnboardingSeen] = useState<boolean | null>(null)
+  const [hasConfiguredGame, setHasConfiguredGame] = useState<boolean | null>(null)
+
   // Remembers the version we last announced so the live event and the
   // getUpdateInfo() hydration (which can both deliver the same version) don't
   // announce it twice.
@@ -83,6 +99,38 @@ function AppContent() {
   // reload in dev is safe and gives no false positives.
   useEffect(() => {
     runStartupMigrations()
+  }, [])
+
+  // Load the first-run onboarding inputs: the seen flag and whether any game is
+  // configured (mirrors GameList's getSettings + onStoreConfigChanged read).
+  useEffect(() => {
+    let cancelled = false
+    void getOnboardingSeen().then((seen) => {
+      if (!cancelled) setOnboardingSeen(seen)
+    })
+
+    const readConfiguredGames = () => {
+      void getSettings()
+        .then((settings) => {
+          if (!cancelled) {
+            setHasConfiguredGame(GAMES.some((game) => !!settings.gamePaths[game.key]))
+          }
+        })
+        .catch((err: unknown) => {
+          console.error('Failed to read games for onboarding gate', err)
+        })
+    }
+    readConfiguredGames()
+    // Only 'import-config' / 'save-settings' can carry gamePaths (mirror GameList).
+    const unsubscribe = onStoreConfigChanged((payload) => {
+      if (payload.reason !== 'import-config' && payload.reason !== 'save-settings') return
+      readConfiguredGames()
+    })
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
   }, [])
 
   // Reflect the active view in the document title and the banner heading so
@@ -327,6 +375,22 @@ function AppContent() {
   // re-fires the open/scroll effect.
   const handleTargetConsumed = useCallback(() => setSettingsTarget(null), [])
 
+  // Brand-new user: not yet onboarded AND no game configured. Both flags must be
+  // resolved (non-null) so the modal never flashes during the initial reads.
+  const showOnboarding = onboardingSeen === false && hasConfiguredGame === false
+
+  const handleOnboardingSetup = () => {
+    setOnboardingSeen(true)
+    void persistOnboardingSeen(true)
+    // Hand off to the Games section, opened + scrolled via the #648 deep-link.
+    handleNavigate('settings', 'games')
+  }
+
+  const handleOnboardingSkip = () => {
+    setOnboardingSeen(true)
+    void persistOnboardingSeen(true)
+  }
+
   return (
     <div
       className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
@@ -460,6 +524,12 @@ function AppContent() {
         }}
         onDiscard={() => setDiscardConfirmOpen(false)}
         onCancel={() => setDiscardConfirmOpen(false)}
+      />
+
+      <OnboardingModal
+        isOpen={showOnboarding}
+        onSetup={handleOnboardingSetup}
+        onSkip={handleOnboardingSkip}
       />
     </div>
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -105,13 +105,13 @@ function AppContent() {
   // configured (mirrors GameList's getSettings + onStoreConfigChanged read).
   useEffect(() => {
     let cancelled = false
-    void getOnboardingSeen().then((seen) => {
+    void getOnboardingSeen().then((seen: boolean) => {
       if (!cancelled) setOnboardingSeen(seen)
     })
 
     const readConfiguredGames = () => {
       void getSettings()
-        .then((settings) => {
+        .then((settings: Settings) => {
           if (!cancelled) {
             setHasConfiguredGame(GAMES.some((game) => !!settings.gamePaths[game.key]))
           }
@@ -122,7 +122,7 @@ function AppContent() {
     }
     readConfiguredGames()
     // Only 'import-config' / 'save-settings' can carry gamePaths (mirror GameList).
-    const unsubscribe = onStoreConfigChanged((payload) => {
+    const unsubscribe = onStoreConfigChanged((payload: StoreConfigChangePayload) => {
       if (payload.reason !== 'import-config' && payload.reason !== 'save-settings') return
       readConfiguredGames()
     })

--- a/src/renderer/src/components/AccentSwatchRow.tsx
+++ b/src/renderer/src/components/AccentSwatchRow.tsx
@@ -1,0 +1,115 @@
+import { useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { DEFAULT_ACCENT_COLOR } from '../lib/config'
+import { ColorPickerPopover } from './ColorPickerPopover'
+import { Tooltip } from './Tooltip'
+
+export const ACCENT_PRESETS = [
+  { name: 'Pit Lane Teal', hex: DEFAULT_ACCENT_COLOR },
+  { name: 'Horizon Blue', hex: '#3080d8' },
+  { name: 'Racing Green', hex: '#008a38' },
+  { name: 'Paddock Orange', hex: '#d84e1c' },
+  { name: 'Pit Night', hex: '#9147ff' },
+  { name: 'Safety Car Gold', hex: '#a88000' },
+  { name: 'Milano Red', hex: '#d50000' }
+]
+
+interface AccentSwatchRowProps {
+  accentPreset: string
+  accentCustom: string
+  isCustomColor: boolean
+  onAccentChange: (hex: string) => void
+  onCustomColorChange: (hex: string) => void
+  /**
+   * Container class for the swatch group. Defaults to the Settings-row control
+   * layout; the onboarding modal passes its own so the row fits that surface.
+   */
+  className?: string
+}
+
+/**
+ * The accent-color swatch row (presets + custom picker). Shared by
+ * AppearanceSection (Settings) and the first-run onboarding modal so both drive
+ * the exact same control. Prop-driven (no context) so it works wherever it is
+ * mounted. #641
+ */
+export function AccentSwatchRow({
+  accentPreset,
+  accentCustom,
+  isCustomColor,
+  onAccentChange,
+  onCustomColorChange,
+  className = 'settings-control'
+}: AccentSwatchRowProps): ReactNode {
+  const [showPicker, setShowPicker] = useState(false)
+  const customSwatchRef = useRef<HTMLButtonElement>(null)
+
+  return (
+    <div className={className} role="group" aria-label="Accent color">
+      {ACCENT_PRESETS.map((preset) => (
+        <Tooltip key={preset.hex} label={preset.name}>
+          <button
+            type="button"
+            onClick={() => onAccentChange(preset.hex)}
+            aria-label={`Accent color ${preset.name}`}
+            aria-pressed={accentPreset === preset.hex}
+            className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
+            style={{ '--preset-color': preset.hex } as CSSProperties}
+          />
+        </Tooltip>
+      ))}
+      <div className="relative">
+        <Tooltip label="Custom Color">
+          <button
+            ref={customSwatchRef}
+            type="button"
+            onClick={() => {
+              setShowPicker(!showPicker)
+              if (!isCustomColor) onAccentChange('custom')
+            }}
+            aria-label={isCustomColor ? 'Custom accent color (selected)' : 'Custom accent color'}
+            aria-haspopup="dialog"
+            aria-expanded={showPicker}
+            aria-controls={showPicker ? 'accent-color-picker' : undefined}
+            className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
+              isCustomColor ? 'scale-110' : ''
+            }`}
+          >
+            {/* Background gradient/color */}
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 rounded-full"
+              style={{
+                background: isCustomColor
+                  ? accentCustom || DEFAULT_ACCENT_COLOR
+                  : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
+              }}
+            />
+
+            {/* Glass overlay for unselected state */}
+            {!isCustomColor && (
+              <div
+                aria-hidden="true"
+                className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none"
+              />
+            )}
+
+            {/* Border to match presets */}
+            <div
+              aria-hidden="true"
+              className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
+            />
+          </button>
+        </Tooltip>
+
+        {showPicker && (
+          <ColorPickerPopover
+            color={accentCustom || DEFAULT_ACCENT_COLOR}
+            onChange={onCustomColorChange}
+            onClose={() => setShowPicker(false)}
+            anchorRef={customSwatchRef}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -87,7 +87,12 @@ export function ColorPickerPopover({
   }, [anchorRef])
 
   return createPortal(
-    <div className="fixed inset-0 z-50">
+    // z-110 sits above the app's modal tier (ConfirmDialog / the onboarding modal
+    // are z-100). The picker is a transient interaction owned by whatever surface
+    // opened it, so it must render above that surface - including a modal. In
+    // Settings it stays above the page content as before (nothing else is open at
+    // this tier there). #641
+    <div className="fixed inset-0 z-110">
       {/* Backdrop dismisses the picker on click without affecting underlying layout. */}
       <div aria-hidden="true" className="absolute inset-0" onClick={onClose} />
       <div

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -62,16 +62,23 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
 
   const handleAccentChange = (hex: string): void => {
     theme.setAccentPreset(hex) // apply live
-    void saveSettings({ accentPreset: hex }) // persist now (no save bar here)
+    // persist now (no save bar here)
+    void saveSettings({ accentPreset: hex }).catch((err: unknown) => {
+      console.error('Failed to persist onboarding accent preset', err)
+    })
   }
   const handleCustomColorChange = (hex: string): void => {
     theme.setAccentCustom(hex)
-    void saveSettings({ accentCustom: hex })
+    void saveSettings({ accentCustom: hex }).catch((err: unknown) => {
+      console.error('Failed to persist onboarding accent custom color', err)
+    })
   }
   const handleZoomFactorChange = (factor: number): void => {
-    setZoom(factor) // apply live
+    void setZoom(factor) // apply live
     setZoomFactorState(factor)
-    void saveSettings({ zoomFactor: factor })
+    void saveSettings({ zoomFactor: factor }).catch((err: unknown) => {
+      console.error('Failed to persist onboarding zoom factor', err)
+    })
   }
 
   if (!isOpen) return null

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -6,6 +6,7 @@ import { setZoom } from '../lib/electron'
 import { getSettings, saveSettings } from '../lib/store'
 import { AccentSwatchRow } from './AccentSwatchRow'
 import { ZoomControl } from './ZoomControl'
+import { BrandWordmarkIcon } from './icons'
 
 interface OnboardingModalProps {
   isOpen: boolean
@@ -92,11 +93,20 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
         aria-describedby={descId}
         className="glass-surface-elevated animate-fade-slide relative w-full max-w-lg rounded-[24px] p-8 shadow-[0_20px_50px_rgba(0,0,0,0.5)] isolation-auto"
       >
-        <h2
-          id={titleId}
-          className="text-2xl font-black italic tracking-tighter uppercase text-(--text-primary) mb-3"
-        >
-          Welcome to SimLauncher
+        {/* Brand wordmark stands in for the title text. It is the same single-vector
+            "SimLauncher" + play-mark used in the header, so the play-mark stays
+            aligned at every zoom. "Launcher" follows the accent (text-(--accent))
+            to tie into the accent picker below; the play-mark keeps its own
+            --launcher-play. The h2 carries the accessible name via aria-label
+            since the logo itself is decorative SVG. #641 */}
+        <h2 id={titleId} aria-label="Welcome to SimLauncher" className="mb-3">
+          <span
+            aria-hidden="true"
+            className="mb-2 block text-xs font-bold uppercase tracking-[0.2em] text-(--text-muted)"
+          >
+            Welcome to
+          </span>
+          <BrandWordmarkIcon aria-hidden="true" className="h-7 w-auto text-(--accent)" />
         </h2>
         <p id={descId} className="text-sm text-(--text-secondary) leading-relaxed mb-6">
           Pick your sims and their companion apps once. One click launches the whole stack in the

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useTheme } from '../contexts/ThemeContext'
+import { setZoom } from '../lib/electron'
+import { getSettings, saveSettings } from '../lib/store'
+import { AccentSwatchRow } from './AccentSwatchRow'
+import { ZoomControl } from './ZoomControl'
+
+interface OnboardingModalProps {
+  isOpen: boolean
+  /** Primary CTA: mark onboarding seen and hand off to Settings -> Games. */
+  onSetup: () => void
+  /** Secondary CTA (and Escape): mark onboarding seen and dismiss. */
+  onSkip: () => void
+}
+
+/**
+ * First-run onboarding. A single-screen modal that explains the one-click launch
+ * loop, offers an optional accent + zoom personalization, and hands off to
+ * Settings to configure the first sim. Shown once (gated on onboardingSeen + a
+ * zero-games config in App). Skippable end-to-end. #641
+ *
+ * The accent + zoom controls are the same shared components Settings uses, but
+ * the modal persists changes immediately (there is no save bar here) so the
+ * picks survive the next launch.
+ */
+export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProps): ReactNode {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const primaryRef = useRef<HTMLButtonElement>(null)
+  // Escape = Skip; initial focus lands on the primary CTA. useFocusTrap also
+  // inerts the background and traps Tab within the dialog.
+  useFocusTrap(isOpen, dialogRef, primaryRef, onSkip)
+
+  const titleId = useId()
+  const descId = useId()
+
+  const theme = useTheme()
+  const [zoomFactor, setZoomFactorState] = useState(1)
+
+  // Read the current zoom once when the modal opens so the pills reflect the
+  // live value. Accent comes straight from ThemeContext (always current).
+  useEffect(() => {
+    if (!isOpen) return
+    let cancelled = false
+    getSettings()
+      .then((settings) => {
+        if (!cancelled && Number.isFinite(settings.zoomFactor)) {
+          setZoomFactorState(settings.zoomFactor)
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to read zoom for onboarding', err)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen])
+
+  const isCustomColor = theme.accentPreset === 'custom'
+
+  const handleAccentChange = (hex: string): void => {
+    theme.setAccentPreset(hex) // apply live
+    void saveSettings({ accentPreset: hex }) // persist now (no save bar here)
+  }
+  const handleCustomColorChange = (hex: string): void => {
+    theme.setAccentCustom(hex)
+    void saveSettings({ accentCustom: hex })
+  }
+  const handleZoomFactorChange = (factor: number): void => {
+    setZoom(factor) // apply live
+    setZoomFactorState(factor)
+    void saveSettings({ zoomFactor: factor })
+  }
+
+  if (!isOpen) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-100 flex items-center justify-center p-4 backdrop-blur-md">
+      {/* Backdrop overlay. No click-to-dismiss: onboarding is dismissed only via
+          the explicit Skip / Set up buttons or Escape, to avoid an accidental
+          mis-click skipping it. */}
+      <div aria-hidden="true" className="absolute inset-0 bg-black/40" />
+
+      {/* Focus is trapped and the background is inerted via useFocusTrap, so
+          aria-modal is honest here. */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className="glass-surface-elevated animate-fade-slide relative w-full max-w-lg rounded-[24px] p-8 shadow-[0_20px_50px_rgba(0,0,0,0.5)] isolation-auto"
+      >
+        <h2
+          id={titleId}
+          className="text-2xl font-black italic tracking-tighter uppercase text-(--text-primary) mb-3"
+        >
+          Welcome to SimLauncher
+        </h2>
+        <p id={descId} className="text-sm text-(--text-secondary) leading-relaxed mb-6">
+          Pick your sims and their companion apps once. One click launches the whole stack in the
+          right order, and one click closes it all again.
+        </p>
+
+        <div className="mb-8">
+          <span className="text-xs font-bold uppercase tracking-wide text-(--text-secondary)">
+            Make it yours (optional)
+          </span>
+          <div className="mt-3 flex flex-col gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span className="text-sm text-(--text-secondary)">Accent</span>
+              <AccentSwatchRow
+                accentPreset={theme.accentPreset}
+                accentCustom={theme.accentCustom}
+                isCustomColor={isCustomColor}
+                onAccentChange={handleAccentChange}
+                onCustomColorChange={handleCustomColorChange}
+                className="flex flex-wrap items-center gap-2"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span className="text-sm text-(--text-secondary)">Scale</span>
+              <ZoomControl
+                zoomFactor={zoomFactor}
+                onZoomFactorChange={handleZoomFactorChange}
+                className="flex flex-wrap items-center gap-2"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <button
+            ref={primaryRef}
+            type="button"
+            onClick={onSetup}
+            className="accent-action action-hover-scale w-full cursor-pointer rounded-xl py-3 text-sm font-bold"
+          >
+            Set up your sims →
+          </button>
+          <button
+            type="button"
+            onClick={onSkip}
+            className="neutral-action action-hover-scale w-full cursor-pointer rounded-xl py-3 text-sm font-semibold"
+          >
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -45,7 +45,7 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
     if (!isOpen) return
     let cancelled = false
     getSettings()
-      .then((settings) => {
+      .then((settings: Settings) => {
         if (!cancelled && Number.isFinite(settings.zoomFactor)) {
           setZoomFactorState(settings.zoomFactor)
         }

--- a/src/renderer/src/components/ZoomControl.tsx
+++ b/src/renderer/src/components/ZoomControl.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+
+export const ZOOM_PRESETS = [
+  { label: '100%', factor: 1.0 },
+  { label: '125%', factor: 1.25 },
+  { label: '150%', factor: 1.5 },
+  { label: '175%', factor: 1.75 }
+]
+
+interface ZoomControlProps {
+  zoomFactor: number
+  onZoomFactorChange: (factor: number) => void
+  /**
+   * Container class for the preset group. Defaults to the Settings-row control
+   * layout; the onboarding modal passes its own. #641
+   */
+  className?: string
+}
+
+/**
+ * The UI-scale zoom preset pills. Shared by AppearanceSection (Settings) and the
+ * first-run onboarding modal. Prop-driven so it works wherever it is mounted.
+ */
+export function ZoomControl({
+  zoomFactor,
+  onZoomFactorChange,
+  className = 'settings-control'
+}: ZoomControlProps): ReactNode {
+  return (
+    <div className={className} role="group" aria-label="UI scale">
+      {ZOOM_PRESETS.map((preset) => (
+        <button
+          key={preset.factor}
+          type="button"
+          onClick={() => onZoomFactorChange(preset.factor)}
+          aria-pressed={zoomFactor === preset.factor}
+          className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
+            zoomFactor === preset.factor
+              ? 'selected-surface text-(--text-primary)'
+              : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
+          }`}
+        >
+          {preset.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -1,27 +1,9 @@
-import { useId, useRef, useState, type CSSProperties, type ReactNode } from 'react'
-import { DEFAULT_ACCENT_COLOR } from '../../lib/config'
+import { useId, type ReactNode } from 'react'
 import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
-import { ColorPickerPopover } from '../ColorPickerPopover'
+import { AccentSwatchRow } from '../AccentSwatchRow'
+import { ZoomControl } from '../ZoomControl'
 import { useAppearanceSettings } from './AppearanceContext'
-import { Tooltip } from '../Tooltip'
-
-const ZOOM_PRESETS = [
-  { label: '100%', factor: 1.0 },
-  { label: '125%', factor: 1.25 },
-  { label: '150%', factor: 1.5 },
-  { label: '175%', factor: 1.75 }
-]
-
-const ACCENT_PRESETS = [
-  { name: 'Pit Lane Teal', hex: DEFAULT_ACCENT_COLOR },
-  { name: 'Horizon Blue', hex: '#3080d8' },
-  { name: 'Racing Green', hex: '#008a38' },
-  { name: 'Paddock Orange', hex: '#d84e1c' },
-  { name: 'Pit Night', hex: '#9147ff' },
-  { name: 'Safety Car Gold', hex: '#a88000' },
-  { name: 'Milano Red', hex: '#d50000' }
-]
 
 const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
   { label: 'Dark', value: 'dark' },
@@ -32,8 +14,6 @@ const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
 export function AppearanceSection(): ReactNode {
   const accentBgTintId = useId()
   const focusActiveTitleId = useId()
-  const [showPicker, setShowPicker] = useState(false)
-  const customSwatchRef = useRef<HTMLButtonElement>(null)
   const {
     accentPreset,
     accentCustom,
@@ -75,75 +55,13 @@ export function AppearanceSection(): ReactNode {
 
       <div className="settings-row settings-row-responsive">
         <span className="settings-label text-(--text-secondary)">Accent Color</span>
-        <div className="settings-control" role="group" aria-label="Accent color">
-          {ACCENT_PRESETS.map((preset) => (
-            <Tooltip key={preset.hex} label={preset.name}>
-              <button
-                type="button"
-                onClick={() => onAccentChange(preset.hex)}
-                aria-label={`Accent color ${preset.name}`}
-                aria-pressed={accentPreset === preset.hex}
-                className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 active:scale-[0.98] bg-(--preset-color) ${accentPreset === preset.hex ? 'border-(--accent) scale-110' : 'border-transparent'}`}
-                style={{ '--preset-color': preset.hex } as CSSProperties}
-              />
-            </Tooltip>
-          ))}
-          <div className="relative">
-            <Tooltip label="Custom Color">
-              <button
-                ref={customSwatchRef}
-                type="button"
-                onClick={() => {
-                  setShowPicker(!showPicker)
-                  if (!isCustomColor) onAccentChange('custom')
-                }}
-                aria-label={
-                  isCustomColor ? 'Custom accent color (selected)' : 'Custom accent color'
-                }
-                aria-haspopup="dialog"
-                aria-expanded={showPicker}
-                aria-controls={showPicker ? 'accent-color-picker' : undefined}
-                className={`relative flex h-8 w-8 cursor-pointer items-center justify-center transition-transform hover:scale-110 active:scale-[0.98] ${
-                  isCustomColor ? 'scale-110' : ''
-                }`}
-              >
-                {/* Background gradient/color */}
-                <div
-                  aria-hidden="true"
-                  className="absolute inset-0 rounded-full"
-                  style={{
-                    background: isCustomColor
-                      ? accentCustom || DEFAULT_ACCENT_COLOR
-                      : 'conic-gradient(from 180deg, #ff5e57, #ffdd59, #0be881, #4bcffa, #575fcf, #ef5777, #ff5e57)'
-                  }}
-                />
-
-                {/* Glass overlay for unselected state */}
-                {!isCustomColor && (
-                  <div
-                    aria-hidden="true"
-                    className="absolute inset-0 rounded-full bg-white/10 dark:bg-black/10 pointer-events-none"
-                  />
-                )}
-
-                {/* Border to match presets */}
-                <div
-                  aria-hidden="true"
-                  className={`absolute inset-0 rounded-full border-2 pointer-events-none ${isCustomColor ? 'border-(--accent)' : 'border-transparent'}`}
-                />
-              </button>
-            </Tooltip>
-
-            {showPicker && (
-              <ColorPickerPopover
-                color={accentCustom || DEFAULT_ACCENT_COLOR}
-                onChange={onCustomColorChange}
-                onClose={() => setShowPicker(false)}
-                anchorRef={customSwatchRef}
-              />
-            )}
-          </div>
-        </div>
+        <AccentSwatchRow
+          accentPreset={accentPreset}
+          accentCustom={accentCustom}
+          isCustomColor={isCustomColor}
+          onAccentChange={onAccentChange}
+          onCustomColorChange={onCustomColorChange}
+        />
       </div>
 
       <div className="settings-row">
@@ -166,23 +84,7 @@ export function AppearanceSection(): ReactNode {
 
       <div className="settings-row settings-row-responsive">
         <span className="settings-label text-(--text-secondary)">UI Scale</span>
-        <div className="settings-control" role="group" aria-label="UI scale">
-          {ZOOM_PRESETS.map((preset) => (
-            <button
-              key={preset.factor}
-              type="button"
-              onClick={() => onZoomFactorChange(preset.factor)}
-              aria-pressed={zoomFactor === preset.factor}
-              className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
-                zoomFactor === preset.factor
-                  ? 'selected-surface text-(--text-primary)'
-                  : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
-              }`}
-            >
-              {preset.label}
-            </button>
-          ))}
-        </div>
+        <ZoomControl zoomFactor={zoomFactor} onZoomFactorChange={onZoomFactorChange} />
       </div>
     </>
   )

--- a/src/renderer/src/hooks/useFocusTrap.ts
+++ b/src/renderer/src/hooks/useFocusTrap.ts
@@ -13,6 +13,13 @@ const FOCUSABLE_SELECTOR = [
 // the last one closes.
 let trapDepth = 0
 
+// Stack of active Escape-capable traps (most recently opened on top). Each trap
+// pushes a unique token while active; only the token on top reacts to Escape, so
+// a stacked picker/dialog dismisses itself before the surface that opened it
+// (both register document-capture listeners, and the first-registered would
+// otherwise stopImmediatePropagation and win). #641
+const escapeStack: object[] = []
+
 function setBackgroundInert(inert: boolean): void {
   const root = document.getElementById('root')
   if (!root) return
@@ -100,20 +107,30 @@ export function useFocusTrap(
     container.addEventListener('keydown', handleKeyDown)
 
     // Escape-to-dismiss (when a handler was supplied). Capture phase so it wins
-    // over background document listeners; a no-op when no onEscape was passed.
+    // over background document listeners. Only the topmost Escape-capable trap
+    // reacts, so a stacked picker/dialog closes itself first instead of the
+    // surface underneath it (see escapeStack). A no-op when no onEscape.
+    const escapeToken = onEscapeRef.current ? {} : null
+    if (escapeToken) escapeStack.push(escapeToken)
     const handleEscape = (e: KeyboardEvent): void => {
       if (e.key !== 'Escape') return
       const onEscape = onEscapeRef.current
       if (!onEscape) return
+      // Not the topmost trap — let the event reach the one that is.
+      if (escapeStack[escapeStack.length - 1] !== escapeToken) return
       e.preventDefault()
       e.stopImmediatePropagation()
       onEscape()
     }
-    document.addEventListener('keydown', handleEscape, true)
+    if (escapeToken) document.addEventListener('keydown', handleEscape, true)
 
     return () => {
       container.removeEventListener('keydown', handleKeyDown)
-      document.removeEventListener('keydown', handleEscape, true)
+      if (escapeToken) {
+        document.removeEventListener('keydown', handleEscape, true)
+        const idx = escapeStack.lastIndexOf(escapeToken)
+        if (idx !== -1) escapeStack.splice(idx, 1)
+      }
       trapDepth = Math.max(0, trapDepth - 1)
       if (trapDepth === 0) setBackgroundInert(false)
       // Restore focus only AFTER un-inerting; focusing an element inside an inert

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -5,6 +5,8 @@ export const saveProfile = window.electronAPI.saveProfile
 export const saveProfiles = window.electronAPI.saveProfiles
 export const getMigrationFlags = () => window.electronAPI.getMigrationFlags()
 export const setMigrationFlags = window.electronAPI.setMigrationFlags
+export const getOnboardingSeen = () => window.electronAPI.getOnboardingSeen()
+export const setOnboardingSeen = window.electronAPI.setOnboardingSeen
 export const onStoreConfigChanged = window.electronAPI.onStoreConfigChanged
 export const exportConfig = () => window.electronAPI.exportConfig()
 export const previewImportConfig = () => window.electronAPI.previewImportConfig()

--- a/tests/main/configImport.test.ts
+++ b/tests/main/configImport.test.ts
@@ -73,6 +73,7 @@ async function loadConfigHandlers(initialStore: Record<string, unknown>) {
   const storeMock = {
     CONFIG_FILE_NAME: 'simlauncher-config.json',
     KNOWN_GAME_KEYS: new Set(['iracing']),
+    LOCAL_ONLY_STORE_KEYS: ['onboardingSeen'],
     MAX_CONFIG_IMPORT_BYTES: 1024 * 1024,
     MAX_CUSTOM_SLOTS: 20,
     consumeConfigRecoveryNotice: vi.fn(() => null),
@@ -137,6 +138,19 @@ test('applying an import replaces the store with the sanitized config', async ()
   // clear() before apply: keys absent from the import must not survive.
   expect(mockStore.data).toEqual(importedConfig)
   expect(migrateProfilesToNamedSets).toHaveBeenCalled()
+})
+
+// Local-only UX flags (onboardingSeen) are excluded from import by design, but
+// import clears the whole store — they must be carried over or they silently
+// reset and re-trigger onboarding for an existing user. #641
+test('applying an import preserves local-only keys (onboardingSeen)', async () => {
+  const { handlers, mockStore } = await loadConfigHandlers({
+    customSlots: 5,
+    onboardingSeen: true
+  })
+
+  await expect(previewThenApply(handlers)).resolves.toMatchObject({ success: true })
+  expect(mockStore.data).toEqual({ ...importedConfig, onboardingSeen: true })
 })
 
 // Data-loss guard: a mid-apply failure leaves the store half-written unless

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -30,6 +30,7 @@ async function loadConfigModule() {
   const storeModuleMock = {
     CONFIG_FILE_NAME: 'simlauncher-config.json',
     KNOWN_GAME_KEYS: new Set(['ac', 'acc']),
+    LOCAL_ONLY_STORE_KEYS: ['onboardingSeen'],
     MAX_CONFIG_IMPORT_BYTES: 1_000_000,
     MAX_CUSTOM_SLOTS: 20,
     consumeConfigRecoveryNotice: vi.fn(() => null),

--- a/tests/renderer/onboarding.test.tsx
+++ b/tests/renderer/onboarding.test.tsx
@@ -115,11 +115,9 @@ async function renderApp(): Promise<{ unmount: () => void }> {
 }
 
 function modalHeading(): HTMLElement | null {
-  return (
-    (Array.from(document.body.querySelectorAll('h2')).find(
-      (el) => el.textContent === 'Welcome to SimLauncher'
-    ) as HTMLElement | undefined) ?? null
-  )
+  // The heading renders the brand wordmark (decorative SVG) with the accessible
+  // name carried by aria-label, so match on that rather than text content.
+  return document.body.querySelector('h2[aria-label="Welcome to SimLauncher"]')
 }
 
 function button(name: RegExp): HTMLButtonElement | null {

--- a/tests/renderer/onboarding.test.tsx
+++ b/tests/renderer/onboarding.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * #641 - first-run onboarding gate + actions.
+ *
+ * The modal shows only for a brand-new user (onboarding not seen AND no game
+ * configured), sets the local-only onboardingSeen flag on Skip or Set up, and
+ * Set up hands off to Settings -> Games via the deep-link target. Existing users
+ * (a game already configured) are never onboarded - the zero-games half of the
+ * gate is false for them, so no backfill migration is needed. Escape = Skip.
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const h = vi.hoisted(() => ({
+  onboardingSeen: false as boolean,
+  gamePaths: {} as Record<string, string>,
+  persistOnboardingSeen: vi.fn(async () => {}),
+  settingsTarget: { current: undefined as string | null | undefined }
+}))
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getOnboardingSeen: vi.fn(async () => h.onboardingSeen),
+  setOnboardingSeen: h.persistOnboardingSeen,
+  getSettings: vi.fn(async () => ({ gamePaths: h.gamePaths, zoomFactor: 1 })),
+  saveSettings: vi.fn(async () => {}),
+  onStoreConfigChanged: vi.fn(() => () => {})
+}))
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  forceClose: vi.fn(async () => {}),
+  forceMinimizeToTray: vi.fn(async () => {}),
+  getStartupNotice: vi.fn(async () => null),
+  getUpdateInfo: vi.fn(async () => null),
+  onCloseRequested: vi.fn(() => () => {}),
+  onUpdateAvailable: vi.fn(() => () => {}),
+  setPendingMinimizeToTray: vi.fn(async () => {}),
+  setRendererDirty: vi.fn(async () => {}),
+  setZoom: vi.fn(async () => {})
+}))
+
+vi.mock('../../src/renderer/src/lib/migrations', () => ({
+  runStartupMigrations: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/globalErrors', () => ({
+  subscribeGlobalErrors: vi.fn(() => () => {})
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: ReactNode }) => children
+}))
+
+vi.mock('../../src/renderer/src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    accentPreset: '#008c99',
+    accentCustom: '',
+    accentBgTint: false,
+    themeMode: 'dark',
+    resolvedAccent: '#008c99',
+    setAccentPreset: vi.fn(),
+    setAccentCustom: vi.fn(),
+    setAccentBgTint: vi.fn(),
+    setThemeMode: vi.fn(),
+    syncThemeFromStore: vi.fn(async () => {})
+  })
+}))
+
+// Heavy children that touch their own contexts/IPC are rendered as null; the
+// SettingsView mock records the deep-link target so the Set-up hand-off is
+// observable.
+vi.mock('../../src/renderer/src/components/WindowControls', () => ({
+  WindowControls: () => null
+}))
+vi.mock('../../src/renderer/src/components/GameList', () => ({
+  GameList: () => null
+}))
+vi.mock('../../src/renderer/src/components/StickySaveBar', () => ({
+  StickySaveBar: () => null
+}))
+vi.mock('../../src/renderer/src/components/settings/SettingsContext', () => ({
+  SettingsProvider: ({ children }: { children: ReactNode }) => children
+}))
+vi.mock('../../src/renderer/src/components/SettingsView', () => ({
+  SettingsView: (props: { targetSection: string | null }) => {
+    h.settingsTarget.current = props.targetSection
+    return null
+  }
+}))
+
+import App from '../../src/renderer/src/App'
+import { GAMES } from '../../src/renderer/src/lib/config'
+
+async function renderApp(): Promise<{ unmount: () => void }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root: Root | null = null
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<App />)
+  })
+  // Let the mount effects' async reads (getOnboardingSeen / getSettings) and
+  // their state updates settle before asserting.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    }
+  }
+}
+
+function modalHeading(): HTMLElement | null {
+  return (
+    (Array.from(document.body.querySelectorAll('h2')).find(
+      (el) => el.textContent === 'Welcome to SimLauncher'
+    ) as HTMLElement | undefined) ?? null
+  )
+}
+
+function button(name: RegExp): HTMLButtonElement | null {
+  return (
+    (Array.from(document.body.querySelectorAll('button')).find((element) =>
+      name.test(element.textContent ?? '')
+    ) as HTMLButtonElement | undefined) ?? null
+  )
+}
+
+describe('First-run onboarding (#641)', () => {
+  beforeEach(() => {
+    h.onboardingSeen = false
+    h.gamePaths = {}
+    h.persistOnboardingSeen.mockClear()
+    h.settingsTarget.current = undefined
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('shows for a brand-new user, focused on the primary CTA', async () => {
+    const harness = await renderApp()
+    try {
+      expect(modalHeading()).not.toBeNull()
+      expect(document.activeElement).toBe(button(/set up your sims/i))
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('hidden once onboarding has been seen', async () => {
+    h.onboardingSeen = true
+    const harness = await renderApp()
+    try {
+      expect(modalHeading()).toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('hidden when a game is already configured (existing user, no migration)', async () => {
+    h.gamePaths = { [GAMES[0].key]: 'C:/Sim/sim.exe' }
+    const harness = await renderApp()
+    try {
+      expect(modalHeading()).toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('Skip sets the seen flag and dismisses', async () => {
+    const harness = await renderApp()
+    try {
+      await act(async () => {
+        button(/^skip$/i)?.click()
+      })
+      expect(h.persistOnboardingSeen).toHaveBeenCalledWith(true)
+      expect(modalHeading()).toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('Set up sets the seen flag and hands off to Settings -> Games', async () => {
+    const harness = await renderApp()
+    try {
+      await act(async () => {
+        button(/set up your sims/i)?.click()
+      })
+      expect(h.persistOnboardingSeen).toHaveBeenCalledWith(true)
+      expect(h.settingsTarget.current).toBe('games')
+      expect(modalHeading()).toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('Escape skips (sets the seen flag and dismisses)', async () => {
+    const harness = await renderApp()
+    try {
+      await act(async () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      })
+      expect(h.persistOnboardingSeen).toHaveBeenCalledWith(true)
+      expect(modalHeading()).toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/useFocusTrapEscape.test.tsx
+++ b/tests/renderer/useFocusTrapEscape.test.tsx
@@ -83,3 +83,42 @@ test('Escape with no onEscape is a no-op and lets the event reach background han
   expect(background).toHaveBeenCalledTimes(1)
   document.removeEventListener('keydown', background)
 })
+
+// #641: a color picker opened from within the onboarding modal stacks two traps.
+// Both register document-capture Escape listeners; without a stack the outer
+// (first-registered) one would stopImmediatePropagation and skip onboarding
+// instead of just closing the picker.
+test('with stacked traps, only the topmost (most recently opened) reacts to Escape', async () => {
+  const outerEscape = vi.fn()
+  const innerEscape = vi.fn()
+
+  const outerContainer = document.createElement('div')
+  document.body.appendChild(outerContainer)
+  const outerRoot = createRoot(outerContainer)
+  await act(async () => {
+    outerRoot.render(<Harness onEscape={outerEscape} />)
+  })
+
+  const innerContainer = document.createElement('div')
+  document.body.appendChild(innerContainer)
+  const innerRoot = createRoot(innerContainer)
+  await act(async () => {
+    innerRoot.render(<Harness onEscape={innerEscape} />)
+  })
+
+  // Topmost (inner) trap handles Escape; the outer one underneath does not.
+  pressEscape(innerContainer.querySelector('button')!)
+  expect(innerEscape).toHaveBeenCalledTimes(1)
+  expect(outerEscape).not.toHaveBeenCalled()
+
+  // Close the inner trap → the outer becomes topmost and now handles Escape.
+  await act(async () => innerRoot.unmount())
+  innerContainer.remove()
+
+  pressEscape(outerContainer.querySelector('button')!)
+  expect(outerEscape).toHaveBeenCalledTimes(1)
+  expect(innerEscape).toHaveBeenCalledTimes(1)
+
+  await act(async () => outerRoot.unmount())
+  outerContainer.remove()
+})


### PR DESCRIPTION
Closes #641

First-run onboarding: a one-click "get started" loop shown once on first launch, with an optional accent + zoom personalization step. Local-only `onboardingSeen` flag gates it (never synced, never exported).

## What's in it
- **Store flag + IPC**: local-only `onboardingSeen` boolean with `get`/`set` handlers (deliberately excluded from export/import — it's a per-machine UX flag).
- **Onboarding modal + gate**: shown when `!onboardingSeen && !hasConfiguredGame`; primary CTA deep-links into the Games setup loop; optional accent-picker + zoom step reuses the live appearance controls.
- **Refactor**: extracted shared `AccentSwatchRow` + `ZoomControl` out of `AppearanceSection` so the modal and Settings share one implementation.
- **Fixes found while building**: accent color picker now renders above the modal; heading uses the brand wordmark logo so the play-mark stays aligned at every zoom.
- **Tests**: onboarding gate + actions covered; full suite 380/380.

## Out of scope (by design — Decision 6)
Re-opening onboarding from Settings is intentionally deferred (same call as the reorder deferral on #642). Not in this PR.

## Note on the last commit
The renderer resolves `window.electronAPI` to `any` (pre-existing; the preload `api.ts` declaration is never emitted → TS6305 silently degrades the import). The onboarding effects were the first code to write bare untyped IPC callbacks, which trip `noImplicitAny` and failed `npm run typecheck`. The final commit annotates the four callbacks to match the existing `GameList` convention. The underlying degradation is filed separately as #667 — **not** fixed here (its fix has repo-wide blast radius).

## Gates (local)
format ✅ · lint ✅ · typecheck ✅ · build ✅ · test ✅ 380/380

## Test plan
- [x] Fresh config (`Remove-Item "$env:APPDATA\SimLauncher\config.json"`) → launch → onboarding modal appears
- [x] Complete the loop → modal dismissed, doesn't reappear on relaunch
- [x] Accent + zoom step applies live and persists
- [x] Existing user (games configured) → modal does NOT appear


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a first-run onboarding flow with setup and skip actions.
  * Added appearance controls for accent presets/custom colors and UI zoom presets.
  * Persisted a local “onboarding seen” setting and exposed it to the renderer.
* **Bug Fixes**
  * Improved modal/picker layering so the color picker and onboarding dialog display above other screens.
  * Prevented onboarding from flashing while app state loads.
  * Fixed stacked Escape handling so only the topmost dialog/picker dismisses.
* **Tests**
  * Added coverage for onboarding visibility, keyboard dismissal, setup navigation, and persistence (including config import preservation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #677
<!-- auto-closes -->

---

## Review round (CodeRabbit + Qodo)

**Fixed (229b539):**
- CodeRabbit ×3 — catch-and-log added to the fire-and-forget onboarding IPC calls (`getOnboardingSeen` gate read, `persistOnboardingSeen` in both CTAs, the modal's three `saveSettings` calls) + voided the async `setZoom` preview. Matches the file's existing convention.
- Qodo 🐞 — config import cleared the store and reset the local-only `onboardingSeen`. Added `LOCAL_ONLY_STORE_KEYS`, preserved across import, + regression test. **Fixes #677.**

**Held (deferred, tracked):**
- Qodo 📎 / CodeRabbit "Linked Issues" — re-open onboarding from Settings is Decision 6, deliberately out of scope (like the #642 reorder deferral). Filed as **#700** so #641's criterion is tracked.

Gates re-run green: format · lint · typecheck · build · test (381/381).

## Review round 2 (Codex — 2 × P2, both fixed in 6b5e22e)

- **Stacked-trap Escape** — Escape while editing a custom color in onboarding skipped the whole flow instead of closing the picker (both register document-capture Escape listeners; the outer one won via `stopImmediatePropagation`). `useFocusTrap` is now stack-aware — only the topmost Escape-capable trap reacts. + regression test.
- **Stale settings on handoff** — personalizing accent/scale then handing off to Settings left the mounted `SettingsProvider` on pre-onboarding values (it ignores `save-settings` broadcasts); the next full Settings save would overwrite the onboarding choices. `finishOnboarding()` now bumps `refreshKey` to remount + re-read (same pattern as discard/import/theme), on both Set up and Skip.

Gates re-run green: format · lint · typecheck · build · test (382/382).