### PR TITLE
refactor: promote profile domain types to src/shared/domain (refs #692)

### DIFF
--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -1,17 +1,25 @@
 import { BUILT_IN_UTILITY_KEYS } from '../shared/domain/registries'
+import type {
+  Profile,
+  NamedProfile,
+  ProfileSet,
+  ProfileEntry,
+  ProfileUtility,
+  GamePosition
+} from '../shared/domain/profile'
 import type { ProfileLaunchEntry } from './processes/types'
 import { getStoredStringRecord, store } from './store'
 import { isRecord, isValidExePath, normalizePathForComparison } from './utils'
 
-export interface StoredProfile extends Record<string, unknown> {
-  utilities?: StoredProfileUtility[]
-  launchAutomatically?: boolean
-  gamePosition?: GamePosition
-  trackingEnabled?: boolean
-  trackedProcessPaths?: string[]
-}
-
-export type GamePosition = 'first' | 'last'
+// Profile domain types are process-agnostic (#692); the canonical defs live in
+// the shared domain layer. Re-exported here under the main process's historical
+// Stored* names so existing importers keep their `from './profiles'` path.
+export type StoredProfile = Profile
+export type StoredNamedProfile = NamedProfile
+export type StoredProfileSet = ProfileSet
+export type StoredProfileEntry = ProfileEntry
+export type StoredProfileUtility = ProfileUtility
+export type { GamePosition }
 
 /**
  * Resolve where the game sits in the launch sequence. Anything other than an
@@ -20,23 +28,6 @@ export type GamePosition = 'first' | 'last'
  */
 export function getGamePosition(profile: StoredProfile): GamePosition {
   return profile.gamePosition === 'last' ? 'last' : 'first'
-}
-
-export interface StoredNamedProfile extends StoredProfile {
-  id: string
-  name: string
-}
-
-export interface StoredProfileSet {
-  activeProfileId: string
-  profiles: StoredNamedProfile[]
-}
-
-export type StoredProfileEntry = StoredProfile | StoredProfileSet
-
-export interface StoredProfileUtility {
-  id: string
-  enabled: boolean
 }
 
 // The built-in utility key list (and its load-bearing order — it is the default

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -7,13 +7,27 @@ import {
   type Game,
   type Utility
 } from '../../../shared/domain/registries'
+import type {
+  Profile,
+  NamedProfile,
+  ProfileSet,
+  ProfileEntry,
+  Profiles,
+  ProfileUtility
+} from '../../../shared/domain/profile'
 
 export { GAMES, BUILT_IN_UTILITIES, type Game, type Utility }
 
-export interface ProfileUtility {
-  id: string
-  enabled: boolean
-}
+// Profile domain types are process-agnostic (#692); the canonical defs live in
+// the shared domain layer. Re-exported here under the renderer's historical
+// Game*/Stored* names so existing importers keep their `from '../lib/config'`
+// import path. New code can import from '../../../shared/domain/profile'.
+export type GameProfile = Profile
+export type NamedGameProfile = NamedProfile
+export type GameProfileSet = ProfileSet
+export type StoredGameProfile = ProfileEntry
+export type { Profiles, ProfileUtility }
+export type { GamePosition } from '../../../shared/domain/profile'
 
 // Namespaced icon-load-error key for a built-in's bundled icon (#727/#728).
 // Bundled and shell icons share one per-surface error store (same state
@@ -25,33 +39,6 @@ export interface ProfileUtility {
 export function getBundledIconErrorKey(key: string): string {
   return `bundled:${key}`
 }
-export type GamePosition = 'first' | 'last'
-export interface GameProfile {
-  // Index signature preserved so that legacy flat keys (e.g. 'simhub': true)
-  // can coexist with the typed properties during migration. Any code reading a
-  // known key should use the typed property, not the index signature.
-  [key: string]: unknown
-  utilities?: ProfileUtility[]
-  launchAutomatically?: boolean
-  gamePosition?: GamePosition
-  trackingEnabled?: boolean
-  killControlsEnabled?: boolean
-  relaunchControlsEnabled?: boolean
-  trackedProcessPaths?: string[]
-}
-export interface NamedGameProfile extends GameProfile {
-  id: string
-  name: string
-}
-export interface GameProfileSet {
-  activeProfileId: string
-  profiles: NamedGameProfile[]
-}
-// The on-disk representation can be either the old flat-profile format
-// (GameProfile) or the newer profile-set format (GameProfileSet). Callers
-// should normalise through normalizeGameProfileSet before operating on profiles.
-export type StoredGameProfile = GameProfile | GameProfileSet
-export type Profiles = Record<string, StoredGameProfile>
 
 export const DEFAULT_ACCENT_COLOR = '#008c99'
 export const DEFAULT_CUSTOM_SLOTS = 1

--- a/src/shared/domain/profile.ts
+++ b/src/shared/domain/profile.ts
@@ -1,0 +1,53 @@
+// Process-agnostic profile domain model (#692).
+//
+// A "profile" is one game's saved launch configuration. It is persisted in the
+// electron-store `profiles` map (keyed by game key) and travels renderer <-> main
+// over IPC unchanged, so both processes must agree on its shape. Before #692 the
+// renderer (renderer/src/lib/config.ts) and the main process (main/profiles.ts)
+// each declared their own structurally-identical copy under different names
+// (Game* vs Stored*); the two had already drifted (killControlsEnabled /
+// relaunchControlsEnabled were typed on the renderer side only). This module is
+// the single source of truth; the old names are kept as re-exported aliases in
+// those files so existing importers do not change.
+
+export interface ProfileUtility {
+  id: string
+  enabled: boolean
+}
+
+// Where the game sits in the launch sequence relative to its utilities. Anything
+// other than an explicit 'last' means 'first' — the behavior before #471.
+export type GamePosition = 'first' | 'last'
+
+export interface Profile {
+  // Index signature preserved so that legacy flat keys (e.g. 'simhub': true) can
+  // coexist with the typed properties during migration. Any code reading a known
+  // key should use the typed property, not the index signature.
+  [key: string]: unknown
+  utilities?: ProfileUtility[]
+  launchAutomatically?: boolean
+  gamePosition?: GamePosition
+  trackingEnabled?: boolean
+  killControlsEnabled?: boolean
+  relaunchControlsEnabled?: boolean
+  trackedProcessPaths?: string[]
+}
+
+// A profile plus its identity within a profile set.
+export interface NamedProfile extends Profile {
+  id: string
+  name: string
+}
+
+export interface ProfileSet {
+  activeProfileId: string
+  profiles: NamedProfile[]
+}
+
+// The on-disk representation for a single game can be either the old flat-profile
+// format (Profile) or the newer profile-set format (ProfileSet). Callers should
+// normalise (normalizeGameProfileSet in the renderer, resolveActiveProfile in the
+// main process) before operating on individual profiles.
+export type ProfileEntry = Profile | ProfileSet
+
+export type Profiles = Record<string, ProfileEntry>


### PR DESCRIPTION
## What

Second slice of #692 (after #756 promoted the game/utility registries). Moves the **profile domain types** to the shared domain layer so renderer and main share one definition.

The profile shape was declared **twice**:
- renderer `src/renderer/src/lib/config.ts` — `GameProfile` / `NamedGameProfile` / `GameProfileSet` / `StoredGameProfile` / `Profiles` / `ProfileUtility` / `GamePosition`
- main `src/main/profiles.ts` — `StoredProfile` / `StoredNamedProfile` / `StoredProfileSet` / `StoredProfileEntry` / `StoredProfileUtility` / `GamePosition`

The two copies had **already drifted**: `killControlsEnabled` / `relaunchControlsEnabled` were typed on the renderer side only. Both processes read the same on-disk `electron-store` `profiles` map and the same IPC payloads, so they must agree on one shape — this drift is exactly the duplication #692 targets.

## How

- New source of truth: `src/shared/domain/profile.ts` with the process-agnostic types `ProfileUtility`, `GamePosition`, `Profile`, `NamedProfile`, `ProfileSet`, `ProfileEntry`, `Profiles`. It carries the **union** of both old field sets (i.e. the renderer superset).
- `config.ts` and `profiles.ts` now re-export those under their historical `Game*` / `Stored*` names, so **every one of the 15 importers keeps its current import path** — zero importer churn (same shim strategy as #756).
- Already checked by both tsconfig projects: `src/shared/**` is in `tsconfig.json` and `tsconfig.node.json` (real in CI since #753).

Pure-type change. **No runtime behaviour moves.** The main-process `StoredProfile` gains the two kill/relaunch control flags it was missing — safe, since it already `extends Record<string, unknown>` (the keys were permitted, just untyped).

## Test plan / verification

Because this is a **type-only** refactor and test files aren't in any tsconfig `include`, the guard is the dual-project typecheck, not a runtime test (a runtime test cannot assert types). All green locally:

- `tsc -p tsconfig.json --noEmit` (renderer + shared) — passes, covers all renderer importers
- `tsc -p tsconfig.node.json --noEmit` (main + preload + shared) — passes, covers all main importers
- `preload:types:check` — passes
- `eslint .` + `prettier --check` — clean
- `vitest run` — 524/524 pass (unchanged; no runtime touched)
- `electron-vite build` — succeeds

Non-typecheck-visible risks of collapsing an `interface` to a `type` alias, swept manually:
- **Declaration merging** — none. The only `interface` declaration of any of these names is `ProfileUtility` in the new shared module itself; nothing augments the old interfaces elsewhere.
- **`keyof` logic** — none on these types.
- **`extends` / `implements`** — only `NamedProfile extends Profile` (in-module) and one generic constraint `<T extends GameProfile>` in `customSlots.ts`, both resolve fine against aliases.

refs #692