### PR TITLE
feat(onboarding): theme control + default new installs to system

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -81,7 +81,7 @@ const STORE_OPTIONS = {
     accentPreset: { type: 'string', default: '' },
     accentCustom: { type: 'string', default: '' },
     accentBgTint: { type: 'boolean', default: false },
-    themeMode: { type: 'string', default: 'dark', enum: ['light', 'dark', 'system'] },
+    themeMode: { type: 'string', default: 'system', enum: ['light', 'dark', 'system'] },
     focusActiveTitle: { type: 'boolean', default: true },
     launchDelayMs: { type: 'number', default: 1000, minimum: 0, maximum: 30000 },
     startWithWindows: { type: 'boolean', default: false },

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,4 +1,12 @@
-import { app, BrowserWindow, dialog, ipcMain, screen, type OpenDialogOptions } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  nativeTheme,
+  screen,
+  type OpenDialogOptions
+} from 'electron'
 import path from 'path'
 
 import {
@@ -20,6 +28,36 @@ let mainWindow: BrowserWindow | null = null
 // Grace period between the renderer finishing its load and force-showing the
 // window when 'ready-to-show' did not arrive (see the #382 comment below).
 const READY_TO_SHOW_FALLBACK_MS = 500
+
+const THEME_MODES = new Set(['light', 'dark', 'system'])
+
+/**
+ * Resolve the concrete theme ('light' | 'dark') to paint on the FIRST frame from
+ * the persisted themeMode. The window is shown on 'ready-to-show' (first paint),
+ * but the renderer only reads settings in a post-paint effect, so without this
+ * the first visible frame is App.css's dark default until that async read lands.
+ * A fresh install now defaults to 'system' (#735), so on a light-mode OS that
+ * would flash dark. Resolving here from the value main already holds keeps the
+ * first frame correct for everyone: 'system' follows the OS, and an existing
+ * persisted 'dark'/'light' is honored as-is (no wrong-theme flash either way).
+ *
+ * Pure (mode + OS preference in, theme out) so the mapping is unit-testable.
+ */
+export function resolveBootTheme(themeMode: unknown, prefersDark: boolean): 'light' | 'dark' {
+  // Unknown/absent falls back to the schema default ('system'); see store.ts.
+  const mode = THEME_MODES.has(themeMode as string) ? (themeMode as string) : 'system'
+
+  if (mode === 'light') return 'light'
+  if (mode === 'dark') return 'dark'
+  return prefersDark ? 'dark' : 'light'
+}
+
+// The additionalArguments token the preload reads to paint the boot theme before
+// first paint. Prefix duplicated in src/preload/initialTheme.ts — keep in sync.
+function getInitialThemeArg(): string {
+  const resolved = resolveBootTheme(store.get('themeMode'), nativeTheme.shouldUseDarkColors)
+  return `--initial-theme=${resolved}`
+}
 
 export type CloseAction = 'quit' | 'hide' | 'confirm-close' | 'confirm-minimize'
 
@@ -166,6 +204,10 @@ export function createWindow(): void {
       // Field diagnostics go through the logs folder + main-error.log (#524).
       devTools: !app.isPackaged,
       zoomFactor,
+      // Hand the preload the resolved boot theme so it can paint before the
+      // renderer's first frame (avoids a dark flash on light-mode fresh
+      // installs now that the default is 'system'). #735
+      additionalArguments: [getInitialThemeArg()],
       preload: path.join(__dirname, '../preload/index.js')
     }
   })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,11 @@ import type {
   StoreConfigChangePayload,
   UpdateErrorPayload
 } from './api'
+import { applyInitialTheme } from './initialTheme'
+
+// Paint the persisted theme main resolved for us before the renderer's first
+// frame, so a fresh 'system' install on a light-mode OS never flashes dark. #735
+applyInitialTheme(process.argv, document.documentElement)
 
 // The channel strings used in ipcRenderer.invoke / ipcRenderer.on must match
 // the ipcMain.handle / sendToRenderer calls in src/main/ipc exactly.

