### PR TITLE
fix(utils): trim path before basename extraction in getExeName

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -34,7 +34,7 @@ export function getExeName(filePath: unknown): string {
   // CI/tests run on Linux where the platform-native path module treats
   // backslashes as literal characters. Forcing win32 keeps the result
   // consistent across host OSes.
-  return path.win32.basename(filePath).toLowerCase()
+  return path.win32.basename(trimmed).toLowerCase()
 }
 
 /**

--- a/tests/main/utils.test.ts
+++ b/tests/main/utils.test.ts
@@ -80,4 +80,10 @@ describe('getExeName (relaxed input)', () => {
   test('preserves current happy-path behaviour', () => {
     expect(getExeName('C:\\Apps\\Foo.exe')).toBe('foo.exe')
   })
+
+  test('trims leading/trailing whitespace before extracting the basename (#679)', () => {
+    expect(getExeName('  C:\\Apps\\Foo.exe  ')).toBe('foo.exe')
+    expect(getExeName('C:\\Apps\\Foo.exe ')).toBe('foo.exe')
+    expect(getExeName(' C:\\Apps\\Foo.exe')).toBe('foo.exe')
+  })
 })


### PR DESCRIPTION
## Summary
- `isValidExePath` trims the path before checking it exists, but `getExeName` extracted the basename from the raw (untrimmed) string, so a path with leading/trailing whitespace (e.g. from a hand-edited `config.json`) would pass validation but produce an exe name (`"simhub.exe "`) that never matches `tasklist` output.
- Fixes `src/main/utils.ts` to call `path.win32.basename` on the already-computed `trimmed` value instead of the raw `filePath`.

## Closes #679

## Test plan
- Added a regression test in `tests/main/utils.test.ts` covering leading, trailing, and both-sided whitespace around an otherwise-valid path.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` all pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `.exe` name detection so leading and trailing whitespace no longer affects the result.
  * Preserved existing behavior for normal file paths while making path handling more reliable.

* **Tests**
  * Added coverage for whitespace-trimmed input to confirm the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->