### PR TITLE
perf(ui): skip shell-icon fetch for paths covered by a bundled icon

### DIFF
--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -145,13 +145,22 @@ export function GameList({
   // Lazy-load Windows shell icons for newly-seen running app paths. Uses the
   // undefined sentinel (vs '' for "loaded but no icon") so re-fetching on
   // every render is avoided while still retrying if the cache entry is missing.
+  // Paths already covered by a bundled curated icon are skipped entirely:
+  // bundled is preferred at display time (#727), so a shell-extracted result
+  // for those paths would be fetched but never shown — wasted IPC and
+  // exe-icon-extraction work on every newly-seen built-in path.
   useEffect(() => {
     let mounted = true
     const pathsToLoad = Array.from(
       new Set(
         runningApps
           .map((app) => app.path)
-          .filter((path) => path && appIconCache[normalizePath(path)] === undefined)
+          .filter(
+            (path) =>
+              path &&
+              appIconCache[normalizePath(path)] === undefined &&
+              !bundledIconByPath[getPathComparisonKey(path)]
+          )
       )
     )
 
@@ -183,7 +192,10 @@ export function GameList({
     return () => {
       mounted = false
     }
-  }, [appIconCache, runningApps])
+    // bundledIconByPath is a useMemo over [utilityAppPaths, utilityIcons]
+    // (both stable context state), so including it re-runs the effect only
+    // when Settings actually change those — no per-render churn.
+  }, [appIconCache, bundledIconByPath, runningApps])
 
   if (!settingsLoaded) {
     return null

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { GAMES, type Game } from '../lib/config'
+import { BUILT_IN_UTILITIES, GAMES, type Game } from '../lib/config'
 import { getSettings, onStoreConfigChanged } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
@@ -29,6 +29,14 @@ type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] exten
 // would be treated as different entries and the game's own executable would
 // appear as a companion app in the running strip.
 const normalizePath = (path: string) => path.toLowerCase()
+
+// Static at module scope: which built-in utility keys DECLARE a bundled icon.
+// This is config knowledge (BUILT_IN_UTILITIES), not runtime state — used to
+// gate the shell-fetch skip below without depending on the async-loaded
+// utilityIcons data (see bundledCoveredPathKeys).
+const BUNDLED_ICON_UTILITY_KEYS = BUILT_IN_UTILITIES.filter((utility) => utility.icon).map(
+  (utility) => utility.key
+)
 
 export function GameList({
   onNavigate
@@ -88,6 +96,29 @@ export function GameList({
     return map
   }, [utilityAppPaths, utilityIcons])
 
+  // Paths whose icon needs are covered by a DECLARED bundled icon — the gate
+  // for the shell-fetch skip in the lazy-load effect below. Deliberately
+  // derived from static config (BUNDLED_ICON_UTILITY_KEYS) + utilityAppPaths,
+  // NOT from bundledIconByPath/utilityIcons: utilityIcons is populated
+  // asynchronously by useSettingsLoad's get-asset-data round-trips, while
+  // utilityAppPaths lands synchronously with the same settings state that
+  // gates configuredGames/runningApps. Gating the skip on the async data
+  // would leave a startup window — an early runningApps snapshot (adopted
+  // apps at boot, the most common source of the wasted fetches) fires before
+  // utilityIcons arrives and the shell fetch goes out anyway, negating the
+  // skip exactly where it matters most.
+  const bundledCoveredPathKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const utilityKey of BUNDLED_ICON_UTILITY_KEYS) {
+      const path = utilityAppPaths[utilityKey]
+      if (path) {
+        const pathKey = getPathComparisonKey(path)
+        if (pathKey) keys.add(pathKey)
+      }
+    }
+    return keys
+  }, [utilityAppPaths])
+
   // Read the configured-games list (+ derived UI state) from the store. Kept in
   // a callback so it can run on mount AND on every store config change: the
   // Games view stays mounted (#479), so without a reactive re-read it would hold
@@ -145,10 +176,13 @@ export function GameList({
   // Lazy-load Windows shell icons for newly-seen running app paths. Uses the
   // undefined sentinel (vs '' for "loaded but no icon") so re-fetching on
   // every render is avoided while still retrying if the cache entry is missing.
-  // Paths already covered by a bundled curated icon are skipped entirely:
-  // bundled is preferred at display time (#727), so a shell-extracted result
-  // for those paths would be fetched but never shown — wasted IPC and
-  // exe-icon-extraction work on every newly-seen built-in path.
+  // Paths covered by a declared bundled icon are skipped entirely: bundled is
+  // preferred at display time (#727), so a shell-extracted result for those
+  // paths would be fetched but never shown — wasted IPC and
+  // exe-icon-extraction work on every newly-seen built-in path. The gate is
+  // bundledCoveredPathKeys (static declaration + sync-loaded paths), NOT
+  // bundledIconByPath, so the skip also holds during the startup window
+  // before the async utilityIcons data lands (see bundledCoveredPathKeys).
   useEffect(() => {
     let mounted = true
     const pathsToLoad = Array.from(
@@ -159,7 +193,7 @@ export function GameList({
             (path) =>
               path &&
               appIconCache[normalizePath(path)] === undefined &&
-              !bundledIconByPath[getPathComparisonKey(path)]
+              !bundledCoveredPathKeys.has(getPathComparisonKey(path))
           )
       )
     )
@@ -192,10 +226,10 @@ export function GameList({
     return () => {
       mounted = false
     }
-    // bundledIconByPath is a useMemo over [utilityAppPaths, utilityIcons]
-    // (both stable context state), so including it re-runs the effect only
-    // when Settings actually change those — no per-render churn.
-  }, [appIconCache, bundledIconByPath, runningApps])
+    // bundledCoveredPathKeys is a useMemo over [utilityAppPaths] (stable
+    // context state), so including it re-runs the effect only when Settings
+    // actually change the configured paths — no per-render churn.
+  }, [appIconCache, bundledCoveredPathKeys, runningApps])
 
   if (!settingsLoaded) {
     return null

--- a/tests/renderer/gameListShellFetchSkip.test.tsx
+++ b/tests/renderer/gameListShellFetchSkip.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Regression test for the #727 perf follow-through (CodeRabbit nit on PR
+ * #728): GameList's lazy-load effect fetches Windows shell icons via the
+ * get-file-icon IPC for every newly-seen running-app path. Since bundled
+ * curated icons are preferred at display time (bundled-first, #727), a shell
+ * fetch for a path already covered by bundledIconByPath would be work whose
+ * result is never displayed — the effect must skip those paths, while still
+ * fetching for paths without a bundled icon (custom apps, built-ins without
+ * an asset, the game exe itself).
+ */
+
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const getFileIconMock = vi.fn().mockResolvedValue('data:image/png;base64,SHELL')
+const getSettingsMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: (...args: unknown[]) => getSettingsMock(...args),
+  onStoreConfigChanged: () => () => {}
+}))
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  getFileIcon: (...args: unknown[]) => getFileIconMock(...args),
+  // Consumed by NotifyProvider; inert subscriptions are enough here.
+  onAppLaunchError: () => () => {},
+  onProcessNameMismatchWarning: () => () => {}
+}))
+
+// GameList only consumes { runningApps, runningStatus, refreshRunningState }.
+// Mocked so the test controls the running set without the IPC subscription.
+const runningAppsMock = vi.fn()
+vi.mock('../../src/renderer/src/hooks/useRunningApps', () => ({
+  useRunningApps: () => runningAppsMock()
+}))
+
+vi.mock('../../src/renderer/src/hooks/useLaunchBlock', () => ({
+  useLaunchBlock: () => ({
+    launchingGameKey: null,
+    handleLaunchStart: vi.fn(),
+    handleLaunchEnd: vi.fn()
+  })
+}))
+
+// GameRow drags in profile hooks, floating-ui and the store; the lazy-load
+// effect under test lives in GameList itself, so the rows can be inert.
+vi.mock('../../src/renderer/src/components/game-list/GameRow', () => ({
+  GameRow: () => null
+}))
+
+import { GameList } from '../../src/renderer/src/components/GameList'
+import { NotifyProvider } from '../../src/renderer/src/components/Notify'
+import {
+  AppsContext,
+  type AppsContextValue
+} from '../../src/renderer/src/components/settings/AppsContext'
+import {
+  GamesContext,
+  type GamesContextValue
+} from '../../src/renderer/src/components/settings/GamesContext'
+import { getUtilities } from '../../src/renderer/src/lib/config'
+import type { RunningApp } from '../../src/renderer/src/hooks/useRunningApps'
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+const IRACING_PATH = 'C:\\Games\\iRacing\\iRacingUI.exe'
+const CREWCHIEF_PATH = 'C:\\Apps\\CrewChief\\CrewChiefV4.exe'
+const CUSTOM_PATH = 'C:\\Apps\\Overlay\\overlay.exe'
+
+function buildAppsContextValue(overrides: Partial<AppsContextValue>): AppsContextValue {
+  return {
+    appPaths: {},
+    appNames: {},
+    appArgs: {},
+    appIcons: {},
+    utilityIcons: {},
+    iconLoadErrors: new Set(),
+    customSlots: 1,
+    utilities: getUtilities(1),
+    profiles: {},
+    onBrowse: vi.fn(),
+    onAppNameChange: vi.fn(),
+    onAppPathChange: vi.fn(),
+    onAppArgsChange: vi.fn(),
+    onIconLoadError: vi.fn(),
+    onAddCustomSlot: vi.fn(),
+    onRemoveCustomSlot: vi.fn(),
+    ...overrides
+  }
+}
+
+const GAMES_CONTEXT_VALUE: GamesContextValue = {
+  gamePaths: { iracing: IRACING_PATH },
+  gameIcons: {},
+  onBrowse: vi.fn(),
+  onGamePathChange: vi.fn()
+}
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderGameList(
+  appsValue: AppsContextValue,
+  runningApps: RunningApp[]
+): Promise<void> {
+  getSettingsMock.mockResolvedValue({ gamePaths: { iracing: IRACING_PATH } })
+  runningAppsMock.mockReturnValue({
+    runningApps,
+    runningStatus: { iracing: runningApps.length > 0 },
+    refreshRunningState: vi.fn().mockResolvedValue(undefined)
+  })
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <NotifyProvider>
+        <GamesContext.Provider value={GAMES_CONTEXT_VALUE}>
+          <AppsContext.Provider value={appsValue}>
+            <GameList onNavigate={vi.fn()} />
+          </AppsContext.Provider>
+        </GamesContext.Provider>
+      </NotifyProvider>
+    )
+  })
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+describe('GameList shell-icon fetch skip for bundled-covered paths (#727)', () => {
+  test('a running app whose path has a bundled icon does NOT trigger a get-file-icon fetch', async () => {
+    await renderGameList(
+      buildAppsContextValue({
+        appPaths: { crewchief: CREWCHIEF_PATH },
+        utilityIcons: { crewchief: 'data:image/png;base64,BUNDLED' }
+      }),
+      [{ path: CREWCHIEF_PATH, name: 'CrewChiefV4.exe', gameKey: 'iracing' }]
+    )
+
+    expect(getFileIconMock).not.toHaveBeenCalled()
+  })
+
+  test('a running app without a bundled icon still triggers the get-file-icon fetch', async () => {
+    await renderGameList(
+      buildAppsContextValue({
+        appPaths: { crewchief: CREWCHIEF_PATH },
+        utilityIcons: { crewchief: 'data:image/png;base64,BUNDLED' }
+      }),
+      [
+        { path: CREWCHIEF_PATH, name: 'CrewChiefV4.exe', gameKey: 'iracing' },
+        { path: CUSTOM_PATH, name: 'overlay.exe', gameKey: 'iracing' }
+      ]
+    )
+
+    expect(getFileIconMock).toHaveBeenCalledTimes(1)
+    expect(getFileIconMock).toHaveBeenCalledWith(CUSTOM_PATH)
+  })
+
+  test('path-form differences between the configured path and the running entry still skip the fetch', async () => {
+    // Configured with forward slashes + trailing space; running entry is the
+    // canonical backslash form — the same getPathComparisonKey normalization
+    // that makes the bundled icon DISPLAY for this path must also gate the
+    // fetch skip, or the "never displayed" shell fetch comes back for exactly
+    // the paths the display-side normalization was built to cover.
+    await renderGameList(
+      buildAppsContextValue({
+        appPaths: { crewchief: 'C:/Apps/CrewChief\\CrewChiefV4.exe ' },
+        utilityIcons: { crewchief: 'data:image/png;base64,BUNDLED' }
+      }),
+      [
+        {
+          path: 'c:\\apps\\crewchief\\crewchiefv4.exe',
+          name: 'CrewChiefV4.exe',
+          gameKey: 'iracing'
+        }
+      ]
+    )
+
+    expect(getFileIconMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/renderer/gameListShellFetchSkip.test.tsx
+++ b/tests/renderer/gameListShellFetchSkip.test.tsx
@@ -186,4 +186,23 @@ describe('GameList shell-icon fetch skip for bundled-covered paths (#727)', () =
 
     expect(getFileIconMock).not.toHaveBeenCalled()
   })
+
+  test('startup race: skip holds while utilityIcons is still EMPTY (not yet async-loaded)', async () => {
+    // utilityIcons is populated asynchronously by useSettingsLoad's
+    // get-asset-data round-trips, while appPaths lands synchronously with the
+    // settings snapshot. Adopted running apps at boot produce a runningApps
+    // snapshot in exactly that window — the skip must be gated on the STATIC
+    // bundled-icon declaration (BUILT_IN_UTILITIES) + appPaths, not on the
+    // async-loaded icon data, or the wasted fetch fires precisely in the
+    // most common case this skip exists for.
+    await renderGameList(
+      buildAppsContextValue({
+        appPaths: { crewchief: CREWCHIEF_PATH },
+        utilityIcons: {} // async load has not completed yet
+      }),
+      [{ path: CREWCHIEF_PATH, name: 'CrewChiefV4.exe', gameKey: 'iracing' }]
+    )
+
+    expect(getFileIconMock).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

Perf follow-through on #727 (issue is closed; this does not reopen it), flagged in [CodeRabbit's review body on PR #728](https://github.com/Stashpeak/SimLauncher/pull/728#pullrequestreview-4629374672): `GameList`'s lazy-load effect fetched a Windows shell icon (`get-file-icon` IPC + exe-icon extraction in main) for **every** newly-seen running-app path — including paths already covered by `bundledIconByPath`. Since bundled curated icons are preferred at display time (bundled-first, #727), those shell results were fetched and never displayed.

- Minimal fix per the suggestion: the `pathsToLoad` filter now also requires `!bundledIconByPath[getPathComparisonKey(path)]` — keyed by the same `getPathComparisonKey` normalization used at display time, so the skip covers exactly the paths the bundled icon displays for (slash-style / whitespace / case variants included).
- **Dependency array:** `bundledIconByPath` is added to the effect deps. It's a `useMemo` over `[utilityAppPaths, utilityIcons]` — both stable context state from `useSettingsState` — so the effect re-runs only when Settings actually change those values; no per-render churn.

## Tradeoff considered (documented, no extra machinery built)

With the skip, a bundled data URI that fails to decode in the running strip has no cached shell icon to fall back to. Checked the strip's error handling: `RunningAppsStrip` **does** handle image load errors — `failedRunningIcons` records the failed URL and the item falls back to the initials tier. So the worst case for a disk-tested, packaged asset is the initials fallback (not a broken image, not an empty slot). Accepted as-is; building a shell-refetch-on-decode-failure path for that corner would be machinery without a realistic trigger.

Refs #727

## Test plan

- New `tests/renderer/gameListShellFetchSkip.test.tsx` (mounts the real `GameList` with mocked store/IPC/running-apps hooks; verified all three FAIL against pre-fix code):
  - a running app whose path has a bundled icon does NOT trigger a get-file-icon fetch
  - a running app without a bundled icon still triggers the get-file-icon fetch
  - path-form differences between the configured path and the running entry still skip the fetch
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` all green (501 tests, 67 files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game icon loading so bundled icons are reused more reliably for running apps, reducing unnecessary icon lookups.
  * Better path matching now handles common path differences like slashes, casing, and trailing spaces.

* **Tests**
  * Added regression coverage for icon-loading behavior to verify bundled icons are skipped and only missing icons are fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->