### PR TITLE
build(deps): isolate the electron stack into its own Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,23 @@ updates:
     schedule:
       interval: 'monthly'
     # Bundle updates into a few grouped PRs instead of one per dependency.
-    # Production deps are grouped separately from dev deps so runtime changes
-    # still get their own reviewable PR.
+    # The electron stack (runtime, packaging, build, updater, store) is isolated
+    # into its own PR so a major bump — which needs a real-launch smoke and a
+    # signed-build check — never rides a batch of lint/test tooling (#634).
+    # Remaining production deps are grouped separately from dev deps so runtime
+    # changes still get their own reviewable PR.
     groups:
+      electron:
+        patterns:
+          - 'electron*'
       production-dependencies:
         dependency-type: 'production'
+        exclude-patterns:
+          - 'electron*'
       development-dependencies:
         dependency-type: 'development'
+        exclude-patterns:
+          - 'electron*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Closes #701

Follow-up to the #634 hold: isolate the electron stack into its own Dependabot group so a major runtime/packaging bump never rides a batch of lint/test tooling.

## What changed
`.github/dependabot.yml`: added an `electron` group matching `electron*` and excluded `electron*` from the `production-dependencies` / `development-dependencies` groups (no double-match). The pattern catches all five: `electron`, `electron-builder`, `electron-vite`, `electron-updater`, `electron-store`.

Every electron-stack bump — especially a major — now arrives as its own reviewable PR that can get a real-launch smoke + signed-build check, instead of being mergeable inside an eslint/vite/vitest batch (#634).

## Test plan
- [x] `.github/dependabot.yml` parses as valid YAML (js-yaml) and passes `prettier --check`
- [x] `electron` group patterns = `["electron*"]`; both prod and dev groups carry `exclude-patterns: ["electron*"]`
- [ ] After merge: confirm GitHub accepts the config (no Dependabot config error on the repo's Insights → Dependency graph → Dependabot tab), and that the next electron bump opens as a standalone "electron" group PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update organization by separating Electron-related package updates into their own update group.
  * Kept Electron packages out of the general production and development dependency update groups for clearer, more targeted upgrade PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->