--- a/src/preload/initialTheme.ts
+++ b/src/preload/initialTheme.ts
@@ -1,0 +1,40 @@
+// Boot-theme handshake between main and this preload. Main resolves the
+// concrete theme from the PERSISTED settings (synchronously, before the window
+// is shown) and passes it here via BrowserWindow webPreferences
+// additionalArguments as `--initial-theme=<light|dark>`. This preload applies it
+// to the document BEFORE first paint, so a fresh install (default 'system') on a
+// light-mode OS does not flash dark while the renderer's async settings read is
+// still in flight. ThemeProvider re-applies the loaded value and subscribes to
+// live OS-preference changes once that read completes. #735
+//
+// The prefix string is duplicated in src/main/window.ts (getInitialThemeArg);
+// like the IPC channel strings, keep the two in sync by hand.
+export const INITIAL_THEME_ARG_PREFIX = '--initial-theme='
+
+/**
+ * Pull the resolved boot theme out of the process arguments main injected.
+ * Returns null when the argument is absent or malformed so the caller leaves the
+ * document untouched (App.css then falls back to its dark default).
+ */
+export function parseInitialThemeArg(argv: readonly string[]): 'light' | 'dark' | null {
+  const arg = argv.find((value) => value.startsWith(INITIAL_THEME_ARG_PREFIX))
+
+  if (!arg) {
+    return null
+  }
+
+  const theme = arg.slice(INITIAL_THEME_ARG_PREFIX.length)
+  return theme === 'light' || theme === 'dark' ? theme : null
+}
+
+/**
+ * Apply the injected boot theme to the document root before first paint. No-ops
+ * when the argument is missing/invalid or the root is unavailable.
+ */
+export function applyInitialTheme(argv: readonly string[], root: HTMLElement | null): void {
+  const theme = parseInitialThemeArg(argv)
+
+  if (theme && root) {
+    root.dataset.theme = theme
+  }
+}

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -18,6 +18,24 @@ interface OnboardingModalProps {
   onSkip: () => void
 }
 
