### PR TITLE
fix: keep other games' companions tracked when closing apps (#677)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -114,6 +114,19 @@ function isFullExePath(appPath: string | undefined): appPath is string {
   )
 }
 
+/**
+ * True when `appPath` is a directory-qualified exe path (has a parent dir),
+ * judged by SHAPE ALONE. Unlike {@link isFullExePath} it does NOT stat the
+ * filesystem. Use this to decide whether basename fallback cleanup is allowed:
+ * scoping must not depend on the exe still being present, or a full-path game
+ * whose exe was removed or is momentarily inaccessible mid-close would fall back
+ * to matching by image name and delete a DIFFERENT game's same-named companion
+ * tracked at another path (#677).
+ */
+function isPathScopedExe(appPath: string | undefined): appPath is string {
+  return typeof appPath === 'string' && path.basename(appPath) !== appPath
+}
+
 function parseProcessIds(output: string) {
   const trimmedOutput = output.trim()
 
@@ -417,11 +430,11 @@ export async function finalizeKillAttempts(
       const imageGoneFromTasklist =
         tasklistReadSucceeded && !processNamesAfterKill.has(attempt.processName)
 
-      // Evaluate once and carry it on the finalized attempt: the cleanup loop
-      // below reuses it, and computing it a second time there would re-stat the
-      // exe across the awaits in between (isFullExePath -> fs.existsSync), which
-      // could flip mid-close if the file were deleted. Aliasing appPath to a
-      // local const lets the type guard still narrow it to string below.
+      // Aliasing appPath to a local const lets the type guard narrow it to
+      // string for the WMI lookup below. This is existence-inclusive
+      // (isFullExePath -> fs.existsSync) on purpose: WMI ExecutablePath matching
+      // needs a real file. Cleanup scoping, by contrast, must NOT depend on
+      // existence (see isPathScopedExe at the cleanup loop below).
       const appPath = attempt.appPath
       const isFullPathAttempt = isFullExePath(appPath)
 
@@ -453,7 +466,6 @@ export async function finalizeKillAttempts(
         ...attempt,
         stillRunning,
         imageGoneFromTasklist,
-        isFullPathAttempt,
         accessDenied: attempt.accessDenied || isElevatedInconclusive
       }
     })
