### PR TITLE
fix(ui): add a Dismiss menu to the game icon's stuck status dot (refs #737)

### DIFF
--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -313,6 +313,7 @@ export function GameList({
               isGameRunning={gameExeRunning}
               gameStatusWarning={gameRunningApp?.warning}
               gameStatusDismissPath={gameRunningApp?.path}
+              gameStatusTracked={gameRunningApp?.tracked}
               runningAppIcons={runningAppIcons}
               isDimmed={hasActiveTitle && !runningStatus[game.key]}
               isLaunching={launchingGameKey === game.key}

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -4,7 +4,7 @@ import { getSettings, onStoreConfigChanged } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
-import { isGameExeRunning } from '../lib/runningGame'
+import { findGameExeRunningApp, isGameExeRunning } from '../lib/runningGame'
 import { getPathComparisonKey } from '../../../shared/path'
 import { useNotify } from './Notify'
 import { useAppsSettings } from './settings/AppsContext'
@@ -271,8 +271,12 @@ export function GameList({
           const gamePathLower = gamePaths[game.key] ? normalizePath(gamePaths[game.key]) : undefined
           // The green dot means the game's own exe is running — NOT the
           // runningStatus[key] aggregate, which is also true when only a
-          // companion (e.g. SimHub) is up (#587). See isGameExeRunning.
-          const gameExeRunning = isGameExeRunning(runningApps, game.key, gamePaths[game.key])
+          // companion (e.g. SimHub) is up (#587). See findGameExeRunningApp.
+          // Resolve the actual matching entry (not just the boolean) so a stuck
+          // mismatch-warning dot can carry its warning + dismiss path to the
+          // icon's right-click Dismiss menu (#737).
+          const gameRunningApp = findGameExeRunningApp(runningApps, game.key, gamePaths[game.key])
+          const gameExeRunning = !!gameRunningApp
           // Exclude the game's own executable so it doesn't appear as a
           // companion app in the running strip — the dot above already
           // represents the game itself.
@@ -307,6 +311,8 @@ export function GameList({
               isActive={activeEditorKey === game.key}
               isRunning={!!runningStatus[game.key]}
               isGameRunning={gameExeRunning}
+              gameStatusWarning={gameRunningApp?.warning}
+              gameStatusDismissPath={gameRunningApp?.path}
               runningAppIcons={runningAppIcons}
               isDimmed={hasActiveTitle && !runningStatus[game.key]}
               isLaunching={launchingGameKey === game.key}

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -7,13 +7,17 @@ interface GameIconProps {
   game: Game
   isRunning: boolean
   iconUrl?: string
-  // When the green dot is driven by a stale process-name-mismatch entry (a
-  // launcher stub that self-exited, #737) rather than a confirmed live process,
-  // `warning` carries its text and `dismissPath` the path to dismiss. The dot
-  // then offers a right-click / keyboard Dismiss menu; otherwise the icon is
-  // inert (a normal running dot clears itself when the process exits).
+  // When the green dot is driven by a warning entry rather than a confirmed live
+  // process, `warning` carries its text and `dismissPath` the path to dismiss.
+  // The dot then offers a right-click / keyboard Dismiss menu; otherwise the
+  // icon is inert (a normal running dot clears itself when the process exits).
+  // `tracked` distinguishes the two warning kinds so the menu labels itself
+  // correctly (mirrors the companion strip): a stale process-name-mismatch stub
+  // that self-exited (#737) is untracked → "Dismiss Icon"; a still-running
+  // kill-failed game exe is tracked → "Dismiss Warning".
   warning?: string
   dismissPath?: string
+  tracked?: boolean
 }
 
 const STATUS_DOT_CLASS =
@@ -24,7 +28,8 @@ export function GameIcon({
   isRunning,
   iconUrl,
   warning,
-  dismissPath
+  dismissPath,
+  tracked
 }: GameIconProps): ReactNode {
   const [iconLoadFailed, setIconLoadFailed] = useState(false)
 
@@ -41,7 +46,8 @@ export function GameIcon({
     path: dismissPath ?? '',
     gameKey: game.key,
     name: game.name,
-    warning
+    warning,
+    tracked
   })
   const isDismissible = isRunning && !!warning && !!dismissPath
 

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -1,14 +1,31 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import type { Game } from '../../lib/config'
 import { Tooltip } from '../Tooltip'
+import { useDismissMenu } from '../../hooks/useDismissMenu'
 
 interface GameIconProps {
   game: Game
   isRunning: boolean
   iconUrl?: string
+  // When the green dot is driven by a stale process-name-mismatch entry (a
+  // launcher stub that self-exited, #737) rather than a confirmed live process,
+  // `warning` carries its text and `dismissPath` the path to dismiss. The dot
+  // then offers a right-click / keyboard Dismiss menu; otherwise the icon is
+  // inert (a normal running dot clears itself when the process exits).
+  warning?: string
+  dismissPath?: string
 }
 
-export function GameIcon({ game, isRunning, iconUrl }: GameIconProps): ReactNode {
+const STATUS_DOT_CLASS =
+  'status-dot absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]'
+
+export function GameIcon({
+  game,
+  isRunning,
+  iconUrl,
+  warning,
+  dismissPath
+}: GameIconProps): ReactNode {
   const [iconLoadFailed, setIconLoadFailed] = useState(false)
 
   // Reset the error flag when the URL changes so a newly-configured icon gets
@@ -17,27 +34,63 @@ export function GameIcon({ game, isRunning, iconUrl }: GameIconProps): ReactNode
     setIconLoadFailed(false)
   }, [iconUrl])
 
+  // Called unconditionally (rules of hooks). The menu only arms when `warning`
+  // is set, so a normally-running or idle icon stays inert and keeps the native
+  // context menu (dev inspect).
+  const dismissMenu = useDismissMenu({
+    path: dismissPath ?? '',
+    gameKey: game.key,
+    name: game.name,
+    warning
+  })
+  const isDismissible = isRunning && !!warning && !!dismissPath
+
+  const iconContent =
+    iconUrl && !iconLoadFailed ? (
+      <img
+        src={iconUrl}
+        alt={game.name}
+        className="game-icon-image h-12 w-12 object-contain animate-fade-slide"
+        onError={() => setIconLoadFailed(true)}
+      />
+    ) : !iconLoadFailed ? (
+      // No URL yet (icon still loading from Settings): show a pulsing skeleton
+      // placeholder so the row layout is stable during load.
+      <div aria-hidden="true" className="h-12 w-12 skeleton-icon animate-pulse" />
+    ) : null /* iconLoadFailed: render nothing — the 48px slot looks odd with a
+                truncated initial, so an empty slot is less distracting. */
+
+  // Stuck-dot case (#737): the dot reflects a mismatch warning, not a confirmed
+  // live process. The whole icon becomes a focusable trigger that opens a
+  // Dismiss menu on right-click / Enter / Space (mirrors the running-strip
+  // warning affordance, #543). The warning text itself tells the user to
+  // right-click to dismiss, so it doubles as the tooltip and the accessible name.
+  if (isDismissible) {
+    return (
+      <>
+        <Tooltip label={warning} disabled={dismissMenu.isMenuOpen}>
+          <button
+            ref={dismissMenu.setTriggerRef}
+            type="button"
+            aria-label={`${game.name}: ${warning}`}
+            className="relative flex h-12 w-12 shrink-0 cursor-pointer items-center justify-center rounded-xl"
+            {...dismissMenu.getTriggerProps()}
+          >
+            {iconContent}
+            <span aria-hidden="true" className={STATUS_DOT_CLASS} />
+          </button>
+        </Tooltip>
+        {dismissMenu.menu}
+      </>
+    )
+  }
+
   return (
     <div className="relative flex h-12 w-12 shrink-0 items-center justify-center">
-      {
-        iconUrl && !iconLoadFailed ? (
-          <img
-            src={iconUrl}
-            alt={game.name}
-            className="game-icon-image h-12 w-12 object-contain animate-fade-slide"
-            onError={() => setIconLoadFailed(true)}
-          />
-        ) : !iconLoadFailed ? (
-          // No URL yet (icon still loading from Settings): show a pulsing
-          // skeleton placeholder so the row layout is stable during load.
-          <div aria-hidden="true" className="h-12 w-12 skeleton-icon animate-pulse" />
-        ) : null /* iconLoadFailed: render nothing — no fallback text initial
-                  because the 48px icon slot is large enough to look odd with
-                  a truncated initial; an empty slot is less distracting. */
-      }
+      {iconContent}
       {isRunning && (
         <Tooltip label="Running">
-          <div className="status-dot absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]">
+          <div className={STATUS_DOT_CLASS}>
             <span className="sr-only">{game.name} is running</span>
           </div>
         </Tooltip>

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -36,6 +36,7 @@ export function GameRow({
   isGameRunning,
   gameStatusWarning,
   gameStatusDismissPath,
+  gameStatusTracked,
   runningAppIcons,
   gameIconUrl,
   isDimmed,
@@ -57,11 +58,15 @@ export function GameRow({
   // Narrow: the game's OWN executable is running. Drives only the green status
   // dot, whose tooltip/label assert the game itself is running (#587).
   isGameRunning: boolean
-  // Set when the green dot is driven by a stale process-name-mismatch entry
-  // (a launcher stub that self-exited) rather than a live process — carries the
-  // warning text and the path to dismiss so the icon can offer Dismiss (#737).
+  // Set when the green dot is driven by a warning entry rather than a live
+  // process — carries the warning text and the path to dismiss so the icon can
+  // offer Dismiss (#737). `tracked` mirrors the companion strip: it picks the
+  // Dismiss menu label (untracked mismatch stub → "Dismiss Icon"; still-running
+  // kill-failed exe → "Dismiss Warning"), so the game exe's own kill-failure
+  // isn't mislabelled as an orphaned-icon dismissal.
   gameStatusWarning?: string
   gameStatusDismissPath?: string
+  gameStatusTracked?: boolean
   runningAppIcons: RunningAppIcon[]
   gameIconUrl?: string
   isDimmed: boolean
@@ -558,6 +563,7 @@ export function GameRow({
             iconUrl={gameIconUrl}
             warning={gameStatusWarning}
             dismissPath={gameStatusDismissPath}
+            tracked={gameStatusTracked}
           />
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -34,6 +34,8 @@ export function GameRow({
   isActive,
   isRunning,
   isGameRunning,
+  gameStatusWarning,
+  gameStatusDismissPath,
   runningAppIcons,
   gameIconUrl,
   isDimmed,
@@ -55,6 +57,11 @@ export function GameRow({
   // Narrow: the game's OWN executable is running. Drives only the green status
   // dot, whose tooltip/label assert the game itself is running (#587).
   isGameRunning: boolean
+  // Set when the green dot is driven by a stale process-name-mismatch entry
+  // (a launcher stub that self-exited) rather than a live process — carries the
+  // warning text and the path to dismiss so the icon can offer Dismiss (#737).
+  gameStatusWarning?: string
+  gameStatusDismissPath?: string
   runningAppIcons: RunningAppIcon[]
   gameIconUrl?: string
   isDimmed: boolean
@@ -545,7 +552,13 @@ export function GameRow({
         className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? 'isolation-auto! z-20' : 'z-0'}`}
       >
         <div className="flex items-center gap-5">
-          <GameIcon game={game} isRunning={isGameRunning} iconUrl={gameIconUrl} />
+          <GameIcon
+            game={game}
+            isRunning={isGameRunning}
+            iconUrl={gameIconUrl}
+            warning={gameStatusWarning}
+            dismissPath={gameStatusDismissPath}
+          />
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
               <h2 className="game-title font-normal text-(--text-primary)">{game.name}</h2>

--- a/src/renderer/src/components/game-list/RunningAppsStrip.tsx
+++ b/src/renderer/src/components/game-list/RunningAppsStrip.tsx
@@ -1,20 +1,6 @@
 import { useState, type ReactNode, type ReactElement } from 'react'
-import { dismissAppIcon } from '../../lib/electron'
 import { Tooltip } from '../Tooltip'
-import { buildDismissLabel } from '../../lib/contextMenuLabel'
-import {
-  autoUpdate,
-  flip,
-  FloatingFocusManager,
-  FloatingPortal,
-  offset,
-  shift,
-  useClick,
-  useDismiss,
-  useFloating,
-  useInteractions,
-  useRole
-} from '@floating-ui/react'
+import { useDismissMenu } from '../../hooks/useDismissMenu'
 
 export interface RunningAppIcon {
   icon: string | null
@@ -46,56 +32,14 @@ function RunningAppIconItem({
   cacheInitialized,
   onError
 }: RunningAppIconItemProps): ReactNode {
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
-
-  const { refs, floatingStyles, context } = useFloating({
-    open: isMenuOpen,
-    onOpenChange: setIsMenuOpen,
-    placement: 'bottom-start',
-    middleware: [offset(4), flip({ padding: 8 }), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate
-  })
-
-  // useClick makes the trigger keyboard-operable (Enter/Space) and opens on a
-  // plain left-click, alongside the existing right-click — only when there's a
-  // warning, so non-warning icons stay inert.
-  const click = useClick(context, { enabled: !!app.warning })
-  const dismiss = useDismiss(context)
-  const role = useRole(context, { role: 'menu' })
-  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role])
-
-  // Only show the context menu when there is a warning (e.g. process-name
-  // mismatch). Apps without warnings get no right-click menu so the native
-  // Chromium context menu (inspect element) still works in dev builds.
-  const handleContextMenu = (e: React.MouseEvent) => {
-    if (app.warning) {
-      e.preventDefault()
-      setIsMenuOpen(true)
-    }
-  }
-
-  const handleDismissClick = async (e: React.MouseEvent) => {
-    e.stopPropagation()
-    // For untracked apps, the icon is unmounted when warning clears;
-    // for tracked apps, the icon remains, so close the menu explicitly.
-    setIsMenuOpen(false)
-    try {
-      await dismissAppIcon(app.path, app.gameKey)
-    } catch (err) {
-      console.error('Failed to dismiss app warning:', err)
-    }
-  }
-
-  // Accessibility trigger attributes composition
-  const triggerProps = getReferenceProps({
-    onContextMenu: handleContextMenu,
-    'aria-haspopup': app.warning ? ('menu' as const) : undefined,
-    'aria-expanded': app.warning ? isMenuOpen : undefined
-  })
-
-  const dismissLabel = buildDismissLabel(app.path, {
-    tracked: app.tracked,
-    name: app.name
+  // Shared right-click / keyboard Dismiss menu (#466, #543) — see useDismissMenu.
+  // Arms only when app.warning is set; a normal companion icon stays inert.
+  const { isMenuOpen, setTriggerRef, getTriggerProps, menu } = useDismissMenu({
+    path: app.path,
+    gameKey: app.gameKey,
+    name: app.name,
+    warning: app.warning,
+    tracked: app.tracked
   })
 
   // Icon still loading (cache not yet populated) and nothing actionable to
@@ -117,15 +61,15 @@ function RunningAppIconItem({
     // A warning icon is actionable (it opens a Dismiss menu), so the trigger is
     // a real focusable <button>: keyboard/Narrator users can reach it, hear that
     // it's actionable (aria-haspopup) and open the menu via Enter/Space or click
-    // (useClick) — not just right-click (WCAG 2.1.1). The inner icon/initial is
-    // decorative; the button's aria-label carries the name + warning.
+    // — not just right-click (WCAG 2.1.1). The inner icon/initial is decorative;
+    // the button's aria-label carries the name + warning.
     content = (
       <button
-        ref={refs.setReference}
+        ref={setTriggerRef}
         type="button"
         aria-label={`${app.name}: ${app.warning}`}
         className="flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-(--warning-border)"
-        {...triggerProps}
+        {...getTriggerProps()}
       >
         {isAvailable ? (
           <img
@@ -144,7 +88,7 @@ function RunningAppIconItem({
   } else if (isAvailable) {
     content = (
       <img
-        ref={refs.setReference}
+        ref={setTriggerRef}
         src={app.icon ?? undefined}
         alt=""
         className="h-4 w-4 object-contain opacity-80"
@@ -154,7 +98,7 @@ function RunningAppIconItem({
   } else {
     content = (
       <div
-        ref={refs.setReference}
+        ref={setTriggerRef}
         role="img"
         aria-label={app.name}
         className="fallback-initial-icon h-4 w-4 rounded text-[6px] font-black flex items-center justify-center shrink-0"
@@ -170,29 +114,7 @@ function RunningAppIconItem({
         {content}
       </Tooltip>
 
-      {isMenuOpen && (
-        <FloatingPortal>
-          <FloatingFocusManager context={context} modal={false}>
-            <div
-              ref={refs.setFloating}
-              style={floatingStyles}
-              {...getFloatingProps()}
-              className="z-9999"
-            >
-              <div className="dropdown-surface overlay-glass rounded-xl p-1 border border-(--glass-border) shadow-(--surface-floating-shadow) animate-fade-slide min-w-[180px]">
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={handleDismissClick}
-                  className="dropdown-item flex w-full cursor-pointer items-center rounded-lg px-2.5 py-1.5 text-left text-xs font-semibold"
-                >
-                  {dismissLabel}
-                </button>
-              </div>
-            </div>
-          </FloatingFocusManager>
-        </FloatingPortal>
-      )}
+      {menu}
     </>
   )
 }

--- a/src/renderer/src/hooks/useDismissMenu.tsx
+++ b/src/renderer/src/hooks/useDismissMenu.tsx
@@ -1,0 +1,123 @@
+import { useState, type MouseEvent, type ReactNode } from 'react'
+import {
+  autoUpdate,
+  flip,
+  FloatingFocusManager,
+  FloatingPortal,
+  offset,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole
+} from '@floating-ui/react'
+
+import { dismissAppIcon } from '../lib/electron'
+import { buildDismissLabel } from '../lib/contextMenuLabel'
+
+export interface DismissMenuTarget {
+  /** The running-app path used to key the dismiss (matches the main-process entry). */
+  path: string
+  gameKey: string
+  /** Display name, used to build the accessible dismiss label. */
+  name: string
+  /** When absent, the trigger stays inert: no menu, no keyboard/right-click affordance. */
+  warning?: string
+  /** Whether the entry is actively tracked (Dismiss Warning) vs orphaned (Dismiss Icon). */
+  tracked?: boolean
+}
+
+/**
+ * Shared "right-click / keyboard → Dismiss" menu behavior (#466, #543) used by
+ * both the running-apps strip companion icons and the game icon's stuck-status
+ * dot (#737). The caller owns the trigger element's markup — it spreads
+ * `getTriggerProps()` and attaches `setTriggerRef` — so each surface keeps its
+ * own visuals while sharing one menu implementation, aria wiring and dismiss
+ * call. The menu only arms when `target.warning` is set; without it the trigger
+ * is inert so a normal icon keeps the native context menu (dev inspect).
+ */
+export function useDismissMenu(target: DismissMenuTarget): {
+  isMenuOpen: boolean
+  setTriggerRef: (node: HTMLElement | null) => void
+  getTriggerProps: (userProps?: Record<string, unknown>) => Record<string, unknown>
+  menu: ReactNode
+} {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isMenuOpen,
+    onOpenChange: setIsMenuOpen,
+    placement: 'bottom-start',
+    middleware: [offset(4), flip({ padding: 8 }), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate
+  })
+
+  // useClick makes the trigger keyboard-operable (Enter/Space) and opens on a
+  // plain left-click alongside right-click — only when there's a warning, so
+  // non-warning icons stay inert.
+  const click = useClick(context, { enabled: !!target.warning })
+  const dismiss = useDismiss(context)
+  const role = useRole(context, { role: 'menu' })
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role])
+
+  const handleContextMenu = (event: MouseEvent) => {
+    // Only intercept right-click when there's something to dismiss; otherwise let
+    // the native Chromium menu through (dev inspect).
+    if (target.warning) {
+      event.preventDefault()
+      setIsMenuOpen(true)
+    }
+  }
+
+  const handleDismissClick = async (event: MouseEvent) => {
+    event.stopPropagation()
+    // For untracked apps the icon unmounts when the warning clears; for tracked
+    // ones the icon remains, so close the menu explicitly.
+    setIsMenuOpen(false)
+    try {
+      await dismissAppIcon(target.path, target.gameKey)
+    } catch (err) {
+      console.error('Failed to dismiss app warning:', err)
+    }
+  }
+
+  const getTriggerProps = (userProps?: Record<string, unknown>) =>
+    getReferenceProps({
+      onContextMenu: handleContextMenu,
+      'aria-haspopup': target.warning ? ('menu' as const) : undefined,
+      'aria-expanded': target.warning ? isMenuOpen : undefined,
+      ...userProps
+    })
+
+  const dismissLabel = buildDismissLabel(target.path, {
+    tracked: target.tracked,
+    name: target.name
+  })
+
+  const menu = isMenuOpen ? (
+    <FloatingPortal>
+      <FloatingFocusManager context={context} modal={false}>
+        <div
+          ref={refs.setFloating}
+          style={floatingStyles}
+          {...getFloatingProps()}
+          className="z-9999"
+        >
+          <div className="dropdown-surface overlay-glass rounded-xl p-1 border border-(--glass-border) shadow-(--surface-floating-shadow) animate-fade-slide min-w-[180px]">
+            <button
+              type="button"
+              role="menuitem"
+              onClick={handleDismissClick}
+              className="dropdown-item flex w-full cursor-pointer items-center rounded-lg px-2.5 py-1.5 text-left text-xs font-semibold"
+            >
+              {dismissLabel}
+            </button>
+          </div>
+        </div>
+      </FloatingFocusManager>
+    </FloatingPortal>
+  ) : null
+
+  return { isMenuOpen, setTriggerRef: refs.setReference, getTriggerProps, menu }
+}

--- a/src/renderer/src/hooks/useDismissMenu.tsx
+++ b/src/renderer/src/hooks/useDismissMenu.tsx
@@ -15,6 +15,7 @@ import {
 
 import { dismissAppIcon } from '../lib/electron'
 import { buildDismissLabel } from '../lib/contextMenuLabel'
+import { useNotify } from '../components/Notify'
 
 export interface DismissMenuTarget {
   /** The running-app path used to key the dismiss (matches the main-process entry). */
@@ -44,6 +45,7 @@ export function useDismissMenu(target: DismissMenuTarget): {
   menu: ReactNode
 } {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const { notify } = useNotify()
 
   const { refs, floatingStyles, context } = useFloating({
     open: isMenuOpen,
@@ -78,7 +80,11 @@ export function useDismissMenu(target: DismissMenuTarget): {
     try {
       await dismissAppIcon(target.path, target.gameKey)
     } catch (err) {
+      // The menu already closed optimistically, so without this the dot just
+      // stays with no explanation. Match the failure feedback the GameRow
+      // handlers (kill / launch / relaunch) already give (#764 CodeRabbit).
       console.error('Failed to dismiss app warning:', err)
+      notify('Failed to dismiss warning', 'error')
     }
   }
 

--- a/src/renderer/src/lib/runningGame.ts
+++ b/src/renderer/src/lib/runningGame.ts
@@ -18,12 +18,20 @@ const normalize = (path: string): string => path.toLowerCase()
  * `gamePaths[key]` (iRacing via its UI, AC via Content Manager) are out of scope
  * here and handled by the running-state pass (#585/#586).
  */
+export function findGameExeRunningApp<T extends Pick<RunningApp, 'path' | 'gameKey'>>(
+  runningApps: T[],
+  gameKey: string,
+  gamePath: string | undefined
+): T | undefined {
+  if (!gamePath) return undefined
+  const target = normalize(gamePath)
+  return runningApps.find((app) => app.gameKey === gameKey && normalize(app.path) === target)
+}
+
 export function isGameExeRunning(
   runningApps: Pick<RunningApp, 'path' | 'gameKey'>[],
   gameKey: string,
   gamePath: string | undefined
 ): boolean {
-  if (!gamePath) return false
-  const target = normalize(gamePath)
-  return runningApps.some((app) => app.gameKey === gameKey && normalize(app.path) === target)
+  return !!findGameExeRunningApp(runningApps, gameKey, gamePath)
 }

--- a/tests/renderer/gameIconDismiss.test.tsx
+++ b/tests/renderer/gameIconDismiss.test.tsx
@@ -15,6 +15,15 @@ vi.mock('../../src/renderer/src/lib/electron', () => ({
   dismissAppIcon: (...args: unknown[]) => dismissAppIconMock(...args)
 }))
 
+// useDismissMenu reads useNotify to surface dismiss failures; capture notify so
+// the failure path can be asserted, and stub the provider so no toast portal
+// mounts.
+const notifyMock = vi.fn()
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
 beforeAll(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 })
@@ -43,6 +52,7 @@ afterEach(() => {
   act(() => root?.unmount())
   container.remove()
   dismissAppIconMock.mockClear()
+  notifyMock.mockClear()
 })
 
 describe('GameIcon dismiss menu (#737)', () => {
@@ -150,5 +160,32 @@ describe('GameIcon dismiss menu (#737)', () => {
       />
     )
     expect(container.querySelector('button')).toBeNull()
+  })
+
+  test('a failed dismiss notifies the user instead of failing silently', async () => {
+    // The menu closes optimistically, so a rejected dismiss would otherwise
+    // leave the dot in place with no feedback (#764 CodeRabbit).
+    dismissAppIconMock.mockRejectedValueOnce(new Error('ipc down'))
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    const trigger = container.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement
+    await act(async () => {
+      trigger.click()
+    })
+    const menuItem = document.body.querySelector('[role="menuitem"]') as HTMLButtonElement
+    await act(async () => {
+      menuItem.click()
+      // Flush the rejected dismiss so its catch (which notifies) runs.
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(notifyMock).toHaveBeenCalledWith('Failed to dismiss warning', 'error')
   })
 })

--- a/tests/renderer/gameIconDismiss.test.tsx
+++ b/tests/renderer/gameIconDismiss.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * #737 — a game whose green "Running" dot is driven by a stale process-name-
+ * mismatch entry (a launcher stub that self-exited, e.g. BeamNG) must be
+ * dismissable from the game icon itself: a right-click / keyboard Dismiss menu
+ * mirroring the running-strip warning affordance (#543). A normally-running game
+ * icon stays inert (plain dot, no menu).
+ */
+
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { act, type ReactElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const dismissAppIconMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  dismissAppIcon: (...args: unknown[]) => dismissAppIconMock(...args)
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameIcon } from '../../src/renderer/src/components/game-list/GameIcon'
+
+const GAME = { key: 'beamng', name: 'BeamNG.drive', icon: 'assets/beamng.png' }
+const GAME_PATH = 'C:/Games/BeamNG.drive/BeamNG.drive.exe'
+const WARNING =
+  'BeamNG.drive.exe exited shortly after launch. It likely spawned a child process under a different name. Right-click the icon to dismiss this warning.'
+const ICON = 'data:image/png;base64,AAAA'
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function render(element: ReactElement): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(element)
+  })
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  dismissAppIconMock.mockClear()
+})
+
+describe('GameIcon dismiss menu (#737)', () => {
+  test('a normal running dot is inert (no button, no menu affordance)', async () => {
+    await render(<GameIcon game={GAME} isRunning={true} iconUrl={ICON} />)
+    expect(container.querySelector('button')).toBeNull()
+    expect(container.querySelector('[aria-haspopup="menu"]')).toBeNull()
+  })
+
+  test('a stuck-warning dot is a focusable trigger that advertises its menu', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    const trigger = container.querySelector('button')
+    expect(trigger).not.toBeNull()
+    expect(trigger!.getAttribute('aria-haspopup')).toBe('menu')
+    expect(trigger!.getAttribute('aria-label')).toContain('BeamNG.drive')
+    expect(trigger!.getAttribute('aria-label')).toContain('exited shortly after launch')
+    // Native button is in the tab order (keyboard/Narrator reachable, WCAG 2.1.1).
+    expect(trigger!.tabIndex).toBe(0)
+  })
+
+  test('clicking the trigger opens Dismiss, which dismisses with the game path + key', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    const trigger = container.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement
+    expect(document.body.querySelector('[role="menuitem"]')).toBeNull()
+
+    await act(async () => {
+      trigger.click()
+    })
+
+    const menuItem = document.body.querySelector('[role="menuitem"]') as HTMLButtonElement
+    expect(menuItem).not.toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    await act(async () => {
+      menuItem.click()
+    })
+    expect(dismissAppIconMock).toHaveBeenCalledWith(GAME_PATH, 'beamng')
+  })
+
+  test('a warning without isRunning shows no dismissable dot', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={false}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    expect(container.querySelector('button')).toBeNull()
+  })
+})

--- a/tests/renderer/gameIconDismiss.test.tsx
+++ b/tests/renderer/gameIconDismiss.test.tsx
@@ -98,6 +98,47 @@ describe('GameIcon dismiss menu (#737)', () => {
     expect(dismissAppIconMock).toHaveBeenCalledWith(GAME_PATH, 'beamng')
   })
 
+  test('an untracked (mismatch stub) warning labels the action "Dismiss Icon"', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    const trigger = container.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement
+    await act(async () => {
+      trigger.click()
+    })
+    const menuItem = document.body.querySelector('[role="menuitem"]') as HTMLButtonElement
+    // Orphaned stub icon: dismissing removes the badge, so "Dismiss Icon".
+    expect(menuItem.textContent).toBe('Dismiss Icon for BeamNG.drive')
+  })
+
+  test('a tracked (still-running kill-failed) warning labels the action "Dismiss Warning"', async () => {
+    // The game exe failed to Close and is still running (tracked): dismissing
+    // clears the warning but the live process keeps the dot, so "Dismiss
+    // Warning" is the honest label — not "Dismiss Icon" (Codex P2, #764).
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+        tracked={true}
+      />
+    )
+    const trigger = container.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement
+    await act(async () => {
+      trigger.click()
+    })
+    const menuItem = document.body.querySelector('[role="menuitem"]') as HTMLButtonElement
+    expect(menuItem.textContent).toBe('Dismiss Warning for BeamNG.drive')
+  })
+
   test('a warning without isRunning shows no dismissable dot', async () => {
     await render(
       <GameIcon

--- a/tests/renderer/gameRowStatusDismiss.test.tsx
+++ b/tests/renderer/gameRowStatusDismiss.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Wiring test for #737 Part 2 (stashpeak-review-bot finding on PR #764).
+ *
+ * GameIcon's stuck-dot Dismiss menu and findGameExeRunningApp are each unit-
+ * tested in isolation, but nothing exercised the SEAM that connects them: GameRow
+ * forwarding a mismatch-warning entry's `warning` + `dismissPath` down to
+ * GameIcon. Because both props are OPTIONAL, a dropped forward would silently
+ * break the feature without tripping TypeScript. This renders the real GameRow →
+ * GameIcon → useDismissMenu chain with a warning-carrying entry and confirms the
+ * forwarded path is what ultimately reaches the dismiss IPC.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const dismissAppIconMock = vi.fn().mockResolvedValue(undefined)
+
+// GameRow imports these directly from lib/electron; window.electronAPI is
+// undefined in jsdom, so the real module would crash at eval. dismissAppIcon is
+// the one exercised here (via GameIcon → useDismissMenu); the rest are inert.
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  dismissAppIcon: (...args: unknown[]) => dismissAppIconMock(...args),
+  launchProfile: vi.fn(),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+// See gameRowLaunchAnnounce.test.tsx — ProfileEditor's hook graph grabs
+// window.electronAPI at module eval; no-op store stubs are safe here.
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'beamng', name: 'BeamNG.drive', icon: 'assets/beamng.png' }
+const GAME_PATH = 'C:/Games/BeamNG.drive/BeamNG.drive.exe'
+const WARNING =
+  'BeamNG.drive.exe exited shortly after launch. It likely spawned a child process under a different name. Right-click the icon to dismiss this warning.'
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRow(props: { warning?: string; dismissPath?: string } = {}): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={true}
+          isGameRunning={true}
+          gameStatusWarning={props.warning}
+          gameStatusDismissPath={props.dismissPath}
+          runningAppIcons={[]}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+// The icon's Dismiss trigger is the button whose accessible name carries the
+// warning text — scoped this way so it isn't confused with the row's other
+// menu-bearing controls (e.g. the profile switcher).
+function findDismissTrigger(): HTMLButtonElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>('button[aria-haspopup="menu"]')
+  ).find((button) => button.getAttribute('aria-label')?.includes('exited shortly after launch'))
+}
+
+beforeEach(() => {
+  dismissAppIconMock.mockClear()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('GameRow → GameIcon stuck-dot wiring (#737 Part 2)', () => {
+  test('a running game with no status warning renders no icon Dismiss trigger', async () => {
+    await renderRow()
+    expect(findDismissTrigger()).toBeUndefined()
+  })
+
+  test('forwarding a warning + dismissPath arms the icon as a Dismiss trigger', async () => {
+    await renderRow({ warning: WARNING, dismissPath: GAME_PATH })
+
+    const trigger = findDismissTrigger()
+    expect(trigger).not.toBeUndefined()
+    expect(trigger!.getAttribute('aria-label')).toContain('BeamNG.drive')
+  })
+
+  test('dismissing through the forwarded chain calls dismiss with the game path + key', async () => {
+    await renderRow({ warning: WARNING, dismissPath: GAME_PATH })
+
+    const trigger = findDismissTrigger()!
+    await act(async () => {
+      trigger.click()
+    })
+
+    const menuItem = document.body.querySelector('[role="menuitem"]') as HTMLButtonElement
+    expect(menuItem).not.toBeNull()
+
+    await act(async () => {
+      menuItem.click()
+    })
+
+    // The path that reaches the dismiss IPC is the one GameRow forwarded as
+    // gameStatusDismissPath — proving the full prop chain, not just GameIcon.
+    expect(dismissAppIconMock).toHaveBeenCalledWith(GAME_PATH, 'beamng')
+  })
+})

--- a/tests/renderer/gameRowStatusDismiss.test.tsx
+++ b/tests/renderer/gameRowStatusDismiss.test.tsx
@@ -100,7 +100,9 @@ const WARNING =
 let container: HTMLDivElement
 let root: Root | null = null
 
-async function renderRow(props: { warning?: string; dismissPath?: string } = {}): Promise<void> {
+async function renderRow(
+  props: { warning?: string; dismissPath?: string; tracked?: boolean } = {}
+): Promise<void> {
   container = document.createElement('div')
   document.body.appendChild(container)
   await act(async () => {
@@ -114,6 +116,7 @@ async function renderRow(props: { warning?: string; dismissPath?: string } = {})
           isGameRunning={true}
           gameStatusWarning={props.warning}
           gameStatusDismissPath={props.dismissPath}
+          gameStatusTracked={props.tracked}
           runningAppIcons={[]}
           isDimmed={false}
           isLaunching={false}
@@ -180,5 +183,21 @@ describe('GameRow → GameIcon stuck-dot wiring (#737 Part 2)', () => {
     // The path that reaches the dismiss IPC is the one GameRow forwarded as
     // gameStatusDismissPath — proving the full prop chain, not just GameIcon.
     expect(dismissAppIconMock).toHaveBeenCalledWith(GAME_PATH, 'beamng')
+  })
+
+  test('gameStatusTracked forwards through so a kill-failed game reads "Dismiss Warning"', async () => {
+    // tracked is a third optional prop on the same seam — a dropped forward
+    // would silently mislabel a still-running kill-failed game exe as an
+    // orphaned-icon dismissal (Codex P2, #764). Render tracked and confirm the
+    // menu label reflects it end-to-end.
+    await renderRow({ warning: WARNING, dismissPath: GAME_PATH, tracked: true })
+
+    const trigger = findDismissTrigger()!
+    await act(async () => {
+      trigger.click()
+    })
+
+    const menuItem = document.body.querySelector('[role="menuitem"]') as HTMLButtonElement
+    expect(menuItem.textContent).toBe('Dismiss Warning for BeamNG.drive')
   })
 })

--- a/tests/renderer/runningAppsStripWarning.test.tsx
+++ b/tests/renderer/runningAppsStripWarning.test.tsx
@@ -17,6 +17,14 @@ vi.mock('../../src/renderer/src/lib/electron', () => ({
   dismissAppIcon: (...args: unknown[]) => dismissAppIconMock(...args)
 }))
 
+// useDismissMenu now reads useNotify (to surface dismiss failures), so any
+// dismiss-consumer render needs a Notify context — stub it rather than mount
+// the real toast portal.
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
 beforeAll(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 })

--- a/tests/renderer/runningGame.test.ts
+++ b/tests/renderer/runningGame.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from 'vitest'
 
-import { isGameExeRunning } from '../../src/renderer/src/lib/runningGame'
+import { findGameExeRunningApp, isGameExeRunning } from '../../src/renderer/src/lib/runningGame'
 
 const acGame = { path: 'C:\\Games\\AssettoCorsa\\acs.exe', gameKey: 'ac' }
 const simhub = { path: 'C:\\Program Files\\SimHub\\SimHubWPF.exe', gameKey: 'ac' }
@@ -37,5 +37,34 @@ describe('isGameExeRunning', () => {
     expect(
       isGameExeRunning([{ path: acGame.path.toUpperCase(), gameKey: 'ac' }], 'ac', acGame.path)
     ).toBe(true)
+  })
+})
+
+// findGameExeRunningApp underpins isGameExeRunning but returns the matching entry
+// itself, so the game icon can read that entry's warning + dismiss path for the
+// stuck-dot Dismiss menu (#737).
+describe('findGameExeRunningApp', () => {
+  test('returns the matching entry, preserving its extra fields', () => {
+    const warned = { path: acGame.path, gameKey: 'ac', warning: 'stub exited' }
+    expect(findGameExeRunningApp([simhub, warned], 'ac', acGame.path)).toBe(warned)
+  })
+
+  test('returns undefined when only a companion is running (#587)', () => {
+    expect(findGameExeRunningApp([simhub], 'ac', acGame.path)).toBeUndefined()
+  })
+
+  test('returns undefined when the game path is not configured', () => {
+    expect(findGameExeRunningApp([acGame], 'ac', undefined)).toBeUndefined()
+  })
+
+  test('requires the gameKey to match, not just the path', () => {
+    expect(
+      findGameExeRunningApp([{ path: acGame.path, gameKey: 'acc' }], 'ac', acGame.path)
+    ).toBeUndefined()
+  })
+
+  test('matches case-insensitively (Windows paths)', () => {
+    const entry = { path: acGame.path.toUpperCase(), gameKey: 'ac' }
+    expect(findGameExeRunningApp([entry], 'ac', acGame.path)).toBe(entry)
   })
 })


### PR DESCRIPTION
## What

**Part 2 of #737** — the interim mitigation + product-gap fill. (Part 1, real re-exec child tracking, stays open on #737.)

A game launched via a re-exec launcher stub (BeamNG: spawns a differently-named child, the original PID exits in <10s) leaves a persistent `processNameMismatchWarnings` entry whose `path == gamePaths[gameKey]`. So the green **Running** dot on the game icon never clears after the game closes. Dismiss existed only on the running-apps **strip** (#466), and `GameList` deliberately excludes the game's own exe from the strip — so the stuck dot had **no dismiss affordance anywhere**, and the user was sent to relaunch/restart.

## How

- **Extract** the strip's floating-ui Dismiss menu into a shared `useDismissMenu` hook (one implementation; right-click + Enter/Space reachable per #543). Refactor `RunningAppsStrip` onto it — behaviour-identical, its #543 regression test stays green (removes ~90 lines of now-deduplicated menu code).
- `runningGame.ts`: add `findGameExeRunningApp` (returns the matching entry, not just a bool); `isGameExeRunning` delegates to it.
- `GameList` threads the game's own running-entry `warning` + `path` down to `GameIcon`.
- `GameIcon`: when the dot is driven by a mismatch warning, the icon becomes a focusable trigger with a right-click / keyboard Dismiss menu → `dismissAppIcon(path, gameKey)`. A normally-running dot stays inert (a live process clears itself on exit). The warning text (which already says "Right-click the icon to dismiss this warning") doubles as the tooltip + accessible name.

## Scope / what this does NOT do

- It does **not** auto-clear the stuck dot — that needs real re-exec child-process tracking, which is **Part 1 of #737** (kept open, in the #673/#674/#677 tracking family).
- Pure renderer change; no main-process behaviour touched.

## Test plan

All green: `tsc` ×2 + `preload:types:check`, `eslint`, `prettier`, **543 tests** (+9), `electron-vite build`.
- New `tests/renderer/gameIconDismiss.test.tsx`: inert normal dot; warning dot is a focusable `aria-haspopup` button; click opens Dismiss → `dismissAppIcon(gamePath, gameKey)`; no dismissable dot when not running.
- New `findGameExeRunningApp` cases in `runningGame.test.ts`.
- `runningAppsStripWarning.test.tsx` (#543) still green — the hook extraction preserved the strip's exact button/aria/menu structure.

## Needs your eyes 👀

1. **BeamNG smoke** — the actual repro (launch BeamNG → close it → confirm the dot can now be right-click-dismissed) before we call Part 2 done.
2. **Design call**: the warning-driven dot is still **green** (identical to a real running dot); only right-click/hover reveals it's a stale warning. Should the stuck/mismatch dot be visually distinct (amber, or a small warning glyph) so it's discoverable at a glance, or is green + tooltip + right-click enough? Happy to make it amber if you prefer.

refs #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dismissible warning states for game icons when a game appears stuck or requires attention.
  * Users can right-click or use the keyboard to open a menu and dismiss the game icon or warning.
  * Warning details and accessible labels are now shown for affected games.
  * Improved matching of running games to distinguish them from companion applications.

* **Bug Fixes**
  * Corrected status handling when matching running applications to configured games.

* **Tests**
  * Added coverage for warning dismissal, accessibility behavior, status forwarding, and running-game detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->