+/** One labelled personalization row (Theme / Accent / Scale) in the modal's
+ * "Make it yours" group: a left-aligned label and its control, wrapping on
+ * narrow widths. Keeps the three rows identical. #735 */
+function PersonalizationRow({
+  label,
+  children
+}: {
+  label: string
+  children: ReactNode
+}): ReactNode {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <span className="text-sm text-(--text-secondary)">{label}</span>
+      {children}
+    </div>
+  )
+}
+
 /**
  * First-run onboarding. A single-screen modal that explains the one-click launch
  * loop, offers an optional theme + accent + zoom personalization, and hands off
@@ -129,16 +147,14 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
             Make it yours (optional)
           </span>
           <div className="mt-3 flex flex-col gap-3">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <span className="text-sm text-(--text-secondary)">Theme</span>
+            <PersonalizationRow label="Theme">
               <ThemeModeControl
                 themeMode={theme.themeMode}
                 onThemeModeChange={handleThemeModeChange}
                 className="flex flex-wrap items-center gap-2"
               />
-            </div>
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <span className="text-sm text-(--text-secondary)">Accent</span>
+            </PersonalizationRow>
+            <PersonalizationRow label="Accent">
               <AccentSwatchRow
                 accentPreset={theme.accentPreset}
                 accentCustom={theme.accentCustom}
@@ -147,15 +163,14 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
                 onCustomColorChange={handleCustomColorChange}
                 className="flex flex-wrap items-center gap-2"
               />
-            </div>
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <span className="text-sm text-(--text-secondary)">Scale</span>
+            </PersonalizationRow>
+            <PersonalizationRow label="Scale">
               <ZoomControl
                 zoomFactor={zoomFactor}
                 onZoomFactorChange={handleZoomFactorChange}
                 className="flex flex-wrap items-center gap-2"
               />
-            </div>
+            </PersonalizationRow>
           </div>
         </div>
 

--- a/src/renderer/src/components/OnboardingModal.tsx
+++ b/src/renderer/src/components/OnboardingModal.tsx
@@ -4,7 +4,9 @@ import { useFocusTrap } from '../hooks/useFocusTrap'
 import { useTheme } from '../contexts/ThemeContext'
 import { setZoom } from '../lib/electron'
 import { getSettings, saveSettings } from '../lib/store'
+import type { ThemeMode } from '../lib/theme'
 import { AccentSwatchRow } from './AccentSwatchRow'
+import { ThemeModeControl } from './ThemeModeControl'
 import { ZoomControl } from './ZoomControl'
 import { BrandWordmarkIcon } from './icons'
 
@@ -18,13 +20,13 @@ interface OnboardingModalProps {
 
 /**
  * First-run onboarding. A single-screen modal that explains the one-click launch
- * loop, offers an optional accent + zoom personalization, and hands off to
- * Settings to configure the first sim. Shown once (gated on onboardingSeen + a
- * zero-games config in App). Skippable end-to-end. #641
+ * loop, offers an optional theme + accent + zoom personalization, and hands off
+ * to Settings to configure the first sim. Shown once (gated on onboardingSeen +
+ * a zero-games config in App). Skippable end-to-end. #641
  *
- * The accent + zoom controls are the same shared components Settings uses, but
- * the modal persists changes immediately (there is no save bar here) so the
- * picks survive the next launch.
+ * The theme + accent + zoom controls are the same shared components Settings
+ * uses, but the modal persists changes immediately (there is no save bar here)
+ * so the picks survive the next launch. #735
  */
 export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProps): ReactNode {
   const dialogRef = useRef<HTMLDivElement>(null)
@@ -60,6 +62,13 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
 
   const isCustomColor = theme.accentPreset === 'custom'
 
+  const handleThemeModeChange = (mode: ThemeMode): void => {
+    theme.setThemeMode(mode) // apply live
+    // persist now (no save bar here)
+    void saveSettings({ themeMode: mode }).catch((err: unknown) => {
+      console.error('Failed to persist onboarding theme mode', err)
+    })
+  }
   const handleAccentChange = (hex: string): void => {
     theme.setAccentPreset(hex) // apply live
     // persist now (no save bar here)
@@ -105,14 +114,10 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
             aligned at every zoom. "Launcher" follows the accent (text-(--accent))
             to tie into the accent picker below; the play-mark keeps its own
             --launcher-play. The h2 carries the accessible name via aria-label
-            since the logo itself is decorative SVG. #641 */}
+            since the logo itself is decorative SVG. The "Welcome to" lockup was
+            dropped to keep the modal height sensible; the wordmark alone still
+            carries identity. #641 #735 */}
         <h2 id={titleId} aria-label="Welcome to SimLauncher" className="mb-3">
-          <span
-            aria-hidden="true"
-            className="mb-2 block text-xs font-bold uppercase tracking-[0.2em] text-(--text-muted)"
-          >
-            Welcome to
-          </span>
           <BrandWordmarkIcon aria-hidden="true" className="h-7 w-auto text-(--accent)" />
         </h2>
         <p id={descId} className="text-sm text-(--text-secondary) leading-relaxed mb-6">
@@ -124,6 +129,14 @@ export function OnboardingModal({ isOpen, onSetup, onSkip }: OnboardingModalProp
             Make it yours (optional)
           </span>
           <div className="mt-3 flex flex-col gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span className="text-sm text-(--text-secondary)">Theme</span>
+              <ThemeModeControl
+                themeMode={theme.themeMode}
+                onThemeModeChange={handleThemeModeChange}
+                className="flex flex-wrap items-center gap-2"
+              />
+            </div>
             <div className="flex flex-wrap items-center justify-between gap-3">
               <span className="text-sm text-(--text-secondary)">Accent</span>
               <AccentSwatchRow

--- a/src/renderer/src/components/ThemeModeControl.tsx
+++ b/src/renderer/src/components/ThemeModeControl.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react'
+import type { ThemeMode } from '../lib/theme'
+
+export const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
+  { label: 'Dark', value: 'dark' },
+  { label: 'Light', value: 'light' },
+  { label: 'System', value: 'system' }
+]
+
+interface ThemeModeControlProps {
+  themeMode: ThemeMode
+  onThemeModeChange: (mode: ThemeMode) => void
+  /**
+   * Container class for the pill group. Defaults to the Settings-row control
+   * layout; the onboarding modal passes its own so the row fits that surface.
+   */
+  className?: string
+}
+
+/**
+ * The segmented Light/Dark/System control. Shared by AppearanceSection
+ * (Settings) and the first-run onboarding modal so both drive the exact same
+ * control. Prop-driven (no context) so it works wherever it is mounted. #735
+ */
+export function ThemeModeControl({
+  themeMode,
+  onThemeModeChange,
+  className = 'settings-control'
+}: ThemeModeControlProps): ReactNode {
+  return (
+    <div className={className} role="group" aria-label="Theme">
+      {THEME_MODE_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onThemeModeChange(option.value)}
+          aria-pressed={themeMode === option.value}
+          className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
+            themeMode === option.value
+              ? 'selected-surface text-(--text-primary)'
+              : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -1,15 +1,9 @@
 import { useId, type ReactNode } from 'react'
-import type { ThemeMode } from '../../lib/theme'
 import { Toggle } from '../Toggle'
 import { AccentSwatchRow } from '../AccentSwatchRow'
+import { ThemeModeControl } from '../ThemeModeControl'
 import { ZoomControl } from '../ZoomControl'
 import { useAppearanceSettings } from './AppearanceContext'
-
-const THEME_MODE_OPTIONS: Array<{ label: string; value: ThemeMode }> = [
-  { label: 'Dark', value: 'dark' },
-  { label: 'Light', value: 'light' },
-  { label: 'System', value: 'system' }
-]
 
 export function AppearanceSection(): ReactNode {
   const accentBgTintId = useId()
@@ -34,23 +28,7 @@ export function AppearanceSection(): ReactNode {
     <>
       <div className="settings-row settings-row-responsive">
         <span className="settings-label text-(--text-secondary)">Theme</span>
-        <div className="settings-control" role="group" aria-label="Theme">
-          {THEME_MODE_OPTIONS.map((option) => (
-            <button
-              key={option.value}
-              type="button"
-              onClick={() => onThemeModeChange(option.value)}
-              aria-pressed={themeMode === option.value}
-              className={`settings-control-pill settings-control-pill-button settings-control-preset glass-surface action-hover-scale tracking-wide transition-colors ${
-                themeMode === option.value
-                  ? 'selected-surface text-(--text-primary)'
-                  : 'accent-subtle-hover text-(--text-secondary) hover:text-(--text-primary)'
-              }`}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
+        <ThemeModeControl themeMode={themeMode} onThemeModeChange={onThemeModeChange} />
       </div>
 
       <div className="settings-row settings-row-responsive">

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -10,7 +10,13 @@ import {
 import { DEFAULT_ACCENT_COLOR } from '../lib/config'
 import { setZoom } from '../lib/electron'
 import { getSettings } from '../lib/store'
-import { applyAccentTheme, applyThemeMode, normalizeThemeMode, type ThemeMode } from '../lib/theme'
+import {
+  applyAccentTheme,
+  applyThemeMode,
+  DEFAULT_THEME_MODE,
+  normalizeThemeMode,
+  type ThemeMode
+} from '../lib/theme'
 
 interface ThemeContextValue {
   accentPreset: string
@@ -41,7 +47,12 @@ export function ThemeProvider({ children }: { children: ReactNode }): ReactNode 
   const [accentPreset, setAccentPresetState] = useState(DEFAULT_ACCENT_COLOR)
   const [accentCustom, setAccentCustomState] = useState('')
   const [accentBgTint, setAccentBgTintState] = useState(false)
-  const [themeMode, setThemeModeState] = useState<ThemeMode>('dark')
+  // The real value loads from the store in syncThemeFromStore; seed with the
+  // shared default (not a hardcoded 'dark') so the pre-load context value tracks
+  // the actual default. The visible first frame is painted by the preload from
+  // the persisted value (see resolveBootTheme in main), so this initial guess is
+  // never applied to the document ahead of the loaded value. #735
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(DEFAULT_THEME_MODE)
 
   const applyAccent = useCallback((preset: string, custom: string) => {
     const hex = preset === 'custom' ? custom : preset

--- a/src/renderer/src/lib/theme.ts
+++ b/src/renderer/src/lib/theme.ts
@@ -1,7 +1,7 @@
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/
 export type ThemeMode = 'light' | 'dark' | 'system'
 
-export const DEFAULT_THEME_MODE: ThemeMode = 'dark'
+export const DEFAULT_THEME_MODE: ThemeMode = 'system'
 
 // Module-level cleanup handle for the system-theme media-query listener.
 // Only one listener exists at a time because applyThemeMode always cancels

--- a/tests/main/electronMock.ts
+++ b/tests/main/electronMock.ts
@@ -147,6 +147,10 @@ export const nativeImage = {
   createFromPath: vi.fn((imagePath: string) => ({ imagePath }))
 }
 
+export const nativeTheme = {
+  shouldUseDarkColors: false
+}
+
 export const screen = {
   getDisplayMatching: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }))
 }

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -113,7 +113,7 @@ test('createInMemoryFallbackStore seeds schema defaults and supports get/set/cle
   const fallback = createInMemoryFallbackStore()
 
   // Seeded with schema defaults so the app behaves like a fresh install.
-  expect(fallback.get('themeMode')).toBe('dark')
+  expect(fallback.get('themeMode')).toBe('system')
   expect(fallback.get('showTrayIcon')).toBe(true)
   expect(fallback.get('customSlots')).toBe(1)
   // Unknown keys honor the get(key, default) form.
@@ -136,7 +136,7 @@ test('createInMemoryFallbackStore seeds schema defaults and supports get/set/cle
 
   // clear() resets to schema defaults, matching electron-store semantics.
   fallback.clear()
-  expect(fallback.get('themeMode')).toBe('dark')
+  expect(fallback.get('themeMode')).toBe('system')
 
   // Object defaults are cloned, not shared by reference: a handler mutating a
   // returned object default (e.g. save-profile does `profiles[key] = ...`) must

--- a/tests/main/window.test.ts
+++ b/tests/main/window.test.ts
@@ -39,6 +39,7 @@ async function loadWindowModuleForCreate(
     showTrayIcon?: boolean
     minimizeToTray?: boolean
     autoCheckUpdates?: boolean
+    themeMode?: string
   } = {}
 ) {
   const { clearIpcHandlers } = await import('electron')
@@ -48,7 +49,8 @@ async function loadWindowModuleForCreate(
     startMinimized: opts.startMinimized ?? false,
     showTrayIcon: opts.showTrayIcon ?? true,
     minimizeToTray: opts.minimizeToTray ?? false,
-    autoCheckUpdates: opts.autoCheckUpdates ?? true
+    autoCheckUpdates: opts.autoCheckUpdates ?? true,
+    themeMode: opts.themeMode
   }
   const storeSet = vi.fn((key: string, value: unknown) => {
     storeValues[key] = value
@@ -96,6 +98,58 @@ async function getCreatedWindow() {
 beforeEach(() => {
   vi.resetModules()
   vi.clearAllMocks()
+})
+
+// #735: the first visible frame must match the PERSISTED theme (the window is
+// shown on 'ready-to-show', before the renderer's async settings read lands).
+// resolveBootTheme maps the persisted mode + OS preference to the concrete
+// theme main hands the preload to paint pre-first-paint.
+test('resolveBootTheme: system follows the OS preference', async () => {
+  const { resolveBootTheme } = await loadWindowModuleForCreate()
+  // Fresh install (default 'system') on a light-mode OS must resolve to light,
+  // not the dark App.css default — this is the flash the fix removes.
+  expect(resolveBootTheme('system', false)).toBe('light')
+  expect(resolveBootTheme('system', true)).toBe('dark')
+})
+
+test('resolveBootTheme: an explicit persisted mode wins over the OS (no wrong-theme flash for existing users)', async () => {
+  const { resolveBootTheme } = await loadWindowModuleForCreate()
+  // An existing dark user on a light-mode OS still boots dark (and vice versa).
+  expect(resolveBootTheme('dark', false)).toBe('dark')
+  expect(resolveBootTheme('light', true)).toBe('light')
+})
+
+test('resolveBootTheme: an unknown/absent mode falls back to system', async () => {
+  const { resolveBootTheme } = await loadWindowModuleForCreate()
+  expect(resolveBootTheme(undefined, false)).toBe('light')
+  expect(resolveBootTheme('bogus', true)).toBe('dark')
+})
+
+test('createWindow injects the resolved boot theme for the preload (#735)', async () => {
+  const electron = await import('electron')
+  ;(
+    electron as unknown as { nativeTheme: { shouldUseDarkColors: boolean } }
+  ).nativeTheme.shouldUseDarkColors = false
+  const { createWindow } = await loadWindowModuleForCreate({ themeMode: 'system' })
+  createWindow()
+  const win = await getCreatedWindow()
+
+  const additionalArguments = win.options.webPreferences?.additionalArguments as string[]
+  // A fresh 'system' install on a light OS gets a light first frame.
+  expect(additionalArguments).toContain('--initial-theme=light')
+})
+
+test('createWindow injects a persisted dark theme even on a light-mode OS (#735)', async () => {
+  const electron = await import('electron')
+  ;(
+    electron as unknown as { nativeTheme: { shouldUseDarkColors: boolean } }
+  ).nativeTheme.shouldUseDarkColors = false
+  const { createWindow } = await loadWindowModuleForCreate({ themeMode: 'dark' })
+  createWindow()
+  const win = await getCreatedWindow()
+
+  const additionalArguments = win.options.webPreferences?.additionalArguments as string[]
+  expect(additionalArguments).toContain('--initial-theme=dark')
 })
 
 // Electron 42 regression context (#382): the renderer's boot-time set-zoom IPC

--- a/tests/renderer/appearanceSectionThemeControl.test.tsx
+++ b/tests/renderer/appearanceSectionThemeControl.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * #735 - the segmented Light/Dark/System control was extracted out of
+ * AppearanceSection into the shared ThemeModeControl (mirroring how
+ * AccentSwatchRow/ZoomControl were extracted for #641). This is a
+ * behavior-preserving refactor: AppearanceSection must still render the Theme
+ * row and still call onThemeModeChange when a pill is clicked.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { AppearanceSection } from '../../src/renderer/src/components/settings/AppearanceSection'
+import { AppearanceContext } from '../../src/renderer/src/components/settings/AppearanceContext'
+
+function button(container: HTMLElement, name: RegExp): HTMLButtonElement | null {
+  return (
+    (Array.from(container.querySelectorAll('button')).find((element) =>
+      name.test(element.textContent ?? '')
+    ) as HTMLButtonElement | undefined) ?? null
+  )
+}
+
+async function renderAppearanceSection(
+  onThemeModeChange: (mode: 'light' | 'dark' | 'system') => void
+): Promise<{
+  container: HTMLElement
+  unmount: () => void
+}> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root: Root | null = null
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppearanceContext.Provider
+        value={{
+          accentPreset: '#008c99',
+          accentCustom: '',
+          accentBgTint: false,
+          themeMode: 'dark',
+          focusActiveTitle: true,
+          zoomFactor: 1,
+          isCustomColor: false,
+          onAccentChange: vi.fn(),
+          onCustomColorChange: vi.fn(),
+          onAccentBgTintChange: vi.fn(),
+          onThemeModeChange,
+          onFocusActiveTitleChange: vi.fn(),
+          onZoomFactorChange: vi.fn()
+        }}
+      >
+        <AppearanceSection />
+      </AppearanceContext.Provider>
+    )
+  })
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    }
+  }
+}
+
+describe('AppearanceSection after ThemeModeControl extraction (#735)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('still renders the Theme row and reflects the current mode', async () => {
+    const harness = await renderAppearanceSection(vi.fn())
+    try {
+      const group = harness.container.querySelector('[role="group"][aria-label="Theme"]')
+      expect(group).not.toBeNull()
+      expect(button(harness.container, /^dark$/i)?.getAttribute('aria-pressed')).toBe('true')
+      expect(button(harness.container, /^light$/i)?.getAttribute('aria-pressed')).toBe('false')
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('still calls onThemeModeChange when a pill is clicked', async () => {
+    const onThemeModeChange = vi.fn()
+    const harness = await renderAppearanceSection(onThemeModeChange)
+    try {
+      await act(async () => {
+        button(harness.container, /^system$/i)?.click()
+      })
+      expect(onThemeModeChange).toHaveBeenCalledWith('system')
+    } finally {
+      harness.unmount()
+    }
+  })
+})

--- a/tests/renderer/initialTheme.test.ts
+++ b/tests/renderer/initialTheme.test.ts
@@ -1,0 +1,52 @@
+/**
+ * #735 - flash-free boot theming. Main resolves the concrete theme from the
+ * PERSISTED settings and hands it to the preload via `--initial-theme=<theme>`;
+ * the preload paints it onto the document BEFORE the renderer's first frame, so
+ * a fresh install (default 'system') on a light-mode OS never flashes dark while
+ * the renderer's async settings read is still in flight.
+ */
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  applyInitialTheme,
+  INITIAL_THEME_ARG_PREFIX,
+  parseInitialThemeArg
+} from '../../src/preload/initialTheme'
+
+describe('parseInitialThemeArg (#735)', () => {
+  test('extracts a valid injected theme from argv', () => {
+    expect(parseInitialThemeArg(['--foo', `${INITIAL_THEME_ARG_PREFIX}light`])).toBe('light')
+    expect(parseInitialThemeArg([`${INITIAL_THEME_ARG_PREFIX}dark`])).toBe('dark')
+  })
+
+  test('returns null when the argument is absent or malformed', () => {
+    expect(parseInitialThemeArg(['--foo', '--bar'])).toBeNull()
+    expect(parseInitialThemeArg([`${INITIAL_THEME_ARG_PREFIX}purple`])).toBeNull()
+    expect(parseInitialThemeArg([])).toBeNull()
+  })
+})
+
+describe('applyInitialTheme (#735)', () => {
+  afterEach(() => {
+    delete document.documentElement.dataset.theme
+  })
+
+  test('paints the injected theme onto the document root before first paint', () => {
+    applyInitialTheme([`${INITIAL_THEME_ARG_PREFIX}light`], document.documentElement)
+    // App.css treats data-theme="light" as light; anything else is the dark
+    // default. A fresh system install on a light OS must land here, not dark.
+    expect(document.documentElement.dataset.theme).toBe('light')
+
+    applyInitialTheme([`${INITIAL_THEME_ARG_PREFIX}dark`], document.documentElement)
+    expect(document.documentElement.dataset.theme).toBe('dark')
+  })
+
+  test('leaves the document untouched when no theme was injected', () => {
+    applyInitialTheme(['--other'], document.documentElement)
+    expect(document.documentElement.dataset.theme).toBeUndefined()
+  })
+
+  test('no-ops when the root is unavailable', () => {
+    expect(() => applyInitialTheme([`${INITIAL_THEME_ARG_PREFIX}light`], null)).not.toThrow()
+  })
+})

--- a/tests/renderer/onboarding.test.tsx
+++ b/tests/renderer/onboarding.test.tsx
@@ -15,6 +15,9 @@ const h = vi.hoisted(() => ({
   onboardingSeen: false as boolean,
   gamePaths: {} as Record<string, string>,
   persistOnboardingSeen: vi.fn(async () => {}),
+  saveSettings: vi.fn(async () => {}),
+  setThemeMode: vi.fn(),
+  themeMode: 'dark' as 'light' | 'dark' | 'system',
   settingsTarget: { current: undefined as string | null | undefined }
 }))
 
@@ -22,7 +25,7 @@ vi.mock('../../src/renderer/src/lib/store', () => ({
   getOnboardingSeen: vi.fn(async () => h.onboardingSeen),
   setOnboardingSeen: h.persistOnboardingSeen,
   getSettings: vi.fn(async () => ({ gamePaths: h.gamePaths, zoomFactor: 1 })),
-  saveSettings: vi.fn(async () => {}),
+  saveSettings: h.saveSettings,
   onStoreConfigChanged: vi.fn(() => () => {})
 }))
 
@@ -56,12 +59,12 @@ vi.mock('../../src/renderer/src/contexts/ThemeContext', () => ({
     accentPreset: '#008c99',
     accentCustom: '',
     accentBgTint: false,
-    themeMode: 'dark',
+    themeMode: h.themeMode,
     resolvedAccent: '#008c99',
     setAccentPreset: vi.fn(),
     setAccentCustom: vi.fn(),
     setAccentBgTint: vi.fn(),
-    setThemeMode: vi.fn(),
+    setThemeMode: h.setThemeMode,
     syncThemeFromStore: vi.fn(async () => {})
   })
 }))
@@ -132,7 +135,10 @@ describe('First-run onboarding (#641)', () => {
   beforeEach(() => {
     h.onboardingSeen = false
     h.gamePaths = {}
+    h.themeMode = 'dark'
     h.persistOnboardingSeen.mockClear()
+    h.saveSettings.mockClear()
+    h.setThemeMode.mockClear()
     h.settingsTarget.current = undefined
   })
 
@@ -205,6 +211,50 @@ describe('First-run onboarding (#641)', () => {
       })
       expect(h.persistOnboardingSeen).toHaveBeenCalledWith(true)
       expect(modalHeading()).toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+})
+
+describe('Onboarding theme control (#735)', () => {
+  beforeEach(() => {
+    h.onboardingSeen = false
+    h.gamePaths = {}
+    h.themeMode = 'dark'
+    h.persistOnboardingSeen.mockClear()
+    h.saveSettings.mockClear()
+    h.setThemeMode.mockClear()
+    h.settingsTarget.current = undefined
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('renders a Theme row with Light/Dark/System options', async () => {
+    const harness = await renderApp()
+    try {
+      const group = document.body.querySelector('[role="group"][aria-label="Theme"]')
+      expect(group).not.toBeNull()
+      expect(button(/^light$/i)).not.toBeNull()
+      expect(button(/^dark$/i)).not.toBeNull()
+      expect(button(/^system$/i)).not.toBeNull()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('selecting a theme mode applies it live and persists it immediately', async () => {
+    const harness = await renderApp()
+    try {
+      await act(async () => {
+        button(/^light$/i)?.click()
+      })
+      // Applies live via ThemeContext (no save bar in the onboarding modal).
+      expect(h.setThemeMode).toHaveBeenCalledWith('light')
+      // Persists immediately, same as the accent/zoom rows.
+      expect(h.saveSettings).toHaveBeenCalledWith({ themeMode: 'light' })
     } finally {
       harness.unmount()
     }

--- a/tests/renderer/themeMode.test.ts
+++ b/tests/renderer/themeMode.test.ts
@@ -1,0 +1,30 @@
+/**
+ * #735 - default new installs to the system theme instead of dark.
+ *
+ * `system` is a fully working, live-reactive mode (theme.ts subscribes to OS
+ * preference changes), so a fresh config should resolve to it rather than a
+ * hardcoded dark default. An existing persisted themeMode must be respected,
+ * not silently overridden - this only changes the baseline for brand-new
+ * configs.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { DEFAULT_THEME_MODE, normalizeThemeMode } from '../../src/renderer/src/lib/theme'
+
+describe('theme mode default (#735)', () => {
+  test('DEFAULT_THEME_MODE is system', () => {
+    expect(DEFAULT_THEME_MODE).toBe('system')
+  })
+
+  test('normalizeThemeMode resolves a missing/invalid value to system for a fresh config', () => {
+    expect(normalizeThemeMode(undefined)).toBe('system')
+    expect(normalizeThemeMode(null)).toBe('system')
+    expect(normalizeThemeMode('bogus')).toBe('system')
+  })
+
+  test('normalizeThemeMode respects an existing persisted value (not overridden)', () => {
+    expect(normalizeThemeMode('dark')).toBe('dark')
+    expect(normalizeThemeMode('light')).toBe('light')
+    expect(normalizeThemeMode('system')).toBe('system')
+  })
+})


### PR DESCRIPTION
## Summary
- Extracts the segmented Light/Dark/System control from `AppearanceSection` into a shared `ThemeModeControl` (`src/renderer/src/components/ThemeModeControl.tsx`), mirroring how `AccentSwatchRow`/`ZoomControl` were extracted for #641. `AppearanceSection` is refactored to use it with no visual/behavior change.
- Adds a Theme row to the first-run onboarding modal, ordered Theme, then Accent, then Scale. It reads `themeMode` from `ThemeContext` and, on change, applies it live (`theme.setThemeMode`) and persists immediately (`saveSettings({ themeMode })`), the same pattern already used for accent and zoom in the modal (no save bar there).
- Drops the "Welcome to" heading line from the modal; the `SIMLAUNCHER▶` wordmark and the subtitle stay, keeping the modal height sensible.
- Changes the default `themeMode` from `dark` to `system` in both `src/main/store.ts` (schema default) and `src/renderer/src/lib/theme.ts` (`DEFAULT_THEME_MODE`). This only affects fresh configs; existing users keep their persisted value.

Closes #735

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (509 tests, all green)
- [x] New/changed tests verified to FAIL on pre-change code (theme row missing from the modal, default still `dark`), then pass after the change:
  - `tests/renderer/onboarding.test.tsx`: "renders a Theme row with Light/Dark/System options", "selecting a theme mode applies it live and persists it immediately"
  - `tests/renderer/themeMode.test.ts` (new): `DEFAULT_THEME_MODE` is `system`, `normalizeThemeMode` resolves a missing/invalid value to `system`, and respects an existing persisted value
  - `tests/main/store.test.ts`: in-memory fallback store schema default updated to `system`
  - `tests/renderer/appearanceSectionThemeControl.test.tsx` (new): behavior-preserving check that `AppearanceSection` still renders the Theme row and still calls `onThemeModeChange` after the extraction

## Screenshots
<!-- founder will drop the onboarding modal shot here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new theme selector in onboarding and appearance settings, with Light, Dark, and System options.
  * New selections apply immediately and are saved for future sessions.

* **Bug Fixes**
  * New or reset setups now default to System theme instead of Dark.
  * Theme settings now preserve existing valid choices while handling missing or invalid values more gracefully.

* **Tests**
  * Added coverage for default theme behavior and theme-selection interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #735
<!-- auto-closes -->