### PR TITLE
ci(review-bot): drop Kimi K3, rotate Terra|Grok per PR

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -1,5 +1,6 @@
 # Copy to .github/workflows/review-bot.yml in a Stashpeak org repo.
-# Secrets needed (org level): CLAUDE_CODE_OAUTH_TOKEN, OPENROUTER_API_KEY, REVIEWBOT_PAT.
+# Secrets needed (org level): CLAUDE_CODE_OAUTH_TOKEN, OPENROUTER_API_KEY, REVIEWBOT_PAT,
+#   REVIEWBOT_SUPABASE_URL + REVIEWBOT_SUPABASE_KEY (optional - central data store).
 # REVIEWBOT_PAT is required because review-bot is a private repo and public org repos
 # cannot resolve private actions via `uses:` - we checkout with the PAT instead.
 name: Review Bot
@@ -58,8 +59,9 @@ jobs:
       - uses: ./.review-bot
         with:
           engine: claude-code
-          # log-only A/B lane: any OpenRouter model id works; each entry costs cents per PR
-          shadow: api:openai/gpt-5.6-terra,api:moonshotai/kimi-k3,api:x-ai/grok-4.5,api:deepseek/deepseek-v4-flash,api:tencent/hy3:free,api:xiaomi/mimo-v2.5
+          # log-only A/B lane: any OpenRouter model id works; each comma-entry costs cents per PR
+          # '|'-separated variants rotate one per PR (prNumber % count): Terra XOR Grok per PR, not both
+          shadow: api:openai/gpt-5.6-terra|api:x-ai/grok-4.5,api:deepseek/deepseek-v4-flash,api:xiaomi/mimo-v2.5,api:tencent/hy3:free
           github-token: ${{ github.token }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
Syncs the review-bot caller workflow with the canonical template (Stashpeak/review-bot).

- **Drop Kimi K3** from the shadow lane — 71% upstream 429 fail rate, most expensive and slowest of the lane (eval: Stashpeak/review-bot#8).
- **Frontier rotation:** `api:openai/gpt-5.6-terra|api:x-ai/grok-4.5` runs one frontier model per PR (picked by PR number), halving frontier spend while still accumulating comparative data.
- **Header fix:** documents REVIEWBOT_SUPABASE_URL/KEY as available org secrets (bot finding on SimLauncher#747).

Log-only lane change; no effect on the primary Claude review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation configuration to document required and optional service settings.
  * Refined the review model selection to use a streamlined set of supported variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->