### PR TITLE
perf(processes): back off idle poll when window is minimized to taskbar

### DIFF
--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -51,10 +51,12 @@ const POST_ACTIVITY_FAST_WINDOW_MS = 30000
 const runningAppsSubscribers = new Set<WebContents>()
 let runningAppsScanTimer: ReturnType<typeof setTimeout> | undefined
 let runningAppsMonitorActive = false
-// Whether the main window is currently visible, fed by its 'show'/'hide' events
-// via setRunningAppsWindowVisible. Starts false because the window is created
-// hidden (`show: false`) and only reveals once the renderer is ready — a
-// start-minimized-to-tray session therefore begins on the SLOW cadence.
+// Whether the main window is currently both shown AND un-minimized, recomputed
+// from live window state on its 'show'/'hide'/'minimize'/'restore'/'focus'
+// events (#708) via setRunningAppsWindowVisible. Starts false because the
+// window is created hidden (`show: false`) and only reveals once the renderer
+// is ready — a start-minimized-to-tray session therefore begins on the SLOW
+// cadence.
 let runningAppsWindowVisible = false
 // Monotonic (performance.now()) timestamp of the last non-scan publish
 // (launch/exit/kill). 0 means "no activity yet this session"; it keeps the poll

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { performance } from 'perf_hooks'
 import type { WebContents } from 'electron'
 
 import {
@@ -55,8 +56,11 @@ let runningAppsMonitorActive = false
 // hidden (`show: false`) and only reveals once the renderer is ready — a
 // start-minimized-to-tray session therefore begins on the SLOW cadence.
 let runningAppsWindowVisible = false
-// Timestamp of the last non-scan publish (launch/exit/kill). 0 means "no
-// activity yet this session"; it keeps the poll FAST for POST_ACTIVITY_FAST_WINDOW_MS.
+// Monotonic (performance.now()) timestamp of the last non-scan publish
+// (launch/exit/kill). 0 means "no activity yet this session"; it keeps the poll
+// FAST for POST_ACTIVITY_FAST_WINDOW_MS. Monotonic rather than Date.now() (#708)
+// so a wall-clock jump (NTP sync, VM host suspend/resume) cannot collapse or
+// extend the window — it can only elapse at real wall-clock speed.
 let lastRunningAppsActivityAt = 0
 let lastRunningAppsSnapshot = ''
 // Number of apps in the last published snapshot. Includes externally-ADOPTED
@@ -363,9 +367,10 @@ export function publishRunningApps(
  */
 function computeRunningAppsScanDelayMs(): number {
   // lastRunningAppsActivityAt === 0 means "no activity yet this session"; guard
-  // that sentinel and a backward clock jump (negative delta) so neither wedges
-  // the poll on FAST.
-  const activityDelta = Date.now() - lastRunningAppsActivityAt
+  // that sentinel. performance.now() is monotonic, so a backward delta can only
+  // come from that sentinel (never a real wall-clock jump), but the guard is
+  // kept as defense in depth.
+  const activityDelta = performance.now() - lastRunningAppsActivityAt
   const withinPostActivityWindow =
     lastRunningAppsActivityAt !== 0 &&
     activityDelta >= 0 &&
@@ -432,14 +437,15 @@ function resetRunningAppsCadence() {
 }
 
 function noteRunningAppsActivity() {
-  lastRunningAppsActivityAt = Date.now()
+  lastRunningAppsActivityAt = performance.now()
   resetRunningAppsCadence()
 }
 
 /**
- * Signal from the main window's 'show'/'hide' events. A visible window pulls the
- * poll back to FAST; hiding lets it fall back to SLOW once nothing is tracked.
- * Safe to call before any subscriber exists — it only records state.
+ * Signal from the main window's visibility state (show/hide AND minimize/restore,
+ * see the #708 comment in window.ts). A visible, non-minimized window pulls the
+ * poll back to FAST; anything else lets it fall back to SLOW once nothing is
+ * tracked. Safe to call before any subscriber exists — it only records state.
  */
 export function setRunningAppsWindowVisible(visible: boolean): void {
   runningAppsWindowVisible = visible
@@ -453,10 +459,18 @@ export async function subscribeRunningApps(
 ): Promise<RunningAppsChangedPayload> {
   runningAppsSubscribers.add(webContents)
   webContents.once('destroyed', () => removeRunningAppsSubscriber(webContents))
-  startRunningAppsMonitor()
 
   const apps = await getRunningApps()
+  // Seed the cadence-gating count from this bootstrap read BEFORE starting the
+  // monitor (#708). Previously the monitor started first and scheduled its
+  // first scan off the pre-subscription (stale, often 0) count, so a
+  // start-minimized launch with an already-running adopted game would
+  // bootstrap on the SLOW cadence for one tick (<=12s) before the first scan
+  // self-corrected it. One-time and self-healing, but avoidable.
+  lastPublishedRunningAppsCount = apps.length
   lastRunningAppsSnapshot = normalizeRunningAppsSnapshot(apps)
+  startRunningAppsMonitor()
+
   return { apps, reason: 'initial', updatedAt: Date.now() } satisfies RunningAppsChangedPayload
 }
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -214,12 +214,31 @@ export function createWindow(): void {
   mainWindow.on('maximize', () => sendToRenderer('window-maximized-changed', true))
   mainWindow.on('unmaximize', () => sendToRenderer('window-maximized-changed', false))
 
-  // Drive the adaptive running-apps poll cadence (#672): a visible window keeps
-  // the poll on its FAST tick, while hiding to the tray lets it back off to SLOW
-  // once nothing is tracked. Hooking 'show'/'hide' specifically targets the
-  // tray case (the primary idle scenario); a taskbar minimize is left as-is.
-  mainWindow.on('show', () => setRunningAppsWindowVisible(true))
-  mainWindow.on('hide', () => setRunningAppsWindowVisible(false))
+  // Drive the adaptive running-apps poll cadence (#672): a visible, non-minimized
+  // window keeps the poll on its FAST tick, while hiding to the tray OR minimizing
+  // to the taskbar lets it back off to SLOW once nothing is tracked.
+  //
+  // #672 only hooked 'show'/'hide', which covers tray-hide but not a plain OS
+  // taskbar minimize: that fires 'minimize'/'restore' instead, and isVisible()
+  // stays true while minimized, so the FAST cadence ran forever (#708). Rather
+  // than track minimize/hide as separate flags that can disagree, every event
+  // recomputes visibility straight from the window's own live state — robust to
+  // a platform occasionally skipping one event of a pair (e.g. 'restore' without
+  // a preceding 'minimize', or vice versa), since any later event self-corrects.
+  // 'focus' is included as an extra safety net for the restore path: taskbar
+  // click-to-restore always focuses the window even on a setup that drops the
+  // 'restore' event itself.
+  const updateRunningAppsVisibility = () => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      return
+    }
+    setRunningAppsWindowVisible(mainWindow.isVisible() && !mainWindow.isMinimized())
+  }
+  mainWindow.on('show', updateRunningAppsVisibility)
+  mainWindow.on('hide', updateRunningAppsVisibility)
+  mainWindow.on('minimize', updateRunningAppsVisibility)
+  mainWindow.on('restore', updateRunningAppsVisibility)
+  mainWindow.on('focus', updateRunningAppsVisibility)
 
   // Show window once ready, or keep it hidden when starting minimized to tray.
   // Only stay hidden if BOTH startMinimized AND the tray exists — otherwise the

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -255,6 +255,66 @@ test('tracked processes keep the poll fast even while hidden and idle (#672)', a
   expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
 })
 
+// --- Taskbar-minimize backoff gap + related residuals (#708) ---
+
+test('the bootstrap read seeds the cadence count, so an already-running adopted app schedules fast on the very first tick (#708)', async () => {
+  // Previously subscribeRunningApps started the monitor BEFORE its own
+  // bootstrap getRunningApps() read updated lastPublishedRunningAppsCount, so
+  // the FIRST scheduled scan used a stale (often 0) count and scheduled SLOW
+  // for one tick even though an adopted game was already running at
+  // subscribe time. Unlike the "keeps the poll fast" test below (which drains
+  // a full SLOW interval before asserting), this checks the very first
+  // scheduled tick, which is exactly where the stale-count bug lived.
+  const { runningModule } = await loadRunningModule({
+    profiles: { iracing: {} },
+    gamePaths: { iracing: 'C:/Games/iRacingSim64DX11.exe' },
+    trackablePaths: ['C:/Games/iRacingSim64DX11.exe']
+  })
+  vi.useFakeTimers()
+  vi.setSystemTime(CLOCK_START_MS)
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['iracingsim64dx11.exe']),
+    succeeded: true
+  })
+  runningModule.setRunningAppsWindowVisible(false)
+  const webContents = createMockWebContents()
+  await runningModule.subscribeRunningApps(webContents as never)
+
+  // No draining: the first scheduled scan alone must already be FAST.
+  const readsAfterSubscribe = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(readsAfterSubscribe)
+})
+
+test('a forward wall-clock jump does not prematurely end the post-activity fast window (#708)', async () => {
+  // The post-activity FAST window is keyed off a monotonic clock
+  // (performance.now()) rather than Date.now(), specifically so a wall-clock
+  // correction (NTP sync, VM host suspend/resume) cannot collapse it early.
+  // Force a large forward Date jump right after activity and verify the poll
+  // still runs FAST across two more ticks afterward — a Date.now()-keyed
+  // window would see the jump as "30s+ have passed" on the very next
+  // reschedule and fall back to SLOW.
+  const { runningModule } = await loadRunningModule()
+  await startMonitorHidden(runningModule)
+
+  await runningModule.publishRunningApps('launch')
+
+  // NTP-style forward correction: hours ahead of where the activity was stamped.
+  vi.setSystemTime(CLOCK_START_MS + 60 * 60 * 1000)
+
+  // Tick 1: already scheduled FAST before the jump, fires regardless.
+  let reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+
+  // Tick 2: this is the reschedule that would observe the jumped wall clock.
+  // On the monotonic clock, only ~2 FAST intervals of real time have passed,
+  // so it stays FAST.
+  reads = readRunningProcessNamesMock.mock.calls.length
+  await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
+  expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+})
+
 test('an externally-adopted app keeps the poll fast even with empty maps (#672)', async () => {
   // A configured game started OUTSIDE SimLauncher is adopted and surfaced via
   // the scan, but never populates runningProcesses/unclosedProcesses. Keying the

--- a/tests/main/windowRunningAppsCadence.test.ts
+++ b/tests/main/windowRunningAppsCadence.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+// Spy on the running-apps module so these tests assert the WIRING (which
+// window events drive which visibility signal) in isolation from the cadence
+// engine itself — that engine's FAST/SLOW behavior is covered directly in
+// running.test.ts (#672 / #708).
+const setRunningAppsWindowVisibleMock = vi.fn()
+
+async function loadWindowModuleForCreate() {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  const storeValues: Record<string, unknown> = {
+    startMinimized: false,
+    showTrayIcon: true,
+    minimizeToTray: false,
+    autoCheckUpdates: false
+  }
+
+  vi.doMock('../../src/main/store', () => ({
+    getStoredBoolean: vi.fn((key: string, defaultValue = false) => {
+      const value = storeValues[key]
+      return typeof value === 'boolean' ? value : defaultValue
+    }),
+    getStoredZoomFactor: vi.fn(() => 1),
+    isWindowBounds: vi.fn(() => false),
+    store: { get: vi.fn((key: string) => storeValues[key]), set: vi.fn() }
+  }))
+  vi.doMock('../../src/main/updater', () => ({
+    registerUpdaterEvents: vi.fn(),
+    checkForUpdates: vi.fn().mockResolvedValue(null)
+  }))
+  vi.doMock('../../src/main/processes/running', () => ({
+    setRunningAppsWindowVisible: setRunningAppsWindowVisibleMock
+  }))
+
+  return import('../../src/main/window')
+}
+
+async function getCreatedWindow() {
+  const { BrowserWindow } = await import('electron')
+  type MockWindow = {
+    show: () => void
+    hide: () => void
+    minimize: () => void
+    restore: () => void
+    isVisible: () => boolean
+    isMinimized: () => boolean
+    emit: (event: string, ...args: unknown[]) => void
+  }
+  return (BrowserWindow as unknown as { instances: MockWindow[] }).instances[0]
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+// #708: minimizing to the taskbar fires 'minimize'/'restore', not 'hide'/'show',
+// and isVisible() stays true while minimized — #672's show/hide-only wiring
+// never told the running-apps cadence about this, so the poll ran FAST forever
+// once a user minimized to the taskbar instead of hiding to the tray.
+test('minimizing to the taskbar marks the running-apps poll not-visible (#708)', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  win.show()
+  win.emit('show')
+  setRunningAppsWindowVisibleMock.mockClear()
+
+  win.minimize()
+  win.emit('minimize')
+
+  expect(setRunningAppsWindowVisibleMock).toHaveBeenCalledWith(false)
+})
+
+test('restoring from the taskbar marks the running-apps poll visible again (#708)', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  win.show()
+  win.emit('show')
+  win.minimize()
+  win.emit('minimize')
+  setRunningAppsWindowVisibleMock.mockClear()
+
+  win.restore()
+  win.emit('restore')
+
+  expect(setRunningAppsWindowVisibleMock).toHaveBeenCalledWith(true)
+})
+
+// The pre-existing tray path (#672) must keep working unchanged.
+test('hiding to the tray still marks the running-apps poll not-visible (#672)', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  win.show()
+  win.emit('show')
+  setRunningAppsWindowVisibleMock.mockClear()
+
+  win.hide()
+  win.emit('hide')
+
+  expect(setRunningAppsWindowVisibleMock).toHaveBeenCalledWith(false)
+})
+
+test('showing from the tray still marks the running-apps poll visible (#672)', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  win.show()
+  win.emit('show')
+
+  expect(setRunningAppsWindowVisibleMock).toHaveBeenCalledWith(true)
+})
+
+// Defensive safety net (#708 fix sketch): some setups fire 'minimize' without a
+// matching 'restore'. 'focus' recomputes visibility from the window's own live
+// state on every event, so a later focus (e.g. clicking the taskbar icon) still
+// self-corrects even if 'restore' itself never fires.
+test('a focus event self-corrects a dropped restore (#708)', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  win.show()
+  win.emit('show')
+  win.minimize()
+  win.emit('minimize')
+  setRunningAppsWindowVisibleMock.mockClear()
+
+  // The platform un-minimizes the window (state changes) but never fires the
+  // 'restore' event itself — only 'focus' arrives, as it reliably does on a
+  // taskbar click-to-restore.
+  win.restore()
+  win.emit('focus')
+
+  expect(setRunningAppsWindowVisibleMock).toHaveBeenCalledWith(true)
+})
+
+// A stray focus event while still minimized must not be misread as "visible" —
+// the handler always recomputes from isVisible() && !isMinimized(), not from
+// the event name alone.
+test('a focus event while still minimized does not mark the poll visible (#708)', async () => {
+  const { createWindow } = await loadWindowModuleForCreate()
+  createWindow()
+  const win = await getCreatedWindow()
+
+  win.show()
+  win.emit('show')
+  win.minimize()
+  win.emit('minimize')
+  setRunningAppsWindowVisibleMock.mockClear()
+
+  win.emit('focus')
+
+  expect(setRunningAppsWindowVisibleMock).toHaveBeenCalledWith(false)
+})


