### PR TITLE
chore: typecheck the main/preload project in CI (Closes #752)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "preload:types:check": "node scripts/generate-preload-types.mjs --check",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "npm run typecheck:tsc && npm run preload:types:check",
-    "typecheck:tsc": "tsc",
+    "typecheck": "npm run typecheck:tsc && npm run typecheck:node && npm run preload:types:check",
+    "typecheck:tsc": "tsc -p tsconfig.json --noEmit",
+    "typecheck:node": "tsc -p tsconfig.node.json --noEmit",
     "preview": "electron-vite preview",
     "prepare": "git config core.hooksPath .githooks"
   },

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -262,7 +262,7 @@ export function getProfileTrackablePaths(
       .filter((profileKey) => isValidExePath(appPaths?.[profileKey]))
       .map((profileKey) => appPaths![profileKey]),
     ...(Array.isArray(profile?.trackedProcessPaths) ? profile.trackedProcessPaths : [])
-  ].filter(isValidExePath)
+  ].filter((candidate): candidate is string => isValidExePath(candidate))
   const seen = new Set<string>()
 
   return trackablePaths.filter((trackablePath) => {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -9,7 +9,12 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-export function isValidExePath(p: unknown): p is string {
+// A validity check, NOT a type guard: a string that fails validation (wrong
+// extension, missing on disk) is still a string. Typing this `p is string`
+// made the false branch of `if (!isValidExePath(alreadyStringValue))` narrow to
+// `never`, which is wrong (see #752). Callers that need to narrow an
+// `unknown`/`string | undefined` down to `string` do so with a local predicate.
+export function isValidExePath(p: unknown): boolean {
   if (typeof p !== 'string') {
     return false
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,5 @@
     "src/renderer/src/**/*.tsx",
     "src/preload/index.d.ts",
     "src/shared/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "target": "ES2020",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
@@ -8,13 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
     "types": ["node", "electron-vite/node"]
   },
-  "include": [
-    "electron.vite.config.ts",
-    "vite.config.ts",
-    "vitest.config.ts",
-    "src/main/**/*.ts",
-    "src/preload/**/*.ts"
-  ]
+  "include": ["src/main/**/*.ts", "src/preload/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

`typecheck:tsc` ran plain `tsc`, which only type-checks the **renderer root project** (`tsconfig.json`). `tsconfig.node.json` (main + preload) was wired as a project reference that plain `tsc` never builds, and nothing in the renderer imports it, so **`src/main` and `src/preload` were only ever checked by the editor, never by CI** — a green gate blind to half the codebase (sibling of #697).

This decouples the two projects and checks each with `--noEmit`:
- `typecheck:tsc` → `tsc -p tsconfig.json --noEmit` (renderer + shared)
- new `typecheck:node` → `tsc -p tsconfig.node.json --noEmit` (main + preload)
- `typecheck` runs both (plus the existing preload-types check)

Removed the now-unneeded `composite`/`references` plumbing that only existed to hang the two projects together.

### Pre-existing errors the blind gate was hiding (now fixed)

- **`spawn.ts:122`** — `isValidExePath` was typed `p is string`, but it is a *validity* check, not a type guard: a string that fails validation (wrong extension / missing on disk) is still a string. On an already-`string` value, the false branch of `if (!isValidExePath(entry.path))` narrowed to `never`, so `entry.path.trim()` was a type error. Changed the return type to `boolean`. The one call site that relied on the `string[]` narrowing (`profiles.ts` trackable-paths filter) keeps it via a local predicate. **No runtime behavior change** — the #639 skip/missing-attribution tests still pass.
- **`electron.vite.config.ts` / `vite.config.ts` / `vitest.config.ts`** — ESM config files using `import.meta` under the CommonJS node typecheck. They run through their own ESM loaders (Vite/vitest), not `tsc`, so they are dropped from the node typecheck scope (product code only).

### Why now

Blocks doing #692 correctly: promoting the domain model into `src/shared` requires the **main** side to import from `src/shared`, and a main-side type error (e.g. a `ReadonlySet` vs `Set` mismatch) must fail CI, not just show in the editor. #692 rides on this landing first.

## Test plan

- [x] `npm run typecheck` green (all 3 passes)
- [x] `npm run lint` green
- [x] `npm run test` green (519/519)
- [x] `npm run build` green
- [x] Gate is live, not vacuous: injecting `const _proof: number = 'not a number'` into a `src/main` file makes `typecheck:node` fail (TS2322); the old `typecheck:tsc` passed it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of executable paths to prevent invalid entries from being included in profile tracking.

* **Chores**
  * Strengthened TypeScript checks across application and Node-specific code.
  * Simplified TypeScript project configuration for more reliable type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->