### PR TITLE
test(system): cover the open-external-url allowlist gate

### DIFF
--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -176,7 +176,8 @@ export const dialog = {
 
 export const shell = {
   openPath: vi.fn().mockResolvedValue(''),
-  showItemInFolder: vi.fn()
+  showItemInFolder: vi.fn(),
+  openExternal: vi.fn().mockResolvedValue(undefined)
 }
 
 export const ipcMain = {

--- a/tests/main/system.test.ts
+++ b/tests/main/system.test.ts
@@ -35,3 +35,60 @@ test('open-logs-folder surfaces shell.openPath result (error string on failure)'
 
   await expect(handlers['open-logs-folder']()).resolves.toBe('Failed to open path')
 })
+
+// open-external-url is the only sanctioned path from the renderer to the OS
+// (window.ts denies will-navigate / setWindowOpenHandler) — it is a security
+// gate, not a convenience wrapper. #657
+test('open-external-url rejects non-string input', async () => {
+  const handlers = await loadSystemHandlers()
+
+  await expect(handlers['open-external-url']({}, 42)).resolves.toBe(false)
+  await expect(handlers['open-external-url']({}, null)).resolves.toBe(false)
+  await expect(handlers['open-external-url']({}, undefined)).resolves.toBe(false)
+  expect(shell.openExternal).not.toHaveBeenCalled()
+})
+
+test('open-external-url rejects an unparseable URL', async () => {
+  const handlers = await loadSystemHandlers()
+
+  await expect(handlers['open-external-url']({}, 'not a url')).resolves.toBe(false)
+  expect(shell.openExternal).not.toHaveBeenCalled()
+})
+
+test('open-external-url rejects a non-https protocol', async () => {
+  const handlers = await loadSystemHandlers()
+
+  await expect(handlers['open-external-url']({}, 'http://github.com')).resolves.toBe(false)
+  await expect(
+    handlers['open-external-url']({}, 'file:///C:/Windows/System32/cmd.exe')
+  ).resolves.toBe(false)
+  expect(shell.openExternal).not.toHaveBeenCalled()
+})
+
+test('open-external-url rejects a host outside the allowlist', async () => {
+  const handlers = await loadSystemHandlers()
+
+  await expect(handlers['open-external-url']({}, 'https://evil.example.com')).resolves.toBe(false)
+  await expect(handlers['open-external-url']({}, 'https://not-github.com.evil.com')).resolves.toBe(
+    false
+  )
+  expect(shell.openExternal).not.toHaveBeenCalled()
+})
+
+test('open-external-url opens an allowlisted https host', async () => {
+  const handlers = await loadSystemHandlers()
+  const url = 'https://github.com/Stashpeak/SimLauncher'
+
+  await expect(handlers['open-external-url']({}, url)).resolves.toBe(true)
+  expect(shell.openExternal).toHaveBeenCalledOnce()
+  expect(shell.openExternal).toHaveBeenCalledWith(url)
+})
+
+test('open-external-url returns false (and does not throw) when shell.openExternal rejects', async () => {
+  ;(shell.openExternal as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+    new Error('no registered handler')
+  )
+  const handlers = await loadSystemHandlers()
+
+  await expect(handlers['open-external-url']({}, 'https://discord.gg/abc123')).resolves.toBe(false)
+})


### PR DESCRIPTION
## Summary
- `open-external-url` (`src/main/ipc/system.ts`) is the only sanctioned path from the renderer to the OS — it rejects non-string input, unparseable URLs, non-https protocols, and any host outside `ALLOWED_EXTERNAL_HOSTS`, then wraps `shell.openExternal` in try/catch. It had zero test coverage.
- Added `openExternal: vi.fn().mockResolvedValue(undefined)` to the `shell` mock in `tests/main/electronMock.ts` (it previously only had `openPath`/`showItemInFolder`).
- Added branch tests in `tests/main/system.test.ts` for all 6 gate outcomes:
  - non-string input → `false`
  - unparseable URL → `false`
  - non-https protocol (`http:`, `file:`) → `false`
  - host not in the allowlist (including a subdomain-confusable host) → `false`
  - allowlisted https host → `true`, and `shell.openExternal` called once with the URL
  - `shell.openExternal` throws → `false` (caught, no crash)

Test-only change, no app code modified (per the issue's stated scope).

## Closes #657

## Test plan
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` all pass locally (452 tests, all green).


<!-- auto-closes -->
Closes #657
<!-- auto-closes -->