### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "repository": {


### PR DESCRIPTION
## Summary
Bumps `1.0.2` → `1.1.0` (minor: onboarding, Track Titan, curated icons + a data-loss/correctness fix wave). CHANGELOG.md is a pointer to GitHub Releases by design, so no changelog edit — full release notes go on the published release.

### What ships (26 commits since v1.0.2)
**New:** first-run onboarding (#641), Track Titan built-in companion (#652), bundled-first curated utility icons across Settings / profile editor / running strip (#727)
**Fixes:** Close Apps cancellation across launch/relaunch/switch pre-launch windows (#670/#716), skipped-exe launch honesty (#639), save-settings reports rejected entries instead of silently dropping (#669), updater won't auto-quit past a dirty-settings prompt (#671), windowBounds import stripping (#691), getExeName trim (#679)
**Perf:** adaptive idle poll backoff when hidden + taskbar-minimized (#672/#708), skip shell-icon fetch for bundled-covered paths (#730)
**UX:** launch button names the active profile (#643), branded mascot empty state (#654)
**CI/build:** verify signed installer before publish + SHA-pinned actions (#663/#690), unsigned local dist config for source builds (#731)

### Footprint (#621)
Idle RAM measured for this release: **~180 MB private working set** (heavy config), +18 MB vs 1.0.2 — feature cost, no regression (see internal-docs baseline). 1.3.0 "Performance & Footprint" drives it down.

## Do NOT publish yet
This PR is the version bump only. After merge → tag `v1.1.0` → CI builds the signed draft installer → **smoke that draft exe** → publish.

## Milestone
1.1.0 — Advanced Features (only #621 remains open; its measurement is done, public-doc follow-up is non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from `1.0.2` to `1.1.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->