### PR TITLE
refactor: promote game/utility registries to src/shared/domain (refs #692)

### DIFF
--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -1,3 +1,4 @@
+import { BUILT_IN_UTILITY_KEYS } from '../shared/domain/registries'
 import type { ProfileLaunchEntry } from './processes/types'
 import { getStoredStringRecord, store } from './store'
 import { isRecord, isValidExePath, normalizePathForComparison } from './utils'
@@ -38,17 +39,11 @@ export interface StoredProfileUtility {
   enabled: boolean
 }
 
-// Must stay in sync with BUILT_IN_UTILITIES in renderer/src/lib/config.ts (key
-// set AND order — order is the default launch-order for legacy flat-boolean
-// profiles, see getEnabledUtilityEntries below).
-export const BUILT_IN_UTILITY_KEYS = [
-  'tracktitan',
-  'simhub',
-  'crewchief',
-  'tradingpaints',
-  'garage61',
-  'secondmonitor'
-]
+// The built-in utility key list (and its load-bearing order — it is the default
+// launch order for legacy flat-boolean profiles, see getEnabledUtilityEntries
+// below) lives in the shared domain layer now (#692). Re-exported so existing
+// importers keep their `from './profiles'` path.
+export { BUILT_IN_UTILITY_KEYS }
 
 export function isStoredProfileUtility(value: unknown): value is StoredProfileUtility {
   if (!isRecord(value)) {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -3,7 +3,13 @@ import fs from 'fs'
 import path from 'path'
 import Store from 'electron-store'
 
+import { BUILT_IN_UTILITY_KEYS, KNOWN_GAME_KEYS } from '../shared/domain/registries'
 import { clamp, isRecord, normalizePathForComparison } from './utils'
+
+// Re-exported for existing importers (ipc/config.ts, ipc/launch.ts) that pull
+// the game-key allowlist from the store module; the list itself lives in the
+// shared domain layer now (#692).
+export { KNOWN_GAME_KEYS }
 
 export const DEFAULT_ZOOM_FACTOR = 1.0
 export const MIN_ZOOM_FACTOR = 0.5
@@ -20,44 +26,6 @@ const MAX_TRACKED_PROCESS_PATHS = 50
 const ACCENT_CUSTOM_PATTERN = /^#[0-9a-fA-F]{6}$/
 const THEME_MODES = new Set(['light', 'dark', 'system'])
 const FORBIDDEN_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
-export const KNOWN_GAME_KEYS = new Set([
-  'ac',
-  'acc',
-  'acevo',
-  'acrally',
-  'aeroflyfs4',
-  'ams',
-  'ams2',
-  'beamng',
-  'dcsw',
-  'dirtrally',
-  'dirtrally2',
-  'eawrc',
-  'f124',
-  'f125',
-  'il2gb',
-  'iracing',
-  'lmu',
-  'msfs2020',
-  'msfs2024',
-  'p3d',
-  'pmr',
-  'raceroom',
-  'rbr',
-  'rennsport',
-  'rf1',
-  'rf2',
-  'xplane12'
-])
-// Must stay in sync with BUILT_IN_UTILITIES in renderer/src/lib/config.ts.
-const KNOWN_UTILITY_KEYS = [
-  'tracktitan',
-  'simhub',
-  'crewchief',
-  'tradingpaints',
-  'garage61',
-  'secondmonitor'
-]
 const PROFILE_BOOLEAN_KEYS = [
   'launchAutomatically',
   'trackingEnabled',
@@ -474,7 +442,7 @@ function getImportableExePath(value: unknown) {
 
 function getUtilityKeySet(customSlots: number) {
   return new Set([
-    ...KNOWN_UTILITY_KEYS,
+    ...BUILT_IN_UTILITY_KEYS,
     ...Array.from({ length: customSlots }, (_value, index) => `customapp${index + 1}`)
   ])
 }

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -1,21 +1,15 @@
-export interface Game {
-  key: string
-  name: string
-  icon: string
-}
-export interface Utility {
-  key: string
-  name: string
-  isCustom?: boolean
-  // Bundled curated icon path (mirrors Game.icon). For a built-in slot the
-  // app identity is known, so when this is set the bundled asset is shown
-  // FIRST — ahead of the Windows shell-extracted exe icon — with shell
-  // extraction only as fallback (#727; originally introduced shell-first by
-  // #652). Shell extraction is unreliable across app versions/icon formats
-  // and can "succeed" with a broken image (e.g. Crew Chief's black-square
-  // alpha artifact), which shell-first would keep forever once cached.
-  icon?: string
-}
+// Game/Utility registries live in the process-agnostic domain layer (#692).
+// Re-exported here so the many renderer importers keep their `from '../lib/config'`
+// import path; new code can import from '../../../shared/domain/registries' directly.
+import {
+  GAMES,
+  BUILT_IN_UTILITIES,
+  type Game,
+  type Utility
+} from '../../../shared/domain/registries'
+
+export { GAMES, BUILT_IN_UTILITIES, type Game, type Utility }
+
 export interface ProfileUtility {
   id: string
   enabled: boolean
@@ -68,49 +62,6 @@ export const MAX_CUSTOM_SLOTS = 20
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
-
-export const GAMES: Game[] = [
-  { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' },
-  { key: 'acc', name: 'Assetto Corsa Competizione', icon: 'assets/acc.png' },
-  { key: 'acevo', name: 'Assetto Corsa Evo', icon: 'assets/acevo.png' },
-  { key: 'acrally', name: 'Assetto Corsa Rally', icon: 'assets/acrally.png' },
-  { key: 'aeroflyfs4', name: 'Aerofly FS 4', icon: 'assets/aeroflyfs4.png' },
-  { key: 'ams', name: 'Automobilista', icon: 'assets/ams.png' },
-  { key: 'ams2', name: 'Automobilista 2', icon: 'assets/ams2.png' },
-  { key: 'beamng', name: 'BeamNG', icon: 'assets/beamng.png' },
-  { key: 'dcsw', name: 'DCS World', icon: 'assets/dcsw.png' },
-  { key: 'dirtrally', name: 'Dirt Rally', icon: 'assets/dirtrally.png' },
-  { key: 'dirtrally2', name: 'Dirt Rally 2.0', icon: 'assets/dirtrally2.png' },
-  { key: 'eawrc', name: 'EA WRC', icon: 'assets/eawrc.png' },
-  { key: 'f124', name: 'F1 24', icon: 'assets/f124.png' },
-  { key: 'f125', name: 'F1 25', icon: 'assets/f125.png' },
-  { key: 'il2gb', name: 'IL-2 Sturmovik: Great Battles', icon: 'assets/il2gb.png' },
-  { key: 'iracing', name: 'iRacing', icon: 'assets/iracing.png' },
-  { key: 'lmu', name: 'Le Mans Ultimate', icon: 'assets/lmu.png' },
-  { key: 'msfs2020', name: 'Microsoft Flight Simulator 2020', icon: 'assets/msfs2020.png' },
-  { key: 'msfs2024', name: 'Microsoft Flight Simulator 2024', icon: 'assets/msfs2024.png' },
-  { key: 'p3d', name: 'Prepar3D', icon: 'assets/p3d.png' },
-  { key: 'pmr', name: 'Project Motor Racing', icon: 'assets/pmr.png' },
-  { key: 'raceroom', name: 'RaceRoom Racing Experience', icon: 'assets/raceroom.png' },
-  { key: 'rbr', name: 'Richard Burns Rally', icon: 'assets/rbr.png' },
-  { key: 'rennsport', name: 'Rennsport', icon: 'assets/rennsport.png' },
-  { key: 'rf1', name: 'rFactor', icon: 'assets/rf1.png' },
-  { key: 'rf2', name: 'rFactor 2', icon: 'assets/rf2.png' },
-  { key: 'xplane12', name: 'X-Plane 12', icon: 'assets/xplane12.png' }
-]
-
-export const BUILT_IN_UTILITIES: Utility[] = [
-  // Listed first: a telemetry recorder needs to be alive before/at session
-  // start to capture the whole lap, so it defaults to the front of the launch
-  // order (#652).
-  { key: 'tracktitan', name: 'Track Titan', icon: 'assets/tracktitan.png' },
-  { key: 'simhub', name: 'SimHub', icon: 'assets/simhub.png' },
-  { key: 'crewchief', name: 'Crew Chief', icon: 'assets/crewchief.png' },
-  { key: 'tradingpaints', name: 'Trading Paints', icon: 'assets/tradingpaints.png' },
-  { key: 'garage61', name: 'Garage 61', icon: 'assets/garage61.png' },
-  // No bundled asset yet — keeps the shell-icon → initials chain (#727).
-  { key: 'secondmonitor', name: 'Second Monitor' }
-]
 
 export function normalizeCustomSlots(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {

--- a/src/shared/domain/registries.ts
+++ b/src/shared/domain/registries.ts
@@ -1,0 +1,82 @@
+// Process-agnostic domain registries: the canonical game + built-in-utility
+// lists and the key collections derived from them. Pure TS, no DOM/Node/electron
+// deps, so the main and renderer processes share ONE source of truth. Before
+// #692 these lists lived as three hand-maintained parallel copies (KNOWN_GAME_KEYS
+// / GAMES, and KNOWN_UTILITY_KEYS / BUILT_IN_UTILITY_KEYS / BUILT_IN_UTILITIES).
+
+export interface Game {
+  key: string
+  name: string
+  icon: string
+}
+
+export interface Utility {
+  key: string
+  name: string
+  isCustom?: boolean
+  // Bundled curated icon path (mirrors Game.icon). For a built-in slot the
+  // app identity is known, so when this is set the bundled asset is shown
+  // FIRST — ahead of the Windows shell-extracted exe icon — with shell
+  // extraction only as fallback (#727; originally introduced shell-first by
+  // #652). Shell extraction is unreliable across app versions/icon formats
+  // and can "succeed" with a broken image (e.g. Crew Chief's black-square
+  // alpha artifact), which shell-first would keep forever once cached.
+  icon?: string
+}
+
+export const GAMES: Game[] = [
+  { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' },
+  { key: 'acc', name: 'Assetto Corsa Competizione', icon: 'assets/acc.png' },
+  { key: 'acevo', name: 'Assetto Corsa Evo', icon: 'assets/acevo.png' },
+  { key: 'acrally', name: 'Assetto Corsa Rally', icon: 'assets/acrally.png' },
+  { key: 'aeroflyfs4', name: 'Aerofly FS 4', icon: 'assets/aeroflyfs4.png' },
+  { key: 'ams', name: 'Automobilista', icon: 'assets/ams.png' },
+  { key: 'ams2', name: 'Automobilista 2', icon: 'assets/ams2.png' },
+  { key: 'beamng', name: 'BeamNG', icon: 'assets/beamng.png' },
+  { key: 'dcsw', name: 'DCS World', icon: 'assets/dcsw.png' },
+  { key: 'dirtrally', name: 'Dirt Rally', icon: 'assets/dirtrally.png' },
+  { key: 'dirtrally2', name: 'Dirt Rally 2.0', icon: 'assets/dirtrally2.png' },
+  { key: 'eawrc', name: 'EA WRC', icon: 'assets/eawrc.png' },
+  { key: 'f124', name: 'F1 24', icon: 'assets/f124.png' },
+  { key: 'f125', name: 'F1 25', icon: 'assets/f125.png' },
+  { key: 'il2gb', name: 'IL-2 Sturmovik: Great Battles', icon: 'assets/il2gb.png' },
+  { key: 'iracing', name: 'iRacing', icon: 'assets/iracing.png' },
+  { key: 'lmu', name: 'Le Mans Ultimate', icon: 'assets/lmu.png' },
+  { key: 'msfs2020', name: 'Microsoft Flight Simulator 2020', icon: 'assets/msfs2020.png' },
+  { key: 'msfs2024', name: 'Microsoft Flight Simulator 2024', icon: 'assets/msfs2024.png' },
+  { key: 'p3d', name: 'Prepar3D', icon: 'assets/p3d.png' },
+  { key: 'pmr', name: 'Project Motor Racing', icon: 'assets/pmr.png' },
+  { key: 'raceroom', name: 'RaceRoom Racing Experience', icon: 'assets/raceroom.png' },
+  { key: 'rbr', name: 'Richard Burns Rally', icon: 'assets/rbr.png' },
+  { key: 'rennsport', name: 'Rennsport', icon: 'assets/rennsport.png' },
+  { key: 'rf1', name: 'rFactor', icon: 'assets/rf1.png' },
+  { key: 'rf2', name: 'rFactor 2', icon: 'assets/rf2.png' },
+  { key: 'xplane12', name: 'X-Plane 12', icon: 'assets/xplane12.png' }
+]
+
+export const BUILT_IN_UTILITIES: Utility[] = [
+  // Listed first: a telemetry recorder needs to be alive before/at session
+  // start to capture the whole lap, so it defaults to the front of the launch
+  // order (#652).
+  { key: 'tracktitan', name: 'Track Titan', icon: 'assets/tracktitan.png' },
+  { key: 'simhub', name: 'SimHub', icon: 'assets/simhub.png' },
+  { key: 'crewchief', name: 'Crew Chief', icon: 'assets/crewchief.png' },
+  { key: 'tradingpaints', name: 'Trading Paints', icon: 'assets/tradingpaints.png' },
+  { key: 'garage61', name: 'Garage 61', icon: 'assets/garage61.png' },
+  // No bundled asset yet — keeps the shell-icon → initials chain (#727).
+  { key: 'secondmonitor', name: 'Second Monitor' }
+]
+
+// Derived key collections. The single source of truth is GAMES / BUILT_IN_UTILITIES
+// above, so these can never drift the way the old hand-maintained copies did.
+
+// Allowlist of recognized game keys — the main process rejects any gameKey that
+// is not in this set before it crosses the IPC boundary. Typed as a mutable Set
+// only to match the existing allowlist-parameter signatures it is passed into;
+// it is never mutated.
+export const KNOWN_GAME_KEYS: Set<string> = new Set(GAMES.map((game) => game.key))
+
+// Built-in utility keys in canonical order. Order is load-bearing: it is the
+// default launch order for legacy flat-boolean profiles (see
+// getEnabledUtilityEntries in src/main/profiles.ts).
+export const BUILT_IN_UTILITY_KEYS: string[] = BUILT_IN_UTILITIES.map((utility) => utility.key)

--- a/tests/main/registries.test.ts
+++ b/tests/main/registries.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GAMES,
+  BUILT_IN_UTILITIES,
+  KNOWN_GAME_KEYS,
+  BUILT_IN_UTILITY_KEYS
+} from '../../src/shared/domain/registries'
+
+// Pins the canonical registry content and the key collections derived from it.
+// Before #692 these lists were three hand-maintained parallel copies; now they
+// have one source, so this guards against an accidental drop/rename/reorder in
+// GAMES or BUILT_IN_UTILITIES silently changing the derived allowlists.
+
+const EXPECTED_GAME_KEYS = [
+  'ac',
+  'acc',
+  'acevo',
+  'acrally',
+  'aeroflyfs4',
+  'ams',
+  'ams2',
+  'beamng',
+  'dcsw',
+  'dirtrally',
+  'dirtrally2',
+  'eawrc',
+  'f124',
+  'f125',
+  'il2gb',
+  'iracing',
+  'lmu',
+  'msfs2020',
+  'msfs2024',
+  'p3d',
+  'pmr',
+  'raceroom',
+  'rbr',
+  'rennsport',
+  'rf1',
+  'rf2',
+  'xplane12'
+]
+
+// Order is load-bearing: it is the default launch order for legacy flat-boolean
+// profiles (see getEnabledUtilityEntries in src/main/profiles.ts).
+const EXPECTED_UTILITY_KEYS = [
+  'tracktitan',
+  'simhub',
+  'crewchief',
+  'tradingpaints',
+  'garage61',
+  'secondmonitor'
+]
+
+describe('shared domain registries', () => {
+  it('exposes exactly the expected game keys', () => {
+    expect(GAMES.map((game) => game.key)).toEqual(EXPECTED_GAME_KEYS)
+  })
+
+  it('exposes exactly the expected built-in utility keys, in order', () => {
+    expect(BUILT_IN_UTILITIES.map((utility) => utility.key)).toEqual(EXPECTED_UTILITY_KEYS)
+  })
+
+  it('derives KNOWN_GAME_KEYS from GAMES', () => {
+    expect([...KNOWN_GAME_KEYS].sort()).toEqual([...EXPECTED_GAME_KEYS].sort())
+    expect(KNOWN_GAME_KEYS.size).toBe(GAMES.length)
+    for (const game of GAMES) {
+      expect(KNOWN_GAME_KEYS.has(game.key)).toBe(true)
+    }
+  })
+
+  it('derives BUILT_IN_UTILITY_KEYS from BUILT_IN_UTILITIES (order preserved)', () => {
+    expect(BUILT_IN_UTILITY_KEYS).toEqual(BUILT_IN_UTILITIES.map((utility) => utility.key))
+    expect(BUILT_IN_UTILITY_KEYS).toEqual(EXPECTED_UTILITY_KEYS)
+  })
+
+  it('every game has a non-empty name and icon path', () => {
+    for (const game of GAMES) {
+      expect(game.name.length).toBeGreaterThan(0)
+      expect(game.icon).toMatch(/^assets\/.+\.png$/)
+    }
+  })
+})

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "types": ["node", "electron-vite/node"]
   },
-  "include": ["src/main/**/*.ts", "src/preload/**/*.ts"]
+  "include": ["src/main/**/*.ts", "src/preload/**/*.ts", "src/shared/**/*.ts"]
 }


### PR DESCRIPTION
First slice of #692 (the domain-model promotion, biggest Tauri-prep win). Rides on #752, which just made the main project actually type-check in CI.

## Summary

The canonical game list and built-in utility list lived as **five parallel copies** that had to be hand-kept in sync:
- game keys: `KNOWN_GAME_KEYS` (main/store.ts) + `GAMES` (renderer/config.ts)
- utility keys: `KNOWN_UTILITY_KEYS` (main/store.ts) + `BUILT_IN_UTILITY_KEYS` (main/profiles.ts) + `BUILT_IN_UTILITIES` (renderer/config.ts)

Collapsed into one process-agnostic source — `src/shared/domain/registries.ts` (pure TS, no DOM/Node/electron) — with the allowlists **derived** from `GAMES`/`BUILT_IN_UTILITIES` (`new Set(GAMES.map(g => g.key))`, `BUILT_IN_UTILITIES.map(u => u.key)`) so they can no longer drift. The old locations re-export from shared, so **no importer changes** (blast radius stays at the definition sites).

Wiring: `src/shared` added to the node tsconfig include — trivial now that #752 decoupled the two projects, and the new main-side typecheck confirms the import resolves.

## Deliberately NOT touched

`LEGACY_GAME_KEYS` / `LEGACY_UTILITY_KEYS` in `renderer/src/lib/migrations.ts` are a **frozen snapshot** of the old localStorage schema (21 games, no flight sims, no Track Titan, explicit `customapp1-5`). They describe a historical format for a one-shot migration and must NOT follow the live registry — deriving them would change how the legacy migration behaves as new games are added. Left as-is by design.

## Scope

This is the registries slice only. Still to come on #692: unified profile types, the slot scanners (as a **strict + loose** pair — the `ipc/config.ts` variant intentionally counts referenced-but-disabled slots to widen the sanitizer whitelist, so it must not be merged into the strict scanner), and the small dupes (`isRecord`, `MAX_CUSTOM_SLOTS`, ...). The two profile-set normalizers are a separate follow-up (migration-coupled).

## Test plan

- [x] `npm run typecheck` green — both renderer and **main** projects (main import of shared resolves)
- [x] `npm run test` green (524/524, +5 new `registries.test.ts` pinning the 27 game keys / 6 utility keys + derivation)
- [x] `npm run lint` green
- [x] `npm run build` green
- [x] Grep-verified no other live registry copy remains; the two legacy lists are intentionally excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)