### PR DESCRIPTION
## Summary

PR #707 (#672) added an adaptive cadence for the running-apps poll: FAST (2s) while it earns its `tasklist.exe` spawn, backing off to SLOW (12s) once the window is hidden and idle. That backoff was wired to the main window's `'show'`/`'hide'` events only, which covers hiding to the tray but not a plain OS **taskbar minimize** — that fires `'minimize'`/`'restore'` instead, and `isVisible()` stays `true` while minimized, so the FAST cadence ran forever for anyone who minimizes rather than tray-hides.

`src/main/window.ts` now recomputes the cadence-visibility signal from the window's own live state (`isVisible() && !isMinimized()`) on `'show'`, `'hide'`, `'minimize'`, and `'restore'`, plus `'focus'` as a safety net for the restore path. Using live state instead of tracking minimize/hide as separate flags makes it self-correcting even if a platform occasionally drops one event of a minimize/restore pair.

Also fixes two smaller residuals from the same adversarial review, both called out in the issue body as in scope:
- **Bootstrap stale count**: `subscribeRunningApps()` started the poll monitor *before* its own bootstrap read updated the cadence-gating running-apps count, so a start-minimized session with an already-running adopted game would schedule its very first scan on the SLOW cadence. The monitor now starts after the count is seeded.
- **Forward clock jump**: the post-activity FAST window was keyed off `Date.now()`, so a wall-clock correction (NTP sync, VM host suspend/resume) could truncate it early. It's now keyed off `performance.now()` (monotonic).

Closes #708

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (454 passed)
- [x] New tests in `tests/main/windowRunningAppsCadence.test.ts` verify the window-event wiring (minimize → not-visible, restore → visible, focus safety net, tray show/hide unchanged) — manually verified each fails against the old show/hide-only wiring.
- [x] New tests in `tests/main/running.test.ts` verify the bootstrap-stale-count fix (first scheduled scan is FAST, not SLOW, for an already-running adopted app) and the forward-clock-jump fix (a large forward `Date` jump right after activity doesn't collapse the FAST window) — manually verified the clock-jump test fails against the old `Date.now()`-based code.


<!-- auto-closes -->
Closes #708
<!-- auto-closes -->