@@ -474,8 +486,10 @@ export async function finalizeKillAttempts(
     // The name fallback is eligible ONLY for bare-name attempts (no full path to
     // scope by). For a full-path attempt the normalized-path match below already
     // deletes exactly its own entry; matching by name as well would also delete
-    // a DIFFERENT game's same-named companion at another path (#677).
-    const nameFallbackEligible = !attempt.isFullPathAttempt
+    // a DIFFERENT game's same-named companion at another path (#677). Judge by
+    // path SHAPE, not isFullExePath: a full-path attempt whose exe is missing at
+    // finalize time must still stay path-scoped, or the #677 bug reappears.
+    const nameFallbackEligible = !isPathScopedExe(attempt.appPath)
     runningProcesses.forEach((appProcess, runningKey) => {
       if (
         (attemptKey && runningKey === attemptKey) ||

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -465,10 +465,15 @@ export async function finalizeKillAttempts(
 
     clearUnclosedProcess(attempt.gameKey, attempt.appPath, attempt.processName)
     const attemptKey = attempt.appPath ? normalizePathForComparison(attempt.appPath) : ''
+    // The name fallback is eligible ONLY for bare-name attempts (no full path to
+    // scope by). For a full-path attempt the normalized-path match below already
+    // deletes exactly its own entry; matching by name as well would also delete
+    // a DIFFERENT game's same-named companion at another path (#677).
+    const nameFallbackEligible = !isFullExePath(attempt.appPath)
     runningProcesses.forEach((appProcess, runningKey) => {
       if (
         (attemptKey && runningKey === attemptKey) ||
-        getExeName(appProcess.path) === attempt.processName
+        (nameFallbackEligible && getExeName(appProcess.path) === attempt.processName)
       ) {
         runningProcesses.delete(runningKey)
       }

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -417,13 +417,18 @@ export async function finalizeKillAttempts(
       const imageGoneFromTasklist =
         tasklistReadSucceeded && !processNamesAfterKill.has(attempt.processName)
 
+      // Evaluate once and carry it on the finalized attempt: the cleanup loop
+      // below reuses it, and computing it a second time there would re-stat the
+      // exe across the awaits in between (isFullExePath -> fs.existsSync), which
+      // could flip mid-close if the file were deleted. Aliasing appPath to a
+      // local const lets the type guard still narrow it to string below.
+      const appPath = attempt.appPath
+      const isFullPathAttempt = isFullExePath(appPath)
+
       let stillRunning: boolean
       let isElevatedInconclusive = false
-      if (isFullExePath(attempt.appPath)) {
-        const { processIds } = await findProcessIdsByExecutablePath(
-          attempt.processName,
-          attempt.appPath
-        )
+      if (isFullPathAttempt) {
+        const { processIds } = await findProcessIdsByExecutablePath(attempt.processName, appPath)
         // When the post-kill tasklist read failed, treat any unverified
         // "process gone" signal as inconclusive rather than success: a
         // notFound result from WMI/taskkill could mean either truly exited
@@ -448,6 +453,7 @@ export async function finalizeKillAttempts(
         ...attempt,
         stillRunning,
         imageGoneFromTasklist,
+        isFullPathAttempt,
         accessDenied: attempt.accessDenied || isElevatedInconclusive
       }
     })
@@ -469,7 +475,7 @@ export async function finalizeKillAttempts(
     // scope by). For a full-path attempt the normalized-path match below already
     // deletes exactly its own entry; matching by name as well would also delete
     // a DIFFERENT game's same-named companion at another path (#677).
-    const nameFallbackEligible = !isFullExePath(attempt.appPath)
+    const nameFallbackEligible = !attempt.isFullPathAttempt
     runningProcesses.forEach((appProcess, runningKey) => {
       if (
         (attemptKey && runningKey === attemptKey) ||

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2804,6 +2804,60 @@ test('killLaunchedApps skips entries flagged as isGame (#343)', async () => {
   )
 })
 
+test('killLaunchedApps closing game A keeps game B same-named companion tracked (#677)', async () => {
+  // End-to-end sibling of the direct finalize #677 test, through the caller and
+  // its gameKey filter: two games each launched a companion named telemetry.exe
+  // from different paths. Closing game A's apps must kill only A's process and
+  // leave game B's still-alive companion tracked (ChildProcess handle intact) —
+  // the gameKey filter keeps B a non-target, and finalize must not prune it by
+  // shared basename.
+  markExistingPath('C:/GameA/telemetry.exe')
+  markExistingPath('C:/GameB/telemetry.exe')
+  processNames.add('telemetry.exe')
+  registerProcess('C:/GameA/telemetry.exe', 'telemetry.exe', '1111')
+  registerProcess('C:/GameB/telemetry.exe', 'telemetry.exe', '2222')
+
+  const { killLaunchedApps, runningProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' },
+    appPaths: {}
+  })
+
+  runningProcesses.set('c:\\gamea\\telemetry.exe', {
+    process: { pid: 1111 } as never,
+    path: 'C:/GameA/telemetry.exe',
+    name: 'telemetry.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+  runningProcesses.set('c:\\gameb\\telemetry.exe', {
+    process: { pid: 2222 } as never,
+    path: 'C:/GameB/telemetry.exe',
+    name: 'telemetry.exe',
+    gameKey: 'iracing',
+    isGame: false
+  })
+
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({
+    success: true,
+    closedCount: 1,
+    failedCount: 0
+  })
+
+  // A pruned; B (different game, different path) stays tracked.
+  expect(runningProcesses.has('c:\\gamea\\telemetry.exe')).toBe(false)
+  expect(runningProcesses.has('c:\\gameb\\telemetry.exe')).toBe(true)
+  // B's PID must never be taskkilled: the gameKey filter kept it a non-target,
+  // so B is spared as a target AND not clobbered by finalize's name arm.
+  expect(execFileCalls).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ command: 'taskkill', args: ['/PID', '2222', '/T', '/F'] })
+    ])
+  )
+})
+
 test('killLaunchedApps should kill tracked utility processes (#350)', async () => {
   const { killLaunchedApps } = await loadProcessModulesWithStore({
     profiles: {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3537,9 +3537,10 @@ test('finalizeKillAttempts prunes only the attempt path, not a same-named compan
   // companion must keep its runningProcesses entry (and its ChildProcess
   // handle). The old name-based cleanup arm deleted B too (name match), which
   // is the collateral tracking loss this fixes.
-  // A's exe must exist so isFullExePath(attempt.appPath) is true — that is the
-  // predicate the fix gates the name fallback on (a real companion's exe is on
-  // disk), and the same one finalize already uses for its still-running check.
+  // A's exe exists here (the common case: a real companion's exe is on disk),
+  // which drives finalize's WMI still-running check. Cleanup scoping itself is
+  // gated on path SHAPE (isPathScopedExe), not existence — the missing-exe
+  // variant is covered by the next test.
   markExistingPath('C:/GameA/telemetry.exe')
   runningProcesses.set('c:\\gamea\\telemetry.exe', {
     process: { pid: 1111 } as never,
@@ -3574,6 +3575,54 @@ test('finalizeKillAttempts prunes only the attempt path, not a same-named compan
   expect(result.success).toBe(true)
   expect(result.closedCount).toBe(1)
   // A pruned by its normalized path; B (different path, different game) survives.
+  expect(runningProcesses.has('c:\\gamea\\telemetry.exe')).toBe(false)
+  expect(runningProcesses.has('c:\\gameb\\telemetry.exe')).toBe(true)
+})
+
+test('finalizeKillAttempts keeps cleanup path-scoped even when the attempt exe is missing (#677)', async () => {
+  const { finalizeKillAttempts, runningProcesses } = await loadProcessModules()
+
+  // Same collision as above, but game A's exe is NOT on disk at finalize time
+  // (uninstalled mid-session, on a disconnected/removable drive, or transiently
+  // locked). isFullExePath is therefore false — yet the attempt is still a FULL
+  // PATH, so cleanup must stay scoped to A's own path and leave B's same-named
+  // companion tracked. Gating the name fallback on isFullExePath (which stats
+  // the file) instead of path shape would reintroduce the #677 collateral
+  // deletion. A's path is deliberately left unmarked (existsSync -> false).
+  runningProcesses.set('c:\\gamea\\telemetry.exe', {
+    process: { pid: 1111 } as never,
+    path: 'C:/GameA/telemetry.exe',
+    name: 'telemetry.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+  runningProcesses.set('c:\\gameb\\telemetry.exe', {
+    process: { pid: 2222 } as never,
+    path: 'C:/GameB/telemetry.exe',
+    name: 'telemetry.exe',
+    gameKey: 'iracing',
+    isGame: false
+  })
+
+  // processNames empty -> tasklist reports the image gone, so the attempt
+  // finalizes as closed and the cleanup loop runs. The missing exe skips the
+  // WMI branch, but stillRunning stays false because the image is gone.
+  const result = await finalizeKillAttempts(
+    [
+      {
+        processName: 'telemetry.exe',
+        appPath: 'C:/GameA/telemetry.exe',
+        gameKey: 'ac',
+        success: true,
+        notFound: true
+      }
+    ],
+    'ac'
+  )
+
+  expect(result.success).toBe(true)
+  expect(result.closedCount).toBe(1)
+  // A pruned by its normalized path; B survives despite A's exe being absent.
   expect(runningProcesses.has('c:\\gamea\\telemetry.exe')).toBe(false)
   expect(runningProcesses.has('c:\\gameb\\telemetry.exe')).toBe(true)
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3524,6 +3524,42 @@ test('finalizeKillAttempts prunes only the attempt path, not a same-named compan
   expect(runningProcesses.has('c:\\gameb\\telemetry.exe')).toBe(true)
 })
 
+test('finalizeKillAttempts still prunes a same-named entry for a bare-name attempt (#677 fallback preserved)', async () => {
+  const { finalizeKillAttempts, runningProcesses } = await loadProcessModules()
+
+  // Bare-name attempts (a UTILITY_COMPANION_PROCESS_NAMES kill issued via
+  // taskkill /IM, no path to scope by) must keep pruning by exe name — that is
+  // the fallback #677 deliberately preserved. The kill was name-scoped, so a
+  // name-scoped prune stays consistent.
+  runningProcesses.set('c:\\tools\\garage61.exe', {
+    process: { pid: 3333 } as never,
+    path: 'C:/Tools/garage61.exe',
+    name: 'garage61.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+
+  // appPath is a BARE NAME -> isFullExePath is false -> the name fallback is the
+  // only thing that can prune the entry (the path arm resolves the bare name to
+  // a cwd-relative absolute path that never matches the entry key).
+  const result = await finalizeKillAttempts(
+    [
+      {
+        processName: 'garage61.exe',
+        appPath: 'garage61.exe',
+        gameKey: 'ac',
+        success: true,
+        notFound: true
+      }
+    ],
+    'ac'
+  )
+
+  expect(result.success).toBe(true)
+  expect(result.closedCount).toBe(1)
+  expect(runningProcesses.has('c:\\tools\\garage61.exe')).toBe(false)
+})
+
 test('finalizeKillAttempts treats image-gone-from-tasklist as closed even when taskkill reported access-denied (#390)', async () => {
   const { finalizeKillAttempts, unclosedProcesses } = await loadProcessModules()
 

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3475,6 +3475,55 @@ test('finalizeKillAttempts treats a notFound attempt as closed and prunes the ru
   expect(unclosedProcesses.size).toBe(0)
 })
 
+test('finalizeKillAttempts prunes only the attempt path, not a same-named companion of another game (#677)', async () => {
+  const { finalizeKillAttempts, runningProcesses } = await loadProcessModules()
+
+  // Two games each launched a companion named telemetry.exe from DIFFERENT
+  // paths. Closing game A's apps must delete A's entry only; B's still-alive
+  // companion must keep its runningProcesses entry (and its ChildProcess
+  // handle). The old name-based cleanup arm deleted B too (name match), which
+  // is the collateral tracking loss this fixes.
+  // A's exe must exist so isFullExePath(attempt.appPath) is true — that is the
+  // predicate the fix gates the name fallback on (a real companion's exe is on
+  // disk), and the same one finalize already uses for its still-running check.
+  markExistingPath('C:/GameA/telemetry.exe')
+  runningProcesses.set('c:\\gamea\\telemetry.exe', {
+    process: { pid: 1111 } as never,
+    path: 'C:/GameA/telemetry.exe',
+    name: 'telemetry.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+  runningProcesses.set('c:\\gameb\\telemetry.exe', {
+    process: { pid: 2222 } as never,
+    path: 'C:/GameB/telemetry.exe',
+    name: 'telemetry.exe',
+    gameKey: 'iracing',
+    isGame: false
+  })
+
+  // processNames empty -> the post-kill tasklist reports the image gone, so A's
+  // full-path attempt finalizes as closed and the cleanup loop runs.
+  const result = await finalizeKillAttempts(
+    [
+      {
+        processName: 'telemetry.exe',
+        appPath: 'C:/GameA/telemetry.exe',
+        gameKey: 'ac',
+        success: true,
+        notFound: true
+      }
+    ],
+    'ac'
+  )
+
+  expect(result.success).toBe(true)
+  expect(result.closedCount).toBe(1)
+  // A pruned by its normalized path; B (different path, different game) survives.
+  expect(runningProcesses.has('c:\\gamea\\telemetry.exe')).toBe(false)
+  expect(runningProcesses.has('c:\\gameb\\telemetry.exe')).toBe(true)
+})
+
 test('finalizeKillAttempts treats image-gone-from-tasklist as closed even when taskkill reported access-denied (#390)', async () => {
   const { finalizeKillAttempts, unclosedProcesses } = await loadProcessModules()
 


### PR DESCRIPTION
## Summary
- `finalizeKillAttempts` pruned `runningProcesses` entries by exe NAME as well as by path, so closing game A's apps deleted game B's still-alive companion when they shared a basename (two `telemetry.exe` at different paths), dropping B's ChildProcess handle and blanking its row.
- Gate the name fallback on `!isFullExePath(attempt.appPath)`: a full-path attempt prunes only the entry keyed by its own normalized path (which reliably matches its spawn-time key); the name fallback stays only for bare-name attempts (`UTILITY_COMPANION_PROCESS_NAMES`), whose kill was name-scoped anyway. `isFullExePath` is evaluated once in the finalize map and carried on the attempt.
- Two independent review passes found no holes. One known, very narrow residual (a companion whose exe is deleted mid-session) is tracked separately in #766, not fixed here.

## Test plan
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (553 pass, +3 for #677)
- Tests added, all mutation-verified (fail on the pre-fix behavior, pass with the fix):
  - direct `finalizeKillAttempts` cross-path survival
  - bare-name attempt still prunes by name (preserved fallback)
  - end-to-end `killLaunchedApps` cross-game survival (guards the caller wiring + gameKey filter)
- [ ] Manual: not required — pure main-process tracking logic, no runtime UI surface, fully unit-covered.

Closes #677


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup when closing games with companion applications that share the same executable name.
  * Full-path process entries are now cleaned up only when they match the specific path, preventing unrelated processes from being removed or terminated.
  * Preserved existing cleanup behavior for applications identified by name alone.
* **Tests**
  * Added coverage for same-named processes running from different locations and games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #677
<!-- auto-closes -->