### PR TITLE
build: unsigned local dist config + dist:win:unsigned script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,29 +63,19 @@ npm run dev
 ## Building the installer
 
 ```bash
-# Build app output
-npm run build
-
-# Build Windows installer (.exe)
-npm run dist:win
-```
-
-Output will appear in `dist/`.
-
-`npm run dist:win` uses `electron-builder.yml`, which carries the Azure
-Artifact Signing options — those credentials only exist in CI, so this
-command fails locally with `Unable to find valid azure env field
-AZURE_TENANT_ID`. If you don't have the Azure signing secrets, build an
-unsigned installer instead:
-
-```bash
+# Build an unsigned Windows installer (.exe) — the right command for
+# building from source; no signing credentials needed
 npm run dist:win:unsigned
 ```
 
-This uses `electron-builder.unsigned.yml` (extends the base config with
-signing disabled) and installs fine — Windows/SmartScreen will just show it
-as unsigned/"NotSigned". CI's release build still goes through the signed
-path.
+Output will appear in `dist/`. The installer works normally; Windows just
+reports it as unsigned ("NotSigned"). It uses `electron-builder.unsigned.yml`,
+which extends the base config with signing disabled.
+
+`npm run dist:win` (the signed variant) uses `electron-builder.yml` directly,
+which carries the Azure Artifact Signing options — those credentials only
+exist in CI, so it fails locally with `Unable to find valid azure env field
+AZURE_TENANT_ID`. CI's release build is the only place that needs it.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,21 @@ npm run dist:win
 
 Output will appear in `dist/`.
 
+`npm run dist:win` uses `electron-builder.yml`, which carries the Azure
+Artifact Signing options — those credentials only exist in CI, so this
+command fails locally with `Unable to find valid azure env field
+AZURE_TENANT_ID`. If you don't have the Azure signing secrets, build an
+unsigned installer instead:
+
+```bash
+npm run dist:win:unsigned
+```
+
+This uses `electron-builder.unsigned.yml` (extends the base config with
+signing disabled) and installs fine — Windows/SmartScreen will just show it
+as unsigned/"NotSigned". CI's release build still goes through the signed
+path.
+
 ## Pull requests
 
 - Target the `main` branch unless the issue says otherwise.

--- a/README.md
+++ b/README.md
@@ -163,8 +163,13 @@ git clone https://github.com/Stashpeak/SimLauncher
 cd SimLauncher
 npm install
 npx install-electron   # Electron >=42 no longer downloads its binary via postinstall
-npm run dist:win       # build a Windows installer into dist/
+npm run dist:win:unsigned   # build an unsigned Windows installer into dist/
 ```
+
+`npm run dist:win` builds the signed installer, but that requires the Azure
+Artifact Signing credentials, which only exist in CI — use
+`dist:win:unsigned` locally instead. See [CONTRIBUTING.md](CONTRIBUTING.md#building-the-installer)
+for details.
 
 For the full development workflow — running in dev mode, the test/lint/typecheck gates, and how to add a game or utility — see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/electron-builder.unsigned.yml
+++ b/electron-builder.unsigned.yml
@@ -1,0 +1,10 @@
+# Local unsigned build config — use when building from source without the
+# Azure Artifact Signing credentials (only CI has them):
+#   npx electron-builder --win --publish never --config electron-builder.unsigned.yml
+# Since #511 the base config carries win.azureSignOptions unconditionally, so a
+# plain `npm run dist:win` fails locally with "Unable to find valid azure env
+# field AZURE_TENANT_ID". This override inherits everything else and just
+# disables the signing step. CI/release builds do NOT use this file.
+extends: ./electron-builder.yml
+win:
+  azureSignOptions: null

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "electron-vite build",
     "dist": "npm run build && electron-builder",
     "dist:win": "npm run build && electron-builder --win",
+    "dist:win:unsigned": "npm run build && electron-builder --win --publish never --config electron-builder.unsigned.yml",
     "lint": "eslint .",
     "preload:types": "node scripts/generate-preload-types.mjs",
     "preload:types:check": "node scripts/generate-preload-types.mjs --check",


### PR DESCRIPTION
## Summary

- `npm run dist:win` requires the Azure Artifact Signing env vars (CI-only, since #511), so plain local builds fail with `Unable to find valid azure env field AZURE_TENANT_ID`.
- Add `electron-builder.unsigned.yml` (extends the base config, `win.azureSignOptions: null`), copied verbatim from the founder's already-verified-working local build.
- Add `dist:win:unsigned` npm script: `npm run build && electron-builder --win --publish never --config electron-builder.unsigned.yml`.
- Document the split in CONTRIBUTING.md's build-from-source section and README.md's build-from-source snippet, pointing contributors without signing credentials at `dist:win:unsigned`.
- `electron-builder.yml` and `release.yml` are untouched — CI's signed release path is unaffected.

Closes #731

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (502 tests passed)
- [ ] Actual `npm run dist:win:unsigned` build was NOT re-run by me — the founder already verified today that this exact `electron-builder.unsigned.yml` produces a working, `NotSigned` installer locally. I copied the file verbatim from his checkout rather than re-running the ~multi-minute build myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local Windows build option that creates an unsigned installer when signing credentials aren’t available.
  * Updated build guidance to point local developers to the unsigned Windows build command.

* **Documentation**
  * Clarified that the standard Windows build path requires Azure signing credentials and is intended for CI releases.
  * Added setup notes for working around local signing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #731
<!-- auto-closes -->