### PR TITLE
ci(release): verify signed installer before publish + pin actions to SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
 
       - name: Verify tag matches package.json version
+        id: version
         shell: bash
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
@@ -32,6 +33,7 @@ jobs:
             exit 1
           fi
           echo "Tag ${GITHUB_REF_NAME} matches package.json version ${pkg_version}."
+          echo "version=${pkg_version}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci
@@ -42,21 +44,30 @@ jobs:
       - name: Build app
         run: npm run build
 
-      - name: Build installer and publish release
+      # `--publish never`: build + sign into dist/ only, no GitHub release is
+      # created or touched here. We verify the exact signed artifact below,
+      # then publish those same files ourselves via `gh release` (#663).
+      # electron-builder's own `--publish always` would upload the installer
+      # to the (draft) release before the verify gate ran, and re-running
+      # electron-builder afterwards to "publish for real" would re-sign and
+      # produce a different artifact (new signature/hash) than the one that
+      # was verified.
+      - name: Build installer
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           # Azure Artifact Signing credentials (service principal). electron-builder
           # reads these automatically for win.azureSignOptions.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: npx electron-builder --win --publish always
+        run: npx electron-builder --win --publish never
 
       # Enforce signing on releases without putting forceCodeSigning in
       # electron-builder.yml (which would break unsigned `npm run dist:win`
       # builds from source). This also asserts the signature is TIMESTAMPED —
       # without a timestamp the signature would expire with the short-lived
-      # Trusted Signing cert (~3 days). A failure here fails the release.
+      # Trusted Signing cert (~3 days). This now runs BEFORE any asset is
+      # published (#663): the installer only exists in dist/ at this point,
+      # so a failure here fails the workflow with nothing uploaded anywhere.
       - name: Verify the installer is signed and timestamped
         shell: pwsh
         run: |
@@ -73,6 +84,33 @@ jobs:
             if (-not $sig.TimeStamperCertificate) { throw "$($exe.Name) is signed but NOT timestamped." }
             Write-Host "OK: $($exe.Name) signed by David Kohout and timestamped."
           }
