### PR TITLE
fix(launch): warn instead of silent success when a profile exe is skipped (#639)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -71,15 +71,18 @@ export async function launchProfileApps(
   const skipped: SkippedLaunchEntry[] = []
   const validApps = normalizedEntries.filter((entry) => {
     if (!isValidExePath(entry.path)) {
-      console.error(`Skipping invalid path: ${entry.path}`)
-      writeAppErrorLog('launch', `[${gameKey}] Skipping invalid path: ${entry.path}`)
       // isValidExePath also checks the resolved path's existence, so a
       // well-formed .exe path that simply no longer exists fails here too —
-      // attribute those as 'missing' (not 'invalid') so the reason reflects
-      // the actual problem (moved/uninstalled exe, #639) rather than a
-      // malformed path.
+      // attribute those as 'missing' (not 'invalid') so the reason AND the
+      // log text reflect the actual problem (moved/uninstalled exe, #639)
+      // rather than a malformed path.
       const trimmedPath = entry.path.trim()
       const looksLikeExePath = trimmedPath.length > 0 && /\.exe$/i.test(trimmedPath)
+      const skipLogText = looksLikeExePath
+        ? `Skipping missing executable: ${entry.path}`
+        : `Skipping invalid path: ${entry.path}`
+      console.error(skipLogText)
+      writeAppErrorLog('launch', `[${gameKey}] ${skipLogText}`)
       skipped.push({
         key: entry.key,
         path: entry.path,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -22,7 +22,13 @@ import {
 } from './state'
 import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
-import type { AppLaunchResult, LaunchResult, ProfileLaunchEntry, ProfileLaunchInput } from './types'
+import type {
+  AppLaunchResult,
+  LaunchResult,
+  ProfileLaunchEntry,
+  ProfileLaunchInput,
+  SkippedLaunchEntry
+} from './types'
 import { publishRunningApps } from './running'
 
 const activeLaunches = new Set<string>()
@@ -59,15 +65,32 @@ export async function launchProfileApps(
   const gamePath = gamePaths?.[gameKey]
   const { processNames } = await readRunningProcessNames()
   const normalizedEntries = profileApps.map((input) => normalizeLaunchInput(input, gameKey))
+  // Entries filtered out below never reach spawn — tracked here (not just
+  // console.error'd) so the caller can tell "some apps launched, one was
+  // silently skipped" apart from a plain success (#639).
+  const skipped: SkippedLaunchEntry[] = []
   const validApps = normalizedEntries.filter((entry) => {
     if (!isValidExePath(entry.path)) {
       console.error(`Skipping invalid path: ${entry.path}`)
       writeAppErrorLog('launch', `[${gameKey}] Skipping invalid path: ${entry.path}`)
+      // isValidExePath also checks the resolved path's existence, so a
+      // well-formed .exe path that simply no longer exists fails here too —
+      // attribute those as 'missing' (not 'invalid') so the reason reflects
+      // the actual problem (moved/uninstalled exe, #639) rather than a
+      // malformed path.
+      const trimmedPath = entry.path.trim()
+      const looksLikeExePath = trimmedPath.length > 0 && /\.exe$/i.test(trimmedPath)
+      skipped.push({
+        key: entry.key,
+        path: entry.path,
+        reason: looksLikeExePath ? 'missing' : 'invalid'
+      })
       return false
     }
     if (!fs.existsSync(entry.path.trim())) {
       console.error(`Skipping missing executable: ${entry.path}`)
       writeAppErrorLog('launch', `[${gameKey}] Skipping missing executable: ${entry.path}`)
+      skipped.push({ key: entry.key, path: entry.path, reason: 'missing' })
       return false
     }
     return true
@@ -75,7 +98,7 @@ export async function launchProfileApps(
 
   if (validApps.length === 0) {
     activeLaunches.delete(gameKey)
-    return { success: false, error: 'No valid executable paths configured.' }
+    return { success: false, error: 'No valid executable paths configured.', skipped }
   }
 
   let launchedAny = false
@@ -89,7 +112,8 @@ export async function launchProfileApps(
         success: true,
         message: 'All profile applications are already running.',
         launchedCount: 0,
-        skippedCount
+        skippedCount,
+        skipped
       }
     }
 
@@ -127,7 +151,8 @@ export async function launchProfileApps(
         launchedCount,
         skippedCount,
         elevatedCount: elevatedResults.length,
-        failedCount: failedResults.length
+        failedCount: failedResults.length,
+        skipped
       }
     }
 
@@ -147,7 +172,8 @@ export async function launchProfileApps(
       warning: elevatedWarning,
       launchedCount,
       skippedCount,
-      elevatedCount: elevatedResults.length
+      elevatedCount: elevatedResults.length,
+      skipped
     }
   } finally {
     if (launchedAny) {

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -40,10 +40,12 @@ export interface LaunchResult {
   warning?: string
   error?: string
   launchedCount?: number
+  /** Apps not (re)launched because they were ALREADY RUNNING. Unrelated to `skipped`. */
   skippedCount?: number
   elevatedCount?: number
   failedCount?: number
   killFailures?: KillFailure[]
+  /** Entries excluded before spawn for an invalid/missing exe path (#639). NOT counted by `skippedCount`. */
   skipped?: SkippedLaunchEntry[]
 }
 

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -15,6 +15,25 @@ export interface KillFailure {
   reason: KillFailureReason
 }
 
+/**
+ * `invalid` — the configured path failed the .exe path-shape check
+ * (isValidExePath). `missing` — the path is a well-formed .exe path but the
+ * file no longer exists on disk (moved after a game update, or uninstalled).
+ */
+export type SkippedLaunchReason = 'invalid' | 'missing'
+
+/**
+ * A profile entry that was filtered out of a launch before any process was
+ * spawned. `key` is the game/utility key (see ProfileLaunchEntry) so the
+ * renderer can resolve it to the display name the user actually configured,
+ * rather than showing the raw path (#639).
+ */
+export interface SkippedLaunchEntry {
+  key: string
+  path: string
+  reason: SkippedLaunchReason
+}
+
 export interface LaunchResult {
   success: boolean
   message?: string
@@ -25,6 +44,7 @@ export interface LaunchResult {
   elevatedCount?: number
   failedCount?: number
   killFailures?: KillFailure[]
+  skipped?: SkippedLaunchEntry[]
 }
 
 export interface KillResult {

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -128,6 +128,24 @@ export interface KillFailure {
   reason: KillFailureReason
 }
 
+/**
+ * `invalid` — the configured path failed the .exe path-shape check.
+ * `missing` — the path is a well-formed .exe path but the file no longer
+ * exists on disk (moved after a game update, or uninstalled).
+ */
+export type SkippedLaunchReason = 'invalid' | 'missing'
+
+/**
+ * A profile entry filtered out of a launch before any process was spawned.
+ * `key` is the game/utility key so the renderer can resolve it to the display
+ * name the user configured, rather than showing the raw path (#639).
+ */
+export interface SkippedLaunchEntry {
+  key: string
+  path: string
+  reason: SkippedLaunchReason
+}
+
 export interface LaunchResult {
   success: boolean
   message?: string
@@ -138,6 +156,7 @@ export interface LaunchResult {
   elevatedCount?: number
   failedCount?: number
   killFailures?: KillFailure[]
+  skipped?: SkippedLaunchEntry[]
 }
 
 export interface KillResult {

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -15,6 +15,7 @@ import {
   relaunchMissingProfile
 } from '../../lib/electron'
 import { formatKillFailures } from '../../lib/killFailures'
+import { formatSkippedLaunchEntries } from '../../lib/skippedLaunchEntries'
 import { useGameProfile } from '../../hooks/useGameProfile'
 import { useProfileMenu } from '../../hooks/useProfileMenu'
 import { GameIcon } from './GameIcon'
@@ -273,6 +274,11 @@ export function GameRow({
           if (result.killFailures && result.killFailures.length > 0) {
             switchWarnings.push(formatKillFailures(result.killFailures))
           }
+          if (result.skipped && result.skipped.length > 0) {
+            switchWarnings.push(
+              formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })
+            )
+          }
           if (result.warning) {
             switchWarnings.push(result.warning)
           }
@@ -363,10 +369,23 @@ export function GameRow({
       }
 
       cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
+      // A moved/deleted exe is filtered out before spawn but must not read as
+      // a plain success (#639) — surface it as a warning naming what was
+      // skipped, alongside any elevated-launch warning.
+      const launchWarnings: string[] = []
+      if (result.skipped && result.skipped.length > 0) {
+        launchWarnings.push(
+          formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })
+        )
+      }
+      if (result.warning) {
+        launchWarnings.push(result.warning)
+      }
+      const launchWarning = launchWarnings.length > 0 ? launchWarnings.join(' ') : undefined
       notify(
-        result.warning || result.message || `Launching ${game.name}`,
-        result.warning ? 'warn' : 'success',
-        result.warning ? 5000 : undefined
+        launchWarning || result.message || `Launching ${game.name}`,
+        launchWarning ? 'warn' : 'success',
+        launchWarning ? 5000 : undefined
       )
     } catch (err) {
       notify('Failed to launch profile', 'error')
@@ -411,10 +430,20 @@ export function GameRow({
       }
 
       cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
+      const relaunchWarnings: string[] = []
+      if (result.skipped && result.skipped.length > 0) {
+        relaunchWarnings.push(
+          formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })
+        )
+      }
+      if (result.warning) {
+        relaunchWarnings.push(result.warning)
+      }
+      const relaunchWarning = relaunchWarnings.length > 0 ? relaunchWarnings.join(' ') : undefined
       notify(
-        result.warning || result.message || 'Relaunching missing apps',
-        result.warning ? 'warn' : 'success',
-        result.warning ? 5000 : undefined
+        relaunchWarning || result.message || 'Relaunching missing apps',
+        relaunchWarning ? 'warn' : 'success',
+        relaunchWarning ? 5000 : undefined
       )
     } catch (err) {
       notify('Failed to relaunch missing apps', 'error')

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -264,7 +264,11 @@ export function GameRow({
           onLaunchStart(game.key)
           const result = await switchProfileApps(game.key, currentProfile.id, nextProfile.id)
           if (!result.success) {
-            notify(result.error || 'Failed to switch profile', 'error')
+            const failedSkippedDetail =
+              result.skipped && result.skipped.length > 0
+                ? ` ${formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })}`
+                : ''
+            notify(`${result.error || 'Failed to switch profile'}${failedSkippedDetail}`, 'error')
             onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
             return
           }
@@ -364,7 +368,13 @@ export function GameRow({
       const result = await launchProfile(game.key)
       if (!result.success) {
         cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-        notify(result.error || 'Failed to launch profile', 'error')
+        // The all-invalid failure ("No valid executable paths configured.")
+        // carries the skipped detail too — name what's broken (#639).
+        const failedSkippedDetail =
+          result.skipped && result.skipped.length > 0
+            ? ` ${formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })}`
+            : ''
+        notify(`${result.error || 'Failed to launch profile'}${failedSkippedDetail}`, 'error')
         return
       }
 
@@ -380,6 +390,11 @@ export function GameRow({
       }
       if (result.warning) {
         launchWarnings.push(result.warning)
+      }
+      // The warning changes the toast type, not the story — keep the launch
+      // summary (e.g. "skipped N already running") instead of dropping it.
+      if (launchWarnings.length > 0 && result.message) {
+        launchWarnings.push(result.message)
       }
       const launchWarning = launchWarnings.length > 0 ? launchWarnings.join(' ') : undefined
       notify(
@@ -425,7 +440,14 @@ export function GameRow({
       const result = await relaunchMissingProfile(game.key)
       if (!result.success) {
         cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-        notify(result.error || 'Failed to relaunch missing apps', 'error')
+        const failedSkippedDetail =
+          result.skipped && result.skipped.length > 0
+            ? ` ${formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })}`
+            : ''
+        notify(
+          `${result.error || 'Failed to relaunch missing apps'}${failedSkippedDetail}`,
+          'error'
+        )
         return
       }
 
@@ -438,6 +460,9 @@ export function GameRow({
       }
       if (result.warning) {
         relaunchWarnings.push(result.warning)
+      }
+      if (relaunchWarnings.length > 0 && result.message) {
+        relaunchWarnings.push(result.message)
       }
       const relaunchWarning = relaunchWarnings.length > 0 ? relaunchWarnings.join(' ') : undefined
       notify(

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -434,7 +434,16 @@ export function useProfileEditor({
       const result = await launchProfile(gameKey)
       cooldownMs = result.launchedCount === 0 ? 0 : 10000
       if (!result.success) {
-        notify(result.error || 'Failed to launch profile', 'error')
+        const failedSkippedDetail =
+          result.skipped && result.skipped.length > 0
+            ? ` ${formatSkippedLaunchEntries(result.skipped, {
+                gameKey,
+                gameName: GAMES.find((game) => game.key === gameKey)?.name ?? gameKey,
+                appNames,
+                utilities
+              })}`
+            : ''
+        notify(`${result.error || 'Failed to launch profile'}${failedSkippedDetail}`, 'error')
       } else {
         // A moved/deleted exe is filtered out before spawn but must not read
         // as a plain success (#639) — surface it as a warning naming what was
@@ -452,6 +461,9 @@ export function useProfileEditor({
         }
         if (result.warning) {
           launchWarnings.push(result.warning)
+        }
+        if (launchWarnings.length > 0 && result.message) {
+          launchWarnings.push(result.message)
         }
         const launchWarning = launchWarnings.length > 0 ? launchWarnings.join(' ') : undefined
         notify(

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -468,7 +468,10 @@ export function useProfileEditor({
         const launchWarning = launchWarnings.length > 0 ? launchWarnings.join(' ') : undefined
         notify(
           launchWarning || result.message || 'Launching profile',
-          launchWarning ? 'warn' : 'success'
+          launchWarning ? 'warn' : 'success',
+          // Longer, more informative warning (names what was skipped) — keep it
+          // up as long as the row-level launch toasts do.
+          launchWarning ? 5000 : undefined
         )
       }
     } catch (err) {

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import { useDirtyTracking } from './useDirtyTracking'
 import {
+  GAMES,
   getActiveGameProfile,
   getUtilities,
   normalizeGameProfileSet,
@@ -23,6 +24,7 @@ import { getSettings, getProfiles, saveProfile } from '../lib/store'
 import { getFileIcon, browsePath, launchProfile } from '../lib/electron'
 import { useAppsSettings } from '../components/settings/AppsContext'
 import { syncProfileUtilitiesWithSettings } from '../lib/profileEditorSettingsSync'
+import { formatSkippedLaunchEntries } from '../lib/skippedLaunchEntries'
 
 export interface ProfileEditorProps {
   gameKey: string
@@ -434,9 +436,27 @@ export function useProfileEditor({
       if (!result.success) {
         notify(result.error || 'Failed to launch profile', 'error')
       } else {
+        // A moved/deleted exe is filtered out before spawn but must not read
+        // as a plain success (#639) — surface it as a warning naming what was
+        // skipped, alongside any elevated-launch warning.
+        const launchWarnings: string[] = []
+        if (result.skipped && result.skipped.length > 0) {
+          launchWarnings.push(
+            formatSkippedLaunchEntries(result.skipped, {
+              gameKey,
+              gameName: GAMES.find((game) => game.key === gameKey)?.name ?? gameKey,
+              appNames,
+              utilities
+            })
+          )
+        }
+        if (result.warning) {
+          launchWarnings.push(result.warning)
+        }
+        const launchWarning = launchWarnings.length > 0 ? launchWarnings.join(' ') : undefined
         notify(
-          result.warning || result.message || 'Launching profile',
-          result.warning ? 'warn' : 'success'
+          launchWarning || result.message || 'Launching profile',
+          launchWarning ? 'warn' : 'success'
         )
       }
     } catch (err) {
@@ -446,13 +466,15 @@ export function useProfileEditor({
       onLaunchEnd?.(cooldownMs)
     }
   }, [
+    appNames,
     gameKey,
     notify,
     onClose,
     onLaunchEnd,
     onLaunchStart,
     onProfileCommitted,
-    setShowLaunchConfirm
+    setShowLaunchConfirm,
+    utilities
   ])
 
   const handleLaunch = useCallback(async () => {

--- a/src/renderer/src/lib/skippedLaunchEntries.ts
+++ b/src/renderer/src/lib/skippedLaunchEntries.ts
@@ -1,0 +1,61 @@
+export type SkippedLaunchReason = 'invalid' | 'missing'
+
+export interface SkippedLaunchEntrySummary {
+  key: string
+  path: string
+  reason: SkippedLaunchReason
+}
+
+export interface SkippedLaunchNameLookup {
+  gameKey: string
+  gameName: string
+  // Only populated where the caller already has the settings-driven name
+  // lookup in scope (the profile editor's own state). GameRow's row-level
+  // launch buttons don't pull in the settings context just for this, so they
+  // fall back to the executable's basename for non-game entries instead.
+  appNames?: Record<string, string>
+  utilities?: { key: string; name: string }[]
+}
+
+function getExeBasenameWithoutExtension(filePath: string): string {
+  const parts = filePath.split(/[/\\]/)
+  const basename = parts[parts.length - 1] || filePath
+  return basename.replace(/\.exe$/i, '') || basename
+}
+
+// Resolution order mirrors getDroppedEntryLabel's settings-save warning
+// (#669): custom name > utility default > a readable fallback derived from
+// the path — never the raw path itself, never an internal key like
+// "customapp3".
+function resolveSkippedEntryName(
+  entry: SkippedLaunchEntrySummary,
+  lookup: SkippedLaunchNameLookup
+): string {
+  if (entry.key === lookup.gameKey) {
+    return lookup.gameName
+  }
+
+  const configuredName = lookup.appNames?.[entry.key]
+  const utilityName = lookup.utilities?.find((utility) => utility.key === entry.key)?.name
+
+  return configuredName || utilityName || getExeBasenameWithoutExtension(entry.path)
+}
+
+/**
+ * Builds the warning toast copy for a launch that succeeded for some profile
+ * apps but skipped others because their configured executable path is no
+ * longer valid — moved after a game update, or uninstalled since it was
+ * configured (#639). Whether the path was malformed or simply missing isn't
+ * surfaced to the user; both point at the same fix (re-browse the path in the
+ * profile editor).
+ */
+export function formatSkippedLaunchEntries(
+  skipped: SkippedLaunchEntrySummary[],
+  lookup: SkippedLaunchNameLookup
+): string {
+  const names = skipped.map((entry) => resolveSkippedEntryName(entry, lookup))
+
+  return names.length === 1
+    ? `${names[0]} was skipped — its path no longer exists.`
+    : `${names.length} apps were skipped because their paths no longer exist (${names.join(', ')}).`
+}

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -891,7 +891,35 @@ test('launchProfileApps rejects empty launches when every configured executable 
     launchProfileApps(sender, 'ac', ['C:/Tools/not-an-exe.txt', 'C:/Tools/Missing.exe'])
   ).resolves.toMatchObject({
     success: false,
-    error: 'No valid executable paths configured.'
+    error: 'No valid executable paths configured.',
+    skipped: [
+      { key: 'C:/Tools/not-an-exe.txt', path: 'C:/Tools/not-an-exe.txt', reason: 'invalid' },
+      { key: 'C:/Tools/Missing.exe', path: 'C:/Tools/Missing.exe', reason: 'missing' }
+    ]
+  })
+})
+
+// #639: a moved/deleted game exe used to be filtered out silently, and the
+// launch still reported plain success as long as one other app started. The
+// caller must be able to tell "some apps launched, one was skipped" apart
+// from a full success via the new `skipped` field.
+test('launchProfileApps reports skipped entries when some profile apps launch and others have a missing or invalid path (#639)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps } = await loadProcessModules()
+
+  await expect(
+    launchProfileApps(sender, 'ac', [
+      'C:/Tools/SimHub.exe',
+      'C:/Games/AC/acs.exe',
+      'C:/Tools/not-an-exe.txt'
+    ])
+  ).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1,
+    skipped: [
+      { key: 'C:/Games/AC/acs.exe', path: 'C:/Games/AC/acs.exe', reason: 'missing' },
+      { key: 'C:/Tools/not-an-exe.txt', path: 'C:/Tools/not-an-exe.txt', reason: 'invalid' }
+    ]
   })
 })
 

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -923,6 +923,21 @@ test('launchProfileApps reports skipped entries when some profile apps launch an
   })
 })
 
+// The on-disk log line must match the attributed reason: a well-formed .exe
+// that no longer exists is "missing", not "invalid" (#639).
+test('a well-formed but missing exe is logged as missing, not invalid', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps } = await loadProcessModules()
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe', 'C:/Games/AC/acs.exe'])
+
+  const loggedLines = appErrorLogFsMock.appendFileSync.mock.calls.map((call) => String(call[1]))
+  expect(
+    loggedLines.some((line) => line.includes('Skipping missing executable: C:/Games/AC/acs.exe'))
+  ).toBe(true)
+  expect(loggedLines.some((line) => line.includes('Skipping invalid path'))).toBe(false)
+})
+
 test('launchProfileApps skips profile apps that are already running', async () => {
   const { launchProfileApps } = await loadProcessModules()
 

--- a/tests/renderer/gameRowLaunchSkipped.test.tsx
+++ b/tests/renderer/gameRowLaunchSkipped.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Regression test for #639: a moved/deleted profile exe used to be filtered
+ * out silently (console.error only) and the launch still reported plain
+ * success as long as one other app started. The user got a positive toast
+ * with no indication their game (or a companion) was skipped.
+ *
+ * Pinned here: when `launchProfile` resolves with a non-empty `skipped`
+ * array, the row's toast must be a WARNING naming what was skipped — not the
+ * plain success message — and must resolve the skipped entry's display name
+ * (game title, or the exe basename for a companion) rather than the raw path.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const notifyMock = vi.fn()
+const launchProfileMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+// Same jsdom-safety stubs as gameRowLaunchAnnounce.test.tsx: GameRow pulls in
+// ProfileEditor's hook graph, which touches window.electronAPI at module eval.
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRow(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={false}
+          isGameRunning={false}
+          runningAppIcons={[]}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+async function clickPlayButton(): Promise<void> {
+  const playButton = container.querySelector(
+    'button[aria-label="Launch Assetto Corsa"]'
+  ) as HTMLButtonElement | null
+  expect(playButton).not.toBeNull()
+
+  await act(async () => {
+    playButton!.click()
+  })
+}
+
+beforeEach(() => {
+  notifyMock.mockClear()
+  launchProfileMock.mockReset()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('GameRow launch skipped-entry warning (#639)', () => {
+  test('warns naming the game when the game exe itself was skipped, instead of showing success', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skipped: [{ key: 'ac', path: 'C:/Games/AC/acs.exe', reason: 'missing' }]
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      'Assetto Corsa was skipped — its path no longer exists.',
+      'warn',
+      5000
+    )
+  })
+
+  test('falls back to the exe basename for a skipped companion app', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skipped: [{ key: 'simhub', path: 'C:/Tools/SimHub.exe', reason: 'missing' }]
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      'SimHub was skipped — its path no longer exists.',
+      'warn',
+      5000
+    )
+  })
+
+  test('shows the plain success toast when nothing was skipped', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      message: 'All profile applications launched.'
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      'All profile applications launched.',
+      'success',
+      undefined
+    )
+  })
+})

--- a/tests/renderer/gameRowLaunchSkipped.test.tsx
+++ b/tests/renderer/gameRowLaunchSkipped.test.tsx
@@ -194,4 +194,44 @@ describe('GameRow launch skipped-entry warning (#639)', () => {
       undefined
     )
   })
+
+  // The skipped warning must not swallow the launch summary — "skipped 1
+  // already running" and "path no longer exists" are independent facts.
+  test('keeps the launch summary message alongside the skipped warning', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skippedCount: 1,
+      message: 'Started 1 app; skipped 1 already running.',
+      skipped: [{ key: 'simhub', path: 'C:/Tools/SimHub.exe', reason: 'missing' }]
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      'SimHub was skipped — its path no longer exists. Started 1 app; skipped 1 already running.',
+      'warn',
+      5000
+    )
+  })
+
+  // The all-invalid failure carries the skipped detail too — the single-app
+  // moved-exe case is the most common #639 trigger and must name the culprit.
+  test('a total launch failure names the skipped entries in the error toast', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: false,
+      launchedCount: 0,
+      error: 'No valid executable paths configured.',
+      skipped: [{ key: 'ac', path: 'C:/Games/AC/acs.exe', reason: 'missing' }]
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      'No valid executable paths configured. Assetto Corsa was skipped — its path no longer exists.',
+      'error'
+    )
+  })
 })

--- a/tests/renderer/profileEditorLaunchSkipped.test.tsx
+++ b/tests/renderer/profileEditorLaunchSkipped.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Regression test for #639 in the profile editor's own launch path
+ * (useProfileEditor's executeLaunch). Mirrors gameRowLaunchSkipped.test.tsx,
+ * but exercises the resolution branch that DOES have the settings-driven
+ * appNames/utilities lookup in scope, so a skipped companion resolves to its
+ * configured display name (not just the exe basename).
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import {
+  useProfileEditor,
+  type UseProfileEditorResult
+} from '../../src/renderer/src/hooks/useProfileEditor'
+
+const getSettingsMock = vi.fn()
+const getProfilesMock = vi.fn()
+const notifyMock = vi.fn()
+const launchProfileMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: (...args: unknown[]) => getSettingsMock(...args),
+  getProfiles: (...args: unknown[]) => getProfilesMock(...args),
+  saveProfile: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  getFileIcon: vi.fn(async () => ''),
+  browsePath: vi.fn(),
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args)
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock })
+}))
+
+const APP_PATHS = { simhub: 'C:/Tools/SimHub.exe' }
+// Custom name for the simhub slot — proves the resolution order picks this up
+// over the built-in "SimHub" utility default (#639 mirrors #669's order).
+const APP_NAMES = { simhub: 'My Dash' }
+
+vi.mock('../../src/renderer/src/components/settings/AppsContext', () => ({
+  useAppsSettings: () => ({ appPaths: APP_PATHS, appNames: APP_NAMES, customSlots: 1 })
+}))
+
+function profileSet() {
+  return {
+    iracing: {
+      activeProfileId: 'p1',
+      profiles: [{ id: 'p1', name: 'Race Day', utilities: [{ id: 'simhub', enabled: true }] }]
+    }
+  }
+}
+
+function Probe({ onCapture }: { onCapture: (api: UseProfileEditorResult) => void }) {
+  onCapture(
+    useProfileEditor({
+      gameKey: 'iracing',
+      activeProfileId: 'p1',
+      onProfilesChanged: vi.fn().mockResolvedValue(undefined),
+      onClose: vi.fn()
+    })
+  )
+  return null
+}
+
+async function mountEditor() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: UseProfileEditorResult | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Probe onCapture={(api) => (captured = api)} />)
+  })
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getApi: () => {
+      if (!captured) throw new Error('Probe did not capture state')
+      return captured
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSettingsMock.mockResolvedValue({ appPaths: APP_PATHS, appNames: APP_NAMES, customSlots: 1 })
+  getProfilesMock.mockResolvedValue(profileSet())
+})
+
+describe('useProfileEditor launch skipped-entry warning (#639)', () => {
+  test('warns naming the game when the game exe itself was skipped', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skipped: [{ key: 'iracing', path: 'C:/Games/iRacing/iRacing.exe', reason: 'missing' }]
+    })
+
+    const harness = await mountEditor()
+    try {
+      await act(async () => {
+        await harness.getApi().handleLaunch()
+      })
+
+      expect(notifyMock).toHaveBeenCalledWith(
+        'iRacing was skipped — its path no longer exists.',
+        'warn'
+      )
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('resolves a skipped companion to its configured custom name, not the raw path', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skipped: [{ key: 'simhub', path: 'C:/Tools/SimHub.exe', reason: 'missing' }]
+    })
+
+    const harness = await mountEditor()
+    try {
+      await act(async () => {
+        await harness.getApi().handleLaunch()
+      })
+
+      expect(notifyMock).toHaveBeenCalledWith(
+        'My Dash was skipped — its path no longer exists.',
+        'warn'
+      )
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('shows the plain success toast when nothing was skipped', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      message: 'All profile applications launched.'
+    })
+
+    const harness = await mountEditor()
+    try {
+      await act(async () => {
+        await harness.getApi().handleLaunch()
+      })
+
+      expect(notifyMock).toHaveBeenCalledWith('All profile applications launched.', 'success')
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/profileEditorLaunchSkipped.test.tsx
+++ b/tests/renderer/profileEditorLaunchSkipped.test.tsx
@@ -113,7 +113,8 @@ describe('useProfileEditor launch skipped-entry warning (#639)', () => {
 
       expect(notifyMock).toHaveBeenCalledWith(
         'iRacing was skipped — its path no longer exists.',
-        'warn'
+        'warn',
+        5000
       )
     } finally {
       harness.unmount()
@@ -135,7 +136,8 @@ describe('useProfileEditor launch skipped-entry warning (#639)', () => {
 
       expect(notifyMock).toHaveBeenCalledWith(
         'My Dash was skipped — its path no longer exists.',
-        'warn'
+        'warn',
+        5000
       )
     } finally {
       harness.unmount()
@@ -155,7 +157,11 @@ describe('useProfileEditor launch skipped-entry warning (#639)', () => {
         await harness.getApi().handleLaunch()
       })
 
-      expect(notifyMock).toHaveBeenCalledWith('All profile applications launched.', 'success')
+      expect(notifyMock).toHaveBeenCalledWith(
+        'All profile applications launched.',
+        'success',
+        undefined
+      )
     } finally {
       harness.unmount()
     }

--- a/tests/renderer/skippedLaunchEntries.test.ts
+++ b/tests/renderer/skippedLaunchEntries.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'vitest'
+import { formatSkippedLaunchEntries } from '../../src/renderer/src/lib/skippedLaunchEntries'
+
+/**
+ * Unit coverage for the skipped-entry toast copy (#639), independent of the
+ * UI wiring in gameRowLaunchSkipped / profileEditorLaunchSkipped: the plural
+ * wording and the full name-resolution precedence (game name > configured
+ * custom name > utility default > exe basename) are pinned here.
+ */
+
+const LOOKUP = {
+  gameKey: 'ac',
+  gameName: 'Assetto Corsa',
+  appNames: { customapp1: 'My Dash' },
+  utilities: [
+    { key: 'customapp1', name: 'Custom App 1' },
+    { key: 'simhub', name: 'SimHub' }
+  ]
+}
+
+test('single skipped entry names it in the singular form', () => {
+  const out = formatSkippedLaunchEntries(
+    [{ key: 'ac', path: 'C:/Games/AC/acs.exe', reason: 'missing' }],
+    LOOKUP
+  )
+
+  expect(out).toBe('Assetto Corsa was skipped — its path no longer exists.')
+})
+
+test('multiple skipped entries use the plural form and list every name', () => {
+  const out = formatSkippedLaunchEntries(
+    [
+      { key: 'ac', path: 'C:/Games/AC/acs.exe', reason: 'missing' },
+      { key: 'simhub', path: 'C:/Tools/SimHub.exe', reason: 'invalid' }
+    ],
+    LOOKUP
+  )
+
+  expect(out).toBe(
+    '2 apps were skipped because their paths no longer exist (Assetto Corsa, SimHub).'
+  )
+})
+
+test('name resolution prefers game name, then configured name, then utility default, then basename', () => {
+  // Game key beats everything.
+  expect(
+    formatSkippedLaunchEntries(
+      [{ key: 'ac', path: 'C:/x/whatever.exe', reason: 'missing' }],
+      LOOKUP
+    )
+  ).toContain('Assetto Corsa')
+
+  // Configured custom name beats the utility default.
+  expect(
+    formatSkippedLaunchEntries(
+      [{ key: 'customapp1', path: 'C:/Tools/dash.exe', reason: 'missing' }],
+      LOOKUP
+    )
+  ).toContain('My Dash')
+
+  // Utility default when no custom name is configured.
+  expect(
+    formatSkippedLaunchEntries(
+      [{ key: 'simhub', path: 'C:/Tools/SimHub.exe', reason: 'missing' }],
+      LOOKUP
+    )
+  ).toContain('SimHub')
+
+  // Unknown key with no lookups falls back to the exe basename, never the raw
+  // path or the internal key.
+  const out = formatSkippedLaunchEntries(
+    [{ key: 'crewchief', path: 'C:/Apps/CrewChiefV4.exe', reason: 'missing' }],
+    { gameKey: 'ac', gameName: 'Assetto Corsa' }
+  )
+  expect(out).toContain('CrewChiefV4')
+  expect(out).not.toContain('C:/Apps')
+})


### PR DESCRIPTION
## Summary

A moved/deleted game (or companion app) executable was silently filtered out of a launch before spawn, but `launchProfileApps` still reported plain **success** as long as at least one other app launched — so the user got a positive toast with no indication their game was skipped. The `"No valid executable paths configured."` error only fired when *every* entry was invalid.

- `LaunchResult` (`src/main/processes/types.ts`) now carries an optional `skipped: SkippedLaunchEntry[]` — each entry's `key`, `path`, and `reason` (`'invalid'` for a malformed/non-.exe path, `'missing'` for a well-formed `.exe` path that no longer exists on disk).
- `launchProfileApps` (`src/main/processes/spawn.ts`) populates `skipped` from the existing validity filter (the `#638` `writeAppErrorLog` calls there are untouched) and threads it through every return path.
- The renderer (`GameRow.tsx`'s launch / relaunch-missing / profile-switch flows, and `useProfileEditor.tsx`'s own launch button) now shows a **warning** toast naming what was skipped whenever some — but not all — profile apps launched, instead of a plain success toast. A fully-successful launch is unchanged.
- A new shared helper, `src/renderer/src/lib/skippedLaunchEntries.ts`, resolves a skipped entry's key to the display name the user already sees in the UI (game title, or the app slot's configured/default name), falling back to the executable's basename — never the raw path. Mirrors the resolution order used for the `#669` settings-save warning.
- Mirrored the new `SkippedLaunchReason` / `SkippedLaunchEntry` types in `src/preload/api.ts` to keep the preload contract in sync with main.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (420 passed, including new regression coverage)
  - `tests/main/processes.test.ts`: `launchProfileApps` now asserts `skipped` entries (with correct `invalid`/`missing` attribution) both when every entry is invalid and when some launch and others are skipped.
  - `tests/renderer/gameRowLaunchSkipped.test.tsx` (new): clicking Launch shows a warning naming the game when the game's own exe was skipped, falls back to the exe basename for a skipped companion, and still shows the plain success toast when nothing was skipped.
  - `tests/renderer/profileEditorLaunchSkipped.test.tsx` (new): same coverage for the profile editor's own launch button, plus proof that a skipped companion resolves to its *configured custom name* (not the built-in default or the raw path).
- [x] `npm run build`

Closes #639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch notifications now include clearer details when some configured apps are skipped.
  * Skipped items are shown with more user-friendly names, including game titles and custom app names where available.

* **Bug Fixes**
  * Improved launch results to distinguish between invalid and missing executable paths.
  * Launch flows now report partial success more accurately, including which entries were skipped and why.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->