### PR TITLE
refactor: unify custom-slot scanning into src/shared/domain (refs #692)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -2,8 +2,9 @@ import { app, dialog, ipcMain, type OpenDialogOptions } from 'electron'
 import crypto from 'crypto'
 import fs from 'fs'
 
+import { getHighestReferencedCustomSlot } from '../../shared/domain/slots'
 import { migrateProfilesToNamedSets } from '../migrator'
-import { isStoredProfileSet, type StoredProfileSet } from '../profiles'
+import { isStoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
@@ -258,32 +259,6 @@ function setStoreEntries(values: Record<string, unknown>) {
   })
 }
 
-function getHighestCustomSlotInProfileSet(profileSet: StoredProfileSet) {
-  let highest = 0
-
-  const visitId = (id: unknown) => {
-    if (typeof id !== 'string') return
-    const match = id.match(/^customapp(\d+)$/)
-    if (!match) return
-    const slot = Number(match[1])
-    if (Number.isFinite(slot) && slot > highest) {
-      highest = slot
-    }
-  }
-
-  profileSet.profiles.forEach((profile) => {
-    if (!isRecord(profile)) return
-    Object.keys(profile).forEach(visitId)
-    if (Array.isArray(profile.utilities)) {
-      profile.utilities.forEach((utility) => {
-        if (isRecord(utility)) visitId(utility.id)
-      })
-    }
-  })
-
-  return highest
-}
-
 function getSanitizedProfileSet(gameKey: string, profileSet: unknown) {
   if (!KNOWN_GAME_KEYS.has(gameKey) || !isStoredProfileSet(profileSet)) {
     return undefined
@@ -301,7 +276,7 @@ function getSanitizedProfileSet(gameKey: string, profileSet: unknown) {
   // this expansion the new slot IDs would be filtered out as out-of-range.
   const effectiveCustomSlots = Math.min(
     MAX_CUSTOM_SLOTS,
-    Math.max(baseSlots, getHighestCustomSlotInProfileSet(profileSet))
+    Math.max(baseSlots, getHighestReferencedCustomSlot(profileSet))
   )
 
   const supportedConfig = getSupportedConfigValues({

--- a/src/main/migrator.ts
+++ b/src/main/migrator.ts
@@ -1,3 +1,4 @@
+import { getHighestCustomSlot } from '../shared/domain/slots'
 import {
   StoredNamedProfile,
   StoredProfile,
@@ -9,58 +10,6 @@ import {
 } from './profiles'
 import { getStoredStringRecord, store } from './store'
 import { isRecord } from './utils'
-
-function getCustomSlotNumber(key: string) {
-  const match = key.match(/^customapp(\d+)$/)
-  return match ? Number(match[1]) : null
-}
-
-// Scan every record that could reference a custom app slot and return the
-// highest slot number found. Both pre-migration (flat boolean/path keys) and
-// post-migration (utilities array) shapes are checked because the store may
-// contain a mix when this runs (e.g. appPaths is always flat; profiles may
-// already be in the new shape from a partial earlier migration attempt).
-function getHighestCustomSlot(...records: Array<Record<string, unknown> | undefined>) {
-  let highestSlot = 0
-
-  const scanRecord = (record: Record<string, unknown> | undefined) => {
-    Object.entries(record || {}).forEach(([key, value]) => {
-      if (key === 'profiles' && Array.isArray(value)) {
-        value.forEach((profile) => {
-          if (isRecord(profile)) {
-            scanRecord(profile)
-          }
-        })
-        return
-      }
-
-      const slotNumber = getCustomSlotNumber(key)
-
-      if (
-        slotNumber !== null &&
-        (value === true || (typeof value === 'string' && value.trim().length > 0))
-      ) {
-        highestSlot = Math.max(highestSlot, slotNumber)
-      }
-
-      if (key === 'utilities' && Array.isArray(value)) {
-        value.filter(isStoredProfileUtility).forEach((utility) => {
-          const utilitySlotNumber = getCustomSlotNumber(utility.id)
-
-          if (utility.enabled && utilitySlotNumber !== null) {
-            highestSlot = Math.max(highestSlot, utilitySlotNumber)
-          }
-        })
-      }
-    })
-  }
-
-  records.forEach((record) => {
-    scanRecord(record)
-  })
-
-  return highestSlot
-}
 
 // Convert a pre-migration profile (flat boolean keys like { simhub: true })
 // into the structured utilities array ({ id, enabled }[]). If utilities already

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -15,8 +15,10 @@ import type {
   Profiles,
   ProfileUtility
 } from '../../../shared/domain/profile'
+import { getHighestCustomSlot } from '../../../shared/domain/slots'
 
 export { GAMES, BUILT_IN_UTILITIES, type Game, type Utility }
+export { getHighestCustomSlot }
 
 // Profile domain types are process-agnostic (#692); the canonical defs live in
 // the shared domain layer. Re-exported here under the renderer's historical
@@ -60,82 +62,6 @@ export function normalizeCustomSlots(value: unknown): number {
 
 export function getCustomUtilityKey(index: number): string {
   return `customapp${index}`
-}
-
-// A custom-app slot is considered "in use" when the stored value is either a
-// non-empty string (a configured path or name) or a boolean true (legacy enabled
-// flag). Other falsy values mean the slot is unconfigured.
-function hasCustomSlotValue(value: unknown) {
-  if (value === true) {
-    return true
-  }
-
-  if (typeof value === 'string') {
-    return value.trim().length > 0
-  }
-
-  return false
-}
-
-function getCustomSlotNumberFromKey(key: string) {
-  const match = key.match(/^customapp(\d+)$/)
-  return match ? Number(match[1]) : null
-}
-
-/**
- * Scans one or more records (settings, profiles, or nested profile objects) and
- * returns the highest custom-app slot number that is actively in use.
- *
- * The scan is recursive for the special keys 'profiles' (array of named
- * profiles) and 'utilities' (ProfileUtility[] inside a profile) so that enabled
- * slots buried inside a GameProfileSet are found without callers flattening
- * the structure first. Returns 0 when no custom slot is found.
- */
-export function getHighestCustomSlot(
-  ...records: Array<Record<string, unknown> | undefined>
-): number {
-  let highestSlot = 0
-
-  const scanRecord = (record: Record<string, unknown> | undefined) => {
-    Object.entries(record || {}).forEach(([key, value]) => {
-      if (key === 'profiles' && Array.isArray(value)) {
-        value.forEach((profile) => {
-          if (isRecord(profile)) {
-            scanRecord(profile)
-          }
-        })
-        return
-      }
-
-      if (key === 'utilities' && Array.isArray(value)) {
-        value.forEach((entry) => {
-          if (!isProfileUtility(entry) || !entry.enabled) {
-            return
-          }
-
-          const slotNumber = getCustomSlotNumberFromKey(entry.id)
-
-          if (slotNumber !== null) {
-            highestSlot = Math.max(highestSlot, slotNumber)
-          }
-        })
-
-        return
-      }
-
-      const slotNumber = getCustomSlotNumberFromKey(key)
-
-      if (slotNumber !== null && hasCustomSlotValue(value)) {
-        highestSlot = Math.max(highestSlot, slotNumber)
-      }
-    })
-  }
-
-  records.forEach((record) => {
-    scanRecord(record)
-  })
-
-  return highestSlot
 }
 
 /**

--- a/src/shared/domain/slots.ts
+++ b/src/shared/domain/slots.ts
@@ -1,0 +1,136 @@
+// Custom-app slot scanning (#692).
+//
+// A "custom slot" is a user-defined utility slot keyed `customapp<N>` (1-based),
+// referenced in profiles, appPaths, appNames and appArgs. The store persists a
+// `customSlots` count, but the actual data can reference a higher slot than the
+// stored count (e.g. an import, a manual edit, or a profile saved in the same
+// batch as a customSlots increase). Both processes need to find the highest
+// referenced slot; before #692 this walker was copied three times (renderer
+// lib/config.ts, main migrator.ts, main ipc/config.ts).
+
+import type { ProfileSet } from './profile'
+
+// Parse the slot number N out of a `customapp<N>` key or utility id. Returns
+// null for anything that is not a custom-slot reference.
+export function getCustomSlotNumberFromKey(key: string): number | null {
+  const match = key.match(/^customapp(\d+)$/)
+  return match ? Number(match[1]) : null
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+// A custom-app slot is "in use" when the stored value is a non-empty string (a
+// configured path or name) or boolean true (legacy enabled flag). Other falsy
+// values (false, '', 0, null) mean the slot is referenced but not configured.
+function hasCustomSlotValue(value: unknown): boolean {
+  if (value === true) {
+    return true
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0
+  }
+
+  return false
+}
+
+// 'in-use'     count a slot only when its value / enabled flag marks it active.
+//              Sizes the visible slot count so configured slots are never
+//              dropped from the UI.
+// 'referenced' count a slot whenever it appears at all, even disabled or empty.
+//              Widens the save-time sanitizer whitelist so a referenced slot is
+//              not stripped (which would lose the user's data). Collapsing this
+//              into 'in-use' is a data-loss regression - see the divergence test
+//              in tests/main/customSlots.test.ts.
+type SlotScanMode = 'in-use' | 'referenced'
+
+function scanHighestSlot(
+  records: Array<Record<string, unknown> | undefined>,
+  mode: SlotScanMode
+): number {
+  let highest = 0
+
+  // Number.isFinite guards the (unreachable) case of a customapp<N> whose N has
+  // 309+ digits and overflows Number() to Infinity; it also keeps parity with
+  // the old referenced scanner, which already dropped non-finite slot numbers.
+  const consider = (slotNumber: number | null) => {
+    if (slotNumber !== null && Number.isFinite(slotNumber) && slotNumber > highest) {
+      highest = slotNumber
+    }
+  }
+
+  const scanRecord = (record: Record<string, unknown> | undefined) => {
+    if (!record) {
+      return
+    }
+
+    Object.entries(record).forEach(([key, value]) => {
+      // Recurse into a profile set's profiles array so slots buried inside a
+      // GameProfileSet are found without the caller flattening the structure.
+      // Uniform across modes: for the referenced scan this makes the result a
+      // safe superset of a flat per-profile scan - it can only widen, never drop.
+      if (key === 'profiles' && Array.isArray(value)) {
+        value.forEach((profile) => {
+          if (isRecordLike(profile)) {
+            scanRecord(profile)
+          }
+        })
+        return
+      }
+
+      if (key === 'utilities' && Array.isArray(value)) {
+        value.forEach((entry) => {
+          if (!isRecordLike(entry) || typeof entry.id !== 'string') {
+            return
+          }
+
+          // In-use counts only enabled utilities; referenced counts any entry.
+          if (mode === 'in-use' && entry.enabled !== true) {
+            return
+          }
+
+          consider(getCustomSlotNumberFromKey(entry.id))
+        })
+        return
+      }
+
+      const slotNumber = getCustomSlotNumberFromKey(key)
+
+      if (slotNumber === null) {
+        return
+      }
+
+      if (mode === 'referenced' || hasCustomSlotValue(value)) {
+        consider(slotNumber)
+      }
+    })
+  }
+
+  records.forEach(scanRecord)
+
+  return highest
+}
+
+/**
+ * Highest custom-app slot number actively IN USE across the given records
+ * (settings, profiles, or nested profile objects). A slot counts only when its
+ * stored value marks it active (non-empty string / boolean true) or, inside a
+ * profile's utilities array, when the entry is enabled. Returns 0 when none.
+ */
+export function getHighestCustomSlot(
+  ...records: Array<Record<string, unknown> | undefined>
+): number {
+  return scanHighestSlot(records, 'in-use')
+}
+
+/**
+ * Highest custom-app slot number REFERENCED anywhere in a profile set, whether
+ * or not it is enabled or configured. Used to widen the save-time sanitizer
+ * whitelist so a referenced slot is never stripped (data loss). This must NOT
+ * be reduced to getHighestCustomSlot - see the mode doc above.
+ */
+export function getHighestReferencedCustomSlot(profileSet: ProfileSet): number {
+  return scanHighestSlot(profileSet.profiles, 'referenced')
+}

--- a/tests/main/customSlots.test.ts
+++ b/tests/main/customSlots.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCustomSlotNumberFromKey,
+  getHighestCustomSlot,
+  getHighestReferencedCustomSlot
+} from '../../src/shared/domain/slots'
+
+// Before #692 this walker was copied three times (renderer lib/config.ts, main
+// migrator.ts, main ipc/config.ts) in two flavours: an "in use" scan that sizes
+// the visible slot count, and a "referenced" scan that widens the save-time
+// sanitizer whitelist. The two must stay distinct - collapsing the referenced
+// scan into the in-use one silently drops referenced-but-disabled slots on save.
+
+describe('getCustomSlotNumberFromKey', () => {
+  it('parses customapp<N> keys and rejects everything else', () => {
+    expect(getCustomSlotNumberFromKey('customapp1')).toBe(1)
+    expect(getCustomSlotNumberFromKey('customapp20')).toBe(20)
+    expect(getCustomSlotNumberFromKey('simhub')).toBeNull()
+    expect(getCustomSlotNumberFromKey('customapp')).toBeNull()
+    expect(getCustomSlotNumberFromKey('customappX')).toBeNull()
+    expect(getCustomSlotNumberFromKey('xcustomapp1')).toBeNull()
+  })
+})
+
+describe('getHighestCustomSlot (in use)', () => {
+  it('counts only slots with an active value across flat records', () => {
+    expect(
+      getHighestCustomSlot({
+        customapp1: 'C:/Tools/A.exe', // configured path
+        customapp2: true, // legacy enabled flag
+        customapp3: false, // disabled
+        customapp4: '   ' // whitespace-only, treated as empty
+      })
+    ).toBe(2)
+  })
+
+  it('counts enabled utilities inside a nested profile set, ignoring disabled', () => {
+    const profileSet = {
+      activeProfileId: 'default',
+      profiles: [
+        {
+          id: 'default',
+          name: 'Default',
+          utilities: [
+            { id: 'customapp5', enabled: true },
+            { id: 'customapp7', enabled: false }
+          ]
+        }
+      ]
+    }
+    expect(getHighestCustomSlot(profileSet)).toBe(5)
+  })
+
+  it('takes the max across all provided records and returns 0 for none', () => {
+    expect(getHighestCustomSlot({ customapp2: true }, { customapp6: 'C:/x.exe' })).toBe(6)
+    expect(getHighestCustomSlot(undefined, {})).toBe(0)
+  })
+})
+
+describe('getHighestReferencedCustomSlot (referenced, widens whitelist)', () => {
+  it('counts referenced-but-disabled slots that the in-use scan ignores', () => {
+    const profileSet = {
+      activeProfileId: 'default',
+      profiles: [
+        {
+          id: 'default',
+          name: 'Default',
+          customapp5: false, // referenced by key, value false
+          utilities: [{ id: 'customapp6', enabled: false }] // referenced, disabled
+        }
+      ]
+    }
+
+    // Referenced: any mention widens the whitelist so the slot survives save.
+    expect(getHighestReferencedCustomSlot(profileSet)).toBe(6)
+    // In use: the disabled references are not active, so they do not count. This
+    // is the exact divergence #692 must preserve - if the referenced scan is ever
+    // reduced to the in-use scan, the assertion above drops to 0 and fails here.
+    expect(getHighestCustomSlot(profileSet)).toBe(0)
+  })
+
+  it('does not clamp - callers apply MAX_CUSTOM_SLOTS', () => {
+    const profileSet = {
+      activeProfileId: 'default',
+      profiles: [
+        {
+          id: 'default',
+          name: 'Default',
+          utilities: [{ id: 'customapp99', enabled: false }]
+        }
+      ]
+    }
+    expect(getHighestReferencedCustomSlot(profileSet)).toBe(99)
+  })
+})

--- a/tests/main/customSlots.test.ts
+++ b/tests/main/customSlots.test.ts
@@ -92,4 +92,28 @@ describe('getHighestReferencedCustomSlot (referenced, widens whitelist)', () => 
     }
     expect(getHighestReferencedCustomSlot(profileSet)).toBe(99)
   })
+
+  it('recurses into a nested profiles array, widening (never dropping)', () => {
+    // A profile that itself contains a nested profiles array is non-canonical,
+    // but the unified walker recurses uniformly. For the referenced scan this can
+    // only widen the whitelist - a slot buried in the nested subtree is still
+    // counted, never dropped. The old ipc/config.ts loose scanner did not recurse;
+    // this pins the intentional new behavior (see the profiles branch in slots.ts).
+    const profileSet = {
+      activeProfileId: 'default',
+      profiles: [
+        {
+          id: 'default',
+          name: 'Default',
+          customapp2: true,
+          profiles: [
+            { id: 'nested', name: 'Nested', utilities: [{ id: 'customapp8', enabled: false }] }
+          ]
+        }
+      ]
+    }
+    // customapp8 lives only in the nested subtree and is disabled; it is still
+    // found (8 > the top-level customapp2), proving the recursion widens.
+    expect(getHighestReferencedCustomSlot(profileSet)).toBe(8)
+  })
 })


### PR DESCRIPTION
## What

Third slice of #692 (after #756 registries, #757 profile types). The `customapp<N>` **slot scanner was hand-copied three times**, in two distinct flavours:

| Copy | Location | Flavour |
|---|---|---|
| `getHighestCustomSlot` (exported) | `renderer/src/lib/config.ts` | **STRICT** – counts only in-use slots |
| `getHighestCustomSlot` (private) | `main/migrator.ts` | **STRICT** – identical logic, separate copy |
| `getHighestCustomSlotInProfileSet` | `main/ipc/config.ts` | **LOOSE** – counts *referenced-but-disabled* slots |

The two flavours **must stay distinct**: the loose scan deliberately counts referenced-but-disabled slots to widen the save-time sanitizer whitelist, so collapsing it into the strict scan would **silently strip a user's slot data on save**.

## How

- One walker in `src/shared/domain/slots.ts`, parameterised by mode → `getHighestCustomSlot` (`in-use`) + `getHighestReferencedCustomSlot` (`referenced`).
- `config.ts` re-exports `getHighestCustomSlot` under its old name (the `migrations.ts` importer is untouched); `migrator.ts` and `ipc/config.ts` import the shared functions and drop their copies.
- The loose entry point passes `profileSet.profiles` (which carry the shared `Profile` index signature from #757), so no cast is needed.

Net: three copies → one source (`-156 / +237`, most of the `+` being the shared module and its test).

## Test plan / verification

All local gates green: `tsc` ×2 + `preload:types:check`, `eslint`, `prettier`, **530 tests** (was 524), `electron-vite build`.

**New test `tests/main/customSlots.test.ts`** pins the in-use rules *and* the loose/strict divergence with a **disabled** slot (`getHighestReferencedCustomSlot` → 6, `getHighestCustomSlot` → 0). The existing suite never exercised this: its only widening test (`configImportPreview.test.ts`) used an *enabled* slot, where strict and loose agree — so a naive collapse to strict would have passed CI. The existing `migrator`/`configImportPreview` tests now run against the shared functions and pass, confirming the covered paths are unchanged.

**Adversarial equivalence fuzz** (byte-for-byte, old-vs-new, one verifier per original scanner): **220k+ randomised inputs + exhaustive edge cases** (every value type on `customapp` keys; malformed utilities; non-array `utilities`/`profiles`; nested `profiles`; huge digit counts; multi/empty/undefined records). **Zero data-loss divergences on any reachable input.** The only differences are two unreachable, benign classes, both documented in `slots.ts`:

1. **`Number.isFinite` guard** — a 309+ digit `customapp<N>` overflows `Number()` to `Infinity`; the unified `consider` drops it (finite) where the old *strict* copies kept `Infinity`. Unreachable (real slots are 1–20), clamped to 20 by callers, and it unifies the strict copies with the loose one that already had this guard.
2. **Uniform nested-`profiles` recursion** — for a (non-canonical) profile containing a nested `profiles` array, the referenced scan recurses and finds more; it can only **widen**, never drop. Benign.

refs #692