+
+      # electron-builder built with `--publish never` above, so nothing has
+      # been uploaded to GitHub yet. Create the (draft) release ourselves and
+      # upload the exact files that were just verified — matching the
+      # draft/title/asset shape electron-builder's own GitHub publisher would
+      # have produced, but with the verify gate strictly in front of it.
+      # electron-builder used to reuse an existing draft for this tag on a
+      # rerun; `gh release create` errors if one already exists, so replace a
+      # leftover *draft* from a prior failed run first (never touches an
+      # already-published release for this tag).
+      - name: Create draft release and upload installer
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          existing_is_draft="$(gh release view "${{ github.ref_name }}" \
+            --repo Stashpeak/SimLauncher --json isDraft -q '.isDraft' 2>/dev/null || true)"
+          if [ "$existing_is_draft" = "true" ]; then
+            echo "Removing leftover draft release for ${{ github.ref_name }} from a prior run."
+            gh release delete "${{ github.ref_name }}" --repo Stashpeak/SimLauncher --yes
+          fi
+          gh release create "${{ github.ref_name }}" \
+            --repo Stashpeak/SimLauncher \
+            --draft \
+            --title "${{ steps.version.outputs.version }}" \
+            --notes "" \
+            dist/*.exe dist/latest.yml dist/*.exe.blockmap
 
       - name: Generate SHA-256 checksums
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,19 +98,42 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # Validate the exact asset set before anything touches GitHub, so a
+          # non-matching glob can never reach gh as a literal pattern and a
+          # changed electron-builder output shape fails loudly here instead.
+          exes=(dist/*.exe)
+          blockmaps=(dist/*.exe.blockmap)
+          if [ "${#exes[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one installer (.exe) in dist/, found ${#exes[@]}: ${exes[*]:-<none>}"
+            exit 1
+          fi
+          if [ "${#blockmaps[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one .exe.blockmap in dist/, found ${#blockmaps[@]}: ${blockmaps[*]:-<none>}"
+            exit 1
+          fi
+          if [ ! -f dist/latest.yml ]; then
+            echo "::error::dist/latest.yml is missing — the auto-update feed would break."
+            exit 1
+          fi
+          assets=("${exes[0]}" dist/latest.yml "${blockmaps[0]}")
+          echo "Validated release assets: ${assets[*]}"
+
           existing_is_draft="$(gh release view "${{ github.ref_name }}" \
-            --repo Stashpeak/SimLauncher --json isDraft -q '.isDraft' 2>/dev/null || true)"
+            --json isDraft -q '.isDraft' 2>/dev/null || true)"
           if [ "$existing_is_draft" = "true" ]; then
             echo "Removing leftover draft release for ${{ github.ref_name }} from a prior run."
-            gh release delete "${{ github.ref_name }}" --repo Stashpeak/SimLauncher --yes
+            gh release delete "${{ github.ref_name }}" --yes
           fi
           gh release create "${{ github.ref_name }}" \
-            --repo Stashpeak/SimLauncher \
             --draft \
             --title "${{ steps.version.outputs.version }}" \
             --notes "" \
-            dist/*.exe dist/latest.yml dist/*.exe.blockmap
+            "${assets[@]}"
 
       - name: Generate SHA-256 checksums
         shell: bash


### PR DESCRIPTION
## Summary

- Reorders `release.yml` so the installer is built and signed with `electron-builder --win --publish never`, the Authenticode signature/timestamp gate then runs against that exact `dist/` artifact, and only after it passes does a new "Create draft release and upload installer" step create the draft GitHub release and upload the `.exe` / `latest.yml` / `.blockmap` itself via `gh release`. No release asset can be published before the signature check passes, and the artifact that is verified is byte-for-byte the artifact that is published (no re-sign in between, since electron-builder never runs a second time).
- Guards the new release-creation step against a stray leftover **draft** from a prior failed run (`gh release create` errors if a release for the tag already exists; electron-builder used to just reuse it) — it deletes a leftover draft for the same tag first, but never touches an already-published release.
- Pins `actions/checkout` and `actions/setup-node` (the only first-party actions in this workflow) to full commit SHAs with version comments, matching how the third-party actions (`anchore/sbom-action`) here are already pinned. This job carries the Azure Trusted Signing service-principal secrets, so its actions shouldn't ride mutable major tags.

Closes #663
Closes #690

## Notes

- #690's body also mentions `actions/github-script` in `sync-pr-closes.yml` and `amannn/action-semantic-pull-request` elsewhere as context for "how third-party pins already look here" — neither of those actions is used in `release.yml`, so this PR only touches `release.yml` as scoped.
- SHA pins chosen (currently-used major tag → resolved commit):
  - `actions/checkout@v7` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (v7.0.0)
  - `actions/setup-node@v6` → `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0)

## Test plan

- [x] Validated YAML with `js-yaml` (`node -e "require('js-yaml').load(...)"`) — parses cleanly, step order confirmed: Checkout → Install Node.js → Verify tag → Install deps → Audit → Build app → **Build installer (`--publish never`)** → **Verify signed & timestamped** → **Create draft release and upload installer** → Generate SHA-256 checksums → Generate SBOM → Attach checksums/SBOM → Generate release notes.
- [x] Confirmed via `electron-publish`'s `gitHubPublisher.js` in `node_modules` that electron-builder's default GitHub release is a **draft** named after the bare version (no `v` prefix) — matched that shape (`--draft --title <version-without-v>`) in the new manual `gh release create` step so the resulting release looks the same as before.
- [x] Cross-checked the exact asset filenames electron-builder publishes today against a real past release (`v1.0.2`: `latest.yml`, `SimLauncher-Setup-1.0.2.exe`, `SimLauncher-Setup-1.0.2.exe.blockmap`) to make sure the new upload globs (`dist/*.exe dist/latest.yml dist/*.exe.blockmap`) cover them.
- [x] Ran `npm ci` + `prettier --check .` locally (via the repo's commit-msg/pre-commit hooks) — passes.
- [ ] Full end-to-end validation only happens on the next tagged release (this workflow only runs on `v*` tag pushes) — first real run should be watched closely for: the draft release appearing with the expected assets, `latest.yml` matching the uploaded `.exe`'s hash, and the signature gate still correctly failing the job if signing ever breaks.


<!-- auto-closes -->
Closes #663
Closes #690
<!-- auto-closes -->