### PR TITLE
feat: add Track Titan as a built-in companion (#652)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,18 @@ npm run dev
    generated automatically as `customapp<N>` keys by `getUtilities(customSlots)`
    and must not be authored by hand.
 
+2. Mirror the new key (same key set, same order) in the two places that
+   duplicate `BUILT_IN_UTILITIES` for the main process:
+   - `BUILT_IN_UTILITY_KEYS` in `src/main/profiles.ts` — order here is the
+     default launch order for legacy flat-boolean profiles.
+   - `KNOWN_UTILITY_KEYS` in `src/main/store.ts` — the config-import allowlist;
+     forgetting a key here silently drops that utility's saved exe path.
+
+3. Optionally bundle a fallback icon: set `icon: 'assets/myutil.png'` on the
+   config entry and place the PNG in `assets/`. This is shown when Windows
+   shell icon extraction from the user's configured exe returns nothing
+   (common for tray-only apps) — see #652.
+
 ## Code style
 
 - Run `npm test`, `npm run build`, `npm run typecheck`, `npm run lint`, and `npm run format:check` before submitting a PR (CI gates all five).

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Assetto Corsa, Assetto Corsa Competizione, Assetto Corsa Evo, Assetto Corsa Rall
 
 ## Supported Utilities
 
-**Built-in:** SimHub, Crew Chief, Trading Paints, Garage 61, Second Monitor.
+**Built-in:** Track Titan, SimHub, Crew Chief, Trading Paints, Garage 61, Second Monitor.
 **Anything else** - overlays, telemetry tools, wheelbase software - goes in up to 20 user-added custom app slots, each launched the same way.
 
 ---

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -38,7 +38,11 @@ export interface StoredProfileUtility {
   enabled: boolean
 }
 
+// Must stay in sync with BUILT_IN_UTILITIES in renderer/src/lib/config.ts (key
+// set AND order — order is the default launch-order for legacy flat-boolean
+// profiles, see getEnabledUtilityEntries below).
 export const BUILT_IN_UTILITY_KEYS = [
+  'tracktitan',
   'simhub',
   'crewchief',
   'tradingpaints',

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -49,7 +49,15 @@ export const KNOWN_GAME_KEYS = new Set([
   'rf2',
   'xplane12'
 ])
-const KNOWN_UTILITY_KEYS = ['simhub', 'crewchief', 'tradingpaints', 'garage61', 'secondmonitor']
+// Must stay in sync with BUILT_IN_UTILITIES in renderer/src/lib/config.ts.
+const KNOWN_UTILITY_KEYS = [
+  'tracktitan',
+  'simhub',
+  'crewchief',
+  'tradingpaints',
+  'garage61',
+  'secondmonitor'
+]
 const PROFILE_BOOLEAN_KEYS = [
   'launchAutomatically',
   'trackingEnabled',

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -5,6 +5,7 @@ import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
 import { isGameExeRunning } from '../lib/runningGame'
+import { getPathComparisonKey } from '../../../shared/path'
 import { useNotify } from './Notify'
 import { useAppsSettings } from './settings/AppsContext'
 import { useGamesSettings } from './settings/GamesContext'
@@ -71,13 +72,17 @@ export function GameList({
   // (#652). Built-in utilities that ship one (currently just Track Titan) use
   // this when Windows shell icon extraction on that same path — the loop
   // below — comes back empty, e.g. a tray-only app whose exe carries no
-  // usable icon resource.
+  // usable icon resource. Keys use getPathComparisonKey (NOT the bare
+  // lowercase normalizePath above): the configured settings value and the
+  // main-process running-entry path can differ in slash style / stray
+  // whitespace, not just case, and main canonicalises its own comparisons via
+  // normalizePathForComparison — a bare toLowerCase() key misses those.
   const bundledIconByPath = useMemo(() => {
     const map: Record<string, string> = {}
     Object.entries(utilityIcons).forEach(([key, data]) => {
       const path = utilityAppPaths[key]
       if (path && data) {
-        map[normalizePath(path)] = data
+        map[getPathComparisonKey(path)] = data
       }
     })
     return map
@@ -234,7 +239,7 @@ export function GameList({
             // gated on load-order between the two icon sources.
             icon:
               appIconCache[normalizePath(a.path)] ||
-              bundledIconByPath[normalizePath(a.path)] ||
+              bundledIconByPath[getPathComparisonKey(a.path)] ||
               null,
             name: a.name,
             path: a.path,

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { GAMES, type Game } from '../lib/config'
 import { getSettings, onStoreConfigChanged } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
@@ -6,6 +6,7 @@ import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
 import { isGameExeRunning } from '../lib/runningGame'
 import { useNotify } from './Notify'
+import { useAppsSettings } from './settings/AppsContext'
 import { useGamesSettings } from './settings/GamesContext'
 import { EmptyState } from './EmptyState'
 import { GameRow } from './game-list/GameRow'
@@ -64,6 +65,23 @@ export function GameList({
     }
   })
   const { gameIcons } = useGamesSettings()
+  const { appPaths: utilityAppPaths, utilityIcons } = useAppsSettings()
+
+  // Reverse-lookup: normalized configured exe path -> bundled fallback icon
+  // (#652). Built-in utilities that ship one (currently just Track Titan) use
+  // this when Windows shell icon extraction on that same path — the loop
+  // below — comes back empty, e.g. a tray-only app whose exe carries no
+  // usable icon resource.
+  const bundledIconByPath = useMemo(() => {
+    const map: Record<string, string> = {}
+    Object.entries(utilityIcons).forEach(([key, data]) => {
+      const path = utilityAppPaths[key]
+      if (path && data) {
+        map[normalizePath(path)] = data
+      }
+    })
+    return map
+  }, [utilityAppPaths, utilityIcons])
 
   // Read the configured-games list (+ derived UI state) from the store. Kept in
   // a callback so it can run on mount AND on every store config change: the
@@ -210,7 +228,14 @@ export function GameList({
             (a) => a.gameKey === game.key && normalizePath(a.path) !== gamePathLower
           )
           const runningAppIcons = appsForGame.map((a) => ({
-            icon: appIconCache[normalizePath(a.path)] ?? null,
+            // Prefer the shell-extracted icon; fall back to a built-in's
+            // bundled icon (#652) when the shell lookup came back empty —
+            // applied at read time (not baked into appIconCache) so it isn't
+            // gated on load-order between the two icon sources.
+            icon:
+              appIconCache[normalizePath(a.path)] ||
+              bundledIconByPath[normalizePath(a.path)] ||
+              null,
             name: a.name,
             path: a.path,
             gameKey: a.gameKey,

--- a/src/renderer/src/components/settings/AppsContext.tsx
+++ b/src/renderer/src/components/settings/AppsContext.tsx
@@ -6,6 +6,9 @@ export interface AppsContextValue {
   appNames: Record<string, string>
   appArgs: Record<string, string>
   appIcons: Record<string, string>
+  // Bundled fallback icons for built-in utilities that ship one (#652), keyed
+  // by utility key. Used when the shell-extracted appIcons entry is missing.
+  utilityIcons: Record<string, string>
   iconLoadErrors: Set<string>
   customSlots: number
   utilities: Utility[]

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -29,6 +29,7 @@ export function AppsSection(): ReactNode {
     appNames,
     appArgs,
     appIcons,
+    utilityIcons,
     iconLoadErrors,
     customSlots,
     onAppNameChange,
@@ -124,6 +125,15 @@ export function AppsSection(): ReactNode {
                 alt="Icon"
                 className="h-8 w-8 object-contain drop-shadow-md shrink-0"
                 onError={() => onIconLoadError(utility.key)}
+              />
+            ) : utilityIcons[utility.key] ? (
+              // Bundled fallback (#652): the configured exe's Windows shell
+              // icon extraction above came back empty (common for tray-only
+              // apps), but this built-in ships its own icon asset.
+              <img
+                src={utilityIcons[utility.key]}
+                alt="Icon"
+                className="h-8 w-8 object-contain drop-shadow-md shrink-0"
               />
             ) : (
               <Tooltip label={`${appNames[utility.key] || utility.name} icon fallback`}>

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -64,6 +64,7 @@ export function SettingsProvider({
       isCustomColor,
       appIcons,
       gameIcons,
+      utilityIcons,
       iconLoadErrors
     },
     setters: {
@@ -89,6 +90,7 @@ export function SettingsProvider({
       setIsCustomColor,
       setAppIcons,
       setGameIcons,
+      setUtilityIcons,
       setIconLoadErrors
     },
     updateSettingsObject,
@@ -153,7 +155,8 @@ export function SettingsProvider({
     setZoomFactor,
     setIsCustomColor,
     setAppIcons,
-    setGameIcons
+    setGameIcons,
+    setUtilityIcons
   })
 
   useEffect(() => {
@@ -413,6 +416,7 @@ export function SettingsProvider({
       appNames,
       appArgs,
       appIcons,
+      utilityIcons,
       iconLoadErrors,
       customSlots,
       utilities,
@@ -430,6 +434,7 @@ export function SettingsProvider({
       appNames,
       appArgs,
       appIcons,
+      utilityIcons,
       iconLoadErrors,
       customSlots,
       utilities,

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, type MutableRefObject } from 'react'
 import {
+  BUILT_IN_UTILITIES,
   DEFAULT_ACCENT_COLOR,
   GAMES,
   isRecord,
@@ -46,6 +47,7 @@ interface UseSettingsLoadArgs {
   setIsCustomColor: (isCustomColor: boolean) => void
   setAppIcons: (appIcons: Record<string, string>) => void
   setGameIcons: (gameIcons: Record<string, string>) => void
+  setUtilityIcons: (utilityIcons: Record<string, string>) => void
 }
 
 export function useSettingsLoad({
@@ -73,7 +75,8 @@ export function useSettingsLoad({
   setZoomFactor,
   setIsCustomColor,
   setAppIcons,
-  setGameIcons
+  setGameIcons,
+  setUtilityIcons
 }: UseSettingsLoadArgs): { loadSettingsFromStore: () => Promise<SettingsStateSnapshot> } {
   const loadSettingsFromStore = useCallback(async (): Promise<SettingsStateSnapshot> => {
     const [settings, savedProfiles] = await Promise.all([getSettings(), getProfiles()])
@@ -162,6 +165,21 @@ export function useSettingsLoad({
     }
     setGameIcons(gIcons)
 
+    // Bundled fallback icons for built-in utilities that ship one (#652) —
+    // e.g. Track Titan's tray Datalogger, whose shell icon extraction above
+    // (appIcons) commonly fails, leaving nothing to show without this.
+    const utilityIconEntries = await Promise.all(
+      BUILT_IN_UTILITIES.filter((utility) => utility.icon).map(async (utility) => {
+        const filename = (utility.icon as string).split('/').pop() || ''
+        return [utility.key, await getAssetData(filename)] as const
+      })
+    )
+    const uIcons: Record<string, string> = {}
+    for (const [key, data] of utilityIconEntries) {
+      if (data) uIcons[key] = data
+    }
+    setUtilityIcons(uIcons)
+
     setLoading(false)
     return snapshot
   }, [
@@ -187,6 +205,7 @@ export function useSettingsLoad({
     setStartMinimized,
     setStartWithWindows,
     setThemeMode,
+    setUtilityIcons,
     setZoomFactor,
     themeRef
   ])

--- a/src/renderer/src/components/settings/useSettingsState.ts
+++ b/src/renderer/src/components/settings/useSettingsState.ts
@@ -40,6 +40,10 @@ export interface SettingsStateBundle {
     isCustomColor: boolean
     appIcons: Record<string, string>
     gameIcons: Record<string, string>
+    // Bundled fallback icons for built-in utilities that ship one (#652),
+    // keyed by utility key. Display-only cache, like gameIcons — not part of
+    // the dirty-tracked settings snapshot.
+    utilityIcons: Record<string, string>
     iconLoadErrors: Set<string>
   }
   setters: {
@@ -65,6 +69,7 @@ export interface SettingsStateBundle {
     setIsCustomColor: Dispatch<SetStateAction<boolean>>
     setAppIcons: Dispatch<SetStateAction<Record<string, string>>>
     setGameIcons: Dispatch<SetStateAction<Record<string, string>>>
+    setUtilityIcons: Dispatch<SetStateAction<Record<string, string>>>
     setIconLoadErrors: Dispatch<SetStateAction<Set<string>>>
   }
   updateSettingsObject: (
@@ -126,6 +131,7 @@ export function useSettingsState(): SettingsStateBundle {
   const [isCustomColor, setIsCustomColor] = useState(false)
   const [appIcons, setAppIcons] = useState<Record<string, string>>({})
   const [gameIcons, setGameIcons] = useState<Record<string, string>>({})
+  const [utilityIcons, setUtilityIcons] = useState<Record<string, string>>({})
   const [iconLoadErrors, setIconLoadErrors] = useState<Set<string>>(new Set())
   const settingsObjectEditVersions = useRef(createSettingsObjectVersions())
   const latestSettingsObjects = useRef<SettingsObjectRecords>({
@@ -227,6 +233,7 @@ export function useSettingsState(): SettingsStateBundle {
       isCustomColor,
       appIcons,
       gameIcons,
+      utilityIcons,
       iconLoadErrors
     },
     setters: {
@@ -252,6 +259,7 @@ export function useSettingsState(): SettingsStateBundle {
       setIsCustomColor,
       setAppIcons,
       setGameIcons,
+      setUtilityIcons,
       setIconLoadErrors
     },
     updateSettingsObject,

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -7,6 +7,10 @@ export interface Utility {
   key: string
   name: string
   isCustom?: boolean
+  // Bundled fallback icon path (mirrors Game.icon), shown when Windows shell
+  // icon extraction from the user's configured exe returns nothing — e.g.
+  // tray-only apps whose exe carries no usable icon resource (#652).
+  icon?: string
 }
 export interface ProfileUtility {
   id: string
@@ -81,6 +85,10 @@ export const GAMES: Game[] = [
 ]
 
 export const BUILT_IN_UTILITIES: Utility[] = [
+  // Listed first: a telemetry recorder needs to be alive before/at session
+  // start to capture the whole lap, so it defaults to the front of the launch
+  // order (#652).
+  { key: 'tracktitan', name: 'Track Titan', icon: 'assets/tracktitan.png' },
   { key: 'simhub', name: 'SimHub' },
   { key: 'crewchief', name: 'Crew Chief' },
   { key: 'tradingpaints', name: 'Trading Paints' },

--- a/src/shared/path.ts
+++ b/src/shared/path.ts
@@ -31,3 +31,36 @@ export function getPathDisplayName(filePath: string): string {
   const last = segments[segments.length - 1]
   return last && last.length > 0 ? last : trimmed
 }
+
+/**
+ * Renderer-safe approximation of main's `normalizePathForComparison`
+ * (src/main/utils.ts): trim, unify separators to backslash, collapse duplicate
+ * separators (preserving a leading UNC `\\`), lowercase.
+ *
+ * WHY an approximation: the main-process canonicaliser uses Node's
+ * `path.win32.resolve`, which is not available in the renderer. Full resolve
+ * additionally absolutises relative paths and strips `.`/`..` segments — but
+ * the paths compared here are absolute exe paths from the settings store and
+ * from main-process process snapshots, so slash style, stray whitespace and
+ * case are the differences that actually occur (#652: a configured
+ * `C:/Tools\App.exe ` must match the running entry's `c:\tools\app.exe`, which
+ * a bare `toLowerCase()` key misses).
+ *
+ * Use for comparison keys only, never for display (see getPathDisplayName).
+ */
+export function getPathComparisonKey(filePath: string): string {
+  if (typeof filePath !== 'string') {
+    return ''
+  }
+
+  const trimmed = filePath.trim()
+  if (trimmed.length === 0) {
+    return ''
+  }
+
+  const unified = trimmed.replace(/\//g, '\\')
+  const isUncPath = unified.startsWith('\\\\')
+  const collapsed = unified.replace(/\\+/g, '\\')
+
+  return `${isUncPath ? '\\' : ''}${collapsed}`.toLowerCase()
+}

--- a/tests/main/utilitiesConfig.test.ts
+++ b/tests/main/utilitiesConfig.test.ts
@@ -1,0 +1,100 @@
+import { expect, test, vi, beforeEach } from 'vitest'
+
+import { BUILT_IN_UTILITIES } from '../../src/renderer/src/lib/config'
+import { BUILT_IN_UTILITY_KEYS } from '../../src/main/profiles'
+
+/**
+ * Regression coverage for #652 (Track Titan built-in companion).
+ *
+ * BUILT_IN_UTILITIES (renderer/src/lib/config.ts) is duplicated in two other
+ * places that must stay in lockstep — profiles.ts' BUILT_IN_UTILITY_KEYS
+ * (drives default launch order for legacy flat-boolean profiles) and store.ts'
+ * KNOWN_UTILITY_KEYS (the config-import allowlist for appPaths). A key added
+ * to one and forgotten in another either silently drops a companion's saved
+ * path (#669-style) or launches utilities out of the intended order.
+ */
+
+test('BUILT_IN_UTILITIES keys match profiles.ts BUILT_IN_UTILITY_KEYS exactly, in order', () => {
+  const configKeys = BUILT_IN_UTILITIES.map((utility) => utility.key)
+  expect(configKeys).toEqual(BUILT_IN_UTILITY_KEYS)
+})
+
+test('Track Titan is registered as a built-in utility, positioned first (#652)', () => {
+  const trackTitan = BUILT_IN_UTILITIES.find((utility) => utility.key === 'tracktitan')
+  expect(trackTitan).toBeDefined()
+  expect(trackTitan?.name).toBe('Track Titan')
+  // A telemetry recorder needs to be alive before/at session start to capture
+  // the whole lap, so it defaults to the front of the launch order.
+  expect(BUILT_IN_UTILITIES[0].key).toBe('tracktitan')
+})
+
+// The save-settings harness below is copied from configSaveSettings.test.ts
+// (#669 coverage) to exercise the REAL store.ts sanitizer + KNOWN_UTILITY_KEYS
+// allowlist through the actual ipcMain handler, rather than reaching into
+// store.ts internals (KNOWN_UTILITY_KEYS itself isn't exported).
+type MockIpcHandler = (...args: unknown[]) => unknown
+interface SaveSettingsResult {
+  settings: { appPaths: Record<string, string> }
+  dropped: { field: string; key: string; reason: string }[]
+}
+
+async function invokeSaveSettings(patch: unknown): Promise<SaveSettingsResult> {
+  const { __ipcHandlers } = await import('electron')
+  return (await (__ipcHandlers as Record<string, MockIpcHandler>)['save-settings'](
+    {},
+    patch
+  )) as SaveSettingsResult
+}
+
+async function loadConfigModule() {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  vi.doMock('electron-store', () => ({
+    default: class MockStore {
+      store: Record<string, unknown> = { customSlots: 1 }
+
+      get(key: string) {
+        return this.store[key]
+      }
+
+      set(key: string, value: unknown) {
+        this.store[key] = value
+      }
+
+      clear() {
+        this.store = {}
+      }
+    }
+  }))
+  vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
+  vi.doMock('../../src/main/profiles', () => ({ isStoredProfileSet: vi.fn() }))
+  vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
+  vi.doMock('../../src/main/window', () => ({
+    applyRuntimeConfigSettings: vi.fn(),
+    getMainWindow: vi.fn(),
+    sendToRenderer: vi.fn()
+  }))
+
+  const mod = await import('../../src/main/ipc/config')
+  mod.registerConfigHandlers()
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+test('save-settings accepts a tracktitan appPaths entry (KNOWN_UTILITY_KEYS allowlist, #652)', async () => {
+  await loadConfigModule()
+
+  const result = await invokeSaveSettings({
+    appPaths: { tracktitan: 'C:/Program Files/Track Titan/Datalogger.exe' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([])
+  expect(result.settings.appPaths).toEqual({
+    tracktitan: 'C:/Program Files/Track Titan/Datalogger.exe'
+  })
+})

--- a/tests/renderer/appsSectionUtilityIcon.test.tsx
+++ b/tests/renderer/appsSectionUtilityIcon.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Regression test for #652 (Track Titan built-in companion / bundled icon
+ * fallback). AppsSection previously only had two icon tiers: the shell icon
+ * extracted from the user's configured exe, or an initials placeholder. Some
+ * built-ins now ship a bundled icon asset (utilityIcons) that renders as a
+ * middle tier when the shell icon lookup comes back empty — e.g. Track
+ * Titan's tray Datalogger, whose exe carries no usable shell icon resource.
+ */
+
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import {
+  AppsContext,
+  type AppsContextValue
+} from '../../src/renderer/src/components/settings/AppsContext'
+import { AppsSection } from '../../src/renderer/src/components/settings/AppsSection'
+import type { Utility } from '../../src/renderer/src/lib/config'
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+const UTILITIES: Utility[] = [{ key: 'tracktitan', name: 'Track Titan' }]
+
+function buildContextValue(overrides: Partial<AppsContextValue>): AppsContextValue {
+  return {
+    appPaths: {},
+    appNames: {},
+    appArgs: {},
+    appIcons: {},
+    utilityIcons: {},
+    iconLoadErrors: new Set(),
+    customSlots: 1,
+    utilities: UTILITIES,
+    profiles: {},
+    onBrowse: vi.fn(),
+    onAppNameChange: vi.fn(),
+    onAppPathChange: vi.fn(),
+    onAppArgsChange: vi.fn(),
+    onIconLoadError: vi.fn(),
+    onAddCustomSlot: vi.fn(),
+    onRemoveCustomSlot: vi.fn(),
+    ...overrides
+  }
+}
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderAppsSection(value: AppsContextValue): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppsContext.Provider value={value}>
+        <AppsSection />
+      </AppsContext.Provider>
+    )
+  })
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('AppsSection utility icon fallback tiers (#652)', () => {
+  test('falls back to the bundled utility icon when no shell icon was extracted', async () => {
+    await renderAppsSection(
+      buildContextValue({
+        utilityIcons: { tracktitan: 'data:image/png;base64,BUNDLED' }
+      })
+    )
+
+    const img = container.querySelector('img[alt="Icon"]') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,BUNDLED')
+  })
+
+  test('shell-extracted icon still takes priority over the bundled fallback', async () => {
+    await renderAppsSection(
+      buildContextValue({
+        appIcons: { tracktitan: 'data:image/png;base64,SHELL' },
+        utilityIcons: { tracktitan: 'data:image/png;base64,BUNDLED' }
+      })
+    )
+
+    const img = container.querySelector('img[alt="Icon"]') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,SHELL')
+  })
+
+  test('falls back to the initials placeholder when neither icon source is available', async () => {
+    await renderAppsSection(buildContextValue({}))
+
+    const img = container.querySelector('img[alt="Icon"]')
+    expect(img).toBeNull()
+    expect(container.textContent).toContain('TT')
+  })
+})

--- a/tests/renderer/sharedPath.test.ts
+++ b/tests/renderer/sharedPath.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { getPathDisplayName } from '../../src/shared/path'
+import { getPathComparisonKey, getPathDisplayName } from '../../src/shared/path'
 
 describe('getPathDisplayName', () => {
   test('returns "" for non-string inputs', () => {
@@ -34,5 +34,39 @@ describe('getPathDisplayName', () => {
   test('falls back to the trimmed input when no separator is present', () => {
     expect(getPathDisplayName('foo.exe')).toBe('foo.exe')
     expect(getPathDisplayName('  bar  ')).toBe('bar')
+  })
+})
+
+describe('getPathComparisonKey', () => {
+  test('returns "" for non-string, empty, and whitespace-only inputs', () => {
+    expect(getPathComparisonKey(undefined as unknown as string)).toBe('')
+    expect(getPathComparisonKey(null as unknown as string)).toBe('')
+    expect(getPathComparisonKey('')).toBe('')
+    expect(getPathComparisonKey('   ')).toBe('')
+  })
+
+  test('trims, unifies separators, and lowercases', () => {
+    expect(getPathComparisonKey('  C:/Apps//Sub\\Foo.EXE  ')).toBe('c:\\apps\\sub\\foo.exe')
+  })
+
+  test('preserves the leading UNC double-backslash while collapsing the rest', () => {
+    expect(getPathComparisonKey('\\\\Server\\Share\\\\App.exe')).toBe('\\\\server\\share\\app.exe')
+  })
+
+  // The #652 bundled-icon regression this helper exists for: the configured
+  // settings value (user-typed, forward slashes, trailing space) and the
+  // main-process running-entry path (canonical backslash form) must produce
+  // the SAME map key, or the bundled Track Titan icon lookup silently misses.
+  test('configured path and running-entry path variants collapse to one key (#652)', () => {
+    const configuredPath = 'C:/Tools\\TrackTitan.exe '
+    const runningEntryPath = 'c:\\tools\\tracktitan.exe'
+
+    const bundledIconByPath: Record<string, string> = {
+      [getPathComparisonKey(configuredPath)]: 'data:image/png;base64,BUNDLED'
+    }
+
+    expect(bundledIconByPath[getPathComparisonKey(runningEntryPath)]).toBe(
+      'data:image/png;base64,BUNDLED'
+    )
   })
 })


### PR DESCRIPTION
## Summary

Track Titan's tray "Datalogger" is a textbook SimLauncher companion (needs to be alive before/at session start to capture a lap) but had no first-class listing — it landed in a generic custom slot, and its Windows shell icon extraction fails (like it does for several tray-only apps), so users saw only a blank placeholder.

- Added `tracktitan` to `BUILT_IN_UTILITIES` in `src/renderer/src/lib/config.ts`, positioned **first** in the array — a recorder should start early, so it defaults to the front of the launch order.
- Mirrored the key into the two main-process arrays that duplicate `BUILT_IN_UTILITIES` and must stay in sync (found by tracing the actual launch/import code paths, not assumed):
  - `BUILT_IN_UTILITY_KEYS` in `src/main/profiles.ts` — order here drives default launch order for legacy flat-boolean profiles.
  - `KNOWN_UTILITY_KEYS` in `src/main/store.ts` — the config-import allowlist for saved exe paths. Forgetting a key here silently drops that utility's path (the exact bug class #669 fixed for a different case).
- README: added Track Titan to the "Built-in" companions list.
- CONTRIBUTING: documented the two sync points above (previously undocumented — the existing "Adding a new utility" section only mentioned `config.ts`), plus the new optional bundled-icon step.

## Icon: no fabricated logo, mechanism only

I checked the issue, its comments (there were none), and the internal Track Titan partnership handbook for a bundled icon asset — none exists in the repo. **I did not fabricate a logo.**

What I found instead: **no built-in utility ships a bundled icon today.** All companion icons (both in Settings and in the running-apps strip) come from `app.getFileIcon()` on whatever exe path the user configures — there's no bundled-asset fallback mechanism at all, for any built-in. The issue's premise ("mirrors how other built-ins ship icons") doesn't hold; this PR adds that mechanism for the first time:

- `Utility` gets an optional `icon` field (mirrors `Game.icon`).
- `useSettingsLoad` loads any built-in's bundled icon via the existing `get-asset-data` IPC channel (same one `GAMES` icons already use).
- **Settings → Apps list** (`AppsSection.tsx`): shell icon → bundled icon → initials placeholder (existing fallback, unchanged for every other utility).
- **Running-apps strip** (`GameList.tsx`): same fallback order, applied via a normalized-path reverse lookup against the user's configured Track Titan exe path.

### Screenshots / assets needed

Please drop a Track Titan icon PNG at:

```
assets/tracktitan.png
```

Match the existing bundled game icons' convention (square, transparent background, e.g. `assets/iRacing.png`). Until the file is dropped in, `tracktitan` behaves exactly like every other built-in today — shell icon if available, otherwise the initials placeholder (`TT`) — so this ships safely with or without the asset.

## Exe path / install location — no default path shipped

The issue mentions a "default install path" but **no built-in utility in this codebase has one** — every companion (SimHub, Crew Chief, Garage 61, etc.) requires the user to Browse to their own exe; there is no auto-detection anywhere. I did not add one for Track Titan either, to stay consistent with the existing pattern (flagging this since the issue's wording implied otherwise). The only place an example Track Titan path appears is a test fixture (`tests/main/utilitiesConfig.test.ts`) exercising the `KNOWN_UTILITY_KEYS` allowlist — not a shipped default.

## Out of scope (per the issue itself)

- Featured/default-on placement — explicitly held back as the partnership deal chip.
- #204's per-app keep-alive-after-session override — separate issue, not touched here.

Closes #652

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (452 passed), including two new files:
  - `tests/main/utilitiesConfig.test.ts` — BUILT_IN_UTILITIES/BUILT_IN_UTILITY_KEYS stay in lockstep (key set + order), Track Titan is first, and a `tracktitan` appPaths entry round-trips through `save-settings` instead of being silently dropped.
  - `tests/renderer/appsSectionUtilityIcon.test.tsx` — the three icon tiers (shell → bundled → initials) render in the right priority.
- [ ] Manual, once `assets/tracktitan.png` is dropped in: configure Track Titan's exe path in Settings, confirm the bundled icon shows in both the Apps list and the running-apps strip while the app is running.


<!-- auto-closes -->
Closes #652
<!-- auto-closes -->