### PR TITLE
fix(launch): cancel in-flight launch sequence when Close Apps is clicked

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -18,6 +18,7 @@ import {
 } from '../utils'
 
 import {
+  abortActiveLaunches,
   processNameMismatchWarnings,
   runningProcesses,
   suppressProcessNameMismatchWarning,
@@ -571,6 +572,12 @@ function getProfileCompanionTargets(gameKey?: string) {
 }
 
 export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
+  // Cancel any in-flight launchProfileApps sequence for this gameKey (or all
+  // of them, for the gameKey-less tray/global kill) before touching the
+  // process list — otherwise the launch loop can spawn its next queued app
+  // during or after this kill (#670).
+  abortActiveLaunches(gameKey)
+
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
   const companionTargets = getProfileCompanionTargets(gameKey)
@@ -679,6 +686,12 @@ export async function killProfileApps(
 
     validAppPathsToKill.push(appPath)
   }
+
+  // Cancel any in-flight launchProfileApps sequence for this gameKey before
+  // doing kill work, same reasoning as killLaunchedApps above (#670). Placed
+  // after validation so a rejected (not-configured-path) request doesn't
+  // cancel a legitimate in-flight launch as a side effect.
+  abortActiveLaunches(gameKey)
 
   // First pass: prefer killing via the ChildProcess handle (PID-based /T /F
   // tree kill) for apps that SimLauncher itself spawned and still owns. This

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -659,7 +659,6 @@ export async function killProfileApps(
   gameKey: string,
   appPathsToKill: string[]
 ): Promise<KillResult> {
-  const { processNames } = await readRunningProcessNames()
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]
   const storedAppPathTargets = getStoredAppPathTargets()
@@ -689,9 +688,14 @@ export async function killProfileApps(
 
   // Cancel any in-flight launchProfileApps sequence for this gameKey before
   // doing kill work, same reasoning as killLaunchedApps above (#670). Placed
-  // after validation so a rejected (not-configured-path) request doesn't
-  // cancel a legitimate in-flight launch as a side effect.
+  // after the synchronous validation so a rejected (not-configured-path)
+  // request doesn't cancel a legitimate in-flight launch as a side effect —
+  // but BEFORE the tasklist scan below: that await can be slow, and a launch
+  // loop sitting in a short inter-app wait could otherwise spawn its next app
+  // before the abort lands, leaving it running past this kill's snapshot.
   abortActiveLaunches(gameKey)
+
+  const { processNames } = await readRunningProcessNames()
 
   // First pass: prefer killing via the ChildProcess handle (PID-based /T /F
   // tree kill) for apps that SimLauncher itself spawned and still owns. This

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -18,7 +18,9 @@ import {
 import {
   consumeProcessNameMismatchWarningSuppression,
   processNameMismatchWarnings,
-  runningProcesses
+  registerActiveLaunch,
+  runningProcesses,
+  unregisterActiveLaunch
 } from './state'
 import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
@@ -60,6 +62,11 @@ export async function launchProfileApps(
   }
 
   activeLaunches.add(gameKey)
+  // Registered for the duration of the sequence so killLaunchedApps/
+  // killProfileApps can cancel it mid-flight (#670). Deliberately separate
+  // from `activeLaunches` above, whose Set-of-gameKeys semantics only gate
+  // concurrent launches and stay untouched.
+  const launchController = registerActiveLaunch(gameKey)
   const launchDelayMs = getLaunchDelayMs()
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]
@@ -101,6 +108,7 @@ export async function launchProfileApps(
 
   if (validApps.length === 0) {
     activeLaunches.delete(gameKey)
+    unregisterActiveLaunch(gameKey, launchController)
     return { success: false, error: 'No valid executable paths configured.', skipped }
   }
 
@@ -123,11 +131,20 @@ export async function launchProfileApps(
     const launchResults: AppLaunchResult[] = []
 
     for (let index = 0; index < appsToLaunch.length; index += 1) {
+      // Checked at the TOP of every iteration, not just after the wait below:
+      // a kill can land in the gap between spawnDetachedApp resolving and the
+      // wait call starting, and an already-aborted signal resolves wait()
+      // immediately — without this check the loop would still spawn one more
+      // app on that immediate resolution (#670).
+      if (launchController.signal.aborted) {
+        break
+      }
+
       launchedAny = true
       launchResults.push(await spawnDetachedApp(sender, gameKey, appsToLaunch[index], gamePath))
 
       if (index < appsToLaunch.length - 1 && launchDelayMs > 0) {
-        await wait(launchDelayMs)
+        await wait(launchDelayMs, launchController.signal)
       }
     }
 
@@ -140,6 +157,23 @@ export async function launchProfileApps(
         result.status === 'failed'
     )
     const launchedCount = launchResults.length - failedResults.length
+
+    // A kill (Close Apps) mid-sequence aborts launchController before doing its
+    // own work (#670) — report this as neither success nor failure, and stop
+    // before the failure/success branches below account for apps that were
+    // deliberately never spawned.
+    if (launchController.signal.aborted) {
+      return {
+        success: false,
+        cancelled: true,
+        message: 'Launch cancelled — closed apps instead.',
+        launchedCount,
+        skippedCount,
+        elevatedCount: elevatedResults.length,
+        failedCount: failedResults.length,
+        skipped
+      }
+    }
 
     if (failedResults.length > 0) {
       const firstFailure = failedResults[0]
@@ -183,6 +217,7 @@ export async function launchProfileApps(
       launchBlockedUntil = Date.now() + POST_LAUNCH_BLOCK_MS
     }
     activeLaunches.delete(gameKey)
+    unregisterActiveLaunch(gameKey, launchController)
   }
 }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -67,54 +67,69 @@ export async function launchProfileApps(
   // from `activeLaunches` above, whose Set-of-gameKeys semantics only gate
   // concurrent launches and stay untouched.
   const launchController = registerActiveLaunch(gameKey)
-  const launchDelayMs = getLaunchDelayMs()
-  const gamePaths = getStoredStringRecord('gamePaths')
-  const gamePath = gamePaths?.[gameKey]
-  const { processNames } = await readRunningProcessNames()
-  const normalizedEntries = profileApps.map((input) => normalizeLaunchInput(input, gameKey))
-  // Entries filtered out below never reach spawn — tracked here (not just
-  // console.error'd) so the caller can tell "some apps launched, one was
-  // silently skipped" apart from a plain success (#639).
-  const skipped: SkippedLaunchEntry[] = []
-  const validApps = normalizedEntries.filter((entry) => {
-    if (!isValidExePath(entry.path)) {
-      // isValidExePath also checks the resolved path's existence, so a
-      // well-formed .exe path that simply no longer exists fails here too —
-      // attribute those as 'missing' (not 'invalid') so the reason AND the
-      // log text reflect the actual problem (moved/uninstalled exe, #639)
-      // rather than a malformed path.
-      const trimmedPath = entry.path.trim()
-      const looksLikeExePath = trimmedPath.length > 0 && /\.exe$/i.test(trimmedPath)
-      const skipLogText = looksLikeExePath
-        ? `Skipping missing executable: ${entry.path}`
-        : `Skipping invalid path: ${entry.path}`
-      console.error(skipLogText)
-      writeAppErrorLog('launch', `[${gameKey}] ${skipLogText}`)
-      skipped.push({
-        key: entry.key,
-        path: entry.path,
-        reason: looksLikeExePath ? 'missing' : 'invalid'
-      })
-      return false
-    }
-    if (!fs.existsSync(entry.path.trim())) {
-      console.error(`Skipping missing executable: ${entry.path}`)
-      writeAppErrorLog('launch', `[${gameKey}] Skipping missing executable: ${entry.path}`)
-      skipped.push({ key: entry.key, path: entry.path, reason: 'missing' })
-      return false
-    }
-    return true
-  })
-
-  if (validApps.length === 0) {
-    activeLaunches.delete(gameKey)
-    unregisterActiveLaunch(gameKey, launchController)
-    return { success: false, error: 'No valid executable paths configured.', skipped }
-  }
-
   let launchedAny = false
 
+  // Everything from here runs under the finally — a throw anywhere below
+  // (store read, tasklist scan, path checks) must still release the launch
+  // guard and the abort registration, or every future launch stays blocked
+  // behind the stale `activeLaunches` entry.
   try {
+    const launchDelayMs = getLaunchDelayMs()
+    const gamePaths = getStoredStringRecord('gamePaths')
+    const gamePath = gamePaths?.[gameKey]
+    const { processNames } = await readRunningProcessNames()
+    const normalizedEntries = profileApps.map((input) => normalizeLaunchInput(input, gameKey))
+    // Entries filtered out below never reach spawn — tracked here (not just
+    // console.error'd) so the caller can tell "some apps launched, one was
+    // silently skipped" apart from a plain success (#639).
+    const skipped: SkippedLaunchEntry[] = []
+    const validApps = normalizedEntries.filter((entry) => {
+      if (!isValidExePath(entry.path)) {
+        // isValidExePath also checks the resolved path's existence, so a
+        // well-formed .exe path that simply no longer exists fails here too —
+        // attribute those as 'missing' (not 'invalid') so the reason AND the
+        // log text reflect the actual problem (moved/uninstalled exe, #639)
+        // rather than a malformed path.
+        const trimmedPath = entry.path.trim()
+        const looksLikeExePath = trimmedPath.length > 0 && /\.exe$/i.test(trimmedPath)
+        const skipLogText = looksLikeExePath
+          ? `Skipping missing executable: ${entry.path}`
+          : `Skipping invalid path: ${entry.path}`
+        console.error(skipLogText)
+        writeAppErrorLog('launch', `[${gameKey}] ${skipLogText}`)
+        skipped.push({
+          key: entry.key,
+          path: entry.path,
+          reason: looksLikeExePath ? 'missing' : 'invalid'
+        })
+        return false
+      }
+      if (!fs.existsSync(entry.path.trim())) {
+        console.error(`Skipping missing executable: ${entry.path}`)
+        writeAppErrorLog('launch', `[${gameKey}] Skipping missing executable: ${entry.path}`)
+        skipped.push({ key: entry.key, path: entry.path, reason: 'missing' })
+        return false
+      }
+      return true
+    })
+
+    // A kill can land during the pre-loop awaits (the tasklist scan above) —
+    // the early returns below must report the cancellation like the loop
+    // paths do, not a plain success/error the user's Close Apps contradicts.
+    if (launchController.signal.aborted) {
+      return {
+        success: false,
+        cancelled: true,
+        message: 'Launch cancelled — closed apps instead.',
+        launchedCount: 0,
+        skipped
+      }
+    }
+
+    if (validApps.length === 0) {
+      return { success: false, error: 'No valid executable paths configured.', skipped }
+    }
+
     const appsToLaunch = validApps.filter((entry) => !isRunningExePath(processNames, entry.path))
     const skippedCount = validApps.length - appsToLaunch.length
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -191,10 +191,19 @@ export async function launchProfileApps(
     // before the failure/success branches below account for apps that were
     // deliberately never spawned.
     if (launchController.signal.aborted) {
+      // Elevated apps that completed their UAC handoff before (or despite)
+      // the abort survive the kill — SimLauncher cannot close them (#670
+      // Codex P2). Name them instead of implying everything was closed.
+      const elevatedNote =
+        elevatedResults.length === 1
+          ? ' One app started with administrator permission and cannot be closed from here.'
+          : elevatedResults.length > 1
+            ? ` ${elevatedResults.length} apps started with administrator permission and cannot be closed from here.`
+            : ''
       return {
         success: false,
         cancelled: true,
-        message: 'Launch cancelled — closed apps instead.',
+        message: `Launch cancelled — closed apps instead.${elevatedNote}`,
         launchedCount,
         skippedCount,
         elevatedCount: elevatedResults.length,
@@ -438,9 +447,26 @@ function createElevatedLaunchCommand(appPath: string, args: string[]) {
   )
 }
 
-function launchElevated(appPath: string, args: string[] = [], gameKey?: string) {
+function launchElevated(
+  appPath: string,
+  args: string[] = [],
+  gameKey?: string,
+  signal?: AbortSignal
+) {
   return new Promise<AppLaunchResult>((resolve) => {
-    execFile(
+    // A kill (Close Apps) can land while the UAC handoff is still pending —
+    // the consent prompt sits on screen until the user answers it, so this
+    // window is wide (#670 Codex P2). Killing the PowerShell host is a best
+    // effort to stop the pending Start-Process from proceeding, and it
+    // unblocks the launch sequence immediately instead of leaving it parked
+    // until the user answers a prompt they no longer want.
+    let handoffPending = true
+    const onAbort = () => {
+      if (handoffPending) {
+        child.kill()
+      }
+    }
+    const child = execFile(
       'powershell.exe',
       [
         '-NoProfile',
@@ -450,7 +476,16 @@ function launchElevated(appPath: string, args: string[] = [], gameKey?: string) 
       ],
       { windowsHide: true },
       (error) => {
+        handoffPending = false
+        signal?.removeEventListener('abort', onAbort)
         if (error) {
+          // An error after the abort is the expected shape of a cancelled
+          // handoff (our own host kill, or the user denying a prompt they no
+          // longer want) — report cancelled, and don't log it as a failure.
+          if (signal?.aborted) {
+            resolve({ status: 'cancelled', appPath })
+            return
+          }
           const message = `Administrator permission was requested for ${path.basename(appPath)}, but Windows did not start it. ${getErrorMessage(error)}`
           console.error(`Error launching ${appPath} as administrator: ${getErrorMessage(error)}`)
           // execFile's error.message embeds the full command line — including
@@ -465,6 +500,10 @@ function launchElevated(appPath: string, args: string[] = [], gameKey?: string) 
           return
         }
 
+        // Success is reported truthfully even when an abort landed mid-handoff
+        // (the user accepted the prompt before the host kill took effect): the
+        // elevated app IS running and the kill cannot close it — the sequence's
+        // cancellation message names it rather than implying it was closed.
         resolve({
           status: 'elevated',
           appPath,
@@ -472,6 +511,7 @@ function launchElevated(appPath: string, args: string[] = [], gameKey?: string) 
         })
       }
     )
+    signal?.addEventListener('abort', onAbort, { once: true })
   })
 }
 
@@ -571,7 +611,7 @@ export async function spawnDetachedApp(
             resolveOnce({ status: 'cancelled', appPath })
             return
           }
-          resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey))
+          resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey, signal))
           return
         }
 
@@ -627,7 +667,7 @@ export async function spawnDetachedApp(
 
       // Same handoff-vs-failure distinction as the 'error' handler above.
       if (isElevatedLaunchError(err)) {
-        launchElevated(appPath, getAppArgs(appKey), gameKey).then(resolveOnce)
+        launchElevated(appPath, getAppArgs(appKey), gameKey, signal).then(resolveOnce)
         return
       }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -562,6 +562,15 @@ export async function spawnDetachedApp(
         // A UAC elevation request is a handoff, not a failure — don't write a
         // failure entry for it; launchElevated logs its own genuine failures.
         if (isElevatedLaunchError(err)) {
+          // A kill (Close Apps) can land between spawn() and this error event.
+          // Handing off now would pop a UAC prompt right after the user's
+          // Close Apps click — and start an elevated app the kill's snapshot
+          // can never include (#670). Nothing is running (the spawn failed),
+          // so report the attempt as cancelled instead.
+          if (signal?.aborted) {
+            resolveOnce({ status: 'cancelled', appPath })
+            return
+          }
           resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey))
           return
         }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -155,8 +155,21 @@ export async function launchProfileApps(
         break
       }
 
+      const launchResult = await spawnDetachedApp(
+        sender,
+        gameKey,
+        appsToLaunch[index],
+        gamePath,
+        launchController.signal
+      )
+      // The abort landed during spawnDetachedApp's pre-spawn probe — nothing
+      // was spawned, so don't count it (and don't arm the post-launch
+      // cooldown for an attempt that never happened).
+      if (launchResult.status === 'cancelled') {
+        break
+      }
       launchedAny = true
-      launchResults.push(await spawnDetachedApp(sender, gameKey, appsToLaunch[index], gamePath))
+      launchResults.push(launchResult)
 
       if (index < appsToLaunch.length - 1 && launchDelayMs > 0) {
         await wait(launchDelayMs, launchController.signal)
@@ -466,7 +479,8 @@ export async function spawnDetachedApp(
   sender: WebContents,
   gameKey: string,
   entry: ProfileLaunchEntry,
-  gamePath?: string
+  gamePath?: string,
+  signal?: AbortSignal
 ): Promise<AppLaunchResult> {
   const { path: appPath, key: appKey } = entry
   // Console-subsystem exes must NOT get DETACHED_PROCESS: without a console
@@ -475,6 +489,15 @@ export async function spawnDetachedApp(
   // and children outlive the parent on Windows either way. GUI apps keep the
   // long-standing detached behavior.
   const consoleApp = await isConsoleExecutable(appPath)
+
+  // A kill (Close Apps) can land while the PE-subsystem probe above is in
+  // flight. The kill's snapshot cannot include a process that hasn't spawned
+  // yet, so spawning now would leave an app running that the user just asked
+  // to close (#670). There is no further await between this check and spawn()
+  // below, so the window is fully closed.
+  if (signal?.aborted) {
+    return { status: 'cancelled', appPath }
+  }
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -13,6 +13,48 @@ export const unclosedProcesses = new Map<string, UnclosedProcessEntry>()
 export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWarningEntry>()
 export const suppressedProcessNameMismatchWarnings = new Set<string>()
 
+// One AbortController per gameKey with an in-flight launchProfileApps sequence.
+// Lives here (not spawn.ts) so kill.ts can abort a sequence without a circular
+// import between the two process-lifecycle modules (#670).
+const activeLaunchControllers = new Map<string, AbortController>()
+
+export function registerActiveLaunch(gameKey: string): AbortController {
+  const controller = new AbortController()
+  activeLaunchControllers.set(gameKey, controller)
+  return controller
+}
+
+/**
+ * Clear the registry entry once launchProfileApps' sequence ends. Only clears
+ * it if `controller` is still the registered one — a new launch for the same
+ * gameKey may have already installed its own fresh controller (started right
+ * after this one was cancelled), and that must not be torn down early.
+ */
+export function unregisterActiveLaunch(gameKey: string, controller: AbortController): void {
+  if (activeLaunchControllers.get(gameKey) === controller) {
+    activeLaunchControllers.delete(gameKey)
+  }
+}
+
+/**
+ * Abort the in-flight launch sequence for `gameKey`, or every in-flight
+ * sequence when `gameKey` is undefined (the tray/global "close everything"
+ * kill has no single gameKey to target). Called from kill.ts before it does
+ * any kill work, so a launch loop already mid-sequence cannot spawn the next
+ * queued app during or after the kill (#670).
+ *
+ * `AbortController.abort()` is itself idempotent (a second call is a no-op),
+ * so this is safe to call on every kill request even when nothing is
+ * currently launching for the target gameKey.
+ */
+export function abortActiveLaunches(gameKey?: string): void {
+  activeLaunchControllers.forEach((controller, key) => {
+    if (gameKey === undefined || key === gameKey) {
+      controller.abort()
+    }
+  })
+}
+
 /**
  * Signal that the upcoming exit of `appPath` is intentional (user-initiated
  * kill). The suppression is consumed exactly once by

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -68,6 +68,9 @@ export type AppLaunchResult =
   | { status: 'launched'; appPath: string }
   | { status: 'elevated'; appPath: string; warning: string }
   | { status: 'failed'; appPath: string; error: string }
+  // The launch was aborted (Close Apps) during the async pre-spawn work, so
+  // the process was deliberately never spawned (#670).
+  | { status: 'cancelled'; appPath: string }
 
 export interface ProfileLaunchEntry {
   /**

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -47,6 +47,12 @@ export interface LaunchResult {
   killFailures?: KillFailure[]
   /** Entries excluded before spawn for an invalid/missing exe path (#639). NOT counted by `skippedCount`. */
   skipped?: SkippedLaunchEntry[]
+  /**
+   * True when a kill (Close Apps) aborted this sequence mid-flight (#670).
+   * `success` is false in this case, but it is not a failure either — the
+   * renderer should show a neutral "cancelled" toast, not an error toast.
+   */
+  cancelled?: boolean
 }
 
 export interface KillResult {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -81,8 +81,29 @@ export function pathsEqual(a: unknown, b: unknown): boolean {
   return normalizedA === normalizedB
 }
 
-export function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+/**
+ * Resolves after `ms`, or immediately if `signal` is already aborted or gets
+ * aborted before the timer fires. Abort resolves rather than rejects — a
+ * cancelled wait is a normal early-exit for the launch loop (#670), not an
+ * error condition callers need to catch.
+ */
+export function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer)
+        resolve()
+      },
+      { once: true }
+    )
+  })
 }
 
 export function getErrorMessage(err: unknown): string {

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -157,6 +157,12 @@ export interface LaunchResult {
   failedCount?: number
   killFailures?: KillFailure[]
   skipped?: SkippedLaunchEntry[]
+  /**
+   * True when a kill (Close Apps) aborted this sequence mid-flight (#670).
+   * `success` is false in this case, but it is not a failure either — the
+   * renderer should show a neutral "cancelled" toast, not an error toast.
+   */
+  cancelled?: boolean
 }
 
 export interface KillResult {

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -366,8 +366,17 @@ export function GameRow({
       // "X is now running" settle cue (#612).
       announce(`Launching ${game.name}`)
       const result = await launchProfile(game.key)
+      cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
+
+      // A kill (Close Apps) mid-sequence stopped the loop before it spawned
+      // everything (#670) — this is neither a success nor a failure, so it
+      // gets its own toast rather than falling into either branch below.
+      if (result.cancelled) {
+        notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+        return
+      }
+
       if (!result.success) {
-        cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
         // The all-invalid failure ("No valid executable paths configured.")
         // carries the skipped detail too — name what's broken (#639).
         const failedSkippedDetail =
@@ -378,7 +387,6 @@ export function GameRow({
         return
       }
 
-      cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
       // A moved/deleted exe is filtered out before spawn but must not read as
       // a plain success (#639) — surface it as a warning naming what was
       // skipped, alongside any elevated-launch warning.
@@ -438,8 +446,15 @@ export function GameRow({
     try {
       onLaunchStart(game.key)
       const result = await relaunchMissingProfile(game.key)
+      cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
+
+      // Same cancellation case as handleLaunch above (#670).
+      if (result.cancelled) {
+        notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+        return
+      }
+
       if (!result.success) {
-        cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
         const failedSkippedDetail =
           result.skipped && result.skipped.length > 0
             ? ` ${formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })}`
@@ -451,7 +466,6 @@ export function GameRow({
         return
       }
 
-      cooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
       const relaunchWarnings: string[] = []
       if (result.skipped && result.skipped.length > 0) {
         relaunchWarnings.push(

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -263,6 +263,14 @@ export function GameRow({
 
           onLaunchStart(game.key)
           const result = await switchProfileApps(game.key, currentProfile.id, nextProfile.id)
+          // Close Apps mid-switch cancels the new profile's launch sequence
+          // (#670) — the user asked to stop, so this is neither a success nor
+          // an error; the switch is not saved and can simply be retried.
+          if (result.cancelled) {
+            notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+            onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
+            return
+          }
           if (!result.success) {
             const failedSkippedDetail =
               result.skipped && result.skipped.length > 0

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -433,7 +433,13 @@ export function useProfileEditor({
     try {
       const result = await launchProfile(gameKey)
       cooldownMs = result.launchedCount === 0 ? 0 : 10000
-      if (!result.success) {
+
+      // A kill (Close Apps) mid-sequence stopped the loop before it spawned
+      // everything (#670) — neither a success nor a failure, so it gets its
+      // own toast rather than the error/success branches below.
+      if (result.cancelled) {
+        notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+      } else if (!result.success) {
         const failedSkippedDetail =
           result.skipped && result.skipped.length > 0
             ? ` ${formatSkippedLaunchEntries(result.skipped, {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -40,6 +40,8 @@ const pidsAccessDeniedButImageGone = new Set<string>()
 // kill verification doesn't treat an empty Set as evidence-of-exit when the
 // read itself was invalid (see #399).
 let tasklistReadShouldFail = false
+// Flips the mocked store read into a throwing mode — see storeModuleMock.
+let storeReadShouldThrow = false
 // When >0, the mocked readRunningProcessNames returns a successful response
 // for the first N calls, then starts failing. Lets a single test simulate a
 // transient tasklist failure on the post-kill recheck only — without breaking
@@ -303,6 +305,11 @@ async function loadProcessModules() {
 
   const storeModuleMock = {
     getStoredStringRecord: (key: string) => {
+      // Models a corrupted/unreadable store so a test can prove a throw during
+      // launch prep releases the launch guard instead of wedging it (#670).
+      if (storeReadShouldThrow) {
+        throw new Error('store corrupted')
+      }
       const value = storeData[key]
 
       if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -451,6 +458,7 @@ beforeEach(async () => {
   processNamesGoneAfterKill.clear()
   pidsAccessDeniedButImageGone.clear()
   tasklistReadShouldFail = false
+  storeReadShouldThrow = false
   tasklistReadFailAfterCalls = 0
   tasklistReadCallCount = 0
   wmiLookupCounts.clear()
@@ -2307,6 +2315,45 @@ test('a fresh launch for the same gameKey after a cancelled one proceeds normall
   expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe', 'C:/Tools/App3.exe'])
 
   dateNow.mockRestore()
+})
+
+// A kill landing during the pre-loop prep (the tasklist scan await) must be
+// reported as cancelled by the early-return paths too — an "All profile
+// applications are already running." success toast right after the user's
+// Close Apps click would contradict what they just did (#670 review finding).
+test('a kill landing during launch prep reports cancelled, not success (#670)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  processNames.add('simhub.exe')
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+  // launchProfileApps suspends on the tasklist read; the kill's abort fires
+  // synchronously before that continuation runs.
+  const launch = launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  await killLaunchedApps('ac')
+
+  await expect(launch).resolves.toMatchObject({ cancelled: true, success: false })
+})
+
+// The launch guard + abort registration are armed before any prep work (store
+// read, tasklist scan, path checks). A throw during that prep must still
+// release both via the finally — otherwise every future launch is permanently
+// blocked behind the stale activeLaunches entry (#670 review finding).
+test('a throw during launch prep releases the launch guard instead of wedging it (#670)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps } = await loadProcessModules()
+
+  storeReadShouldThrow = true
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).rejects.toThrow(
+    'store corrupted'
+  )
+
+  // The next launch must proceed normally — NOT "Another profile is already
+  // launching." from a leaked guard entry.
+  storeReadShouldThrow = false
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
 })
 
 test('killLaunchedApps skips entries flagged as isGame (#343)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2317,6 +2317,30 @@ test('a fresh launch for the same gameKey after a cancelled one proceeds normall
   dateNow.mockRestore()
 })
 
+// The abort can land while spawnDetachedApp is still in its async pre-spawn
+// probe (PE subsystem read). The kill's snapshot can't include a process that
+// hasn't spawned yet — spawning after the abort would leave an app running
+// that the user just closed (#670 Codex P1). The signal is re-checked right
+// before spawn(), with no await in between.
+test('spawnDetachedApp does not spawn when the abort landed during its pre-spawn probe (#670)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { spawnDetachedApp } = await loadProcessModules()
+
+  const controller = new AbortController()
+  controller.abort()
+
+  const result = await spawnDetachedApp(
+    sender,
+    'ac',
+    { key: 'simhub', path: 'C:/Tools/SimHub.exe' },
+    undefined,
+    controller.signal
+  )
+
+  expect(result).toEqual({ status: 'cancelled', appPath: 'C:/Tools/SimHub.exe' })
+  expect(spawnCalls).toEqual([])
+})
+
 // A kill landing during the pre-loop prep (the tasklist scan await) must be
 // reported as cancelled by the early-return paths too — an "All profile
 // applications are already running." success toast right after the user's

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -42,6 +42,10 @@ const pidsAccessDeniedButImageGone = new Set<string>()
 let tasklistReadShouldFail = false
 // Flips the mocked store read into a throwing mode — see storeModuleMock.
 let storeReadShouldThrow = false
+// When set, the NEXT readRunningProcessNames call resolves only after this
+// promise does — models a slow tasklist scan so a test can prove ordering
+// against it (#670). Consumed once, then cleared.
+let tasklistReadBlocker: Promise<void> | null = null
 // When >0, the mocked readRunningProcessNames returns a successful response
 // for the first N calls, then starts failing. Lets a single test simulate a
 // transient tasklist failure on the post-kill recheck only — without breaking
@@ -290,11 +294,18 @@ async function loadProcessModules() {
       // errors and resolves with an empty Set + succeeded: false. Modelling
       // the empty-Set here is what lets the regression test distinguish
       // "image is gone" from "we don't know" (see #399).
-      return Promise.resolve(
-        shouldFailNow
-          ? { processNames: new Set<string>(), succeeded: false }
-          : { processNames: new Set(processNames), succeeded: true }
-      )
+      const result = shouldFailNow
+        ? { processNames: new Set<string>(), succeeded: false }
+        : { processNames: new Set(processNames), succeeded: true }
+      // A one-shot blocker models a slow tasklist scan (#670). Consumed here
+      // so only the call it was armed for is delayed; the unarmed path keeps
+      // its exact microtask timing (other tests depend on it).
+      if (tasklistReadBlocker) {
+        const blocker = tasklistReadBlocker
+        tasklistReadBlocker = null
+        return blocker.then(() => result)
+      }
+      return Promise.resolve(result)
     })
   }
   vi.doMock('./tasklist', () => tasklistMock)
@@ -459,6 +470,7 @@ beforeEach(async () => {
   pidsAccessDeniedButImageGone.clear()
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
+  tasklistReadBlocker = null
   tasklistReadFailAfterCalls = 0
   tasklistReadCallCount = 0
   wmiLookupCounts.clear()
@@ -2315,6 +2327,36 @@ test('a fresh launch for the same gameKey after a cancelled one proceeds normall
   expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe', 'C:/Tools/App3.exe'])
 
   dateNow.mockRestore()
+})
+
+// killProfileApps must signal the in-flight launch BEFORE its own tasklist
+// scan — that await can be slow, and a launch loop sitting in a short
+// inter-app wait would otherwise spawn its next app past the kill's snapshot
+// (#670 Codex P2). The blocked tasklist read below models the slow scan: the
+// launch must still resolve cancelled while the kill is stuck in it.
+test('killProfileApps aborts the launch before waiting on its tasklist scan (#670)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { customapp1: 'C:/Tools/App1.exe', customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+
+  // Arm AFTER the launch's own scan: only the kill's entry scan is delayed.
+  let releaseTasklistRead: () => void = () => {}
+  tasklistReadBlocker = new Promise((resolve) => (releaseTasklistRead = resolve))
+
+  const killPromise = killProfileApps('ac', ['C:/Tools/App1.exe'])
+  // The abort fired in killProfileApps' synchronous prefix, so the launch
+  // resolves cancelled even though the kill is still stuck in its scan.
+  await expect(launchPromise).resolves.toMatchObject({ cancelled: true, launchedCount: 1 })
+  expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe'])
+
+  releaseTasklistRead()
+  await killPromise
 })
 
 // The abort can land while spawnDetachedApp is still in its async pre-spawn

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -46,6 +46,12 @@ let storeReadShouldThrow = false
 // promise does — models a slow tasklist scan so a test can prove ordering
 // against it (#670). Consumed once, then cleared.
 let tasklistReadBlocker: Promise<void> | null = null
+// When set, the `atCall`-th isConsoleExecutable call (1-based) resolves only
+// after `promise` does — models a slow PE-subsystem probe so the abort-point
+// sweep can land a kill inside spawnDetachedApp's pre-spawn window for a
+// specific app in the sequence (#670). Consumed once, then cleared.
+let consoleProbeBlocker: { atCall: number; promise: Promise<void> } | null = null
+let consoleProbeCallCount = 0
 // When >0, the mocked readRunningProcessNames returns a successful response
 // for the first N calls, then starts failing. Lets a single test simulate a
 // transient tasklist failure on the post-kill recheck only — without breaking
@@ -275,7 +281,19 @@ async function loadProcessModules() {
   }))
 
   const subsystemMock = {
-    isConsoleExecutable: vi.fn((exePath: string) => Promise.resolve(consoleExePaths.has(exePath)))
+    isConsoleExecutable: vi.fn((exePath: string) => {
+      consoleProbeCallCount += 1
+      const result = consoleExePaths.has(exePath)
+      // One-shot blocker, same shape as tasklistReadBlocker above: only the
+      // call it was armed for is delayed; every other call keeps its exact
+      // microtask timing (other tests depend on it).
+      if (consoleProbeBlocker && consoleProbeCallCount === consoleProbeBlocker.atCall) {
+        const blocker = consoleProbeBlocker.promise
+        consoleProbeBlocker = null
+        return blocker.then(() => result)
+      }
+      return Promise.resolve(result)
+    })
   }
   vi.doMock('./subsystem', () => subsystemMock)
   vi.doMock('/src/main/processes/subsystem.ts', () => subsystemMock)
@@ -471,6 +489,8 @@ beforeEach(async () => {
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
   tasklistReadBlocker = null
+  consoleProbeBlocker = null
+  consoleProbeCallCount = 0
   tasklistReadFailAfterCalls = 0
   tasklistReadCallCount = 0
   wmiLookupCounts.clear()
@@ -2420,6 +2440,148 @@ test('a throw during launch prep releases the launch guard instead of wedging it
     success: true,
     launchedCount: 1
   })
+})
+
+// Abort-point sweep (#670): the "nothing spawns after a kill's abort" invariant
+// is enforced by a separate check at EVERY await in the launch path — each
+// suspension point is its own race window, and all five #714 review findings
+// were instances of this one class landing at different points. The sweep
+// drives the full launch sequence through each suspension point in turn, lands
+// the abort while the launch is provably parked there, and asserts nothing
+// further spawned. Adding a new await to the launch path? Add a row here.
+// (The post-spawn EACCES elevation handoff is the one abortable point this
+// table can't reach — it has its own test right below.)
+const abortPointSweep: {
+  point: string
+  launchDelayMs: number
+  arm: () => { release: () => void; consumed: () => boolean } | null
+  spawnsBeforeAbort: number
+  launchedCount: number
+}[] = [
+  {
+    point: 'pre-loop tasklist scan',
+    launchDelayMs: 0,
+    arm: () => {
+      let release: () => void = () => {}
+      tasklistReadBlocker = new Promise((resolve) => (release = resolve))
+      return { release, consumed: () => tasklistReadBlocker === null }
+    },
+    spawnsBeforeAbort: 0,
+    launchedCount: 0
+  },
+  {
+    point: "first app's pre-spawn console probe",
+    launchDelayMs: 0,
+    arm: () => {
+      let release: () => void = () => {}
+      consoleProbeBlocker = { atCall: 1, promise: new Promise((resolve) => (release = resolve)) }
+      return { release, consumed: () => consoleProbeBlocker === null }
+    },
+    spawnsBeforeAbort: 0,
+    launchedCount: 0
+  },
+  {
+    point: "second app's pre-spawn console probe",
+    launchDelayMs: 0,
+    arm: () => {
+      let release: () => void = () => {}
+      consoleProbeBlocker = { atCall: 2, promise: new Promise((resolve) => (release = resolve)) }
+      return { release, consumed: () => consoleProbeBlocker === null }
+    },
+    spawnsBeforeAbort: 1,
+    launchedCount: 1
+  },
+  {
+    point: 'inter-app delay wait',
+    launchDelayMs: 5000,
+    // The real (unmocked) wait() is abortable by design — the kill's abort
+    // itself releases this point, so there is nothing to arm.
+    arm: () => null,
+    spawnsBeforeAbort: 1,
+    launchedCount: 1
+  }
+]
+
+test.each(abortPointSweep)(
+  'no app spawns after an abort landing during the $point (#670)',
+  async ({ launchDelayMs, arm, spawnsBeforeAbort, launchedCount }) => {
+    markExistingPath('C:/Tools/App1.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    storeData.launchDelayMs = launchDelayMs
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+    const blocker = arm()
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/App1.exe',
+      'C:/Tools/App2.exe'
+    ])
+    await flushMicrotasks()
+
+    // Prove the launch is parked at the swept point before aborting: the armed
+    // blocker was consumed (so the point still exists in the launch path — a
+    // refactor that removes it must fail here, not pass vacuously) and only
+    // the spawns from BEFORE the point have landed.
+    if (blocker) {
+      expect(blocker.consumed()).toBe(true)
+    }
+    expect(spawnCalls.length).toBe(spawnsBeforeAbort)
+
+    await killLaunchedApps('ac')
+    blocker?.release()
+
+    await expect(launchPromise).resolves.toMatchObject({
+      success: false,
+      cancelled: true,
+      launchedCount
+    })
+    // The invariant under sweep: after the abort, not one more spawn.
+    expect(spawnCalls.length).toBe(spawnsBeforeAbort)
+  }
+)
+
+// The abort can also land AFTER spawn() was attempted: the child fails with
+// EACCES (asynchronously, some time after spawn returns) and the error handler
+// hands off to an elevated launch — which would pop a UAC prompt right after
+// the user's Close Apps click and start an elevated app the kill's snapshot
+// can never include (and that SimLauncher cannot close). The handoff must
+// re-check the signal and report the attempt as cancelled instead (#670).
+test('an EACCES elevation handoff arriving after the abort does not launch elevated (#670)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+  const { spawnDetachedApp } = await loadProcessModules()
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const controller = new AbortController()
+  const resultPromise = spawnDetachedApp(
+    sender,
+    'ac',
+    { key: 'simhub', path: 'C:/Tools/SimHub.exe' },
+    undefined,
+    controller.signal
+  )
+  // Let the pre-spawn probe resolve and spawn() run — the child's handlers are
+  // registered but no event has fired yet.
+  await flushMicrotasks()
+
+  // The abort lands in the window between spawn() and the error event.
+  controller.abort()
+  childHandlers.get('error')!(makeAccessDeniedError())
+
+  await expect(resultPromise).resolves.toEqual({
+    status: 'cancelled',
+    appPath: 'C:/Tools/SimHub.exe'
+  })
+  // The elevated relaunch (powershell Start-Process -Verb RunAs) must never fire.
+  expect(execFileCalls.filter((call) => call.command === 'powershell.exe')).toEqual([])
 })
 
 test('killLaunchedApps skips entries flagged as isGame (#343)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2584,6 +2584,116 @@ test('an EACCES elevation handoff arriving after the abort does not launch eleva
   expect(execFileCalls.filter((call) => call.command === 'powershell.exe')).toEqual([])
 })
 
+// Sets up spawnDetachedApp parked in a PENDING UAC handoff: the child fails
+// with EACCES, launchElevated starts, and the powershell callback is held so
+// the test controls when (and how) the handoff concludes (#670 Codex P2).
+async function startPendingElevationHandoff() {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+  const { spawnDetachedApp } = await loadProcessModules()
+  const childProcessModule = vi.mocked(await import('child_process'))
+  childProcessModule.spawn.mockReturnValueOnce(child as never)
+
+  let concludeHandoff: (error: Error | null) => void = () => {}
+  const elevationHostKill = vi.fn()
+  childProcessModule.execFile.mockImplementationOnce(((
+    _command: string,
+    _args: string[],
+    _options: unknown,
+    callback: (error: Error | null, stdout: string, stderr: string) => void
+  ) => {
+    concludeHandoff = (error) => callback(error, '', '')
+    return { kill: elevationHostKill }
+  }) as never)
+
+  const controller = new AbortController()
+  const resultPromise = spawnDetachedApp(
+    sender,
+    'ac',
+    { key: 'simhub', path: 'C:/Tools/SimHub.exe' },
+    undefined,
+    controller.signal
+  )
+  await flushMicrotasks()
+  // EACCES arrives with the signal still clean → the handoff starts and parks
+  // on the held powershell callback.
+  childHandlers.get('error')!(makeAccessDeniedError())
+  await flushMicrotasks()
+
+  return { resultPromise, controller, concludeHandoff, elevationHostKill }
+}
+
+// The abort can land while the UAC handoff itself is pending — the consent
+// prompt sits on screen until the user answers, so this window is wide. The
+// abort must kill the powershell host (best-effort stop + unblocks the launch
+// sequence immediately) and the resulting execFile error must be reported as
+// cancelled, not logged as a launch failure (#670 Codex P2).
+test('an abort during the pending UAC handoff kills the host and reports cancelled (#670)', async () => {
+  const { resultPromise, controller, concludeHandoff, elevationHostKill } =
+    await startPendingElevationHandoff()
+
+  controller.abort()
+  expect(elevationHostKill).toHaveBeenCalledTimes(1)
+  // The killed host surfaces as an execFile error.
+  concludeHandoff(new Error('powershell host killed'))
+
+  await expect(resultPromise).resolves.toEqual({
+    status: 'cancelled',
+    appPath: 'C:/Tools/SimHub.exe'
+  })
+  const launchLogLines = appErrorLogFsMock.appendFileSync.mock.calls.map((call) => String(call[1]))
+  expect(launchLogLines.filter((line) => line.includes('administrator'))).toEqual([])
+})
+
+// If the user accepts the UAC prompt before the host kill takes effect, the
+// elevated app IS running — the result must say so (status 'elevated'), not
+// pretend the cancellation prevented it (#670 Codex P2).
+test('a UAC handoff accepted despite the abort still reports elevated (#670)', async () => {
+  const { resultPromise, controller, concludeHandoff } = await startPendingElevationHandoff()
+
+  controller.abort()
+  concludeHandoff(null)
+
+  await expect(resultPromise).resolves.toMatchObject({
+    status: 'elevated',
+    appPath: 'C:/Tools/SimHub.exe'
+  })
+})
+
+// Sequence-level honesty: elevated apps that completed their handoff survive
+// the kill (SimLauncher cannot close them) — the cancellation toast must name
+// them instead of implying everything was closed (#670 Codex P2).
+test('the cancellation message names elevated apps the kill cannot close (#670)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+  // App1's spawn fails EACCES; the default execFile mock resolves the
+  // powershell handoff immediately as success → status 'elevated'.
+  spawnErrors.set('C:/Tools/App1.exe', makeAccessDeniedError())
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+  await killLaunchedApps('ac')
+
+  await expect(launchPromise).resolves.toMatchObject({
+    success: false,
+    cancelled: true,
+    elevatedCount: 1,
+    message:
+      'Launch cancelled — closed apps instead. One app started with administrator permission and cannot be closed from here.'
+  })
+})
+
 test('killLaunchedApps skips entries flagged as isGame (#343)', async () => {
   markExistingPath('C:/Games/AssettoCorsa.exe')
   markExistingPath('C:/Tools/SimHub.exe')

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -417,6 +417,15 @@ function asWebContents(webContents: MockWebContents) {
   return webContents as unknown as WebContents
 }
 
+// Flushes the microtask queue via a macrotask boundary (setImmediate always
+// runs after every microtask already queued). Used to let launchProfileApps'
+// loop advance past a spawned app and reach its (real, unmocked) inter-app
+// `wait()` call — at which point its setTimeout/abort-listener is already
+// registered — without needing fake timers (#670).
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
 const sender = {
   isDestroyed: () => false,
   send: vi.fn()
@@ -2174,6 +2183,128 @@ test('launchBlockedUntil is not set when no apps were actually launched (#342)',
     launchedCount: 0,
     skippedCount: 1
   })
+
+  dateNow.mockRestore()
+})
+
+// #670: a kill mid-sequence used to only stop what was already running — the
+// launch loop kept going and spawned the remaining profile apps regardless,
+// ending in a success toast for apps the user had just asked to close.
+test('killLaunchedApps mid-sequence cancels the launch loop before remaining apps spawn (#670)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  markExistingPath('C:/Tools/App3.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+  const launchPromise = launchProfileApps(sender, 'ac', [
+    'C:/Tools/App1.exe',
+    'C:/Tools/App2.exe',
+    'C:/Tools/App3.exe'
+  ])
+
+  // Let App1 spawn and the loop reach its (real, 5s) inter-app delay before
+  // the kill lands, proving the abort interrupts THIS wait rather than
+  // merely preventing a future one.
+  await flushMicrotasks()
+
+  const killResult = await killLaunchedApps('ac')
+  const launchResult = await launchPromise
+
+  expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe'])
+  expect(launchResult).toMatchObject({
+    success: false,
+    cancelled: true,
+    launchedCount: 1
+  })
+  expect(killResult.success).toBe(true)
+  expect(killResult.closedCount).toBe(1)
+})
+
+test('killProfileApps mid-sequence also cancels the launch loop before remaining apps spawn (#670)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { customapp1: 'C:/Tools/App1.exe', customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+
+  await killProfileApps('ac', ['C:/Tools/App1.exe'])
+  const launchResult = await launchPromise
+
+  expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe'])
+  expect(launchResult).toMatchObject({ success: false, cancelled: true, launchedCount: 1 })
+})
+
+test('two concurrent Close Apps clicks during the same sequence do not throw (idempotent abort, #670)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+
+  const [firstKill, secondKill] = await Promise.all([
+    killLaunchedApps('ac'),
+    killLaunchedApps('ac')
+  ])
+  const launchResult = await launchPromise
+
+  expect(firstKill.success).toBe(true)
+  expect(secondKill.success).toBe(true)
+  expect(launchResult).toMatchObject({ success: false, cancelled: true, launchedCount: 1 })
+  // App2 must never have spawned, regardless of the double kill.
+  expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe'])
+})
+
+test('Close Apps clicked again after the sequence already ended is a clean no-op (#670)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({ success: true, closedCount: 1 })
+  await expect(launchPromise).resolves.toMatchObject({ cancelled: true })
+
+  // The in-flight sequence's controller was already unregistered when it
+  // ended above — this must find nothing to abort and resolve cleanly, not
+  // throw (#670).
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({ success: true, closedCount: 0 })
+})
+
+test('a fresh launch for the same gameKey after a cancelled one proceeds normally (#670)', async () => {
+  const dateNow = vi.spyOn(Date, 'now')
+  dateNow.mockReturnValue(0)
+
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  markExistingPath('C:/Tools/App3.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+  const firstLaunch = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+  await killLaunchedApps('ac')
+  await expect(firstLaunch).resolves.toMatchObject({ cancelled: true, launchedCount: 1 })
+
+  // Past the post-launch cooldown (#342), with a fresh controller for the
+  // same gameKey — must launch normally, not inherit the previous
+  // cancellation's aborted signal (#670).
+  dateNow.mockReturnValue(20_000)
+  storeData.launchDelayMs = 0
+  const secondResult = await launchProfileApps(sender, 'ac', ['C:/Tools/App3.exe'])
+
+  expect(secondResult.success).toBe(true)
+  expect(secondResult.launchedCount).toBe(1)
+  expect(secondResult.cancelled).toBeUndefined()
+  expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe', 'C:/Tools/App3.exe'])
 
   dateNow.mockRestore()
 })

--- a/tests/renderer/gameRowLaunchCancelled.test.tsx
+++ b/tests/renderer/gameRowLaunchCancelled.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Regression test for #670: "Close Apps" during an in-flight launch sequence
+ * used to only kill what was already running — the main-process launch loop
+ * kept going and spawned the remaining profile apps regardless, ending in a
+ * plain "All profile applications launched." success toast for apps the user
+ * had just asked to close.
+ *
+ * Pinned here: when `launchProfile`/`relaunchMissingProfile` resolves with
+ * `cancelled: true`, the row's toast must read as a neutral cancellation
+ * ("Launch cancelled — closed apps instead.") — never the success toast, and
+ * never the plain error toast either.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const notifyMock = vi.fn()
+const launchProfileMock = vi.fn()
+const relaunchMissingProfileMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: (...args: unknown[]) => relaunchMissingProfileMock(...args),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+// Same jsdom-safety stubs as gameRowLaunchSkipped.test.tsx: GameRow pulls in
+// ProfileEditor's hook graph, which touches window.electronAPI at module eval.
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRow(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={false}
+          isGameRunning={false}
+          runningAppIcons={[]}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+async function clickPlayButton(): Promise<void> {
+  const playButton = container.querySelector(
+    'button[aria-label="Launch Assetto Corsa"]'
+  ) as HTMLButtonElement | null
+  expect(playButton).not.toBeNull()
+
+  await act(async () => {
+    playButton!.click()
+  })
+}
+
+beforeEach(() => {
+  notifyMock.mockClear()
+  launchProfileMock.mockReset()
+  relaunchMissingProfileMock.mockReset()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('GameRow launch cancellation toast (#670)', () => {
+  test('shows a neutral cancellation toast instead of the success toast', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: false,
+      cancelled: true,
+      launchedCount: 1,
+      message: 'Launch cancelled — closed apps instead.'
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith('Launch cancelled — closed apps instead.', 'warn')
+    expect(notifyMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('All profile applications launched.'),
+      'success',
+      expect.anything()
+    )
+  })
+
+  test('falls back to a default message when the result carries no message', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: false,
+      cancelled: true,
+      launchedCount: 1
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).toHaveBeenCalledWith('Launch cancelled — closed apps instead.', 'warn')
+  })
+
+  // cancelled must be checked before the plain failure branch — otherwise a
+  // cancellation (success: false) would read as a generic launch error.
+  test('does not fall through to the generic failure toast', async () => {
+    launchProfileMock.mockResolvedValue({
+      success: false,
+      cancelled: true,
+      launchedCount: 1,
+      message: 'Launch cancelled — closed apps instead.'
+    })
+
+    await renderRow()
+    await clickPlayButton()
+
+    expect(notifyMock).not.toHaveBeenCalledWith('Failed to launch profile', 'error')
+  })
+})

--- a/tests/renderer/gameRowLaunchCancelled.test.tsx
+++ b/tests/renderer/gameRowLaunchCancelled.test.tsx
@@ -159,11 +159,9 @@ describe('GameRow launch cancellation toast (#670)', () => {
     await clickPlayButton()
 
     expect(notifyMock).toHaveBeenCalledWith('Launch cancelled — closed apps instead.', 'warn')
-    expect(notifyMock).not.toHaveBeenCalledWith(
-      expect.stringContaining('All profile applications launched.'),
-      'success',
-      expect.anything()
-    )
+    // Arg-shape-independent: a cancellation must not produce ANY success
+    // toast, however many args the call carries.
+    expect(notifyMock.mock.calls.some((call) => call[1] === 'success')).toBe(false)
   })
 
   test('falls back to a default message when the result carries no message', async () => {


### PR DESCRIPTION
## Summary

`Close Apps` clicked during an in-flight launch sequence only killed what was already running — the launch loop had no cancellation token, so it kept spawning the remaining profile apps after the kill and finished with a success toast for apps the user had just asked to close.

- `launchProfileApps` (`src/main/processes/spawn.ts`) now registers a per-`gameKey` `AbortController` for the duration of its sequence (kept separate from the existing `activeLaunches` Set, whose semantics for the concurrent-launch guard are unchanged).
- The inter-app `wait()` (`src/main/utils.ts`) is now abortable via an optional `AbortSignal`; abort resolves it immediately instead of waiting out the real delay.
- The loop checks the abort flag at the top of every iteration (not just after the wait) — the gap between a spawn resolving and the next `wait()` call starting is covered too.
- `killLaunchedApps` and `killProfileApps` (`src/main/processes/kill.ts`) abort the matching in-flight sequence (via a new `abortActiveLaunches` in `src/main/processes/state.ts`) *before* doing any kill work — for `killLaunchedApps(gameKey)` with no `gameKey` (tray/global close), every in-flight sequence is aborted. This lives on the kill side so future callers (tray #519, CLI #619) get the same protection automatically.
- `LaunchResult` gains a `cancelled?: boolean` flag (mirrored in the preload `api.ts` contract). `GameRow.tsx` and `useProfileEditor.tsx` now check `result.cancelled` before their existing success/failure branches and show a neutral toast — "Launch cancelled — closed apps instead." — instead of the success or generic-error toast. `handleRelaunchMissing` gets the same treatment since it goes through the same `launchProfileApps` sequence.
- A fresh launch for the same `gameKey` after a cancellation gets a brand-new `AbortController` (registered fresh each call), so it is unaffected by the previous cancellation.

Out of scope (deliberately not touched): #644 (confirm-before-close) and the UI button-enabling logic in `GameRowActions.tsx`/`GameRow.tsx`'s `canKill`.

Closes #670

## Test plan

- [x] `tests/main/processes.test.ts` — 5 new regression tests (all verified to fail — via `Test timed out in 5000ms` — against the pre-fix code):
  - kill mid-sequence (`killLaunchedApps`) stops the loop before remaining apps spawn, and the result reports `cancelled: true`
  - `killProfileApps` mid-sequence does the same
  - two concurrent Close Apps clicks during the same sequence don't throw (idempotent abort)
  - Close Apps clicked again after the sequence already ended is a clean no-op
  - a fresh launch for the same `gameKey` after a cancelled one proceeds normally
- [x] `tests/renderer/gameRowLaunchCancelled.test.tsx` — new renderer test (follows `gameRowLaunchSkipped.test.tsx`'s pattern) covering the cancelled toast, the message fallback, and that it doesn't fall through to the generic error toast.
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck` (preload contract regenerated/verified via `preload:types:check`)
- [x] `npm run test` — 434/434 passing
- [x] `npm run build`

## Screenshots

Not applicable — this is a main-process/renderer-logic fix with no visual change; the only user-visible difference is toast copy on a Close-Apps-mid-launch cancellation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closing apps can now cancel in-flight profile launches, preventing additional apps from starting mid-sequence.
  * Cancellation is surfaced as a neutral “cancelled” outcome and handled consistently across launch flows.

* **Bug Fixes**
  * Improved kill/close timing so active launches are aborted before remaining targets are processed.
  * Launch cancellation is now interruptible during both pre-spawn checks and inter-app delays.

* **Tests**
  * Added extensive regression coverage for launch/close cancellation races and verified correct behavior for repeated closes and subsequent launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->