### PR TITLE
fix(ui): bundled-first utility icons in the profile editor

### DIFF
--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -106,6 +106,7 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
           appPaths={editor.appPaths}
           appNames={editor.appNames}
           appIconCache={editor.appIconCache}
+          utilityIcons={editor.utilityIcons}
           failedIcons={editor.failedIcons}
           fetchingIcons={editor.fetchingIcons}
           dragUtilityId={editor.dragUtilityId}

--- a/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileUtilitiesSection.tsx
@@ -1,11 +1,15 @@
 import type { DragEvent, ReactNode } from 'react'
-import type { ProfileUtility, Utility } from '../../lib/config'
+import { getBundledIconErrorKey, type ProfileUtility, type Utility } from '../../lib/config'
 import { Toggle } from '../Toggle'
 
 interface ProfileUtilitiesSectionProps {
   appPaths: Record<string, string>
   appNames: Record<string, string>
   appIconCache: Record<string, string>
+  // Bundled curated icons for built-ins that ship one, keyed by utility key.
+  // Preferred over the shell-extracted appIconCache entry (bundled-first,
+  // #727) — same precedence as AppsSection and the GameList running strip.
+  utilityIcons: Record<string, string>
   failedIcons: Record<string, boolean>
   fetchingIcons: boolean
   dragUtilityId: string | null
@@ -73,7 +77,19 @@ function renderUtilityRow(
   // (renderUtilityRow is a plain function, so useId() isn't available here).
   const toggleId = `utility-toggle-${utility.key}`
   const iconPath = props.appPaths[utility.key]?.toLowerCase()
-  const icon = iconPath ? props.appIconCache[iconPath] : null
+  const shellIcon = iconPath ? props.appIconCache[iconPath] : null
+  // Bundled-first (#727): a built-in slot's app identity is known, so its
+  // curated icon is always at least as correct as an arbitrary
+  // shell-extracted exe icon — and shell extraction can "succeed" with a
+  // broken image (e.g. Crew Chief's black-square alpha artifact). Only
+  // built-ins that declare a bundled `icon` populate utilityIcons (see
+  // useSettingsLoad), so custom slots and secondmonitor (no asset yet) fall
+  // through to the shell-icon tier unchanged. A bundled data URI that fails
+  // to decode is recorded under a namespaced failedIcons key (onError below)
+  // so the render falls through instead of showing a broken image.
+  const bundledIcon = props.failedIcons[getBundledIconErrorKey(utility.key)]
+    ? null
+    : props.utilityIcons[utility.key]
   const dropPlacement = props.dropTarget?.id === utility.key ? props.dropTarget.placement : null
 
   return (
@@ -186,9 +202,16 @@ function renderUtilityRow(
           </svg>
         </div>
         <div className="relative flex h-6 w-6 shrink-0 items-center justify-center">
-          {icon && !props.failedIcons[utility.key] ? (
+          {bundledIcon ? (
             <img
-              src={icon}
+              src={bundledIcon}
+              alt=""
+              className="h-full w-full object-contain animate-fade-slide"
+              onError={() => props.onIconFailed(getBundledIconErrorKey(utility.key))}
+            />
+          ) : shellIcon && !props.failedIcons[utility.key] ? (
+            <img
+              src={shellIcon}
               alt=""
               className="h-full w-full object-contain animate-fade-slide"
               onError={() => props.onIconFailed(utility.key)}

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import { MAX_CUSTOM_SLOTS } from '../../lib/config'
+import { getBundledIconErrorKey, MAX_CUSTOM_SLOTS } from '../../lib/config'
 import { useAppsSettings } from './AppsContext'
 import { ChevronDownIcon } from '../icons'
 import { Tooltip } from '../Tooltip'
@@ -20,15 +20,6 @@ function getInitials(label: string) {
 
 function getCustomSlotNumber(key: string) {
   return Number(key.replace('customapp', ''))
-}
-
-// Namespaced iconLoadErrors key for a built-in's bundled icon. Bundled and
-// shell icons share the one error set (same state shape, same lifecycle);
-// the prefix keeps their failure states independent, so a failed bundled
-// data URI falls through to the shell icon without masking it. Never
-// collides with utility keys or custom-slot renumbering (customapp<N>).
-function getBundledIconErrorKey(key: string): string {
-  return `bundled:${key}`
 }
 
 export function AppsSection(): ReactNode {

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -66,6 +66,11 @@ export interface UseProfileEditorResult {
   setRelaunchControlsEnabled: Dispatch<SetStateAction<boolean>>
   trackedProcessPaths: string[]
   appIconCache: Record<string, string>
+  // Bundled curated icons for built-ins that ship one, keyed by utility key.
+  // Resolved once by useSettingsLoad (get-asset-data) and read from
+  // AppsContext — NOT re-read from disk here. Preferred over the
+  // shell-extracted appIconCache entry (bundled-first, #727).
+  utilityIcons: Record<string, string>
   failedIcons: Record<string, boolean>
   setFailedIcons: Dispatch<SetStateAction<Record<string, boolean>>>
   fetchingIcons: boolean
@@ -118,7 +123,8 @@ export function useProfileEditor({
   const {
     appPaths: settingsAppPaths,
     appNames: settingsAppNames,
-    customSlots: settingsCustomSlots
+    customSlots: settingsCustomSlots,
+    utilityIcons
   } = useAppsSettings()
   const [loading, setLoading] = useState(true)
   const [appPaths, setAppPaths] = useState<Record<string, string>>({})
@@ -702,6 +708,7 @@ export function useProfileEditor({
     setRelaunchControlsEnabled,
     trackedProcessPaths,
     appIconCache,
+    utilityIcons,
     failedIcons,
     setFailedIcons,
     fetchingIcons,

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -20,6 +20,17 @@ export interface ProfileUtility {
   id: string
   enabled: boolean
 }
+
+// Namespaced icon-load-error key for a built-in's bundled icon (#727/#728).
+// Bundled and shell icons share one per-surface error store (same state
+// shape, same lifecycle); the prefix keeps their failure states independent,
+// so a failed bundled data URI falls through to the shell icon without
+// masking it. Never collides with utility keys or custom-slot renumbering
+// (customapp<N>). Shared by every surface that renders utility icons
+// (AppsSection, ProfileUtilitiesSection).
+export function getBundledIconErrorKey(key: string): string {
+  return `bundled:${key}`
+}
 export type GamePosition = 'first' | 'last'
 export interface GameProfile {
   // Index signature preserved so that legacy flat keys (e.g. 'simhub': true)

--- a/tests/renderer/profileUtilitiesSectionIcon.test.tsx
+++ b/tests/renderer/profileUtilitiesSectionIcon.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Regression test for #727 (bundled-first curated icons) on the profile
+ * editor's "Utilities to launch" list — the third utility-icon surface,
+ * missed by the first #727 pass (which covered AppsSection and the GameList
+ * running strip). ProfileUtilitiesSection resolves icons in the same
+ * three-tier order as those surfaces: a built-in's bundled curated icon
+ * (utilityIcons) first, the shell icon extracted from the configured exe
+ * (appIconCache) as fallback, initials last. A bundled data URI that fails
+ * to decode is recorded in failedIcons under the namespaced
+ * getBundledIconErrorKey key so the render falls through to the shell tier
+ * (mirrors the AppsSection onError approach from #728).
+ */
+
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { act, useState, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { ProfileUtilitiesSection } from '../../src/renderer/src/components/profile-editor/ProfileUtilitiesSection'
+import type { ProfileUtility, Utility } from '../../src/renderer/src/lib/config'
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+const UTILITIES: Utility[] = [
+  { key: 'tracktitan', name: 'Track Titan', icon: 'assets/tracktitan.png' },
+  { key: 'secondmonitor', name: 'Second Monitor' },
+  { key: 'customapp1', name: 'Custom App 1', isCustom: true }
+]
+
+const ENTRIES: ProfileUtility[] = UTILITIES.map((utility) => ({
+  id: utility.key,
+  enabled: true
+}))
+
+type SectionProps = Parameters<typeof ProfileUtilitiesSection>[0]
+
+function buildProps(overrides: Partial<SectionProps>): SectionProps {
+  return {
+    appPaths: {
+      tracktitan: 'C:\\Apps\\TrackTitan.exe',
+      secondmonitor: 'C:\\Apps\\SecondMonitor.exe',
+      customapp1: 'C:\\Apps\\Custom.exe'
+    },
+    appNames: {},
+    appIconCache: {},
+    utilityIcons: {},
+    failedIcons: {},
+    fetchingIcons: false,
+    dragUtilityId: null,
+    dropTarget: null,
+    utilityByKey: new Map(UTILITIES.map((utility) => [utility.key, utility])),
+    availableUtilities: UTILITIES,
+    enabledUtilityEntries: ENTRIES,
+    disabledUtilityEntries: [],
+    onToggleUtility: vi.fn(),
+    onMoveEnabledUtility: vi.fn(),
+    onStartUtilityDrag: vi.fn(),
+    onDropTargetChange: vi.fn(),
+    onDragUtilityIdChange: vi.fn(),
+    onIconFailed: vi.fn(),
+    ...overrides
+  }
+}
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderSection(props: SectionProps): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<ProfileUtilitiesSection {...props} />)
+  })
+}
+
+// Stateful harness for the onError fallthrough tests: owns failedIcons as
+// real state so a dispatched image `error` event re-renders the section with
+// the failure recorded — exercising the actual onError → onIconFailed →
+// next-tier chain end-to-end (same pattern as the AppsSection icon tests).
+function StatefulHarness({ props }: { props: SectionProps }): ReactNode {
+  const [failedIcons, setFailedIcons] = useState<Record<string, boolean>>(props.failedIcons)
+  return (
+    <ProfileUtilitiesSection
+      {...props}
+      failedIcons={failedIcons}
+      onIconFailed={(key: string) => setFailedIcons((prev) => ({ ...prev, [key]: true }))}
+    />
+  )
+}
+
+async function renderStatefulSection(props: SectionProps): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<StatefulHarness props={props} />)
+  })
+}
+
+async function fireIconError(img: HTMLImageElement): Promise<void> {
+  await act(async () => {
+    img.dispatchEvent(new Event('error'))
+  })
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+// Each utility row is a direct child of the enabled-entries grid, in ENTRIES
+// order; the single <img> (or none) inside it is that row's resolved icon.
+function getRow(label: string): Element {
+  const rows = [...container.querySelectorAll('.grid > div')]
+  const row = rows.find((candidate) => candidate.textContent?.includes(label))
+  if (!row) throw new Error(`No utility row found for label "${label}"`)
+  return row
+}
+
+function getRowIcon(label: string): HTMLImageElement | null {
+  return getRow(label).querySelector<HTMLImageElement>('img')
+}
+
+describe('ProfileUtilitiesSection icon precedence (bundled-first, #727)', () => {
+  test('built-in with a bundled icon uses it even when shell extraction also returned a usable icon', async () => {
+    await renderSection(
+      buildProps({
+        appIconCache: { 'c:\\apps\\tracktitan.exe': 'data:image/png;base64,SHELL' },
+        utilityIcons: { tracktitan: 'data:image/png;base64,BUNDLED' }
+      })
+    )
+
+    const img = getRowIcon('Track Titan')
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,BUNDLED')
+  })
+
+  test('built-in with a bundled icon uses it when shell extraction returned nothing', async () => {
+    await renderSection(
+      buildProps({
+        utilityIcons: { tracktitan: 'data:image/png;base64,BUNDLED' }
+      })
+    )
+
+    const img = getRowIcon('Track Titan')
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,BUNDLED')
+  })
+
+  test('built-in without a bundled icon (secondmonitor) still uses the shell icon', async () => {
+    await renderSection(
+      buildProps({
+        appIconCache: { 'c:\\apps\\secondmonitor.exe': 'data:image/png;base64,SHELL' }
+      })
+    )
+
+    const img = getRowIcon('Second Monitor')
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,SHELL')
+  })
+
+  test('custom app slots are unchanged: shell icon wins, no bundled tier applies', async () => {
+    await renderSection(
+      buildProps({
+        appIconCache: { 'c:\\apps\\custom.exe': 'data:image/png;base64,SHELL' }
+      })
+    )
+
+    const img = getRowIcon('Custom App 1')
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,SHELL')
+  })
+
+  test('falls back to the initials placeholder when neither icon source is available', async () => {
+    await renderSection(buildProps({}))
+
+    expect(getRowIcon('Track Titan')).toBeNull()
+    expect(getRow('Track Titan').textContent).toContain('Tr')
+  })
+})
+
+describe('ProfileUtilitiesSection bundled icon decode-failure fallthrough (#727)', () => {
+  test('bundled icon error falls through to the shell icon', async () => {
+    await renderStatefulSection(
+      buildProps({
+        appIconCache: { 'c:\\apps\\tracktitan.exe': 'data:image/png;base64,SHELL' },
+        utilityIcons: { tracktitan: 'data:image/png;base64,BUNDLED' }
+      })
+    )
+
+    const bundledImg = getRowIcon('Track Titan')
+    expect(bundledImg!.src).toBe('data:image/png;base64,BUNDLED')
+
+    await fireIconError(bundledImg!)
+
+    const img = getRowIcon('Track Titan')
+    expect(img).not.toBeNull()
+    expect(img!.src).toBe('data:image/png;base64,SHELL')
+  })
+
+  test('bundled AND shell icon errors fall through to the initials placeholder', async () => {
+    await renderStatefulSection(
+      buildProps({
+        appIconCache: { 'c:\\apps\\tracktitan.exe': 'data:image/png;base64,SHELL' },
+        utilityIcons: { tracktitan: 'data:image/png;base64,BUNDLED' }
+      })
+    )
+
+    await fireIconError(getRowIcon('Track Titan')!)
+    // After the bundled failure the shell icon renders; fail that too.
+    await fireIconError(getRowIcon('Track Titan')!)
+
+    expect(getRowIcon('Track Titan')).toBeNull()
+    expect(getRow('Track Titan').textContent).toContain('Tr')
+  })
+})


### PR DESCRIPTION
## Summary

The profile editor's "Utilities to launch" list was the third utility-icon surface, missed by #728: `ProfileUtilitiesSection` resolved icons only from the shell-extracted `appIconCache`, so Crew Chief / Trading Paints / Garage 61 still showed shell artifacts or initials there. This applies the same **bundled-first → shell-extracted → initials** chain used by `AppsSection` and the `GameList` running strip.

- **How the icons reach the component:** no new asset reads. `useProfileEditor` already consumes `AppsContext`, which carries `utilityIcons` (resolved once by `useSettingsLoad` via the `get-asset-data` IPC). The hook now exposes it and `ProfileEditor` threads it down as a prop — the same path `appIconCache` already takes.
- **Decode-failure fallthrough** consistent with #728: a bundled data URI that fails to decode is recorded in the section's existing `failedIcons` record under the namespaced key, and the render falls through to the shell tier, then initials.
- `getBundledIconErrorKey` is promoted from a private helper in `AppsSection.tsx` to `src/renderer/src/lib/config.ts` so both surfaces share one definition.

Surface sweep (so there's no fourth round): grepped the renderer for anything else rendering utility icons from `appIconCache`/`appIcons`/`getFileIcon` — the only three surfaces are `AppsSection` (#728), `GameList` running strip (#728), and `ProfileUtilitiesSection` (this PR). `GameRow` receives pre-resolved icons from `GameList`; `OnboardingModal` renders only the brand wordmark; no dialog/tray-related UI renders utility icons.

Closes #727

## Test plan

- New `tests/renderer/profileUtilitiesSectionIcon.test.tsx` (renders the real component; error tests use a stateful harness dispatching real image `error` events):
  - built-in with a bundled icon uses it even when shell extraction also returned a usable icon
  - built-in with a bundled icon uses it when shell extraction returned nothing
  - built-in without a bundled icon (`secondmonitor`) still uses the shell icon
  - custom app slots unchanged: shell icon wins, no bundled tier applies
  - falls back to the initials placeholder when neither icon source is available
  - bundled icon error falls through to the shell icon
  - bundled AND shell icon errors fall through to the initials placeholder
- Existing `appsSectionUtilityIcon.test.tsx` still green after the helper promotion.
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` all green (498 tests, 66 files).

Note: Second Monitor remains the tracked bundled-asset gap (kept on shell → initials until a curated asset exists).
