### PR TITLE
fix(launch): honor Close Apps cancellation during relaunch/switch pre-launch windows

### DIFF
--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -5,6 +5,7 @@ import {
   type KillResult,
   type ProfileLaunchEntry,
   getRunningApps,
+  hasOtherActiveLaunchControllers,
   isAnyLaunchActive,
   isRunningExePath,
   killLaunchedApps,
@@ -109,7 +110,13 @@ export function registerLaunchHandlers(): void {
     // unreachable by Close Apps (the #670 bug class via a new path). There is
     // no await between this check and the registration, so the event loop
     // makes the check-then-register pair atomic.
-    if (isAnyLaunchActive()) {
+    //
+    // Both halves are required: isAnyLaunchActive() covers a sequence already
+    // inside launchProfileApps, while hasOtherActiveLaunchControllers() covers
+    // another handler still in its PRE-launch window — registered, but not yet
+    // in launchProfileApps, so activeLaunches is still empty (#716 review
+    // finding, inverse window).
+    if (isAnyLaunchActive() || hasOtherActiveLaunchControllers()) {
       return { success: false, error: 'Another profile is already launching.' }
     }
 
@@ -232,11 +239,14 @@ export function registerLaunchHandlers(): void {
 
       // Mirrors launchProfileApps' own entry gate, and must run BEFORE the
       // registerActiveLaunch below — same eviction reasoning as the
-      // relaunch-missing-profile handler above (#716 review finding). Bailing
-      // out here also means the switch never kills the outgoing profile's
-      // apps for a launch that could not proceed anyway. No await sits
-      // between this check and the registration, so the pair is atomic.
-      if (isAnyLaunchActive()) {
+      // relaunch-missing-profile handler above (#716 review finding), and the
+      // same two-half gate: hasOtherActiveLaunchControllers() catches another
+      // handler still in its pre-launch window, which isAnyLaunchActive()
+      // cannot see (activeLaunches fills only once launchProfileApps starts).
+      // Bailing out here also means the switch never kills the outgoing
+      // profile's apps for a launch that could not proceed anyway. No await
+      // sits between this check and the registration, so the pair is atomic.
+      if (isAnyLaunchActive() || hasOtherActiveLaunchControllers()) {
         return { success: false, error: 'Another profile is already launching.' }
       }
 

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -10,7 +10,9 @@ import {
   killProfileApps,
   launchProfileApps,
   readRunningProcessNames,
+  registerActiveLaunch,
   subscribeRunningApps,
+  unregisterActiveLaunch,
   unsubscribeRunningApps
 } from '../processes'
 import { KNOWN_GAME_KEYS, getStoredStringRecord } from '../store'
@@ -97,19 +99,38 @@ export function registerLaunchHandlers(): void {
       return { success: false, error: 'No executable paths configured for this profile.' }
     }
 
-    const { processNames } = await readRunningProcessNames()
-    const missingEntries = allEntries.filter((entry) => !isRunningExePath(processNames, entry.path))
+    // Registered BEFORE the tasklist scan below (not inside launchProfileApps,
+    // which only runs after it) so a Close Apps click landing during that scan
+    // has something to abort — otherwise the scan's await was a window where
+    // the click was a no-op and the sequence still launched with a fresh,
+    // un-aborted controller right after (#716, #670 residual).
+    const launchController = registerActiveLaunch(gameKey)
+    try {
+      const { processNames } = await readRunningProcessNames()
+      const missingEntries = allEntries.filter(
+        (entry) => !isRunningExePath(processNames, entry.path)
+      )
 
-    if (missingEntries.length === 0) {
-      return {
-        success: true,
-        message: 'All profile apps are already running.',
-        launchedCount: 0,
-        skippedCount: 0
+      if (missingEntries.length === 0) {
+        return {
+          success: true,
+          message: 'All profile apps are already running.',
+          launchedCount: 0,
+          skippedCount: 0
+        }
       }
-    }
 
-    return launchProfileApps(event.sender, gameKey, missingEntries)
+      // `await` (not a bare `return`) matters here: it keeps the controller
+      // registered until the sequence actually finishes, so the `finally`
+      // below doesn't unregister it out from under a still-running launch
+      // loop — which would make a Close Apps click during the loop itself a
+      // no-op again.
+      return await launchProfileApps(event.sender, gameKey, missingEntries, {
+        controller: launchController
+      })
+    } finally {
+      unregisterActiveLaunch(gameKey, launchController)
+    }
   })
 
   ipcMain.handle(
@@ -194,52 +215,75 @@ export function registerLaunchHandlers(): void {
       // move must still trigger a stop + relaunch even though the path is
       // unchanged.
       const toEntryIds = new Set(toEntries.map(getProfileLaunchEntryId))
-      const { processNames: processNamesBeforeSwitch } = await readRunningProcessNames()
 
-      const entriesToStop = fromEntries.filter(
-        (entry) =>
-          !toEntryIds.has(getProfileLaunchEntryId(entry)) &&
-          processNamesBeforeSwitch.has(getExeName(entry.path))
-      )
-      let killResult: KillResult | undefined
+      // Registered BEFORE the pre-switch scan below — covers that scan, the
+      // whole kill phase (killProfileApps can take seconds with WMI lookups),
+      // and the post-stop scan, all of which run before the launch call. A
+      // Close Apps click landing anywhere in that window used to find nothing
+      // registered to abort (#716, #670 residual).
+      const launchController = registerActiveLaunch(gameKey)
+      try {
+        const { processNames: processNamesBeforeSwitch } = await readRunningProcessNames()
 
-      if (entriesToStop.length > 0) {
-        killResult = await killProfileApps(
-          gameKey,
-          entriesToStop.map((entry) => entry.path)
+        const entriesToStop = fromEntries.filter(
+          (entry) =>
+            !toEntryIds.has(getProfileLaunchEntryId(entry)) &&
+            processNamesBeforeSwitch.has(getExeName(entry.path))
         )
-      }
+        let killResult: KillResult | undefined
 
-      const { processNames: processNamesAfterStop } = await readRunningProcessNames()
-      // If we just stopped a slot pointing at the same exe (different key
-      // and args), the incoming slot still needs to start with its own
-      // args — treat that exe as "needs to launch" regardless of post-kill
-      // tasklist state. Without this, a same-exe key swap would skip the
-      // relaunch and leave the old args active.
-      const stoppedExeNames = new Set(entriesToStop.map((entry) => getExeName(entry.path)))
-      const entriesToStart = toEntries.filter(
-        (entry) =>
-          stoppedExeNames.has(getExeName(entry.path)) ||
-          !processNamesAfterStop.has(getExeName(entry.path))
-      )
+        if (entriesToStop.length > 0) {
+          // `except: launchController` is the self-abort-trap fix: without
+          // it, this kill's own abortActiveLaunches(gameKey) call would
+          // cancel the switch's OWN registration above — the switch would
+          // then always report itself as cancelled, even with no Close Apps
+          // click involved.
+          killResult = await killProfileApps(
+            gameKey,
+            entriesToStop.map((entry) => entry.path),
+            { except: launchController }
+          )
+        }
 
-      if (entriesToStart.length === 0) {
+        const { processNames: processNamesAfterStop } = await readRunningProcessNames()
+        // If we just stopped a slot pointing at the same exe (different key
+        // and args), the incoming slot still needs to start with its own
+        // args — treat that exe as "needs to launch" regardless of post-kill
+        // tasklist state. Without this, a same-exe key swap would skip the
+        // relaunch and leave the old args active.
+        const stoppedExeNames = new Set(entriesToStop.map((entry) => getExeName(entry.path)))
+        const entriesToStart = toEntries.filter(
+          (entry) =>
+            stoppedExeNames.has(getExeName(entry.path)) ||
+            !processNamesAfterStop.has(getExeName(entry.path))
+        )
+
+        if (entriesToStart.length === 0) {
+          return {
+            success: true,
+            message: killResult?.message,
+            launchedCount: 0,
+            skippedCount: 0,
+            failedCount: killResult?.failedCount,
+            killFailures: killResult?.failures
+          }
+        }
+
+        // Sharing launchController here is what makes a Close Apps click
+        // landing during the pre-switch scan or the kill phase above actually
+        // stop profile B from launching — launchProfileApps checks the same
+        // signal before it spawns anything.
+        const launchResult = await launchProfileApps(event.sender, gameKey, entriesToStart, {
+          controller: launchController
+        })
+
         return {
-          success: true,
-          message: killResult?.message,
-          launchedCount: 0,
-          skippedCount: 0,
-          failedCount: killResult?.failedCount,
+          ...launchResult,
+          failedCount: (launchResult.failedCount || 0) + (killResult?.failedCount || 0),
           killFailures: killResult?.failures
         }
-      }
-
-      const launchResult = await launchProfileApps(event.sender, gameKey, entriesToStart)
-
-      return {
-        ...launchResult,
-        failedCount: (launchResult.failedCount || 0) + (killResult?.failedCount || 0),
-        killFailures: killResult?.failures
+      } finally {
+        unregisterActiveLaunch(gameKey, launchController)
       }
     }
   )

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -293,6 +293,25 @@ export function registerLaunchHandlers(): void {
         )
 
         if (entriesToStart.length === 0) {
+          // A Close Apps click during the pre-scan or the kill phase above
+          // aborts launchController. When profile B has apps to start, the
+          // launchProfileApps call below reports that abort as cancelled —
+          // this early return must do the same (mirroring launchProfileApps'
+          // exact cancelled shape), or a switch with nothing new to start
+          // would return plain success and the renderer would commit the
+          // profile switch the user just cancelled (#716 Codex P2).
+          if (launchController.signal.aborted) {
+            return {
+              success: false,
+              cancelled: true,
+              message: 'Launch cancelled — closed apps instead.',
+              launchedCount: 0,
+              skippedCount: 0,
+              failedCount: killResult?.failedCount,
+              killFailures: killResult?.failures
+            }
+          }
+
           return {
             success: true,
             message: killResult?.message,

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -5,6 +5,7 @@ import {
   type KillResult,
   type ProfileLaunchEntry,
   getRunningApps,
+  isAnyLaunchActive,
   isRunningExePath,
   killLaunchedApps,
   killProfileApps,
@@ -97,6 +98,19 @@ export function registerLaunchHandlers(): void {
 
     if (allEntries.length === 0) {
       return { success: false, error: 'No executable paths configured for this profile.' }
+    }
+
+    // Mirrors launchProfileApps' own entry gate, and must run BEFORE the
+    // registerActiveLaunch below: registerActiveLaunch overwrites per gameKey,
+    // so registering while a launch sequence is already mid-flight would EVICT
+    // that sequence's controller from the registry — this handler would then
+    // bounce off launchProfileApps' gate and its finally would delete its own
+    // controller, leaving the registry EMPTY while the first loop still runs,
+    // unreachable by Close Apps (the #670 bug class via a new path). There is
+    // no await between this check and the registration, so the event loop
+    // makes the check-then-register pair atomic.
+    if (isAnyLaunchActive()) {
+      return { success: false, error: 'Another profile is already launching.' }
     }
 
     // Registered BEFORE the tasklist scan below (not inside launchProfileApps,
@@ -215,6 +229,16 @@ export function registerLaunchHandlers(): void {
       // move must still trigger a stop + relaunch even though the path is
       // unchanged.
       const toEntryIds = new Set(toEntries.map(getProfileLaunchEntryId))
+
+      // Mirrors launchProfileApps' own entry gate, and must run BEFORE the
+      // registerActiveLaunch below — same eviction reasoning as the
+      // relaunch-missing-profile handler above (#716 review finding). Bailing
+      // out here also means the switch never kills the outgoing profile's
+      // apps for a launch that could not proceed anyway. No await sits
+      // between this check and the registration, so the pair is atomic.
+      if (isAnyLaunchActive()) {
+        return { success: false, error: 'Another profile is already launching.' }
+      }
 
       // Registered BEFORE the pre-switch scan below — covers that scan, the
       // whole kill phase (killProfileApps can take seconds with WMI lookups),

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -5,7 +5,12 @@ export {
   subscribeRunningApps,
   unsubscribeRunningApps
 } from './processes/running'
-export { dismissAppIcon, registerActiveLaunch, unregisterActiveLaunch } from './processes/state'
+export {
+  dismissAppIcon,
+  hasOtherActiveLaunchControllers,
+  registerActiveLaunch,
+  unregisterActiveLaunch
+} from './processes/state'
 export { launchProfileApps, isAnyLaunchActive, isRunningExePath } from './processes/spawn'
 export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -6,7 +6,7 @@ export {
   unsubscribeRunningApps
 } from './processes/running'
 export { dismissAppIcon, registerActiveLaunch, unregisterActiveLaunch } from './processes/state'
-export { launchProfileApps, isRunningExePath } from './processes/spawn'
+export { launchProfileApps, isAnyLaunchActive, isRunningExePath } from './processes/spawn'
 export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'
 export type {

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -5,7 +5,7 @@ export {
   subscribeRunningApps,
   unsubscribeRunningApps
 } from './processes/running'
-export { dismissAppIcon } from './processes/state'
+export { dismissAppIcon, registerActiveLaunch, unregisterActiveLaunch } from './processes/state'
 export { launchProfileApps, isRunningExePath } from './processes/spawn'
 export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -27,7 +27,7 @@ import {
 } from './state'
 import { publishRunningApps } from './running'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
-import type { KillFailure, KillFailureReason, KillResult } from './types'
+import type { KillFailure, KillFailureReason, KillProfileAppsOptions, KillResult } from './types'
 
 // Generous for a healthy system (the query usually returns in tens of ms) but
 // bounded so a wedged WMI service cannot hang a kill request forever.
@@ -657,7 +657,8 @@ export async function hasClosableLaunchedApps(gameKey?: string): Promise<boolean
 
 export async function killProfileApps(
   gameKey: string,
-  appPathsToKill: string[]
+  appPathsToKill: string[],
+  options?: KillProfileAppsOptions
 ): Promise<KillResult> {
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]
@@ -693,7 +694,13 @@ export async function killProfileApps(
   // but BEFORE the tasklist scan below: that await can be slow, and a launch
   // loop sitting in a short inter-app wait could otherwise spawn its next app
   // before the abort lands, leaving it running past this kill's snapshot.
-  abortActiveLaunches(gameKey)
+  //
+  // `options.except` is set by switch-profile-apps (#716): that handler
+  // registers its own controller before calling this to kill the outgoing
+  // profile's apps, and must not have that same call self-abort the switch
+  // it is in the middle of performing. A real Close Apps click never passes
+  // `except`, so it still cancels a switch's launch as before.
+  abortActiveLaunches(gameKey, options)
 
   const { processNames } = await readRunningProcessNames()
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -26,6 +26,7 @@ import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type {
   AppLaunchResult,
+  LaunchProfileAppsOptions,
   LaunchResult,
   ProfileLaunchEntry,
   ProfileLaunchInput,
@@ -47,7 +48,8 @@ let launchBlockedUntil = 0
 export async function launchProfileApps(
   sender: WebContents,
   gameKey: string,
-  profileApps: ProfileLaunchInput[]
+  profileApps: ProfileLaunchInput[],
+  options?: LaunchProfileAppsOptions
 ): Promise<LaunchResult> {
   if (activeLaunches.size > 0) {
     return { success: false, error: 'Another profile is already launching.' }
@@ -62,11 +64,12 @@ export async function launchProfileApps(
   }
 
   activeLaunches.add(gameKey)
-  // Registered for the duration of the sequence so killLaunchedApps/
-  // killProfileApps can cancel it mid-flight (#670). Deliberately separate
-  // from `activeLaunches` above, whose Set-of-gameKeys semantics only gate
-  // concurrent launches and stay untouched.
-  const launchController = registerActiveLaunch(gameKey)
+  // Use the caller's pre-registered controller when one is supplied — the
+  // two IPC flows with async work BEFORE this call (relaunch-missing-profile,
+  // switch-profile-apps) register early so a Close Apps click during that
+  // pre-launch window has something to abort (#716). Every other caller falls
+  // back to self-registration here, unchanged from #670.
+  const launchController = options?.controller ?? registerActiveLaunch(gameKey)
   let launchedAny = false
 
   // Everything from here runs under the finally — a throw anywhere below

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -17,6 +17,7 @@ import {
 
 import {
   consumeProcessNameMismatchWarningSuppression,
+  hasOtherActiveLaunchControllers,
   processNameMismatchWarnings,
   registerActiveLaunch,
   runningProcesses,
@@ -65,7 +66,18 @@ export async function launchProfileApps(
   profileApps: ProfileLaunchInput[],
   options?: LaunchProfileAppsOptions
 ): Promise<LaunchResult> {
-  if (activeLaunches.size > 0) {
+  // Two-part gate (#716 review finding). `activeLaunches` alone misses two
+  // windows where a relaunch/switch handler has REGISTERED its controller but
+  // not yet reached this function (its pre-launch scans / kill phase run
+  // first, and only this function fills `activeLaunches`):
+  //   (a) a plain launch-profile call landing in that window would pass an
+  //       activeLaunches-only gate and self-register below — evicting the
+  //       handler's controller from the registry, and
+  //   (b) the two handlers' own mirror of this gate has the same blind spot,
+  //       covered by the same registry check on their side.
+  // `options?.controller` as the `except` keeps a handler's own pre-registered
+  // controller from blocking the very launch it was registered for.
+  if (activeLaunches.size > 0 || hasOtherActiveLaunchControllers(options?.controller)) {
     return { success: false, error: 'Another profile is already launching.' }
   }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -45,6 +45,20 @@ const POST_LAUNCH_BLOCK_MS = 10000
 const PROCESS_NAME_MISMATCH_WARNING_CHANNEL = 'process-name-mismatch-warning'
 let launchBlockedUntil = 0
 
+/**
+ * Whether ANY launch sequence is currently in flight — the same condition as
+ * launchProfileApps' own entry gate below. Exposed for the IPC handlers that
+ * register their own cancellation controller BEFORE calling launchProfileApps
+ * (#716): they must mirror this gate before registering, because
+ * registerActiveLaunch overwrites per gameKey — registering while a sequence
+ * for the same gameKey is mid-flight would EVICT that sequence's controller
+ * from the registry, leaving its still-running loop unreachable by Close Apps
+ * (the #670 bug class, via a new path).
+ */
+export function isAnyLaunchActive(): boolean {
+  return activeLaunches.size > 0
+}
+
 export async function launchProfileApps(
   sender: WebContents,
   gameKey: string,

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { getExeName, normalizePathForComparison } from '../utils'
 
 import type {
+  KillProfileAppsOptions,
   ProcessNameMismatchWarningEntry,
   RunningProcessEntry,
   UnclosedProcessEntry
@@ -43,12 +44,23 @@ export function unregisterActiveLaunch(gameKey: string, controller: AbortControl
  * any kill work, so a launch loop already mid-sequence cannot spawn the next
  * queued app during or after the kill (#670).
  *
+ * `options.except` skips one specific controller regardless of which gameKey
+ * it is registered under. This is for a caller that registered its OWN
+ * controller before doing kill work as part of a launch sequence it is
+ * itself orchestrating (`switch-profile-apps`, #716) — without it, that
+ * kill's own `abortActiveLaunches(gameKey)` call would self-abort the very
+ * sequence it belongs to. A real Close Apps click never passes `except`, so
+ * it still aborts everything as before.
+ *
  * `AbortController.abort()` is itself idempotent (a second call is a no-op),
  * so this is safe to call on every kill request even when nothing is
  * currently launching for the target gameKey.
  */
-export function abortActiveLaunches(gameKey?: string): void {
+export function abortActiveLaunches(gameKey?: string, options?: KillProfileAppsOptions): void {
   activeLaunchControllers.forEach((controller, key) => {
+    if (controller === options?.except) {
+      return
+    }
     if (gameKey === undefined || key === gameKey) {
       controller.abort()
     }

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -38,6 +38,28 @@ export function unregisterActiveLaunch(gameKey: string, controller: AbortControl
 }
 
 /**
+ * Whether the registry holds any controller other than `except`. This is the
+ * second half of the launch gate (#716 review finding): spawn.ts's
+ * `activeLaunches` Set only fills once launchProfileApps starts, but the
+ * relaunch/switch IPC handlers register their controller BEFORE their
+ * pre-launch async work (tasklist scans, the switch's kill phase). During
+ * that window `activeLaunches` is still empty, so any gate reading only it
+ * would let a competing launch through — whose registration would then evict
+ * the first handler's controller from this registry, leaving its sequence
+ * unreachable by Close Apps. `except` lets launchProfileApps' own gate skip
+ * the caller's own threaded-through controller, so a handler's launch is not
+ * blocked by its own registration.
+ */
+export function hasOtherActiveLaunchControllers(except?: AbortController): boolean {
+  for (const controller of activeLaunchControllers.values()) {
+    if (controller !== except) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Abort the in-flight launch sequence for `gameKey`, or every in-flight
  * sequence when `gameKey` is undefined (the tray/global "close everything"
  * kill has no single gameKey to target). Called from kill.ts before it does

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -64,6 +64,30 @@ export interface KillResult {
   failures: KillFailure[]
 }
 
+/**
+ * Options threaded into `launchProfileApps` by a caller that has already
+ * registered its own cancellation token before the sequence starts. The two
+ * IPC flows with async work ahead of the launch call (`relaunch-missing-profile`,
+ * `switch-profile-apps` — see `ipc/launch.ts`) register early so a Close Apps
+ * click during that pre-launch window has something to abort (#716). When
+ * omitted, `launchProfileApps` registers its own controller, unchanged from
+ * #670.
+ */
+export interface LaunchProfileAppsOptions {
+  controller?: AbortController
+}
+
+/**
+ * Options threaded into `killProfileApps` so a caller that has already
+ * registered its OWN in-flight launch controller for the same `gameKey` (the
+ * `switch-profile-apps` handler, mid-switch) can kill the outgoing profile's
+ * apps without self-aborting that registration (#716) — see
+ * `abortActiveLaunches`'s `except` parameter.
+ */
+export interface KillProfileAppsOptions {
+  except?: AbortController
+}
+
 export type AppLaunchResult =
   | { status: 'launched'; appPath: string }
   | { status: 'elevated'; appPath: string; warning: string }

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -14,6 +14,9 @@ const buildNamedProfileLaunchEntries = vi.fn()
 // so they need the actual AbortController bookkeeping, not a mock of it.
 const registerActiveLaunch = vi.fn()
 const unregisterActiveLaunch = vi.fn()
+// Models spawn.ts's `activeLaunches.size > 0` gate. Default false (nothing in
+// flight); the eviction-guard regression tests below flip it to true.
+const isAnyLaunchActive = vi.fn(() => false)
 
 const GAME_ENTRY = { key: 'iracing', path: 'C:/Games/iRacingUI.exe' }
 const SIMHUB_ENTRY = { key: 'simhub', path: 'C:/Tools/SimHub.exe' }
@@ -51,7 +54,8 @@ async function loadLaunchHandlers() {
     subscribeRunningApps: vi.fn(),
     unsubscribeRunningApps: vi.fn(),
     registerActiveLaunch,
-    unregisterActiveLaunch
+    unregisterActiveLaunch,
+    isAnyLaunchActive
   }
   vi.doMock('../processes', () => processesMock)
   vi.doMock('/src/main/processes.ts', () => processesMock)
@@ -87,6 +91,7 @@ const event = { sender }
 beforeEach(() => {
   vi.resetModules()
   vi.clearAllMocks()
+  isAnyLaunchActive.mockReturnValue(false)
   readRunningProcessNames.mockResolvedValue({ processNames: new Set(), succeeded: true })
   launchProfileApps.mockResolvedValue({ success: true, launchedCount: 1, skippedCount: 0 })
   killProfileApps.mockResolvedValue({
@@ -244,6 +249,88 @@ test('relaunch-missing-profile keeps its controller registered until launchProfi
   await resultPromise
 
   expect(unregisterActiveLaunch).toHaveBeenCalled()
+})
+
+// #716 review finding (registry eviction): the handlers register BEFORE
+// launchProfileApps' `activeLaunches.size > 0` gate ever runs. Without their
+// own mirror of that gate, a second request for the same gameKey while a
+// launch is already in flight would registerActiveLaunch → EVICT the
+// in-flight sequence's controller from the registry, then bounce off the
+// gate, then its finally would delete its own controller — leaving the
+// registry EMPTY while the first launch loop still runs. A Close Apps click
+// after that finds nothing to abort: the #670 bug class, reintroduced via a
+// new path. The handler must bail out via isAnyLaunchActive() BEFORE
+// registering.
+test('relaunch-missing-profile while a launch is in flight does not evict the in-flight controller', async () => {
+  const handlers = await loadLaunchHandlers()
+  const state = await import('../../src/main/processes/state')
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+
+  // The in-flight launch loop's own controller (what spawn.ts registered).
+  const inFlight = state.registerActiveLaunch('iracing')
+  isAnyLaunchActive.mockReturnValue(true)
+  // Faithful to the real gate: launchProfileApps would refuse anyway. The
+  // point of this test is that the handler must never get far enough to
+  // evict `inFlight` from the registry on the way to that refusal.
+  launchProfileApps.mockResolvedValue({
+    success: false,
+    error: 'Another profile is already launching.'
+  })
+
+  try {
+    await expect(handlers['relaunch-missing-profile'](event, 'iracing')).resolves.toEqual({
+      success: false,
+      error: 'Another profile is already launching.'
+    })
+
+    // The handler must not have registered (and thus evicted) anything...
+    expect(registerActiveLaunch).not.toHaveBeenCalled()
+    // ...so a Close Apps click still reaches the in-flight launch loop.
+    state.abortActiveLaunches('iracing')
+    expect(inFlight.signal.aborted).toBe(true)
+  } finally {
+    state.unregisterActiveLaunch('iracing', inFlight)
+  }
+})
+
+test('switch-profile-apps while a launch is in flight does not evict the in-flight controller', async () => {
+  const handlers = await loadLaunchHandlers()
+  const state = await import('../../src/main/processes/state')
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+
+  const inFlight = state.registerActiveLaunch('iracing')
+  isAnyLaunchActive.mockReturnValue(true)
+  launchProfileApps.mockResolvedValue({
+    success: false,
+    error: 'Another profile is already launching.'
+  })
+
+  try {
+    await expect(
+      handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+    ).resolves.toEqual({
+      success: false,
+      error: 'Another profile is already launching.'
+    })
+
+    expect(registerActiveLaunch).not.toHaveBeenCalled()
+    // The bail-out must also come before the kill phase: killing the outgoing
+    // profile's apps as part of a switch that can never proceed would leave
+    // the user with apps closed and nothing started.
+    expect(killProfileApps).not.toHaveBeenCalled()
+    state.abortActiveLaunches('iracing')
+    expect(inFlight.signal.aborted).toBe(true)
+  } finally {
+    state.unregisterActiveLaunch('iracing', inFlight)
+  }
 })
 
 // THE profile-switch invariant: switching profiles mid-session must never

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -55,7 +55,12 @@ async function loadLaunchHandlers() {
     unsubscribeRunningApps: vi.fn(),
     registerActiveLaunch,
     unregisterActiveLaunch,
-    isAnyLaunchActive
+    isAnyLaunchActive,
+    // Real implementation, resolved lazily so the handlers' second gate half
+    // reads the same registry the tests pre-register controllers into (#716
+    // inverse window).
+    hasOtherActiveLaunchControllers: (except?: AbortController) =>
+      stateModule.hasOtherActiveLaunchControllers(except)
   }
   vi.doMock('../processes', () => processesMock)
   vi.doMock('/src/main/processes.ts', () => processesMock)
@@ -325,6 +330,70 @@ test('switch-profile-apps while a launch is in flight does not evict the in-flig
     // The bail-out must also come before the kill phase: killing the outgoing
     // profile's apps as part of a switch that can never proceed would leave
     // the user with apps closed and nothing started.
+    expect(killProfileApps).not.toHaveBeenCalled()
+    state.abortActiveLaunches('iracing')
+    expect(inFlight.signal.aborted).toBe(true)
+  } finally {
+    state.unregisterActiveLaunch('iracing', inFlight)
+  }
+})
+
+// #716 review finding, INVERSE window of the isAnyLaunchActive guard: during
+// another handler's pre-launch async window (relaunch's scan / the switch's
+// kill phase) the controller IS registered but launchProfileApps has not
+// started yet — spawn.ts's activeLaunches Set is still empty, so
+// isAnyLaunchActive() reports false. A second relaunch/switch for the same
+// game used to pass the guard on that alone and registerActiveLaunch would
+// evict the first handler's controller: Close Apps then aborted only the
+// newer one and the first sequence still proceeded to launch. The gate must
+// also count pre-registered controllers (hasOtherActiveLaunchControllers).
+test('relaunch-missing-profile is rejected while another handler is in its pre-launch window (no eviction)', async () => {
+  const handlers = await loadLaunchHandlers()
+  const state = await import('../../src/main/processes/state')
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+
+  // Another handler's pre-launch window: registered, but no active launch —
+  // isAnyLaunchActive stays at its default false. That's the whole point.
+  const inFlight = state.registerActiveLaunch('iracing')
+
+  try {
+    await expect(handlers['relaunch-missing-profile'](event, 'iracing')).resolves.toEqual({
+      success: false,
+      error: 'Another profile is already launching.'
+    })
+
+    expect(registerActiveLaunch).not.toHaveBeenCalled()
+    state.abortActiveLaunches('iracing')
+    expect(inFlight.signal.aborted).toBe(true)
+  } finally {
+    state.unregisterActiveLaunch('iracing', inFlight)
+  }
+})
+
+test('switch-profile-apps is rejected while another handler is in its pre-launch window (no eviction)', async () => {
+  const handlers = await loadLaunchHandlers()
+  const state = await import('../../src/main/processes/state')
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+
+  const inFlight = state.registerActiveLaunch('iracing')
+
+  try {
+    await expect(
+      handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+    ).resolves.toEqual({
+      success: false,
+      error: 'Another profile is already launching.'
+    })
+
+    expect(registerActiveLaunch).not.toHaveBeenCalled()
     expect(killProfileApps).not.toHaveBeenCalled()
     state.abortActiveLaunches('iracing')
     expect(inFlight.signal.aborted).toBe(true)

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -487,6 +487,58 @@ test('switch-profile-apps honors a Close Apps click landing during its own kill 
   })
 })
 
+// #716 Codex P2: the entries-to-start === 0 early-success return never
+// checked the abort signal. A Close Apps click during the pre-scan or the
+// kill phase, on a switch where profile B has nothing new to start, returned
+// plain success — and the renderer committed the profile switch the user had
+// just cancelled. Inconsistent with the has-apps-to-start path, which reports
+// the same abort as cancelled via launchProfileApps.
+test('switch-profile-apps with nothing to start reports cancelled when Close Apps aborted mid-switch', async () => {
+  const handlers = await loadLaunchHandlers()
+  const state = await import('../../src/main/processes/state')
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  // Profile B carries only the game exe, which the handler filters out of the
+  // switch — so entriesToStart is guaranteed empty and the early return runs.
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+
+  let resolveKill!: (value: {
+    success: boolean
+    closedCount: number
+    failedCount: number
+    failures: unknown[]
+  }) => void
+  killProfileApps.mockReturnValue(
+    new Promise((resolve) => {
+      resolveKill = resolve
+    })
+  )
+
+  const resultPromise = handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+
+  // Let the handler reach the kill phase, then land the Close Apps abort
+  // while the kill is still pending.
+  await flushMicrotasks()
+  state.abortActiveLaunches('iracing')
+  resolveKill({ success: true, closedCount: 1, failedCount: 0, failures: [] })
+
+  // Must be the same cancelled shape launchProfileApps produces on abort —
+  // NOT success — so the renderer's `result.cancelled` branch handles both
+  // paths identically and does not commit the cancelled switch.
+  await expect(resultPromise).resolves.toMatchObject({
+    success: false,
+    cancelled: true,
+    message: 'Launch cancelled — closed apps instead.',
+    launchedCount: 0
+  })
+  expect(launchProfileApps).not.toHaveBeenCalled()
+})
+
 // #716: the entries-to-start === 0 branch returns before ever calling
 // launchProfileApps (nothing new needs to start), so — like the analogous
 // relaunch-missing-profile no-op path — the handler itself must release the

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -7,6 +7,13 @@ const killProfileApps = vi.fn()
 const readRunningProcessNames = vi.fn()
 const buildActiveProfileLaunchEntries = vi.fn()
 const buildNamedProfileLaunchEntries = vi.fn()
+// Backed by the REAL src/main/processes/state.ts implementation (assigned in
+// loadLaunchHandlers below) rather than a bare vi.fn() stub — these tests are
+// about the IPC handlers' registration/cancellation WIRING (#716: the two
+// pre-launch windows where a Close Apps click used to find nothing to abort),
+// so they need the actual AbortController bookkeeping, not a mock of it.
+const registerActiveLaunch = vi.fn()
+const unregisterActiveLaunch = vi.fn()
 
 const GAME_ENTRY = { key: 'iracing', path: 'C:/Games/iRacingUI.exe' }
 const SIMHUB_ENTRY = { key: 'simhub', path: 'C:/Tools/SimHub.exe' }
@@ -16,9 +23,22 @@ function exeNameOf(appPath: string) {
   return appPath.split(/[\\/]/).pop()!.toLowerCase()
 }
 
+// Flushes the microtask queue via a macrotask boundary (setImmediate always
+// runs after every microtask already queued). Used to let an IPC handler
+// advance past a real `await` (e.g. readRunningProcessNames' default resolved
+// mock) up to its next call, so a test can land an abort exactly inside a
+// specific pre-launch window (#716).
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
 async function loadLaunchHandlers() {
   const { clearIpcHandlers } = await import('electron')
   ;(clearIpcHandlers as () => void)()
+
+  const stateModule = await import('../../src/main/processes/state')
+  registerActiveLaunch.mockImplementation(stateModule.registerActiveLaunch)
+  unregisterActiveLaunch.mockImplementation(stateModule.unregisterActiveLaunch)
 
   const processesMock = {
     launchProfileApps,
@@ -29,7 +49,9 @@ async function loadLaunchHandlers() {
       processNames.has(exeNameOf(appPath)),
     getRunningApps: vi.fn(async () => []),
     subscribeRunningApps: vi.fn(),
-    unsubscribeRunningApps: vi.fn()
+    unsubscribeRunningApps: vi.fn(),
+    registerActiveLaunch,
+    unregisterActiveLaunch
   }
   vi.doMock('../processes', () => processesMock)
   vi.doMock('/src/main/processes.ts', () => processesMock)
@@ -121,7 +143,14 @@ test('relaunch-missing-profile launches only entries that are not running', asyn
 
   await handlers['relaunch-missing-profile'](event, 'iracing')
 
-  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [GAME_ENTRY, CREWCHIEF_ENTRY])
+  // #716: registered BEFORE the tasklist scan above, and threaded through so
+  // launchProfileApps shares it instead of minting its own fresh (never
+  // aborted) controller.
+  expect(registerActiveLaunch).toHaveBeenCalledWith('iracing')
+  const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [GAME_ENTRY, CREWCHIEF_ENTRY], {
+    controller
+  })
 })
 
 test('relaunch-missing-profile is a no-op when everything is already running', async () => {
@@ -139,6 +168,82 @@ test('relaunch-missing-profile is a no-op when everything is already running', a
     skippedCount: 0
   })
   expect(launchProfileApps).not.toHaveBeenCalled()
+  // #716: this early return (nothing to relaunch) never reaches
+  // launchProfileApps, which is the only other place that unregisters the
+  // controller — the handler itself must release it here, or a Close Apps
+  // click after this call keeps "finding" a controller for an already-ended
+  // relaunch attempt.
+  expect(registerActiveLaunch).toHaveBeenCalledWith('iracing')
+  const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
+  expect(unregisterActiveLaunch).toHaveBeenCalledWith('iracing', controller)
+})
+
+// #716 regression: Close Apps landing during the pre-scan tasklist read (the
+// `await readRunningProcessNames()` above the launchProfileApps call) used to
+// have nothing registered yet to abort — the sequence would then launch with
+// a fresh, un-aborted controller right after the user asked to close
+// everything. registerActiveLaunch must run BEFORE that scan so the abort
+// lands on a real registration.
+test('relaunch-missing-profile honors a Close Apps click landing during its pre-scan', async () => {
+  const handlers = await loadLaunchHandlers()
+  const { abortActiveLaunches } = await import('../../src/main/processes/state')
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+
+  let resolveScan!: (value: { processNames: Set<string>; succeeded: boolean }) => void
+  readRunningProcessNames.mockReturnValue(
+    new Promise((resolve) => {
+      resolveScan = resolve
+    })
+  )
+  // Models launchProfileApps' real documented contract (already covered end
+  // to end in tests/main/processes.test.ts): it must not spawn anything once
+  // the shared controller is aborted, and must report `cancelled: true`.
+  launchProfileApps.mockImplementation(async (_s, _k, entries, options) => {
+    if (options?.controller?.signal.aborted) {
+      return { success: false, cancelled: true, launchedCount: 0 }
+    }
+    return { success: true, launchedCount: entries.length, skippedCount: 0 }
+  })
+
+  const resultPromise = handlers['relaunch-missing-profile'](event, 'iracing')
+
+  // registerActiveLaunch runs synchronously before the pre-scan await, so by
+  // this point (still in the same tick) there is already something for a
+  // real Close Apps click to abort.
+  abortActiveLaunches('iracing')
+  resolveScan({ processNames: new Set(), succeeded: true })
+
+  await expect(resultPromise).resolves.toMatchObject({ success: false, cancelled: true })
+})
+
+// #716 regression: the IPC handler's own controller bookkeeping must not race
+// ahead of launchProfileApps actually finishing. `return launchProfileApps(...)`
+// (no `await`) would run the handler's finally as soon as the promise is
+// obtained — unregistering the controller from the registry WHILE the launch
+// loop is still using it, making a Close Apps click during the loop a no-op
+// again for the remainder of the sequence.
+test('relaunch-missing-profile keeps its controller registered until launchProfileApps actually finishes', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+  readRunningProcessNames.mockResolvedValue({ processNames: new Set(), succeeded: true })
+
+  let resolveLaunch!: (value: unknown) => void
+  launchProfileApps.mockReturnValue(
+    new Promise((resolve) => {
+      resolveLaunch = resolve
+    })
+  )
+
+  const resultPromise = handlers['relaunch-missing-profile'](event, 'iracing')
+  await flushMicrotasks()
+
+  expect(launchProfileApps).toHaveBeenCalled()
+  expect(unregisterActiveLaunch).not.toHaveBeenCalled()
+
+  resolveLaunch({ success: true, launchedCount: 2, skippedCount: 0 })
+  await resultPromise
+
+  expect(unregisterActiveLaunch).toHaveBeenCalled()
 })
 
 // THE profile-switch invariant: switching profiles mid-session must never
@@ -160,8 +265,92 @@ test('switch-profile-apps never kills or relaunches the game executable', async 
   }
 
   expect(result.success).toBe(true)
-  expect(killProfileApps).toHaveBeenCalledWith('iracing', [utilA.path])
-  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [utilB])
+  // #716: the switch registers its OWN controller before doing any of its
+  // async pre-launch work, and must pass it as `except` to its own
+  // killProfileApps call — otherwise that call's abortActiveLaunches(gameKey)
+  // would self-abort the switch it is in the middle of performing (the
+  // "self-abort trap" from the issue's fix sketch). The SAME controller is
+  // then threaded into launchProfileApps for the incoming profile.
+  expect(registerActiveLaunch).toHaveBeenCalledWith('iracing')
+  const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
+  expect(controller.signal.aborted).toBe(false)
+  expect(killProfileApps).toHaveBeenCalledWith('iracing', [utilA.path], { except: controller })
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [utilB], { controller })
+  expect(unregisterActiveLaunch).toHaveBeenCalledWith('iracing', controller)
+})
+
+// #716 regression: Close Apps landing during the switch's OWN kill phase
+// (killProfileApps stopping the outgoing profile's apps, which the issue
+// calls out as potentially taking seconds via WMI lookups) used to have no
+// effect on the switch already in flight — profile B would still launch
+// right after. The switch's controller must still be shared with
+// launchProfileApps so that check catches it.
+test('switch-profile-apps honors a Close Apps click landing during its own kill phase', async () => {
+  const handlers = await loadLaunchHandlers()
+  const { abortActiveLaunches } = await import('../../src/main/processes/state')
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+
+  let resolveKill!: (value: {
+    success: boolean
+    closedCount: number
+    failedCount: number
+    failures: unknown[]
+  }) => void
+  killProfileApps.mockReturnValue(
+    new Promise((resolve) => {
+      resolveKill = resolve
+    })
+  )
+  launchProfileApps.mockImplementation(async (_s, _k, entries, options) => {
+    if (options?.controller?.signal.aborted) {
+      return { success: false, cancelled: true, launchedCount: 0 }
+    }
+    return { success: true, launchedCount: entries.length, skippedCount: 0 }
+  })
+
+  const resultPromise = handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+
+  // Let the handler reach and call killProfileApps (the "kill phase") before
+  // landing the abort — a real Close Apps click while that call is still
+  // pending must still stop profile B from launching once it resolves.
+  await flushMicrotasks()
+  abortActiveLaunches('iracing')
+  resolveKill({ success: true, closedCount: 1, failedCount: 0, failures: [] })
+
+  await expect(resultPromise).resolves.toMatchObject({ success: false, cancelled: true })
+  expect(launchProfileApps).not.toHaveBeenCalledWith(sender, 'iracing', [utilB], {
+    controller: expect.objectContaining({ signal: expect.objectContaining({ aborted: false }) })
+  })
+})
+
+// #716: the entries-to-start === 0 branch returns before ever calling
+// launchProfileApps (nothing new needs to start), so — like the analogous
+// relaunch-missing-profile no-op path — the handler itself must release the
+// controller it registered up front.
+test('switch-profile-apps unregisters its controller when nothing new needs to start', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY] : [GAME_ENTRY]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe']),
+    succeeded: true
+  })
+
+  await handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+
+  expect(launchProfileApps).not.toHaveBeenCalled()
+  expect(registerActiveLaunch).toHaveBeenCalledWith('iracing')
+  const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
+  expect(unregisterActiveLaunch).toHaveBeenCalledWith('iracing', controller)
 })
 
 test('get-profile-switch-diff counts stops/starts without the game executable', async () => {

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -98,8 +98,11 @@ vi.mock('../../src/main/processes', async () => {
     registerActiveLaunch: state.registerActiveLaunch,
     unregisterActiveLaunch: state.unregisterActiveLaunch,
     // These tests never simulate a concurrent in-flight launch, so the
-    // handlers' eviction guard (#716 review finding) always passes.
-    isAnyLaunchActive: () => false
+    // handlers' eviction guard (#716 review finding) always passes. The
+    // registry half of the gate reads the real (empty-at-handler-entry)
+    // registry, so it passes too.
+    isAnyLaunchActive: () => false,
+    hasOtherActiveLaunchControllers: state.hasOtherActiveLaunchControllers
   }
 })
 

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -96,7 +96,10 @@ vi.mock('../../src/main/processes', async () => {
     subscribeRunningApps: vi.fn(),
     unsubscribeRunningApps: vi.fn(),
     registerActiveLaunch: state.registerActiveLaunch,
-    unregisterActiveLaunch: state.unregisterActiveLaunch
+    unregisterActiveLaunch: state.unregisterActiveLaunch,
+    // These tests never simulate a concurrent in-flight launch, so the
+    // handlers' eviction guard (#716 review finding) always passes.
+    isAnyLaunchActive: () => false
   }
 })
 

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -26,9 +26,16 @@ const mocks = vi.hoisted(() => ({
     async () => ({ processNames: new Set<string>(), succeeded: true })
   ),
   launchProfileApps: vi.fn<
-    (sender: WebContents, gameKey: string, entries: ProfileLaunchInput[]) => Promise<unknown>
+    (
+      sender: WebContents,
+      gameKey: string,
+      entries: ProfileLaunchInput[],
+      options?: { controller?: AbortController }
+    ) => Promise<unknown>
   >(async () => ({ success: true, launchedCount: 0, skippedCount: 0 })),
-  killProfileApps: vi.fn<(gameKey: string, paths: string[]) => Promise<unknown>>(async () => ({
+  killProfileApps: vi.fn<
+    (gameKey: string, paths: string[], options?: { except?: AbortController }) => Promise<unknown>
+  >(async () => ({
     success: true,
     closedCount: 0,
     failedCount: 0,
@@ -61,18 +68,37 @@ vi.mock('../../src/main/profiles', () => ({
     mocks.buildNamedProfileLaunchEntries(gameKey, profileId)
 }))
 
-vi.mock('../../src/main/processes', () => ({
-  readRunningProcessNames: () => mocks.readRunningProcessNames(),
-  launchProfileApps: (sender: WebContents, gameKey: string, entries: ProfileLaunchInput[]) =>
-    mocks.launchProfileApps(sender, gameKey, entries),
-  killProfileApps: (gameKey: string, paths: string[]) => mocks.killProfileApps(gameKey, paths),
-  killLaunchedApps: vi.fn(),
-  getRunningApps: vi.fn(),
-  isRunningExePath: (processNames: Set<string>, appPath: string) =>
-    processNames.has(appPath.split(/[\\/]/).pop()?.toLowerCase() ?? ''),
-  subscribeRunningApps: vi.fn(),
-  unsubscribeRunningApps: vi.fn()
-}))
+vi.mock('../../src/main/processes', async () => {
+  // registerActiveLaunch/unregisterActiveLaunch are backed by the REAL
+  // src/main/processes/state.ts implementation rather than bare vi.fn()
+  // stubs — the switch-profile-apps tests below assert on the exact
+  // controller threaded through killProfileApps' `except` option and
+  // launchProfileApps' `controller` option (#716), which needs a real
+  // AbortController, not a mock return value.
+  const state = await vi.importActual<typeof import('../../src/main/processes/state')>(
+    '../../src/main/processes/state'
+  )
+
+  return {
+    readRunningProcessNames: () => mocks.readRunningProcessNames(),
+    launchProfileApps: (
+      sender: WebContents,
+      gameKey: string,
+      entries: ProfileLaunchInput[],
+      options?: { controller?: AbortController }
+    ) => mocks.launchProfileApps(sender, gameKey, entries, options),
+    killProfileApps: (gameKey: string, paths: string[], options?: { except?: AbortController }) =>
+      mocks.killProfileApps(gameKey, paths, options),
+    killLaunchedApps: vi.fn(),
+    getRunningApps: vi.fn(),
+    isRunningExePath: (processNames: Set<string>, appPath: string) =>
+      processNames.has(appPath.split(/[\\/]/).pop()?.toLowerCase() ?? ''),
+    subscribeRunningApps: vi.fn(),
+    unsubscribeRunningApps: vi.fn(),
+    registerActiveLaunch: state.registerActiveLaunch,
+    unregisterActiveLaunch: state.unregisterActiveLaunch
+  }
+})
 
 vi.mock('../../src/main/utils', () => {
   const normalizePathForComparison = (p: unknown) =>
@@ -238,10 +264,17 @@ test('switch-profile-apps stops and relaunches when a slot moves to a new key bu
   const sender = { isDestroyed: () => false, send: vi.fn() } as unknown as WebContents
   await handler({ sender } as never, 'ac', 'from', 'to')
 
-  expect(mocks.killProfileApps).toHaveBeenCalledWith('ac', ['C:/Tools/Shared Utility.exe'])
-  expect(mocks.launchProfileApps).toHaveBeenCalledWith(sender, 'ac', [
-    { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
-  ])
+  expect(mocks.killProfileApps).toHaveBeenCalledWith(
+    'ac',
+    ['C:/Tools/Shared Utility.exe'],
+    expect.objectContaining({ except: expect.any(AbortController) })
+  )
+  expect(mocks.launchProfileApps).toHaveBeenCalledWith(
+    sender,
+    'ac',
+    [{ key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }],
+    expect.objectContaining({ controller: expect.any(AbortController) })
+  )
 })
 
 test('switch-profile-apps relaunches the incoming slot even when its exe is still in tasklist after the kill', async () => {
@@ -272,9 +305,12 @@ test('switch-profile-apps relaunches the incoming slot even when its exe is stil
   const sender = { isDestroyed: () => false, send: vi.fn() } as unknown as WebContents
   await handler({ sender } as never, 'ac', 'from', 'to')
 
-  expect(mocks.launchProfileApps).toHaveBeenCalledWith(sender, 'ac', [
-    { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
-  ])
+  expect(mocks.launchProfileApps).toHaveBeenCalledWith(
+    sender,
+    'ac',
+    [{ key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }],
+    expect.objectContaining({ controller: expect.any(AbortController) })
+  )
 })
 
 test('switch-profile-apps treats unchanged {key, path} entries as no-op', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -426,6 +426,9 @@ async function loadProcessModules() {
     finalizeKillAttempts: killModule.finalizeKillAttempts,
     pruneUnclosedProcesses: killModule.pruneUnclosedProcesses,
     dismissAppIcon: stateModule.dismissAppIcon,
+    registerActiveLaunch: stateModule.registerActiveLaunch,
+    unregisterActiveLaunch: stateModule.unregisterActiveLaunch,
+    abortActiveLaunches: stateModule.abortActiveLaunches,
     processNameMismatchWarnings: stateModule.processNameMismatchWarnings,
     suppressedProcessNameMismatchWarnings: stateModule.suppressedProcessNameMismatchWarnings,
     runningProcesses: stateModule.runningProcesses,
@@ -2172,6 +2175,55 @@ test('concurrent launchProfileApps rejects with the active-launch message (#342)
   // Release the first launch so the test does not leak the active-launch flag.
   childHandlers.get('spawn')?.()
   await firstLaunch
+})
+
+// #716 review finding (inverse window): a plain launch-profile call landing
+// while a relaunch/switch IPC handler is still in its pre-launch async window
+// (its controller registered via registerActiveLaunch, but launchProfileApps
+// not yet entered — so activeLaunches is still EMPTY) used to pass the
+// activeLaunches gate and SELF-REGISTER for the same gameKey, evicting the
+// handler's controller from the registry. Close Apps then aborted only the
+// newer controller and the handler's sequence still proceeded. The gate must
+// also count pre-registered controllers.
+test('launchProfileApps is rejected while a foreign launch controller is pre-registered (#716)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps, registerActiveLaunch, unregisterActiveLaunch, abortActiveLaunches } =
+    await loadProcessModules()
+
+  // Models an IPC handler mid pre-launch window for the same game.
+  const preRegistered = registerActiveLaunch('ac')
+
+  try {
+    await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toEqual({
+      success: false,
+      error: 'Another profile is already launching.'
+    })
+
+    // Nothing spawned, and the handler's controller was NOT evicted — a
+    // Close Apps click still reaches it.
+    expect(spawnCalls).toHaveLength(0)
+    abortActiveLaunches('ac')
+    expect(preRegistered.signal.aborted).toBe(true)
+  } finally {
+    unregisterActiveLaunch('ac', preRegistered)
+  }
+})
+
+// Positive control for the gate above: the controller threaded through
+// options IS the pre-registered one, so it must not block its own launch —
+// otherwise the relaunch/switch handlers could never launch at all.
+test('launchProfileApps with its own pre-registered controller via options is not self-blocked (#716)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps, registerActiveLaunch } = await loadProcessModules()
+
+  const controller = registerActiveLaunch('ac')
+
+  await expect(
+    launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'], { controller })
+  ).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
 })
 
 test('rapid re-launch within the cooldown window returns the settling message (#342)', async () => {

--- a/tests/main/state.test.ts
+++ b/tests/main/state.test.ts
@@ -2,16 +2,19 @@ import type { ChildProcess } from 'child_process'
 import { beforeEach, expect, test } from 'vitest'
 
 import {
+  abortActiveLaunches,
   consumeProcessNameMismatchWarningSuppression,
   dismissAppIcon,
   getUnclosedProcessKey,
   processNameMismatchWarnings,
   pruneExpiredProcessNameMismatchWarnings,
   pruneStoppedRunningProcesses,
+  registerActiveLaunch,
   runningProcesses,
   suppressProcessNameMismatchWarning,
   suppressedProcessNameMismatchWarnings,
-  unclosedProcesses
+  unclosedProcesses,
+  unregisterActiveLaunch
 } from '../../src/main/processes/state'
 import { normalizePathForComparison } from '../../src/main/utils'
 
@@ -108,4 +111,35 @@ test('dismissAppIcon clears both the mismatch warning and the unclosed entry for
   expect(processNameMismatchWarnings.size).toBe(0)
   // Only the matching game's unclosed entry is dismissed.
   expect([...unclosedProcesses.keys()]).toEqual([getUnclosedProcessKey('acc', appPath, 'foo.exe')])
+})
+
+// #716: switch-profile-apps registers its OWN launch controller before it
+// kills the outgoing profile's apps, and passes that same controller as
+// `except` to killProfileApps so its own kill step doesn't self-abort the
+// switch it is in the middle of performing (the "self-abort trap" named in
+// the issue's fix sketch). A real user's Close Apps click never passes
+// `except`, so it must still abort everything as before.
+test('abortActiveLaunches skips the except controller but still aborts every other one', () => {
+  const ownSwitchController = registerActiveLaunch('iracing')
+  const unrelatedController = registerActiveLaunch('acc')
+
+  try {
+    abortActiveLaunches('iracing', { except: ownSwitchController })
+    expect(ownSwitchController.signal.aborted).toBe(false)
+    expect(unrelatedController.signal.aborted).toBe(false)
+
+    // The gameKey-less "close everything" form (tray/global kill) must also
+    // respect `except` — a real Close Apps click for a DIFFERENT gameKey
+    // (or the global kill) must still leave the excluded controller alone.
+    abortActiveLaunches(undefined, { except: ownSwitchController })
+    expect(ownSwitchController.signal.aborted).toBe(false)
+    expect(unrelatedController.signal.aborted).toBe(true)
+
+    // A real Close Apps click (no `except`) must still abort it.
+    abortActiveLaunches('iracing')
+    expect(ownSwitchController.signal.aborted).toBe(true)
+  } finally {
+    unregisterActiveLaunch('iracing', ownSwitchController)
+    unregisterActiveLaunch('acc', unrelatedController)
+  }
 })


### PR DESCRIPTION
## Summary

`Close Apps` clicked during either of two IPC flows' async pre-launch work landed as a no-op, and the flow then launched anyway with a fresh, un-aborted cancellation controller:

- **`relaunch-missing-profile`** — `await readRunningProcessNames()` (tasklist scan) runs before the `launchProfileApps` call.
- **`switch-profile-apps`** — a pre-switch scan, the whole kill phase (`killProfileApps`, can take seconds with WMI lookups), and a post-stop scan all run before the `launchProfileApps` call.

#670 (PR #714) made `launchProfileApps` itself cancellable via a per-`gameKey` `AbortController`, but that controller is only registered *inside* `launchProfileApps` — so a Close Apps click landing in either handler's pre-launch window above had nothing registered yet to abort.

### Fix

- `relaunch-missing-profile` and `switch-profile-apps` (`src/main/ipc/launch.ts`) now call `registerActiveLaunch(gameKey)` themselves, before their async pre-launch work, and thread that controller into `launchProfileApps` via a new `{ controller }` option (`launchProfileApps` falls back to self-registering when omitted — the plain `launch-profile` handler, which has no pre-await window, is unchanged).
- `switch-profile-apps` passes its own controller to `killProfileApps` as a new `{ except }` option so its own kill of the outgoing profile's apps doesn't self-abort the switch it is in the middle of performing (`abortActiveLaunches` gained an `except` parameter for this). A real Close Apps click never passes `except`, so it still cancels everything as before.
- Both handlers unregister the controller in a `finally` on every early return (e.g. "nothing to relaunch", "nothing new to start"), and use `return await launchProfileApps(...)` rather than a bare `return` — a bare `return` would let the `finally` unregister the controller *before* the launch sequence actually finishes, making a Close Apps click during the loop itself a no-op again.

Out of scope: #715, which restructures cancellation more broadly for 1.2.0 so this invariant stops being distributed per call site — this is the narrower tactical fix for the two known pre-launch windows.

Closes #716

## Test plan

- [x] `tests/main/ipcLaunch.test.ts` — new regression tests (verified to fail against the pre-fix code):
  - `relaunch-missing-profile honors a Close Apps click landing during its pre-scan`
  - `relaunch-missing-profile keeps its controller registered until launchProfileApps actually finishes` (guards the `return` vs `return await` race)
  - `relaunch-missing-profile is a no-op when everything is already running` — extended to assert the early-return path unregisters its controller
  - `switch-profile-apps never kills or relaunches the game executable` — extended to assert the exact controller is passed as `except` to `killProfileApps` and as `controller` to `launchProfileApps` (the self-abort-trap regression guard)
  - `switch-profile-apps honors a Close Apps click landing during its own kill phase`
  - `switch-profile-apps unregisters its controller when nothing new needs to start`
  - `relaunch-missing-profile launches only entries that are not running` — updated for the new `controller` option
- [x] `tests/main/state.test.ts` — new test: `abortActiveLaunches skips the except controller but still aborts every other one`
- [x] `tests/main/launch.test.ts` — updated the existing `switch-profile-apps` mocks/assertions for the new options
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 451/451 passing


<!-- auto-closes -->
Closes #716
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching or switching profiles, preventing overlapping launch actions from conflicting with each other.
  * Fixed cases where “Close Apps” or other cancellations could interrupt the wrong launch flow.
  * Profile switching now handles edge cases more gracefully and returns a proper cancelled result when launch is stopped mid-way.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->