### PR TITLE
chore: rebrand review-bot re-review trigger to @stashpeakbot

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -25,7 +25,7 @@ jobs:
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-       contains(github.event.comment.body, '@claude review'))
+       contains(github.event.comment.body, '@stashpeakbot'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Changes the on-demand re-review trigger from `@claude review` to `@stashpeakbot`, matching the review-bot GitHub App identity. `@stashpeakbot` is not a real account, so it renders as plain text (no ping). The gate matches the stable `@stashpeakbot` mention; the command word after it is parsed centrally in `Stashpeak/review-bot`, so **this is the last per-repo trigger edit** — future command changes stay central.

_Auto-review on PR open is unchanged; this only affects the manual re-review comment._

🤖 Generated with [Claude Code](https://claude.com/claude-code)