### PR TITLE
refactor: consolidate shared guards and MAX_CUSTOM_SLOTS (refs #692)

### DIFF
--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -1,4 +1,8 @@
 import { BUILT_IN_UTILITY_KEYS } from '../shared/domain/registries'
+import {
+  isProfileUtility as isStoredProfileUtility,
+  isProfileSet as isStoredProfileSet
+} from '../shared/domain/guards'
 import type {
   Profile,
   NamedProfile,
@@ -36,21 +40,9 @@ export function getGamePosition(profile: StoredProfile): GamePosition {
 // importers keep their `from './profiles'` path.
 export { BUILT_IN_UTILITY_KEYS }
 
-export function isStoredProfileUtility(value: unknown): value is StoredProfileUtility {
-  if (!isRecord(value)) {
-    return false
-  }
-
-  return typeof value.id === 'string' && typeof value.enabled === 'boolean'
-}
-
-export function isStoredProfileSet(value: unknown): value is StoredProfileSet {
-  if (!isRecord(value)) {
-    return false
-  }
-
-  return typeof value.activeProfileId === 'string' && Array.isArray(value.profiles)
-}
+// The profile discriminators live in the shared domain layer now (#692);
+// re-exported under their historical Stored* names so importers are unchanged.
+export { isStoredProfileUtility, isStoredProfileSet }
 
 export function getStoredProfiles(): Record<string, StoredProfileEntry> {
   const value = store.get('profiles')

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -4,17 +4,20 @@ import path from 'path'
 import Store from 'electron-store'
 
 import { BUILT_IN_UTILITY_KEYS, KNOWN_GAME_KEYS } from '../shared/domain/registries'
+import { MAX_CUSTOM_SLOTS } from '../shared/domain/slots'
 import { clamp, isRecord, normalizePathForComparison } from './utils'
 
 // Re-exported for existing importers (ipc/config.ts, ipc/launch.ts) that pull
 // the game-key allowlist from the store module; the list itself lives in the
 // shared domain layer now (#692).
 export { KNOWN_GAME_KEYS }
+// MAX_CUSTOM_SLOTS lives in the shared domain layer now (#692); re-exported so
+// ipc/config.ts keeps importing it from the store module.
+export { MAX_CUSTOM_SLOTS }
 
 export const DEFAULT_ZOOM_FACTOR = 1.0
 export const MIN_ZOOM_FACTOR = 0.5
 export const MAX_ZOOM_FACTOR = 3.0
-export const MAX_CUSTOM_SLOTS = 20
 export const MAX_CONFIG_IMPORT_BYTES = 1_000_000
 
 const MAX_IMPORT_PATH_LENGTH = 300

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,12 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 
+// isRecord lives in the shared domain layer now (#692); re-exported so the many
+// main-process importers keep their `from './utils'` path.
+export { isRecord } from '../shared/domain/guards'
+
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 // A validity check, NOT a type guard: a string that fails validation (wrong

--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -15,10 +15,16 @@ import type {
   Profiles,
   ProfileUtility
 } from '../../../shared/domain/profile'
-import { getHighestCustomSlot } from '../../../shared/domain/slots'
+import { getHighestCustomSlot, MAX_CUSTOM_SLOTS } from '../../../shared/domain/slots'
+import {
+  isRecord,
+  isProfileUtility,
+  isProfileSet as isGameProfileSet
+} from '../../../shared/domain/guards'
 
 export { GAMES, BUILT_IN_UTILITIES, type Game, type Utility }
-export { getHighestCustomSlot }
+export { getHighestCustomSlot, MAX_CUSTOM_SLOTS }
+export { isRecord, isProfileUtility, isGameProfileSet }
 
 // Profile domain types are process-agnostic (#692); the canonical defs live in
 // the shared domain layer. Re-exported here under the renderer's historical
@@ -46,11 +52,6 @@ export const DEFAULT_ACCENT_COLOR = '#008c99'
 export const DEFAULT_CUSTOM_SLOTS = 1
 export const DEFAULT_PROFILE_ID = 'default'
 export const DEFAULT_PROFILE_NAME = 'Default'
-export const MAX_CUSTOM_SLOTS = 20
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value)
-}
 
 export function normalizeCustomSlots(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -96,14 +97,6 @@ export function getCustomUtilities(customSlots: unknown): Utility[] {
 
 export function getUtilities(customSlots: unknown): Utility[] {
   return [...BUILT_IN_UTILITIES, ...getCustomUtilities(customSlots)]
-}
-
-export function isProfileUtility(value: unknown): value is ProfileUtility {
-  if (!isRecord(value)) {
-    return false
-  }
-
-  return typeof value.id === 'string' && typeof value.enabled === 'boolean'
 }
 
 /**
@@ -184,14 +177,6 @@ export function migrateProfileToUtilityOrder(
   })
 
   return migratedProfile
-}
-
-export function isGameProfileSet(value: unknown): value is GameProfileSet {
-  if (!isRecord(value)) {
-    return false
-  }
-
-  return typeof value.activeProfileId === 'string' && Array.isArray(value.profiles)
 }
 
 export function normalizeProfiles(value: unknown): Profiles {

--- a/src/shared/domain/guards.ts
+++ b/src/shared/domain/guards.ts
@@ -1,0 +1,23 @@
+// Process-agnostic runtime guards (#692).
+//
+// isRecord was duplicated in the renderer (lib/config.ts) and the main process
+// (utils.ts); the two profile discriminators were duplicated under different
+// names (config.ts's isGameProfileSet / isProfileUtility and profiles.ts's
+// isStoredProfileSet / isStoredProfileUtility). This is the single source; the
+// old names are re-exported from those files so importers do not change.
+
+import type { ProfileSet, ProfileUtility } from './profile'
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function isProfileUtility(value: unknown): value is ProfileUtility {
+  return isRecord(value) && typeof value.id === 'string' && typeof value.enabled === 'boolean'
+}
+
+export function isProfileSet(value: unknown): value is ProfileSet {
+  return (
+    isRecord(value) && typeof value.activeProfileId === 'string' && Array.isArray(value.profiles)
+  )
+}

--- a/src/shared/domain/slots.ts
+++ b/src/shared/domain/slots.ts
@@ -9,16 +9,18 @@
 // lib/config.ts, main migrator.ts, main ipc/config.ts).
 
 import type { ProfileSet } from './profile'
+import { isRecord } from './guards'
+
+// The maximum number of custom-app slots a user can configure. Shared so the
+// renderer clamp (lib/config.ts) and the store schema/sanitizer (main store.ts)
+// can never drift out of agreement.
+export const MAX_CUSTOM_SLOTS = 20
 
 // Parse the slot number N out of a `customapp<N>` key or utility id. Returns
 // null for anything that is not a custom-slot reference.
 export function getCustomSlotNumberFromKey(key: string): number | null {
   const match = key.match(/^customapp(\d+)$/)
   return match ? Number(match[1]) : null
-}
-
-function isRecordLike(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 // A custom-app slot is "in use" when the stored value is a non-empty string (a
@@ -73,7 +75,7 @@ function scanHighestSlot(
       // safe superset of a flat per-profile scan - it can only widen, never drop.
       if (key === 'profiles' && Array.isArray(value)) {
         value.forEach((profile) => {
-          if (isRecordLike(profile)) {
+          if (isRecord(profile)) {
             scanRecord(profile)
           }
         })
@@ -82,7 +84,7 @@ function scanHighestSlot(
 
       if (key === 'utilities' && Array.isArray(value)) {
         value.forEach((entry) => {
-          if (!isRecordLike(entry) || typeof entry.id !== 'string') {
+          if (!isRecord(entry) || typeof entry.id !== 'string') {
             return
           }
 

--- a/tests/main/guards.test.ts
+++ b/tests/main/guards.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { isRecord, isProfileUtility, isProfileSet } from '../../src/shared/domain/guards'
+
+// Before #692 these guards were duplicated across the renderer (config.ts:
+// isRecord/isProfileUtility/isGameProfileSet) and main (utils.ts: isRecord,
+// profiles.ts: isStoredProfileUtility/isStoredProfileSet). Pin the shared source.
+
+describe('isRecord', () => {
+  it('accepts plain objects and rejects arrays / null / primitives', () => {
+    expect(isRecord({})).toBe(true)
+    expect(isRecord({ a: 1 })).toBe(true)
+    expect(isRecord([])).toBe(false)
+    expect(isRecord(null)).toBe(false)
+    expect(isRecord(undefined)).toBe(false)
+    expect(isRecord('x')).toBe(false)
+    expect(isRecord(3)).toBe(false)
+  })
+})
+
+describe('isProfileUtility', () => {
+  it('requires a string id and a boolean enabled', () => {
+    expect(isProfileUtility({ id: 'simhub', enabled: true })).toBe(true)
+    expect(isProfileUtility({ id: 'simhub', enabled: false })).toBe(true)
+    expect(isProfileUtility({ id: 'simhub' })).toBe(false)
+    expect(isProfileUtility({ id: 5, enabled: true })).toBe(false)
+    expect(isProfileUtility({ id: 'simhub', enabled: 'yes' })).toBe(false)
+    expect(isProfileUtility(null)).toBe(false)
+  })
+})
+
+describe('isProfileSet', () => {
+  it('requires a string activeProfileId and a profiles array', () => {
+    expect(isProfileSet({ activeProfileId: 'default', profiles: [] })).toBe(true)
+    expect(
+      isProfileSet({ activeProfileId: 'default', profiles: [{ id: 'p1', name: 'One' }] })
+    ).toBe(true)
+    expect(isProfileSet({ activeProfileId: 'default' })).toBe(false)
+    expect(isProfileSet({ profiles: [] })).toBe(false)
+    expect(isProfileSet({ activeProfileId: 5, profiles: [] })).toBe(false)
+    expect(isProfileSet({ activeProfileId: 'default', profiles: {} })).toBe(false)
+    expect(isProfileSet(null)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Final cleanup slice of the #692 domain promotion (after #756 registries, #757 profile types, #758 slot scanners). Four helpers were duplicated across the process boundary with **byte-identical** bodies:

| Helper | Duplicated in |
|---|---|
| `isRecord` | renderer `lib/config.ts` + main `utils.ts` (+ a third inline copy `isRecordLike` in `slots.ts`) |
| `isProfileUtility` ≡ `isStoredProfileUtility` | `config.ts` / `profiles.ts` |
| `isGameProfileSet` ≡ `isStoredProfileSet` | `config.ts` / `profiles.ts` |
| `MAX_CUSTOM_SLOTS` (= 20) | renderer `config.ts` + main `store.ts` |

## How

- Guards → `src/shared/domain/guards.ts` (`isRecord`, `isProfileUtility`, `isProfileSet`).
- `MAX_CUSTOM_SLOTS` → `src/shared/domain/slots.ts` (cohesive with the custom-slot logic).
- Re-exported from every old location under their historical names — `config.ts` keeps `isGameProfileSet`/`isProfileUtility`/`isRecord`/`MAX_CUSTOM_SLOTS`, `profiles.ts` keeps `isStored*`, `utils.ts` keeps `isRecord`, `store.ts` keeps re-exporting `MAX_CUSTOM_SLOTS` (for `ipc/config.ts`). **Every importer is untouched.**
- `slots.ts` now uses the shared `isRecord` instead of its own inline copy.

Sharing `MAX_CUSTOM_SLOTS` means the renderer clamp and the store schema/sanitizer can no longer drift out of agreement.

## Test plan

Pure relocation of identical logic, guarded by the dual-project `tsc` (every importer resolves) + the full suite. All green: `tsc` ×2 + `preload:types:check`, `eslint`, `prettier`, **534 tests** (was 531), `electron-vite build`. New `tests/main/guards.test.ts` pins the three guards.

## Deliberately NOT included

- `DEFAULT_PROFILE_ID` / `DEFAULT_PROFILE_NAME` — the renderer names them but main uses inline `'default'`/`'Default'` literals, so it is not a named cross-process dupe; promoting it means editing main's profile-resolution logic for little value.
- The `normalize*ProfileSet` functions — `normalizeGameProfileSet` (renderer, runtime) vs the migration-coupled `normalizeStoredProfileSet` (main) serve different purposes; that is a behavioral question, not a mechanical dedup.

With this, the #692 shared domain layer holds `registries` + `profile` + `slots` + `guards`.

refs #692