### PR TITLE
style(ux): name the active profile in the launch-button label (#643)

### DIFF
--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -568,6 +568,7 @@ export function GameRow({
           onRelaunchMissing={handleRelaunchMissing}
           onToggleEditor={handleToggle}
           gameName={game.name}
+          activeProfileName={activeProfile.name}
           editorId={editorId}
           profileMenuProps={{
             profileSet,

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 
+import { DEFAULT_PROFILE_NAME } from '../../lib/config'
 import { GameRowProfileMenu, type GameRowProfileMenuProps } from './GameRowProfileMenu'
 import { RefreshIcon, KillIcon, PlayMarkIcon, SettingsIcon } from '../icons'
 import { Tooltip } from '../Tooltip'
@@ -15,6 +16,11 @@ export interface GameRowActionsProps {
   onRelaunchMissing: () => void
   onToggleEditor: () => void
   gameName: string
+  // Name of the profile that will actually launch (#643). Suppressed from the
+  // label when it's the default single-profile case (DEFAULT_PROFILE_NAME) so
+  // the common "one profile per game" user never sees redundant noise — it
+  // only surfaces once a game has more than one named profile to disambiguate.
+  activeProfileName: string
   editorId: string
   profileMenuProps: GameRowProfileMenuProps
 }
@@ -30,12 +36,21 @@ export function GameRowActions({
   onRelaunchMissing,
   onToggleEditor,
   gameName,
+  activeProfileName,
   editorId,
   profileMenuProps
 }: GameRowActionsProps): ReactNode {
   const primaryAction = canKill ? onKill : onPrimary
   const primaryButtonClass = canKill ? 'danger-action' : 'accent-surface-action'
-  const primaryTitle = isLaunching && !canKill ? 'Launching' : canKill ? 'Close Apps' : 'Launch'
+  // What will actually start: the game, plus its named profile when the user
+  // has more than the trivial default one to choose from (#643 — the launch
+  // button previously just said "Launch", leaving which profile/apps ambiguous).
+  const launchTarget =
+    activeProfileName === DEFAULT_PROFILE_NAME
+      ? gameName
+      : `${gameName} — ${activeProfileName} profile`
+  const primaryTitle =
+    isLaunching && !canKill ? 'Launching' : canKill ? 'Close Apps' : `Launch ${launchTarget}`
 
   return (
     <div className="flex items-center gap-3 no-drag">
@@ -76,7 +91,7 @@ export function GameRowActions({
                 ? `Launching ${gameName}`
                 : canKill
                   ? `Close companion apps for ${gameName}`
-                  : `Launch ${gameName}`
+                  : `Launch ${launchTarget}`
             }
             aria-busy={isLaunching && !canKill ? true : undefined}
           >

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 
-import { DEFAULT_PROFILE_NAME } from '../../lib/config'
 import { GameRowProfileMenu, type GameRowProfileMenuProps } from './GameRowProfileMenu'
 import { RefreshIcon, KillIcon, PlayMarkIcon, SettingsIcon } from '../icons'
 import { Tooltip } from '../Tooltip'
@@ -16,10 +15,9 @@ export interface GameRowActionsProps {
   onRelaunchMissing: () => void
   onToggleEditor: () => void
   gameName: string
-  // Name of the profile that will actually launch (#643). Suppressed from the
-  // label when it's the default single-profile case (DEFAULT_PROFILE_NAME) so
-  // the common "one profile per game" user never sees redundant noise — it
-  // only surfaces once a game has more than one named profile to disambiguate.
+  // Name of the profile that will actually launch (#643). Always present:
+  // getActiveGameProfile → normalizeGameProfileSet guarantees at least one
+  // profile with a non-empty name ("Default" / "Profile N" fallbacks).
   activeProfileName: string
   editorId: string
   profileMenuProps: GameRowProfileMenuProps
@@ -42,13 +40,12 @@ export function GameRowActions({
 }: GameRowActionsProps): ReactNode {
   const primaryAction = canKill ? onKill : onPrimary
   const primaryButtonClass = canKill ? 'danger-action' : 'accent-surface-action'
-  // What will actually start: the game, plus its named profile when the user
-  // has more than the trivial default one to choose from (#643 — the launch
-  // button previously just said "Launch", leaving which profile/apps ambiguous).
-  const launchTarget =
-    activeProfileName === DEFAULT_PROFILE_NAME
-      ? gameName
-      : `${gameName} — ${activeProfileName} profile`
+  // What will actually start: the game AND its active profile — the profile
+  // determines which companion apps launch even when it's the default one
+  // (#643 — the button previously just said "Launch", leaving that ambiguous).
+  // WHY a colon separator: no em dashes in public-facing copy, and profile
+  // names often contain hyphens, so a dash-style separator would get lost.
+  const launchTarget = `${gameName}: ${activeProfileName} profile`
   const primaryTitle =
     isLaunching && !canKill ? 'Launching' : canKill ? 'Close Apps' : `Launch ${launchTarget}`
 

--- a/tests/renderer/gameRowLaunchAnnounce.test.tsx
+++ b/tests/renderer/gameRowLaunchAnnounce.test.tsx
@@ -150,9 +150,9 @@ describe('GameRow launch a11y (#612)', () => {
     await renderRow()
 
     // The idle Play button (runningAppIcons empty AND not launching → canKill
-    // false) is named "Launch <game>".
+    // false) is named "Launch <game>: <profile> profile" (#643).
     const playButton = container.querySelector(
-      'button[aria-label="Launch Assetto Corsa"]'
+      'button[aria-label="Launch Assetto Corsa: Default profile"]'
     ) as HTMLButtonElement | null
     expect(playButton).not.toBeNull()
 

--- a/tests/renderer/gameRowLaunchCancelled.test.tsx
+++ b/tests/renderer/gameRowLaunchCancelled.test.tsx
@@ -126,7 +126,7 @@ async function renderRow(): Promise<void> {
 
 async function clickPlayButton(): Promise<void> {
   const playButton = container.querySelector(
-    'button[aria-label="Launch Assetto Corsa"]'
+    'button[aria-label="Launch Assetto Corsa: Default profile"]'
   ) as HTMLButtonElement | null
   expect(playButton).not.toBeNull()
 

--- a/tests/renderer/gameRowLaunchLabel.test.tsx
+++ b/tests/renderer/gameRowLaunchLabel.test.tsx
@@ -3,11 +3,12 @@
  *
  * The launch button previously said just "Launch" (tooltip) / "Launch <game>"
  * (aria-label) regardless of which profile would actually run — ambiguous the
- * moment a game has more than one profile. Pinned behavior:
- *   1. Default single-profile case: label stays the plain "Launch <game>"
- *      (no redundant "— Default profile" noise for the common case).
- *   2. Named non-default profile: label grows to "Launch <game> — <profile>
- *      profile" so it's unambiguous which profile/apps are about to start.
+ * moment a game has more than one profile. Pinned behavior (founder-approved
+ * copy): the label ALWAYS names the active profile — "Launch <game>:
+ * <profile> profile" — because the profile determines which apps start even
+ * when it's the default one. Colon separator, not a dash: no em dashes in
+ * public-facing copy, and profile names often contain hyphens, so a
+ * dash-style separator would get lost.
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
@@ -131,18 +132,20 @@ afterEach(() => {
 })
 
 describe('GameRow launch button label (#643)', () => {
-  test('default single profile: label stays the plain "Launch <game>"', async () => {
+  test('default profile: label still names the profile ("Launch <game>: Default profile")', async () => {
     activeProfileSet = {
       activeProfileId: 'default',
       profiles: [{ id: 'default', name: 'Default' }]
     }
     await renderRow()
 
-    const playButton = container.querySelector('button[aria-label="Launch Assetto Corsa"]')
+    const playButton = container.querySelector(
+      'button[aria-label="Launch Assetto Corsa: Default profile"]'
+    )
     expect(playButton).not.toBeNull()
   })
 
-  test('named non-default profile: label names the profile that will launch', async () => {
+  test('named profile: label names the profile that will launch', async () => {
     activeProfileSet = {
       activeProfileId: 'rain',
       profiles: [{ id: 'rain', name: 'Rain Setup' }]
@@ -150,7 +153,7 @@ describe('GameRow launch button label (#643)', () => {
     await renderRow()
 
     const playButton = container.querySelector(
-      'button[aria-label="Launch Assetto Corsa — Rain Setup profile"]'
+      'button[aria-label="Launch Assetto Corsa: Rain Setup profile"]'
     )
     expect(playButton).not.toBeNull()
   })

--- a/tests/renderer/gameRowLaunchLabel.test.tsx
+++ b/tests/renderer/gameRowLaunchLabel.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Regression test for #643 (ux: clarify the launch-button label).
+ *
+ * The launch button previously said just "Launch" (tooltip) / "Launch <game>"
+ * (aria-label) regardless of which profile would actually run — ambiguous the
+ * moment a game has more than one profile. Pinned behavior:
+ *   1. Default single-profile case: label stays the plain "Launch <game>"
+ *      (no redundant "— Default profile" noise for the common case).
+ *   2. Named non-default profile: label grows to "Launch <game> — <profile>
+ *      profile" so it's unambiguous which profile/apps are about to start.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const launchProfileMock = vi.fn().mockResolvedValue({ success: true, launchedCount: 1 })
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+// Mutable so each test can point the active profile at a different entry
+// without re-mocking the module.
+let activeProfileSet = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: activeProfileSet,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(activeProfileSet),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(activeProfileSet),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRow(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={false}
+          isGameRunning={false}
+          runningAppIcons={[]}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+beforeEach(() => {
+  launchProfileMock.mockClear()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('GameRow launch button label (#643)', () => {
+  test('default single profile: label stays the plain "Launch <game>"', async () => {
+    activeProfileSet = {
+      activeProfileId: 'default',
+      profiles: [{ id: 'default', name: 'Default' }]
+    }
+    await renderRow()
+
+    const playButton = container.querySelector('button[aria-label="Launch Assetto Corsa"]')
+    expect(playButton).not.toBeNull()
+  })
+
+  test('named non-default profile: label names the profile that will launch', async () => {
+    activeProfileSet = {
+      activeProfileId: 'rain',
+      profiles: [{ id: 'rain', name: 'Rain Setup' }]
+    }
+    await renderRow()
+
+    const playButton = container.querySelector(
+      'button[aria-label="Launch Assetto Corsa — Rain Setup profile"]'
+    )
+    expect(playButton).not.toBeNull()
+  })
+})

--- a/tests/renderer/gameRowLaunchSkipped.test.tsx
+++ b/tests/renderer/gameRowLaunchSkipped.test.tsx
@@ -124,7 +124,7 @@ async function renderRow(): Promise<void> {
 
 async function clickPlayButton(): Promise<void> {
   const playButton = container.querySelector(
-    'button[aria-label="Launch Assetto Corsa"]'
+    'button[aria-label="Launch Assetto Corsa: Default profile"]'
   ) as HTMLButtonElement | null
   expect(playButton).not.toBeNull()
 


### PR DESCRIPTION
## Summary

- The primary launch button's tooltip/aria-label just said "Launch" / "Launch \<game\>", which never disambiguated *which profile* (and therefore which companion apps) was about to start. For a game with multiple profiles this is a real first-click comprehension snag.
- The label now **always** reads `Launch <game>: <profile> profile` — e.g. `Launch iRacing: VR - Road profile`, or `Launch BeamNG: Default profile` for the default. The profile determines what starts even when it's the default, so it's always named.
- No launch behavior changed — copy/affordance only, per the issue's acceptance criteria.

## Copy decision (founder-approved, `17a962b`)

Format: **`Launch <game>: <profile> profile`** — game + profile name, never an enumeration of companion apps.

- **Colon separator, not an em dash:** no em dashes in public-facing copy, and profile names often contain hyphens (`VR - Road`), so a dash-style separator would get lost.
- **Profile always named** (no trivial-default suppression): the label's purpose (#643) is to say what will start, and the profile determines that even when it's `Default`. This also simplified the code — the conditional and the plain `Launch <game>` branch are gone entirely, which is safe because `getActiveGameProfile` → `normalizeGameProfileSet` guarantees every game always has an active profile with a non-empty name.
- **Game + profile over app enumeration:** reuses the naming already established by the profile dropdown; listing every enabled companion app in a tooltip/aria-label would get long and unstable as apps are toggled — the running-strip answers "which apps" once they're running, the profile editor before launch.

Closes #643

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (448 passed; `tests/renderer/gameRowLaunchLabel.test.tsx` pins both cases — named profile and Default — in the new colon format; the three pre-existing GameRow launch tests were updated to the new accessible name)
- [ ] Manual: confirm the launch button tooltip/Narrator name reads `Launch <game>: <profile> profile` for both a default-profile game and a multi-profile game.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch buttons now include the selected profile name in their label, making it clearer which game/profile combination will start.

* **Bug Fixes**
  * Improved launch button accessibility text for more accurate screen reader and tooltip wording.
  * Updated launch-related checks so cancelled, skipped, and success states target the correct button label.
  * Added coverage for profile-specific launch labeling across default and named profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #643
<!-- auto-closes -->