### PR TITLE
fix(store): rebuild windowBounds from validated fields on import

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -828,7 +828,12 @@ export function getSupportedConfigValues(config: Record<string, unknown>): Recor
 
     if (key === 'windowBounds') {
       if (isWindowBounds(value)) {
-        supportedConfig.windowBounds = value
+        supportedConfig.windowBounds = {
+          x: value.x,
+          y: value.y,
+          width: value.width,
+          height: value.height
+        }
       }
       return
     }

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -252,6 +252,27 @@ test('sanitizeImportedConfig filters path, name, args, and prototype pollution k
   })
 })
 
+// #691: windowBounds must go through the same forbidden-key stripping as
+// every other imported record instead of being assigned wholesale.
+// JSON.parse (unlike an object literal) creates a genuine own '__proto__'
+// property, which is the real-world hand-crafted-config attack shape.
+test('sanitizeImportedConfig rebuilds windowBounds from validated fields only', async () => {
+  const { sanitizeImportedConfig } = await loadStoreModule()
+  const polluted = JSON.parse(
+    '{"windowBounds":{"x":10,"y":20,"width":800,"height":600,"__proto__":"polluted","extra":"nope"}}'
+  )
+
+  const sanitized = sanitizeImportedConfig(polluted)
+
+  expect(sanitized.windowBounds).toEqual({ x: 10, y: 20, width: 800, height: 600 })
+  expect(Object.keys(sanitized.windowBounds as object).sort()).toEqual([
+    'height',
+    'width',
+    'x',
+    'y'
+  ])
+})
+
 test('sanitizeSettingsPatch filters object settings like config import', async () => {
   const { sanitizeSettingsPatch, store } = await loadStoreModule()
   store.set('customSlots', 2)


### PR DESCRIPTION
## Summary
- `windowBounds` import bypassed the forbidden-key stripping every other imported record goes through: `isWindowBounds` only checked that `x`/`y`/`width`/`height` are finite numbers, then the raw parsed object was assigned wholesale to `supportedConfig.windowBounds` — unlike `appPaths`/`profiles`/etc. which are rebuilt through `getSafeObjectEntries` (which drops `__proto__`/`constructor`/`prototype` own-properties).
- `src/main/store.ts` now rebuilds `{ x, y, width, height }` from the validated fields instead of assigning the parsed value directly, aligning it with the stripping path used everywhere else.
- Not exploitable on its own (a JSON `"__proto__"` key is an own property, not prototype pollution, and coordinates are re-clamped at read time in `window.ts`) — this is a hygiene/consistency fix per the audit finding.

## Closes #691

## Test plan
- Added a regression test in `tests/main/store.test.ts` that imports a `windowBounds` object with an extra property and a JSON-parsed literal `__proto__` own-property (the realistic hand-crafted-config attack shape), asserting the sanitized result contains only `x`/`y`/`width`/`height`.
- Verified the new test fails against the pre-fix code (reproduced by temporarily reverting the store.ts change) and passes after the fix.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` all pass locally.


<!-- auto-closes -->
Closes #691
<!-- auto-closes -->