### PR TITLE
chore: pass review-bot App identity (app-id/app-private-key)

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -63,6 +63,8 @@ jobs:
           # '|'-separated variants rotate one per PR (prNumber % count): Terra XOR Grok per PR, not both
           shadow: api:openai/gpt-5.6-terra|api:x-ai/grok-4.5,api:deepseek/deepseek-v4-flash,api:xiaomi/mimo-v2.5,api:tencent/hy3:free
           github-token: ${{ github.token }}
+          app-id: ${{ vars.REVIEWBOT_APP_ID }}
+          app-private-key: ${{ secrets.REVIEWBOT_APP_PRIVATE_KEY }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           supabase-url: ${{ secrets.REVIEWBOT_SUPABASE_URL }}


### PR DESCRIPTION
Adds the two App-identity inputs to the `./.review-bot` step:

```yaml
          app-id: ${{ vars.REVIEWBOT_APP_ID }}
          app-private-key: ${{ secrets.REVIEWBOT_APP_PRIVATE_KEY }}
```

So the review posts under the review-bot GitHub App (custom name + avatar) instead of `github-actions[bot]`. **Backward-safe** — with the org/account var+secret unset it falls back to `github.token`, so this is safe to merge before the credentials are configured.

One-time wiring (GitHub only exposes secrets to workflows, not to actions). Setup: Stashpeak/review-bot `docs/github-app-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)