### PR TITLE
perf(processes): adaptive poll cadence — back off when hidden and idle (#672)

### DIFF
--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -2,7 +2,6 @@ export { hasClosableLaunchedApps, killLaunchedApps, killProfileApps } from './pr
 export {
   getRunningApps,
   publishRunningApps,
-  setRunningAppsWindowVisible,
   subscribeRunningApps,
   unsubscribeRunningApps
 } from './processes/running'

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -2,6 +2,7 @@ export { hasClosableLaunchedApps, killLaunchedApps, killProfileApps } from './pr
 export {
   getRunningApps,
   publishRunningApps,
+  setRunningAppsWindowVisible,
   subscribeRunningApps,
   unsubscribeRunningApps
 } from './processes/running'

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -37,9 +37,27 @@ export interface RunningAppsChangedPayload {
 }
 
 const RUNNING_APPS_CHANGED_CHANNEL = 'running-apps-changed'
-const RUNNING_APPS_SCAN_INTERVAL_MS = 2000
+// The process scan spawns `tasklist.exe` (plus a `conhost.exe`) every tick, so
+// the cadence is adaptive (#672): keep the responsive FAST poll only while it
+// earns that cost and back off to SLOW when idle in the tray, where a stale-by-
+// a-few-seconds list costs the user nothing.
+const FAST_RUNNING_APPS_SCAN_INTERVAL_MS = 2000
+const SLOW_RUNNING_APPS_SCAN_INTERVAL_MS = 12000
+// After any launch/exit/kill, stay on FAST for this long so a settling launch
+// sequence (spawn → child re-exec → external adoption) is still tracked live
+// even once the window is hidden.
+const POST_ACTIVITY_FAST_WINDOW_MS = 30000
 const runningAppsSubscribers = new Set<WebContents>()
-let runningAppsMonitor: ReturnType<typeof setInterval> | undefined
+let runningAppsScanTimer: ReturnType<typeof setTimeout> | undefined
+let runningAppsMonitorActive = false
+// Whether the main window is currently visible, fed by its 'show'/'hide' events
+// via setRunningAppsWindowVisible. Starts false because the window is created
+// hidden (`show: false`) and only reveals once the renderer is ready — a
+// start-minimized-to-tray session therefore begins on the SLOW cadence.
+let runningAppsWindowVisible = false
+// Timestamp of the last non-scan publish (launch/exit/kill). 0 means "no
+// activity yet this session"; it keeps the poll FAST for POST_ACTIVITY_FAST_WINDOW_MS.
+let lastRunningAppsActivityAt = 0
 let lastRunningAppsSnapshot = ''
 let publishRunningAppsPromise: Promise<RunningAppsChangedPayload | null> | undefined
 
@@ -255,9 +273,8 @@ function normalizeRunningAppsSnapshot(apps: RunningApp[]) {
 function removeRunningAppsSubscriber(webContents: WebContents) {
   runningAppsSubscribers.delete(webContents)
 
-  if (runningAppsSubscribers.size === 0 && runningAppsMonitor) {
-    clearInterval(runningAppsMonitor)
-    runningAppsMonitor = undefined
+  if (runningAppsSubscribers.size === 0 && runningAppsMonitorActive) {
+    stopRunningAppsMonitor()
     // Reset the snapshot so the first emission after the next subscriber
     // re-subscribes is always sent regardless of whether the app list changed
     // while there were no subscribers.
@@ -307,6 +324,13 @@ async function publishRunningAppsInternal(
 export function publishRunningApps(
   reason: RunningAppsChangeReason = 'scan'
 ): Promise<RunningAppsChangedPayload | null> {
+  // Any non-scan publish is real activity (launch/exit/kill) — pull the poll
+  // back to FAST and hold it there for POST_ACTIVITY_FAST_WINDOW_MS so the
+  // settling process set is tracked live even if the window is hidden.
+  if (reason !== 'scan') {
+    noteRunningAppsActivity()
+  }
+
   const next = (publishRunningAppsPromise || Promise.resolve(null))
     .catch(() => null)
     .then(() => publishRunningAppsInternal(reason))
@@ -320,16 +344,87 @@ export function publishRunningApps(
   return publishRunningAppsPromise
 }
 
-function startRunningAppsMonitor() {
-  if (runningAppsMonitor) {
+/**
+ * Pick the delay until the next process scan. FAST while the poll is earning its
+ * `tasklist.exe` spawn — recent launch activity, a visible window, or any app
+ * currently tracked — and SLOW only when the window is hidden AND nothing is
+ * tracked (the idle-in-tray case #672 targets). The poll never stops, so
+ * external-launch adoption still works, just detected a few seconds later.
+ */
+function computeRunningAppsScanDelayMs(): number {
+  const withinPostActivityWindow =
+    Date.now() - lastRunningAppsActivityAt < POST_ACTIVITY_FAST_WINDOW_MS
+  const hasTrackedProcesses = runningProcesses.size > 0 || unclosedProcesses.size > 0
+
+  if (withinPostActivityWindow || runningAppsWindowVisible || hasTrackedProcesses) {
+    return FAST_RUNNING_APPS_SCAN_INTERVAL_MS
+  }
+
+  return SLOW_RUNNING_APPS_SCAN_INTERVAL_MS
+}
+
+// Self-rescheduling scan: each tick re-evaluates the cadence, so the poll can
+// move between FAST and SLOW as visibility/activity/tracking change without ever
+// stopping. A one-shot setTimeout (not setInterval) is what lets the delay vary.
+function scheduleNextRunningAppsScan() {
+  if (!runningAppsMonitorActive) {
     return
   }
 
-  runningAppsMonitor = setInterval(() => {
-    publishRunningApps('scan').catch((err) => {
-      console.error('Running apps monitor error:', err)
-    })
-  }, RUNNING_APPS_SCAN_INTERVAL_MS)
+  if (runningAppsScanTimer) {
+    clearTimeout(runningAppsScanTimer)
+  }
+
+  runningAppsScanTimer = setTimeout(() => {
+    publishRunningApps('scan')
+      .catch((err) => {
+        console.error('Running apps monitor error:', err)
+      })
+      .finally(scheduleNextRunningAppsScan)
+  }, computeRunningAppsScanDelayMs())
+}
+
+function startRunningAppsMonitor() {
+  if (runningAppsMonitorActive) {
+    return
+  }
+
+  runningAppsMonitorActive = true
+  scheduleNextRunningAppsScan()
+}
+
+function stopRunningAppsMonitor() {
+  runningAppsMonitorActive = false
+  if (runningAppsScanTimer) {
+    clearTimeout(runningAppsScanTimer)
+    runningAppsScanTimer = undefined
+  }
+}
+
+// Recompute the cadence now instead of waiting out a pending SLOW timer. Called
+// when something should pull the poll back to FAST (launch activity, the window
+// becoming visible); a no-op when the monitor isn't running.
+function resetRunningAppsCadence() {
+  if (runningAppsMonitorActive) {
+    scheduleNextRunningAppsScan()
+  }
+}
+
+function noteRunningAppsActivity() {
+  lastRunningAppsActivityAt = Date.now()
+  resetRunningAppsCadence()
+}
+
+/**
+ * Signal from the main window's 'show'/'hide' events. A visible window pulls the
+ * poll back to FAST; hiding lets it fall back to SLOW once nothing is tracked.
+ * Safe to call before any subscriber exists — it only records state.
+ */
+export function setRunningAppsWindowVisible(visible: boolean): void {
+  runningAppsWindowVisible = visible
+  if (visible) {
+    resetRunningAppsCadence()
+  }
 }
 
 export async function subscribeRunningApps(

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -352,8 +352,14 @@ export function publishRunningApps(
  * external-launch adoption still works, just detected a few seconds later.
  */
 function computeRunningAppsScanDelayMs(): number {
+  // lastRunningAppsActivityAt === 0 means "no activity yet this session"; guard
+  // that sentinel and a backward clock jump (negative delta) so neither wedges
+  // the poll on FAST.
+  const activityDelta = Date.now() - lastRunningAppsActivityAt
   const withinPostActivityWindow =
-    Date.now() - lastRunningAppsActivityAt < POST_ACTIVITY_FAST_WINDOW_MS
+    lastRunningAppsActivityAt !== 0 &&
+    activityDelta >= 0 &&
+    activityDelta < POST_ACTIVITY_FAST_WINDOW_MS
   const hasTrackedProcesses = runningProcesses.size > 0 || unclosedProcesses.size > 0
 
   if (withinPostActivityWindow || runningAppsWindowVisible || hasTrackedProcesses) {

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -59,6 +59,12 @@ let runningAppsWindowVisible = false
 // activity yet this session"; it keeps the poll FAST for POST_ACTIVITY_FAST_WINDOW_MS.
 let lastRunningAppsActivityAt = 0
 let lastRunningAppsSnapshot = ''
+// Number of apps in the last published snapshot. Includes externally-ADOPTED
+// apps (a configured game started outside SimLauncher) which are surfaced via
+// the scan but never populate runningProcesses/unclosedProcesses — so the
+// cadence must consult this, not only the launcher-owned maps, or an adopted
+// external session would wrongly back off to SLOW. #672
+let lastPublishedRunningAppsCount = 0
 let publishRunningAppsPromise: Promise<RunningAppsChangedPayload | null> | undefined
 
 /**
@@ -301,6 +307,9 @@ async function publishRunningAppsInternal(
   }
 
   const apps = await getRunningApps()
+  // Refresh on every scan (before the change-gate below) so the cadence always
+  // reflects what's actually surfaced, including adopted external apps.
+  lastPublishedRunningAppsCount = apps.length
   const snapshot = normalizeRunningAppsSnapshot(apps)
 
   if (snapshot === lastRunningAppsSnapshot && reason === 'scan') {
@@ -347,9 +356,10 @@ export function publishRunningApps(
 /**
  * Pick the delay until the next process scan. FAST while the poll is earning its
  * `tasklist.exe` spawn — recent launch activity, a visible window, or any app
- * currently tracked — and SLOW only when the window is hidden AND nothing is
- * tracked (the idle-in-tray case #672 targets). The poll never stops, so
- * external-launch adoption still works, just detected a few seconds later.
+ * currently running (launcher-owned OR externally adopted, via the last
+ * published count) — and SLOW only when the window is hidden AND nothing is
+ * running (the idle-in-tray case #672 targets). The poll never stops, so a
+ * first external launch is still adopted within one slow tick, then held FAST.
  */
 function computeRunningAppsScanDelayMs(): number {
   // lastRunningAppsActivityAt === 0 means "no activity yet this session"; guard
@@ -362,7 +372,12 @@ function computeRunningAppsScanDelayMs(): number {
     activityDelta < POST_ACTIVITY_FAST_WINDOW_MS
   const hasTrackedProcesses = runningProcesses.size > 0 || unclosedProcesses.size > 0
 
-  if (withinPostActivityWindow || runningAppsWindowVisible || hasTrackedProcesses) {
+  if (
+    withinPostActivityWindow ||
+    runningAppsWindowVisible ||
+    hasTrackedProcesses ||
+    lastPublishedRunningAppsCount > 0
+  ) {
     return FAST_RUNNING_APPS_SCAN_INTERVAL_MS
   }
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -10,6 +10,7 @@ import {
   setRendererDirty
 } from './app-state'
 import { markRecentlyBrowsedPath } from './ipc/icons'
+import { setRunningAppsWindowVisible } from './processes'
 import { getStoredBoolean, getStoredZoomFactor, isWindowBounds, store } from './store'
 import { checkForUpdates, registerUpdaterEvents } from './updater'
 import { clamp } from './utils'
@@ -212,6 +213,13 @@ export function createWindow(): void {
   // this state on its own (#500).
   mainWindow.on('maximize', () => sendToRenderer('window-maximized-changed', true))
   mainWindow.on('unmaximize', () => sendToRenderer('window-maximized-changed', false))
+
+  // Drive the adaptive running-apps poll cadence (#672): a visible window keeps
+  // the poll on its FAST tick, while hiding to the tray lets it back off to SLOW
+  // once nothing is tracked. Hooking 'show'/'hide' specifically targets the
+  // tray case (the primary idle scenario); a taskbar minimize is left as-is.
+  mainWindow.on('show', () => setRunningAppsWindowVisible(true))
+  mainWindow.on('hide', () => setRunningAppsWindowVisible(false))
 
   // Show window once ready, or keep it hidden when starting minimized to tray.
   // Only stay hidden if BOTH startMinimized AND the tray exists — otherwise the

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -10,7 +10,7 @@ import {
   setRendererDirty
 } from './app-state'
 import { markRecentlyBrowsedPath } from './ipc/icons'
-import { setRunningAppsWindowVisible } from './processes'
+import { setRunningAppsWindowVisible } from './processes/running'
 import { getStoredBoolean, getStoredZoomFactor, isWindowBounds, store } from './store'
 import { checkForUpdates, registerUpdaterEvents } from './updater'
 import { clamp } from './utils'

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'child_process'
-import { beforeEach, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 const readRunningProcessNamesMock = vi.fn()
 const pruneUnclosedProcessesMock = vi.fn()
@@ -69,6 +69,10 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 // A failed tasklist read returns an empty Set carrying no signal value.
 // Treating it as "everything exited" would wipe running/unclosed state and
 // silently drop kill/relaunch controls mid-session (#399).
@@ -113,4 +117,125 @@ test('a successful tasklist read keeps entries whose exe is still running', asyn
     'C:/Tools/CrewChief.exe',
     'C:/Tools/SimHub.exe'
   ])
+})
+
+// --- Adaptive poll cadence (#672) ---
+//
+// These must stay in sync with the constants in running.ts.
+const FAST_SCAN_MS = 2000
+const SLOW_SCAN_MS = 12000
+
+// A fixed, large clock so `Date.now() - lastActivityAt` starts well outside the
+// 30s post-activity window (lastActivityAt defaults to 0) — otherwise a faked
+// clock starting near 0 would read as "just had activity" and force FAST.
+const CLOCK_START_MS = 2_000_000_000_000
+
+function createMockWebContents() {
+  return {
+    once: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    send: vi.fn()
+  }
+}
+
+async function startMonitorHidden(
+  runningModule: Awaited<ReturnType<typeof loadRunningModule>>['runningModule']
+) {
+  vi.useFakeTimers()
+  vi.setSystemTime(CLOCK_START_MS)
+  readRunningProcessNamesMock.mockResolvedValue({ processNames: new Set(), succeeded: true })
+  // Window hidden in the tray + zero tracked processes = the backoff condition.
+  runningModule.setRunningAppsWindowVisible(false)
+  const webContents = createMockWebContents()
+  await runningModule.subscribeRunningApps(webContents as never)
+  return webContents
+}
+
+test('hidden + empty backs off to the slow scan interval (#672)', async () => {
+  const { runningModule } = await loadRunningModule()
+  await startMonitorHidden(runningModule)
+
+  // No scan fires on the FAST cadence — the poll has backed off.
+  const readsAfterSubscribe = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBe(readsAfterSubscribe)
+
+  // It still fires once the SLOW interval elapses (polling is never stopped).
+  await vi.advanceTimersByTimeAsync(SLOW_SCAN_MS - FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(readsAfterSubscribe)
+})
+
+test('polling keeps firing on the slow cadence — it is never stopped (#672)', async () => {
+  const { runningModule } = await loadRunningModule()
+  await startMonitorHidden(runningModule)
+
+  let reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(SLOW_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+
+  // A second slow interval also fires — the self-rescheduling timer persists.
+  reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(SLOW_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+})
+
+test('a launch/activity resets the cadence back to fast (#672)', async () => {
+  const { runningModule } = await loadRunningModule()
+  await startMonitorHidden(runningModule)
+
+  // Baseline: on the slow cadence nothing fires within a FAST interval.
+  let reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBe(reads)
+
+  // A non-scan publish (launch/exit/kill) is activity → pull back to FAST.
+  await runningModule.publishRunningApps('launch')
+  reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+})
+
+test('the window becoming visible resets the cadence back to fast (#672)', async () => {
+  const { runningModule } = await loadRunningModule()
+  await startMonitorHidden(runningModule)
+
+  // Baseline: hidden + empty stays slow (no FAST-interval tick).
+  let reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBe(reads)
+
+  // Showing the window pulls the poll back to FAST.
+  runningModule.setRunningAppsWindowVisible(true)
+  reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+})
+
+test('tracked processes keep the poll fast even while hidden and idle (#672)', async () => {
+  const { runningModule, stateModule } = await loadRunningModule()
+  await startMonitorHidden(runningModule)
+
+  // A tracked launched process is part of the backoff condition (state must be
+  // empty to go slow). Keep it alive across the scan by having the tasklist read
+  // still report its exe, so the prune does not clear it.
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['simhub.exe']),
+    succeeded: true
+  })
+  stateModule.runningProcesses.set('launched', {
+    process: {} as ChildProcess,
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'iracing',
+    isGame: false
+  })
+
+  // Drain the pending SLOW interval so the cadence is recomputed with the
+  // tracked process present — no launch activity, still hidden.
+  await vi.advanceTimersByTimeAsync(SLOW_SCAN_MS)
+
+  // The recomputed cadence is FAST: a scan now fires within a FAST interval.
+  const reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
 })

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -4,7 +4,20 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 const readRunningProcessNamesMock = vi.fn()
 const pruneUnclosedProcessesMock = vi.fn()
 
-async function loadRunningModule() {
+async function loadRunningModule(opts?: {
+  profiles?: Record<string, unknown>
+  gamePaths?: Record<string, string>
+  appPaths?: Record<string, string>
+  trackablePaths?: string[]
+}) {
+  // utils.isValidExePath checks fs.existsSync; pretend every .exe exists so
+  // adoption (which validates the configured game path) works host-independently.
+  vi.doMock('fs', () => ({
+    default: {
+      existsSync: (filePath: unknown) => typeof filePath === 'string' && /\.exe$/i.test(filePath)
+    }
+  }))
+
   const tasklistMock = {
     readRunningProcessNames: readRunningProcessNamesMock,
     invalidateProcessNameCache: vi.fn()
@@ -25,9 +38,9 @@ async function loadRunningModule() {
   vi.doMock('../../src/main/processes/kill.ts', () => killMock)
 
   const profilesMock = {
-    getStoredProfiles: vi.fn(() => ({})),
+    getStoredProfiles: vi.fn(() => opts?.profiles ?? {}),
     getActiveStoredProfile: vi.fn(() => undefined),
-    getProfileTrackablePaths: vi.fn(() => [])
+    getProfileTrackablePaths: vi.fn(() => opts?.trackablePaths ?? [])
   }
   vi.doMock('../profiles', () => profilesMock)
   vi.doMock('/src/main/profiles.ts', () => profilesMock)
@@ -35,7 +48,9 @@ async function loadRunningModule() {
   vi.doMock('../../src/main/profiles.ts', () => profilesMock)
 
   const storeMock = {
-    getStoredStringRecord: vi.fn(() => ({}))
+    getStoredStringRecord: vi.fn((key: string) =>
+      key === 'gamePaths' ? (opts?.gamePaths ?? {}) : (opts?.appPaths ?? {})
+    )
   }
   vi.doMock('../store', () => storeMock)
   vi.doMock('/src/main/store.ts', () => storeMock)
@@ -235,6 +250,39 @@ test('tracked processes keep the poll fast even while hidden and idle (#672)', a
   await vi.advanceTimersByTimeAsync(SLOW_SCAN_MS)
 
   // The recomputed cadence is FAST: a scan now fires within a FAST interval.
+  const reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+})
+
+test('an externally-adopted app keeps the poll fast even with empty maps (#672)', async () => {
+  // A configured game started OUTSIDE SimLauncher is adopted and surfaced via
+  // the scan, but never populates runningProcesses/unclosedProcesses. Keying the
+  // cadence only on those maps would let an adopted external session poll at the
+  // SLOW 12s cadence for its whole duration (Codex review) — the published count
+  // must hold it FAST.
+  const { runningModule } = await loadRunningModule({
+    profiles: { iracing: {} },
+    gamePaths: { iracing: 'C:/Games/iRacingSim64DX11.exe' },
+    trackablePaths: ['C:/Games/iRacingSim64DX11.exe']
+  })
+  vi.useFakeTimers()
+  vi.setSystemTime(CLOCK_START_MS)
+  // The game's exe is running externally (adopted); the launcher-owned maps stay empty.
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['iracingsim64dx11.exe']),
+    succeeded: true
+  })
+  runningModule.setRunningAppsWindowVisible(false)
+  const webContents = createMockWebContents()
+  await runningModule.subscribeRunningApps(webContents as never)
+
+  // Drain the initial SLOW interval so a scan runs and publishes the adopted app
+  // (published count > 0) and the cadence recomputes.
+  await vi.advanceTimersByTimeAsync(SLOW_SCAN_MS)
+
+  // Despite hidden + empty maps, the published count now holds it FAST: a scan
+  // fires within a FAST interval (on the old maps-only condition it stayed SLOW).
   const reads = readRunningProcessNamesMock.mock.calls.length
   await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
   expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)


### PR DESCRIPTION
Closes #672

## What

The running-apps monitor spawned `tasklist.exe` (plus a `conhost.exe` per spawn) **every 2s for the whole session** — even while the window was hidden in the tray with zero tracked apps. For an app that lives idle-in-tray during a race, that was the single largest idle cost (~43k spawns/24h).

This is the stage-S fix from the issue only (**adaptive cadence**). The stage-M native `CreateToolhelp32Snapshot` snapshot is intentionally out of scope (separate future effort).

## How

Replaced the fixed `setInterval` in `src/main/processes/running.ts` with a self-rescheduling `setTimeout` that recomputes its delay every tick:

- **FAST = 2000ms** (the current value, unchanged) while the poll earns its spawn:
  - during and for **~30s** after any launch/exit/kill activity (`POST_ACTIVITY_FAST_WINDOW_MS`), **or**
  - while the window is visible, **or**
  - while any app is tracked (`runningProcesses`/`unclosedProcesses` non-empty).
- **SLOW = 12000ms** (in the issue's 10–15s range) **only** when the window is **hidden AND nothing is tracked** — the pure idle-in-tray case.

**Exact backoff condition** (go SLOW): `!withinPostActivityWindow && !windowVisible && runningProcesses.size === 0 && unclosedProcesses.size === 0`.

The poll **never stops**, so external-launch adoption still works — just detected a few seconds later.

Wiring is minimal and contained:
- **Activity signal:** any non-`scan` `publishRunningApps` reason (`launch`/`exit`/`kill`) marks activity and pulls back to FAST — no change to the spawn/kill paths.
- **Visibility signal:** the main window's `'show'`/`'hide'` events call a new `setRunningAppsWindowVisible()`; either transition to visible resets to FAST immediately instead of waiting out a pending slow timer. Default is hidden (window is created with `show: false`), so a start-minimized-to-tray session correctly begins SLOW.

Untouched: the change-gated publish (only emits IPC when the snapshot changed), the refcounted subscriber teardown, and the 500ms tasklist burst cache.

## Test plan

- `tests/main/running.test.ts` extended with 5 vitest fake-timer cases:
  - hidden + empty → backs off to the SLOW interval (no tick at 2s, tick at 12s)
  - polling keeps firing on the SLOW cadence across two intervals (never stopped)
  - a launch/activity resets the cadence back to FAST
  - the window becoming visible resets the cadence back to FAST
  - tracked processes keep the poll FAST even while hidden and idle
- Local gates all green on a fresh worktree (`npm ci`): `format:check`, `lint`, `typecheck`, `build`, `test` (387 passed).

### Manual idle-CPU smoke (to run before release)
1. Launch SimLauncher, don't launch any profile, close it to the tray.
2. Watch `tasklist.exe`/`conhost.exe` spawns (e.g. Process Monitor or `Get-Process conhost` polling): should drop from every ~2s to every ~12s.
3. Launch a profile → confirm the list updates at the FAST 2s cadence again, and stays FAST for ~30s after the last spawn and while apps are tracked.
4. Restore the window from the tray → confirm it immediately returns to FAST (fresh list within ~2s, not up to 12s).
5. Start an external game while hidden + idle → confirm it is still adopted (within ~12s).
