### PR TITLE
style: simplify onboarding welcome message copy (refs #641)

### DIFF
--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -116,8 +116,7 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
           <BrandWordmarkIcon aria-hidden="true" className="h-7 w-auto text-(--accent)" />
         </h2>
         <p id={descId} className="text-sm text-(--text-secondary) leading-relaxed mb-6">
-          Pick your sims and their companion apps once. One click launches the whole stack in the
-          right order, and one click closes it all again.
+          Configure your simulation games and companion apps.
         </p>
 
         <div className="mb-8">

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -153,7 +153,7 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
             onClick={onSetup}
             className="accent-action action-hover-scale w-full cursor-pointer rounded-xl py-3 text-sm font-bold"
           >
-            Set up your sims →
+            Configure Games
           </button>
           <button
             type="button"

--- a/tests/renderer/onboarding.test.tsx
+++ b/tests/renderer/onboarding.test.tsx
@@ -144,7 +144,7 @@ describe('First-run onboarding (#641)', () => {
     const harness = await renderApp()
     try {
       expect(modalHeading()).not.toBeNull()
-      expect(document.activeElement).toBe(button(/set up your sims/i))
+      expect(document.activeElement).toBe(button(/configure games/i))
     } finally {
       harness.unmount()
     }
@@ -187,7 +187,7 @@ describe('First-run onboarding (#641)', () => {
     const harness = await renderApp()
     try {
       await act(async () => {
-        button(/set up your sims/i)?.click()
+        button(/configure games/i)?.click()
       })
       expect(h.persistOnboardingSeen).toHaveBeenCalledWith(true)
       expect(h.settingsTarget.current).toBe('games')


### PR DESCRIPTION
This PR simplifies the welcome text on the first-run onboarding screen to be cleaner and more concise: 'Configure your simulation games and companion apps.'