### PR TITLE
fix(ui): skipped-launch toast copy — generic noun, no em dash (#639)

### DIFF
--- a/src/renderer/src/lib/skippedLaunchEntries.ts
+++ b/src/renderer/src/lib/skippedLaunchEntries.ts
@@ -56,6 +56,6 @@ export function formatSkippedLaunchEntries(
   const names = skipped.map((entry) => resolveSkippedEntryName(entry, lookup))
 
   return names.length === 1
-    ? `${names[0]} was skipped — its path no longer exists.`
-    : `${names.length} apps were skipped because their paths no longer exist (${names.join(', ')}).`
+    ? `${names[0]} was skipped: its path no longer exists.`
+    : `${names.length} items were skipped because their paths no longer exist (${names.join(', ')}).`
 }

--- a/tests/renderer/gameRowLaunchSkipped.test.tsx
+++ b/tests/renderer/gameRowLaunchSkipped.test.tsx
@@ -155,7 +155,7 @@ describe('GameRow launch skipped-entry warning (#639)', () => {
     await clickPlayButton()
 
     expect(notifyMock).toHaveBeenCalledWith(
-      'Assetto Corsa was skipped — its path no longer exists.',
+      'Assetto Corsa was skipped: its path no longer exists.',
       'warn',
       5000
     )
@@ -172,7 +172,7 @@ describe('GameRow launch skipped-entry warning (#639)', () => {
     await clickPlayButton()
 
     expect(notifyMock).toHaveBeenCalledWith(
-      'SimHub was skipped — its path no longer exists.',
+      'SimHub was skipped: its path no longer exists.',
       'warn',
       5000
     )
@@ -210,7 +210,7 @@ describe('GameRow launch skipped-entry warning (#639)', () => {
     await clickPlayButton()
 
     expect(notifyMock).toHaveBeenCalledWith(
-      'SimHub was skipped — its path no longer exists. Started 1 app; skipped 1 already running.',
+      'SimHub was skipped: its path no longer exists. Started 1 app; skipped 1 already running.',
       'warn',
       5000
     )
@@ -230,7 +230,7 @@ describe('GameRow launch skipped-entry warning (#639)', () => {
     await clickPlayButton()
 
     expect(notifyMock).toHaveBeenCalledWith(
-      'No valid executable paths configured. Assetto Corsa was skipped — its path no longer exists.',
+      'No valid executable paths configured. Assetto Corsa was skipped: its path no longer exists.',
       'error'
     )
   })

--- a/tests/renderer/profileEditorLaunchSkipped.test.tsx
+++ b/tests/renderer/profileEditorLaunchSkipped.test.tsx
@@ -112,7 +112,7 @@ describe('useProfileEditor launch skipped-entry warning (#639)', () => {
       })
 
       expect(notifyMock).toHaveBeenCalledWith(
-        'iRacing was skipped — its path no longer exists.',
+        'iRacing was skipped: its path no longer exists.',
         'warn',
         5000
       )
@@ -135,7 +135,7 @@ describe('useProfileEditor launch skipped-entry warning (#639)', () => {
       })
 
       expect(notifyMock).toHaveBeenCalledWith(
-        'My Dash was skipped — its path no longer exists.',
+        'My Dash was skipped: its path no longer exists.',
         'warn',
         5000
       )

--- a/tests/renderer/skippedLaunchEntries.test.ts
+++ b/tests/renderer/skippedLaunchEntries.test.ts
@@ -24,7 +24,7 @@ test('single skipped entry names it in the singular form', () => {
     LOOKUP
   )
 
-  expect(out).toBe('Assetto Corsa was skipped — its path no longer exists.')
+  expect(out).toBe('Assetto Corsa was skipped: its path no longer exists.')
 })
 
 test('multiple skipped entries use the plural form and list every name', () => {
@@ -37,7 +37,7 @@ test('multiple skipped entries use the plural form and list every name', () => {
   )
 
   expect(out).toBe(
-    '2 apps were skipped because their paths no longer exist (Assetto Corsa, SimHub).'
+    '2 items were skipped because their paths no longer exist (Assetto Corsa, SimHub).'
   )
 })
 


### PR DESCRIPTION
## Summary
Two copy nits found while smoke-testing the merged #639 skipped-launch warning, batched before the 1.1.0 publish:

1. **Plural form miscalled a game an "app"** — `N apps were skipped ... (iRacing, ...)` lumped the game in as an app. Switched the noun to **items** so it's correct for games + companions alike.
2. **Singular form used an em dash** — `X was skipped — its path...` violates the no-em-dash-in-public-copy rule (#721). Now a colon.

Both are in `src/renderer/src/lib/skippedLaunchEntries.ts`; unit assertions updated to match.

## Test plan
- [x] `npx vitest run tests/renderer/skippedLaunchEntries.test.ts` — 3/3 pass
- [ ] CI green (lint + full test)
- Re-smoke: trigger a partial skipped launch (rename a configured game's exe folder, launch) → toast reads "iRacing was skipped: its path no longer exists." (singular) / "2 items were skipped because their paths no longer exist (...)" (plural).

Follow-up to #639. No behavior change, copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the warning message shown when launch entries are skipped because their paths no longer exist.
  * Improved the wording for both single and multiple skipped items for clearer, more consistent feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->