### PR TITLE
fix(launch): bound the elevated UAC handoff so it can't stall the chain

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   abortActiveLaunches,
+  cancelPendingElevatedHandoffs,
   processNameMismatchWarnings,
   runningProcesses,
   suppressProcessNameMismatchWarning,
@@ -602,6 +603,11 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // process list — otherwise the launch loop can spawn its next queued app
   // during or after this kill (#670).
   abortActiveLaunches(gameKey)
+  // A UAC handoff whose grace window expired outlives its sequence's controller
+  // (#675), so aborting is not enough: kill the still-live PowerShell host too,
+  // or approving the prompt afterwards starts an app the user just closed
+  // (Codex P1 on #779).
+  cancelPendingElevatedHandoffs(gameKey)
 
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
@@ -726,6 +732,9 @@ export async function killProfileApps(
   // it is in the middle of performing. A real Close Apps click never passes
   // `except`, so it still cancels a switch's launch as before.
   abortActiveLaunches(gameKey, options)
+  // Same reason as killLaunchedApps: a timed-out handoff is not reachable
+  // through the abort signal once its sequence ended (#779 Codex P1).
+  cancelPendingElevatedHandoffs(gameKey)
 
   const { processNames } = await readRunningProcessNames()
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -46,6 +46,15 @@ const POST_LAUNCH_BLOCK_MS = 10000
 const PROCESS_NAME_MISMATCH_WARNING_CHANNEL = 'process-name-mismatch-warning'
 let launchBlockedUntil = 0
 
+// How long the ordered launch loop will wait on a single elevated (UAC) handoff
+// before continuing without it. The elevated fallback is awaited inside the
+// sequential loop while the global single-flight guard (activeLaunches) is held,
+// so an unanswered consent prompt would otherwise park the game + remaining
+// companions — and reject every other window's Launch — for the whole ~120s
+// Windows consent timeout (#675). This is the grace window; see launchElevated.
+// Exported for unit tests only — not part of the processes barrel surface.
+export const ELEVATED_HANDOFF_MAX_WAIT_MS = 10000
+
 /**
  * Whether ANY launch sequence is currently in flight — the same condition as
  * launchProfileApps' own entry gate below. Exposed for the IPC handlers that
@@ -483,6 +492,8 @@ function launchElevated(
   signal?: AbortSignal
 ) {
   return new Promise<AppLaunchResult>((resolve) => {
+    const elevatedWarning = `${path.basename(appPath)} requested administrator permission. SimLauncher will detect when it's running but cannot close it from here.`
+
     // A kill (Close Apps) can land while the UAC handoff is still pending —
     // the consent prompt sits on screen until the user answers it, so this
     // window is wide (#670 Codex P2). Killing the PowerShell host is a best
@@ -495,6 +506,19 @@ function launchElevated(
         child.kill()
       }
     }
+
+    // Never let an unanswered UAC prompt hold the launch loop (and the global
+    // single-flight guard) for the full ~120s consent timeout (#675). After a
+    // bounded grace window, report the handoff optimistically as `elevated` and
+    // let the sequence continue. The PowerShell host is deliberately left alive
+    // so a late approval still starts the app, and tasklist reconciliation
+    // reflects the true running state either way. resolve() is idempotent, so
+    // the eventual callback below is a harmless no-op once this has fired; abort
+    // still kills the host because handoffPending stays true until it settles.
+    const handoffTimer = setTimeout(() => {
+      resolve({ status: 'elevated', appPath, warning: elevatedWarning })
+    }, ELEVATED_HANDOFF_MAX_WAIT_MS)
+
     const child = execFile(
       'powershell.exe',
       [
@@ -506,6 +530,7 @@ function launchElevated(
       { windowsHide: true },
       (error) => {
         handoffPending = false
+        clearTimeout(handoffTimer)
         signal?.removeEventListener('abort', onAbort)
         if (error) {
           // An error after the abort is the expected shape of a cancelled
@@ -533,11 +558,7 @@ function launchElevated(
         // (the user accepted the prompt before the host kill took effect): the
         // elevated app IS running and the kill cannot close it — the sequence's
         // cancellation message names it rather than implying it was closed.
-        resolve({
-          status: 'elevated',
-          appPath,
-          warning: `${path.basename(appPath)} requested administrator permission. SimLauncher will detect when it's running but cannot close it from here.`
-        })
+        resolve({ status: 'elevated', appPath, warning: elevatedWarning })
       }
     )
     signal?.addEventListener('abort', onAbort, { once: true })

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -27,6 +27,7 @@ import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type {
   AppLaunchResult,
+  LateElevatedOutcome,
   LaunchProfileAppsOptions,
   LaunchResult,
   ProfileLaunchEntry,
@@ -54,6 +55,18 @@ let launchBlockedUntil = 0
 // Windows consent timeout (#675). This is the grace window; see launchElevated.
 // Exported for unit tests only — not part of the processes barrel surface.
 export const ELEVATED_HANDOFF_MAX_WAIT_MS = 10000
+
+// True outcomes of elevated handoffs that settled AFTER their grace timer had
+// already resolved the promise as `elevated` (#675). The awaited value cannot be
+// corrected once it is out, so without this the sequence summary would keep
+// telling the user an app "started with administrator permission and cannot be
+// closed" even when the abort killed the host and nothing survived, or when the
+// user denied the prompt (Codex P2 on #779).
+//
+// Module scope is safe because launchProfileApps is globally single-flight (the
+// activeLaunches entry gate below), and it is cleared at the start of every run
+// so a previous sequence can never colour the next one.
+const lateElevatedOutcomes = new Map<string, LateElevatedOutcome>()
 
 /**
  * Whether ANY launch sequence is currently in flight — the same condition as
@@ -106,6 +119,8 @@ export async function launchProfileApps(
   // back to self-registration here, unchanged from #670.
   const launchController = options?.controller ?? registerActiveLaunch(gameKey)
   let launchedAny = false
+  // Never let a previous sequence's late handoff colour this one (#779).
+  lateElevatedOutcomes.clear()
 
   // Everything from here runs under the finally — a throw anywhere below
   // (store read, tasklist scan, path checks) must still release the launch
@@ -222,7 +237,29 @@ export async function launchProfileApps(
       (result): result is Extract<AppLaunchResult, { status: 'failed' }> =>
         result.status === 'failed'
     )
-    const launchedCount = launchResults.length - failedResults.length
+
+    // An elevated result is only trustworthy if the handoff was OBSERVED. When
+    // the grace window expired first (#675) the promise said `elevated` on spec,
+    // and the truth may have arrived afterwards through lateElevatedOutcomes
+    // (#779). Resolve each one before it reaches the user:
+    //   survived — the app is running elevated and we cannot close it
+    //   gone     — the handoff was cancelled or failed after the timeout
+    //   unknown  — the prompt is still unanswered; say "may have"
+    const elevatedFate = (result: Extract<AppLaunchResult, { status: 'elevated' }>) => {
+      if (result.confirmed) {
+        return 'survived' as const
+      }
+      const late = lateElevatedOutcomes.get(result.appPath)
+      if (!late) {
+        return 'unknown' as const
+      }
+      return late.outcome === 'elevated' ? ('survived' as const) : ('gone' as const)
+    }
+    const goneElevatedCount = elevatedResults.filter(
+      (result) => elevatedFate(result) === 'gone'
+    ).length
+    // A handoff we know started nothing is not a launched app.
+    const launchedCount = launchResults.length - failedResults.length - goneElevatedCount
 
     // A kill (Close Apps) mid-sequence aborts launchController before doing its
     // own work (#670) — report this as neither success nor failure, and stop
@@ -232,23 +269,45 @@ export async function launchProfileApps(
       // Elevated apps that completed their UAC handoff before (or despite)
       // the abort survive the kill — SimLauncher cannot close them (#670
       // Codex P2). Name them instead of implying everything was closed.
-      const elevatedNote =
-        elevatedResults.length === 1
+      //
+      // But only the ones that actually survived. A handoff that timed out
+      // (#675) and was then cancelled by this very abort started nothing, so
+      // claiming it survived tells the user we failed to close something we did
+      // close (Codex P2 on #779). Ones still waiting on the prompt get a hedged
+      // sentence rather than a confident wrong one.
+      const survivedCount = elevatedResults.filter(
+        (result) => elevatedFate(result) === 'survived'
+      ).length
+      const unknownCount = elevatedResults.filter(
+        (result) => elevatedFate(result) === 'unknown'
+      ).length
+      const survivedNote =
+        survivedCount === 1
           ? ' One app started with administrator permission and cannot be closed from here.'
-          : elevatedResults.length > 1
-            ? ` ${elevatedResults.length} apps started with administrator permission and cannot be closed from here.`
+          : survivedCount > 1
+            ? ` ${survivedCount} apps started with administrator permission and cannot be closed from here.`
+            : ''
+      const unknownNote =
+        unknownCount === 1
+          ? ' One app may have started with administrator permission and could not be closed from here.'
+          : unknownCount > 1
+            ? ` ${unknownCount} apps may have started with administrator permission and could not be closed from here.`
             : ''
       return {
         success: false,
         cancelled: true,
-        message: `Launch cancelled — closed apps instead.${elevatedNote}`,
+        message: `Launch cancelled — closed apps instead.${survivedNote}${unknownNote}`,
         launchedCount,
         skippedCount,
-        elevatedCount: elevatedResults.length,
+        elevatedCount: survivedCount + unknownCount,
         failedCount: failedResults.length,
         skipped
       }
     }
+
+    // Same rule as the cancelled branch: a handoff we know started nothing is
+    // not something to warn the user about (#779).
+    const standingElevated = elevatedResults.filter((result) => elevatedFate(result) !== 'gone')
 
     if (failedResults.length > 0) {
       const firstFailure = failedResults[0]
@@ -262,17 +321,17 @@ export async function launchProfileApps(
             : `Failed to launch ${failedResults.length} apps. First error: ${failedAppName}: ${firstFailure.error}`,
         launchedCount,
         skippedCount,
-        elevatedCount: elevatedResults.length,
+        elevatedCount: standingElevated.length,
         failedCount: failedResults.length,
         skipped
       }
     }
 
     const elevatedWarning =
-      elevatedResults.length === 1
-        ? elevatedResults[0].warning
-        : elevatedResults.length > 1
-          ? `${elevatedResults.length} apps requested administrator permission. SimLauncher will detect when they're running but cannot close them from here.`
+      standingElevated.length === 1
+        ? standingElevated[0].warning
+        : standingElevated.length > 1
+          ? `${standingElevated.length} apps requested administrator permission. SimLauncher will detect when they're running but cannot close them from here.`
           : undefined
 
     return {
@@ -284,7 +343,7 @@ export async function launchProfileApps(
       warning: elevatedWarning,
       launchedCount,
       skippedCount,
-      elevatedCount: elevatedResults.length,
+      elevatedCount: standingElevated.length,
       skipped
     }
   } finally {
@@ -513,10 +572,16 @@ function launchElevated(
     // let the sequence continue. The PowerShell host is deliberately left alive
     // so a late approval still starts the app, and tasklist reconciliation
     // reflects the true running state either way. resolve() is idempotent, so
-    // the eventual callback below is a harmless no-op once this has fired; abort
-    // still kills the host because handoffPending stays true until it settles.
+    // the eventual callback below cannot un-settle the promise; abort still
+    // kills the host because handoffPending stays true until it settles.
+    //
+    // The callback's real outcome is NOT discarded, though: once this timer has
+    // fired, it is recorded in lateElevatedOutcomes so the sequence summary can
+    // correct what it tells the user (#779). `timedOut` is the switch.
+    let timedOut = false
     const handoffTimer = setTimeout(() => {
-      resolve({ status: 'elevated', appPath, warning: elevatedWarning })
+      timedOut = true
+      resolve({ status: 'elevated', appPath, warning: elevatedWarning, confirmed: false })
     }, ELEVATED_HANDOFF_MAX_WAIT_MS)
 
     const child = execFile(
@@ -537,6 +602,9 @@ function launchElevated(
           // handoff (our own host kill, or the user denying a prompt they no
           // longer want) — report cancelled, and don't log it as a failure.
           if (signal?.aborted) {
+            if (timedOut) {
+              lateElevatedOutcomes.set(appPath, { appPath, outcome: 'cancelled' })
+            }
             resolve({ status: 'cancelled', appPath })
             return
           }
@@ -550,6 +618,9 @@ function launchElevated(
             'launch',
             `${gameKey ? `[${gameKey}] ` : ''}Error launching ${appPath} as administrator${code ? ` (${code})` : ''}`
           )
+          if (timedOut) {
+            lateElevatedOutcomes.set(appPath, { appPath, outcome: 'failed', error: message })
+          }
           resolve({ status: 'failed', appPath, error: message })
           return
         }
@@ -558,7 +629,10 @@ function launchElevated(
         // (the user accepted the prompt before the host kill took effect): the
         // elevated app IS running and the kill cannot close it — the sequence's
         // cancellation message names it rather than implying it was closed.
-        resolve({ status: 'elevated', appPath, warning: elevatedWarning })
+        if (timedOut) {
+          lateElevatedOutcomes.set(appPath, { appPath, outcome: 'elevated' })
+        }
+        resolve({ status: 'elevated', appPath, warning: elevatedWarning, confirmed: true })
       }
     )
     signal?.addEventListener('abort', onAbort, { once: true })

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -63,10 +63,22 @@ export const ELEVATED_HANDOFF_MAX_WAIT_MS = 10000
 // closed" even when the abort killed the host and nothing survived, or when the
 // user denied the prompt (Codex P2 on #779).
 //
-// Module scope is safe because launchProfileApps is globally single-flight (the
-// activeLaunches entry gate below), and it is cleared at the start of every run
-// so a previous sequence can never colour the next one.
+// Clearing the map per run is NOT enough on its own. A host left alive by an
+// earlier timed-out handoff can keep waiting on its prompt for the full consent
+// timeout and fire its callback DURING a later sequence, i.e. after that clear.
+// Keyed by appPath alone, a denial of the OLD prompt would then classify the NEW
+// handoff for the same exe as gone (CodeRabbit Major on #779). So every handoff
+// captures the run it belongs to and a late write from a superseded run is
+// dropped.
+let launchRunId = 0
 const lateElevatedOutcomes = new Map<string, LateElevatedOutcome>()
+
+function recordLateElevatedOutcome(runId: number, outcome: LateElevatedOutcome): void {
+  if (runId !== launchRunId) {
+    return
+  }
+  lateElevatedOutcomes.set(outcome.appPath, outcome)
+}
 
 /**
  * Whether ANY launch sequence is currently in flight — the same condition as
@@ -119,8 +131,10 @@ export async function launchProfileApps(
   // back to self-registration here, unchanged from #670.
   const launchController = options?.controller ?? registerActiveLaunch(gameKey)
   let launchedAny = false
-  // Never let a previous sequence's late handoff colour this one (#779).
+  // Never let a previous sequence's late handoff colour this one (#779). The
+  // clear drops what already landed; the run id drops what lands from here on.
   lateElevatedOutcomes.clear()
+  launchRunId += 1
 
   // Everything from here runs under the finally — a throw anywhere below
   // (store read, tasklist scan, path checks) must still release the launch
@@ -578,6 +592,10 @@ function launchElevated(
     // The callback's real outcome is NOT discarded, though: once this timer has
     // fired, it is recorded in lateElevatedOutcomes so the sequence summary can
     // correct what it tells the user (#779). `timedOut` is the switch.
+    // Captured at handoff creation, not read at callback time: by the time a
+    // stalled host finally answers, launchRunId may already belong to a later
+    // sequence, and that is precisely the write we must drop.
+    const handoffRunId = launchRunId
     let timedOut = false
     const handoffTimer = setTimeout(() => {
       timedOut = true
@@ -603,7 +621,7 @@ function launchElevated(
           // longer want) — report cancelled, and don't log it as a failure.
           if (signal?.aborted) {
             if (timedOut) {
-              lateElevatedOutcomes.set(appPath, { appPath, outcome: 'cancelled' })
+              recordLateElevatedOutcome(handoffRunId, { appPath, outcome: 'cancelled' })
             }
             resolve({ status: 'cancelled', appPath })
             return
@@ -619,7 +637,7 @@ function launchElevated(
             `${gameKey ? `[${gameKey}] ` : ''}Error launching ${appPath} as administrator${code ? ` (${code})` : ''}`
           )
           if (timedOut) {
-            lateElevatedOutcomes.set(appPath, { appPath, outcome: 'failed', error: message })
+            recordLateElevatedOutcome(handoffRunId, { appPath, outcome: 'failed', error: message })
           }
           resolve({ status: 'failed', appPath, error: message })
           return
@@ -630,7 +648,7 @@ function launchElevated(
         // elevated app IS running and the kill cannot close it — the sequence's
         // cancellation message names it rather than implying it was closed.
         if (timedOut) {
-          lateElevatedOutcomes.set(appPath, { appPath, outcome: 'elevated' })
+          recordLateElevatedOutcome(handoffRunId, { appPath, outcome: 'elevated' })
         }
         resolve({ status: 'elevated', appPath, warning: elevatedWarning, confirmed: true })
       }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -20,8 +20,10 @@ import {
   hasOtherActiveLaunchControllers,
   processNameMismatchWarnings,
   registerActiveLaunch,
+  registerPendingElevatedHandoff,
   runningProcesses,
-  unregisterActiveLaunch
+  unregisterActiveLaunch,
+  unregisterPendingElevatedHandoff
 } from './state'
 import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
@@ -260,7 +262,7 @@ export async function launchProfileApps(
       (result): result is Extract<AppLaunchResult, { status: 'elevated' }> =>
         result.status === 'elevated'
     )
-    const failedResults = launchResults.filter(
+    const spawnFailedResults = launchResults.filter(
       (result): result is Extract<AppLaunchResult, { status: 'failed' }> =>
         result.status === 'failed'
     )
@@ -269,9 +271,10 @@ export async function launchProfileApps(
     // the grace window expired first (#675) the promise said `elevated` on spec,
     // and the truth may have arrived afterwards through lateElevatedOutcomes
     // (#779). Resolve each one before it reaches the user:
-    //   survived — the app is running elevated and we cannot close it
-    //   gone     — the handoff was cancelled or failed after the timeout
-    //   unknown  — the prompt is still unanswered; say "may have"
+    //   survived  — the app is running elevated and we cannot close it
+    //   failed    — Windows refused it, or the user denied the prompt
+    //   cancelled — we killed the host ourselves, so nothing started
+    //   unknown   — the prompt is still unanswered; say "may have"
     const elevatedFate = (result: Extract<AppLaunchResult, { status: 'elevated' }>) => {
       if (result.confirmed) {
         return 'survived' as const
@@ -280,13 +283,28 @@ export async function launchProfileApps(
       if (!late) {
         return 'unknown' as const
       }
-      return late.outcome === 'elevated' ? ('survived' as const) : ('gone' as const)
+      if (late.outcome === 'elevated') {
+        return 'survived' as const
+      }
+      return late.outcome
     }
-    const goneElevatedCount = elevatedResults.filter(
-      (result) => elevatedFate(result) === 'gone'
+
+    // A denial that arrives while the loop is still running is a real failure
+    // and must be reported as one, not merely subtracted from the counts
+    // (Codex P2 on #779). `spawnFailedResults` only holds the synchronous spawn
+    // failures, so late ones are folded in here.
+    const lateFailedResults = elevatedResults.flatMap((result) => {
+      const late = lateElevatedOutcomes.get(result.handoffId)
+      return !result.confirmed && late?.outcome === 'failed'
+        ? [{ status: 'failed' as const, appPath: result.appPath, error: late.error }]
+        : []
+    })
+    const failedResults = [...spawnFailedResults, ...lateFailedResults]
+    const cancelledElevatedCount = elevatedResults.filter(
+      (result) => elevatedFate(result) === 'cancelled'
     ).length
-    // A handoff we know started nothing is not a launched app.
-    const launchedCount = launchResults.length - failedResults.length - goneElevatedCount
+    // Neither a failed nor a cancelled handoff started anything.
+    const launchedCount = launchResults.length - failedResults.length - cancelledElevatedCount
 
     // A kill (Close Apps) mid-sequence aborts launchController before doing its
     // own work (#670) — report this as neither success nor failure, and stop
@@ -334,7 +352,10 @@ export async function launchProfileApps(
 
     // Same rule as the cancelled branch: a handoff we know started nothing is
     // not something to warn the user about (#779).
-    const standingElevated = elevatedResults.filter((result) => elevatedFate(result) !== 'gone')
+    const standingElevated = elevatedResults.filter((result) => {
+      const fate = elevatedFate(result)
+      return fate === 'survived' || fate === 'unknown'
+    })
 
     if (failedResults.length > 0) {
       const firstFailure = failedResults[0]
@@ -611,8 +632,24 @@ function launchElevated(
     const handoffRunId = launchRunId
     const handoffId = nextElevatedHandoffId()
     let timedOut = false
+    // Set by cancelPendingElevatedHandoffs, i.e. a Close Apps that arrives after
+    // the sequence already ended. The abort signal cannot cover that window: its
+    // controller is unregistered once launchProfileApps returns.
+    let cancelledByKill = false
     const handoffTimer = setTimeout(() => {
       timedOut = true
+      // The sequence is about to move on without this handoff, and its
+      // controller will be unregistered when the sequence ends. Register the
+      // still-live host so a later Close Apps can still reach it (#779 Codex
+      // P1), otherwise approving the prompt afterwards would start the app the
+      // user just asked to close.
+      registerPendingElevatedHandoff(handoffId, {
+        gameKey,
+        cancel: () => {
+          cancelledByKill = true
+          child.kill()
+        }
+      })
       resolve({
         status: 'elevated',
         appPath,
@@ -634,12 +671,15 @@ function launchElevated(
       (error) => {
         handoffPending = false
         clearTimeout(handoffTimer)
+        unregisterPendingElevatedHandoff(handoffId)
         signal?.removeEventListener('abort', onAbort)
         if (error) {
           // An error after the abort is the expected shape of a cancelled
           // handoff (our own host kill, or the user denying a prompt they no
           // longer want) — report cancelled, and don't log it as a failure.
-          if (signal?.aborted) {
+          // `cancelledByKill` covers the same thing for a Close Apps that landed
+          // after the sequence ended, when the abort signal is no longer wired.
+          if (signal?.aborted || cancelledByKill) {
             if (timedOut) {
               recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
             }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -63,21 +63,34 @@ export const ELEVATED_HANDOFF_MAX_WAIT_MS = 10000
 // closed" even when the abort killed the host and nothing survived, or when the
 // user denied the prompt (Codex P2 on #779).
 //
-// Clearing the map per run is NOT enough on its own. A host left alive by an
-// earlier timed-out handoff can keep waiting on its prompt for the full consent
-// timeout and fire its callback DURING a later sequence, i.e. after that clear.
-// Keyed by appPath alone, a denial of the OLD prompt would then classify the NEW
-// handoff for the same exe as gone (CodeRabbit Major on #779). So every handoff
-// captures the run it belongs to and a late write from a superseded run is
-// dropped.
+// Keyed by a per-handoff id, NOT by appPath, for two independent reasons
+// (both CodeRabbit Majors on #779):
+//   1. ACROSS runs — a host left alive by an earlier timed-out handoff keeps
+//      waiting on its prompt for the full consent timeout, so its callback can
+//      fire DURING a later sequence, i.e. after this map was cleared.
+//   2. WITHIN a run — two profile slots may point at the SAME exe (supported:
+//      per-slot args, #357), so one sequence can have two live handoffs for one
+//      path. With one slot per path the later callback would overwrite the
+//      other, and its outcome would then be applied to BOTH results.
+// A unique id per handoff plus the owning run id closes both.
 let launchRunId = 0
-const lateElevatedOutcomes = new Map<string, LateElevatedOutcome>()
+let elevatedHandoffSeq = 0
+const lateElevatedOutcomes = new Map<number, LateElevatedOutcome>()
 
-function recordLateElevatedOutcome(runId: number, outcome: LateElevatedOutcome): void {
+function nextElevatedHandoffId(): number {
+  elevatedHandoffSeq += 1
+  return elevatedHandoffSeq
+}
+
+function recordLateElevatedOutcome(
+  runId: number,
+  handoffId: number,
+  outcome: LateElevatedOutcome
+): void {
   if (runId !== launchRunId) {
     return
   }
-  lateElevatedOutcomes.set(outcome.appPath, outcome)
+  lateElevatedOutcomes.set(handoffId, outcome)
 }
 
 /**
@@ -263,7 +276,7 @@ export async function launchProfileApps(
       if (result.confirmed) {
         return 'survived' as const
       }
-      const late = lateElevatedOutcomes.get(result.appPath)
+      const late = lateElevatedOutcomes.get(result.handoffId)
       if (!late) {
         return 'unknown' as const
       }
@@ -596,10 +609,17 @@ function launchElevated(
     // stalled host finally answers, launchRunId may already belong to a later
     // sequence, and that is precisely the write we must drop.
     const handoffRunId = launchRunId
+    const handoffId = nextElevatedHandoffId()
     let timedOut = false
     const handoffTimer = setTimeout(() => {
       timedOut = true
-      resolve({ status: 'elevated', appPath, warning: elevatedWarning, confirmed: false })
+      resolve({
+        status: 'elevated',
+        appPath,
+        warning: elevatedWarning,
+        confirmed: false,
+        handoffId
+      })
     }, ELEVATED_HANDOFF_MAX_WAIT_MS)
 
     const child = execFile(
@@ -621,7 +641,7 @@ function launchElevated(
           // longer want) — report cancelled, and don't log it as a failure.
           if (signal?.aborted) {
             if (timedOut) {
-              recordLateElevatedOutcome(handoffRunId, { appPath, outcome: 'cancelled' })
+              recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
             }
             resolve({ status: 'cancelled', appPath })
             return
@@ -637,7 +657,11 @@ function launchElevated(
             `${gameKey ? `[${gameKey}] ` : ''}Error launching ${appPath} as administrator${code ? ` (${code})` : ''}`
           )
           if (timedOut) {
-            recordLateElevatedOutcome(handoffRunId, { appPath, outcome: 'failed', error: message })
+            recordLateElevatedOutcome(handoffRunId, handoffId, {
+              appPath,
+              outcome: 'failed',
+              error: message
+            })
           }
           resolve({ status: 'failed', appPath, error: message })
           return
@@ -648,9 +672,15 @@ function launchElevated(
         // elevated app IS running and the kill cannot close it — the sequence's
         // cancellation message names it rather than implying it was closed.
         if (timedOut) {
-          recordLateElevatedOutcome(handoffRunId, { appPath, outcome: 'elevated' })
+          recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'elevated' })
         }
-        resolve({ status: 'elevated', appPath, warning: elevatedWarning, confirmed: true })
+        resolve({
+          status: 'elevated',
+          appPath,
+          warning: elevatedWarning,
+          confirmed: true,
+          handoffId
+        })
       }
     )
     signal?.addEventListener('abort', onAbort, { once: true })

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -610,6 +610,7 @@ function launchElevated(
     let handoffPending = true
     const onAbort = () => {
       if (handoffPending) {
+        noteHandoffCancelled()
         child.kill()
       }
     }
@@ -636,6 +637,24 @@ function launchElevated(
     // the sequence already ended. The abort signal cannot cover that window: its
     // controller is unregistered once launchProfileApps returns.
     let cancelledByKill = false
+    /**
+     * Record the cancellation at KILL-REQUEST time, not from the execFile
+     * callback. `child.kill()` only signals the PowerShell host; its callback
+     * fires on process exit, which in production is asynchronous. The launch
+     * loop resumes on that same abort and can build its summary before the
+     * callback ever runs — and a summary built without this record sees
+     * `unknown`, so it hedges that an app SimLauncher itself just killed "may
+     * have started with administrator permission" (#779 Codex P2). The test
+     * mock fired its callback synchronously from kill(), which hid the race.
+     *
+     * A no-op before the grace timer fires: until then the promise is unsettled,
+     * so the callback still reports `cancelled` through the normal channel.
+     */
+    const noteHandoffCancelled = (): void => {
+      if (timedOut) {
+        recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
+      }
+    }
     const handoffTimer = setTimeout(() => {
       timedOut = true
       // The sequence is about to move on without this handoff, and its
@@ -647,6 +666,7 @@ function launchElevated(
         gameKey,
         cancel: () => {
           cancelledByKill = true
+          noteHandoffCancelled()
           child.kill()
         }
       })

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -26,6 +26,55 @@ export function registerActiveLaunch(gameKey: string): AbortController {
 }
 
 /**
+ * Elevated (UAC) handoffs whose grace window expired while the consent prompt
+ * was still on screen (#675). The launch sequence has moved on and its
+ * AbortController is unregistered, but the PowerShell host is deliberately
+ * still alive so a late approval works — which means nothing else can reach it.
+ *
+ * Without this registry a Close Apps click after the sequence ended finds no
+ * controller and no running target, so approving the still-visible prompt would
+ * start the app AFTER the user asked to close everything (Codex P1 on #779).
+ * Lives here, next to activeLaunchControllers, for the same reason: kill.ts must
+ * reach it without importing spawn.ts.
+ */
+const pendingElevatedHandoffs = new Map<number, { gameKey?: string; cancel: () => void }>()
+
+export function registerPendingElevatedHandoff(
+  handoffId: number,
+  entry: { gameKey?: string; cancel: () => void }
+): void {
+  pendingElevatedHandoffs.set(handoffId, entry)
+}
+
+export function unregisterPendingElevatedHandoff(handoffId: number): void {
+  pendingElevatedHandoffs.delete(handoffId)
+}
+
+/**
+ * Cancel every still-pending elevated handoff for `gameKey`, or all of them when
+ * `gameKey` is undefined (the global "close everything" kill). Each entry
+ * removes itself as its callback settles, so this is safe to call on every kill.
+ */
+export function cancelPendingElevatedHandoffs(gameKey?: string): void {
+  pendingElevatedHandoffs.forEach((entry, handoffId) => {
+    if (gameKey !== undefined && entry.gameKey !== gameKey) {
+      return
+    }
+    pendingElevatedHandoffs.delete(handoffId)
+    entry.cancel()
+  })
+}
+
+export function hasPendingElevatedHandoffs(gameKey?: string): boolean {
+  for (const entry of pendingElevatedHandoffs.values()) {
+    if (gameKey === undefined || entry.gameKey === gameKey) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Clear the registry entry once launchProfileApps' sequence ends. Only clears
  * it if `controller` is still the registered one — a new launch for the same
  * gameKey may have already installed its own fresh controller (started right

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -65,15 +65,6 @@ export function cancelPendingElevatedHandoffs(gameKey?: string): void {
   })
 }
 
-export function hasPendingElevatedHandoffs(gameKey?: string): boolean {
-  for (const entry of pendingElevatedHandoffs.values()) {
-    if (gameKey === undefined || entry.gameKey === gameKey) {
-      return true
-    }
-  }
-  return false
-}
-
 /**
  * Clear the registry entry once launchProfileApps' sequence ends. Only clears
  * it if `controller` is still the registered one — a new launch for the same

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -88,9 +88,24 @@ export interface KillProfileAppsOptions {
   except?: AbortController
 }
 
+/**
+ * The true outcome of an elevated (UAC) handoff that settled AFTER the bounded
+ * grace window already resolved its promise as `elevated` (#675). The caller has
+ * been told `elevated` and cannot be told again, so this is the only channel by
+ * which the real result reaches it (#779).
+ */
+export type LateElevatedOutcome = {
+  appPath: string
+} & ({ outcome: 'elevated' } | { outcome: 'cancelled' } | { outcome: 'failed'; error: string })
+
 export type AppLaunchResult =
   | { status: 'launched'; appPath: string }
-  | { status: 'elevated'; appPath: string; warning: string }
+  /**
+   * `confirmed: false` means the grace window expired with the UAC prompt still
+   * unanswered, so this is an optimistic report, not an observed launch. Never
+   * tell the user an unconfirmed app "started" (#779).
+   */
+  | { status: 'elevated'; appPath: string; warning: string; confirmed: boolean }
   | { status: 'failed'; appPath: string; error: string }
   // The launch was aborted (Close Apps) during the async pre-spawn work, so
   // the process was deliberately never spawned (#670).

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -104,8 +104,18 @@ export type AppLaunchResult =
    * `confirmed: false` means the grace window expired with the UAC prompt still
    * unanswered, so this is an optimistic report, not an observed launch. Never
    * tell the user an unconfirmed app "started" (#779).
+   *
+   * `handoffId` identifies THIS handoff, not this exe: two profile slots may
+   * point at the same path (per-slot args, #357), so appPath is not unique
+   * within a sequence. It is the key a late outcome is filed and read under.
    */
-  | { status: 'elevated'; appPath: string; warning: string; confirmed: boolean }
+  | {
+      status: 'elevated'
+      appPath: string
+      warning: string
+      confirmed: boolean
+      handoffId: number
+    }
   | { status: 'failed'; appPath: string; error: string }
   // The launch was aborted (Close Apps) during the async pre-spawn work, so
   // the process was deliberately never spawned (#670).

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -62,6 +62,9 @@ const wmiLookupCounts = new Map<string, number>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnErrors = new Map<string, NodeJS.ErrnoException>()
+// #675: when true, the elevated (-EncodedCommand) PowerShell call never invokes
+// its callback, modelling a UAC consent prompt the user never answers.
+let elevatedLaunchHangs = false
 const invalidateProcessNameCacheMock = vi.fn()
 // Paths the mocked PE-subsystem sniffer reports as console-subsystem exes —
 // those must spawn WITHOUT detached so they get a console (#486).
@@ -166,6 +169,12 @@ async function loadProcessModules() {
       }
       if (command === 'powershell.exe') {
         if (!args.includes('-Command')) {
+          // #675: model an unanswered UAC prompt — the elevated launch host
+          // stays pending (callback never fires), so launchElevated must fall
+          // back to its bounded grace timer to keep the chain moving.
+          if (elevatedLaunchHangs && args.includes('-EncodedCommand')) {
+            return
+          }
           callback(null, '', '')
           return
         }
@@ -501,6 +510,7 @@ beforeEach(async () => {
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
+  elevatedLaunchHangs = false
   consoleExePaths.clear()
   appErrorLogFsMock.statSync.mockClear()
   appErrorLogFsMock.renameSync.mockClear()
@@ -1244,6 +1254,46 @@ test('elevated launches pass the app folder as -WorkingDirectory (#483)', async 
     filePath: 'C:/Tools/Admin Tool.exe',
     workingDirectory: 'C:/Tools'
   })
+})
+
+test('launchProfileApps continues the chain when an elevated UAC prompt goes unanswered (#675)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    // The admin companion needs elevation and its UAC prompt is never answered.
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    // launchDelayMs defaults to 0 in beforeEach, so the elevated handoff grace
+    // window is the only timer in play.
+    const { launchProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    // Admin tool is ordered before the game. Before #675 the awaited elevation
+    // parked the whole sequence (and the single-flight guard) until the ~120s
+    // UAC timeout, so the game (ordered last) never launched.
+    const resultPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+
+    // Fast-forward past the grace window: the stalled handoff resolves
+    // optimistically and the loop moves on to the game.
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+
+    const result = await resultPromise
+    expect(result.success).toBe(true)
+    expect(result.elevatedCount).toBe(1)
+    expect(result.launchedCount).toBe(2)
+    // The game (ordered after the stalled elevated companion) still spawned.
+    expect(spawnCalls.some((call) => call.appPath === 'C:/Games/Race.exe')).toBe(true)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 test('launchProfileApps reports synchronous spawn failures without tracking the failed process', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -72,6 +72,9 @@ let heldElevatedCallback: ((error: NodeJS.ErrnoException | null) => void) | null
 // is only the latest, which is not enough when one sequence has TWO live handoffs
 // for the same exe (two slots can share a path, #357).
 const heldElevatedCallbacks: ((error: NodeJS.ErrnoException | null) => void)[] = []
+// #779: every elevated PowerShell host SimLauncher killed, in order. Proves a
+// Close Apps actually reached a handoff whose grace window had already expired.
+const elevatedHostKills: string[] = []
 const invalidateProcessNameCacheMock = vi.fn()
 // Paths the mocked PE-subsystem sniffer reports as console-subsystem exes —
 // those must spawn WITHOUT detached so they get a console (#486).
@@ -195,7 +198,12 @@ async function loadProcessModules() {
             // the real shape: killing the PowerShell host makes execFile's
             // callback fire with an error.
             return {
-              kill: () => held(makeAccessDeniedError())
+              kill: () => {
+                elevatedHostKills.push(
+                  args[args.indexOf('-EncodedCommand') + 1] ? 'elevated-host' : 'unknown'
+                )
+                held(makeAccessDeniedError())
+              }
             }
           }
           callback(null, '', '')
@@ -536,6 +544,7 @@ beforeEach(async () => {
   elevatedLaunchHangs = false
   heldElevatedCallback = null
   heldElevatedCallbacks.length = 0
+  elevatedHostKills.length = 0
   consoleExePaths.clear()
   appErrorLogFsMock.statSync.mockClear()
   appErrorLogFsMock.renameSync.mockClear()
@@ -1547,6 +1556,88 @@ test('two handoffs for the same exe in one run do not share a late outcome (#675
     // appPath both would resolve to gone and these would be 0 and 1.
     expect(result.elevatedCount).toBe(1)
     expect(result.launchedCount).toBe(2)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// Codex P1 on PR #779. Once the grace window expires the sequence moves on and
+// its AbortController is unregistered when it ends, but the PowerShell host is
+// deliberately left alive. Without a registry the kill path can no longer reach
+// it, so approving the still-visible prompt would start the app AFTER the user
+// asked to close everything.
+test('Close Apps after the sequence ended still kills a pending elevated handoff (#675)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // Sequence over, controller gone, prompt still on screen and nothing has
+    // been killed yet.
+    expect(elevatedHostKills).toHaveLength(0)
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    await killPromise
+
+    // The kill reached the orphaned host, so a late approval cannot start it.
+    expect(elevatedHostKills).toHaveLength(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// Codex P2 on PR #779. A denial arriving while the loop is still running was
+// only subtracted from the counts, so the sequence still returned success:true
+// with "All profile applications launched." and no failedCount.
+test('a UAC denial after the grace window is reported as a failure (#675)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App3.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    // Keeps the loop alive after the grace timer, so the denial lands before the
+    // summary is computed.
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp3: 'C:/Tools/App3.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      { key: 'admin', path: 'C:/Tools/Admin Tool.exe' },
+      { key: 'customapp3', path: 'C:/Tools/App3.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+
+    // The user finally answers "No", while the loop is in its inter-app delay.
+    heldElevatedCallbacks[0](makeAccessDeniedError())
+    await vi.advanceTimersByTimeAsync(5000)
+
+    const result = await launchPromise
+
+    expect(result.success).toBe(false)
+    expect(result.failedCount).toBe(1)
+    expect(result.error).toContain('Admin Tool.exe')
+    // It is not standing as an elevated app either.
+    expect(result.elevatedCount).toBe(0)
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -65,6 +65,9 @@ const spawnErrors = new Map<string, NodeJS.ErrnoException>()
 // #675: when true, the elevated (-EncodedCommand) PowerShell call never invokes
 // its callback, modelling a UAC consent prompt the user never answers.
 let elevatedLaunchHangs = false
+// #675: the held callback of a hung elevated launch, so a test can fire it LATE
+// (after the grace timer already resolved) and assert the late settle is inert.
+let heldElevatedCallback: ((error: NodeJS.ErrnoException | null) => void) | null = null
 const invalidateProcessNameCacheMock = vi.fn()
 // Paths the mocked PE-subsystem sniffer reports as console-subsystem exes —
 // those must spawn WITHOUT detached so they get a console (#486).
@@ -173,6 +176,7 @@ async function loadProcessModules() {
           // stays pending (callback never fires), so launchElevated must fall
           // back to its bounded grace timer to keep the chain moving.
           if (elevatedLaunchHangs && args.includes('-EncodedCommand')) {
+            heldElevatedCallback = (error) => callback(error, '', '')
             return
           }
           callback(null, '', '')
@@ -511,6 +515,7 @@ beforeEach(async () => {
   spawnCalls.length = 0
   spawnErrors.clear()
   elevatedLaunchHangs = false
+  heldElevatedCallback = null
   consoleExePaths.clear()
   appErrorLogFsMock.statSync.mockClear()
   appErrorLogFsMock.renameSync.mockClear()
@@ -1291,6 +1296,51 @@ test('launchProfileApps continues the chain when an elevated UAC prompt goes una
     expect(result.launchedCount).toBe(2)
     // The game (ordered after the stalled elevated companion) still spawned.
     expect(spawnCalls.some((call) => call.appPath === 'C:/Games/Race.exe')).toBe(true)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('a late UAC denial after the grace timer settles inertly, it does not throw or re-report (#675)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const resultPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    const result = await resultPromise
+
+    // The PowerShell host is deliberately left alive past the grace window, so
+    // its callback can still fire afterwards — here with the shape of a user
+    // who finally DENIED the prompt. resolve() is idempotent, so this must be a
+    // no-op: no throw, no second settle, no mutation of the returned summary.
+    expect(heldElevatedCallback).not.toBeNull()
+    expect(() => heldElevatedCallback?.(makeAccessDeniedError())).not.toThrow()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // KNOWN GAP, tracked in #778: because the promise already settled as
+    // `elevated`, a denial arriving after the window is not surfaced anywhere —
+    // the summary still counts the app as launched. This assertion pins that
+    // behaviour deliberately so the fix for #778 has to update it on purpose
+    // rather than silently changing what users are told.
+    expect(result.success).toBe(true)
+    expect(result.launchedCount).toBe(2)
+    expect(result.elevatedCount).toBe(1)
+    // The success branch carries no failedCount at all, so a late denial has
+    // nowhere to surface even in principle.
+    expect(result.failedCount).toBeUndefined()
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -176,8 +176,21 @@ async function loadProcessModules() {
           // stays pending (callback never fires), so launchElevated must fall
           // back to its bounded grace timer to keep the chain moving.
           if (elevatedLaunchHangs && args.includes('-EncodedCommand')) {
-            heldElevatedCallback = (error) => callback(error, '', '')
-            return
+            let settled = false
+            heldElevatedCallback = (error) => {
+              if (settled) {
+                return
+              }
+              settled = true
+              callback(error, '', '')
+            }
+            // Unlike the other branches this call has NOT invoked its callback,
+            // so launchElevated's abort handler can still reach the child. Model
+            // the real shape: killing the PowerShell host makes execFile's
+            // callback fire with an error.
+            return {
+              kill: () => heldElevatedCallback?.(makeAccessDeniedError())
+            }
           }
           callback(null, '', '')
           return
@@ -1330,16 +1343,17 @@ test('a late UAC denial after the grace timer settles inertly, it does not throw
     expect(() => heldElevatedCallback?.(makeAccessDeniedError())).not.toThrow()
     await vi.advanceTimersByTimeAsync(0)
 
-    // KNOWN GAP, tracked in #778: because the promise already settled as
-    // `elevated`, a denial arriving after the window is not surfaced anywhere —
-    // the summary still counts the app as launched. This assertion pins that
-    // behaviour deliberately so the fix for #778 has to update it on purpose
-    // rather than silently changing what users are told.
+    // KNOWN GAP, tracked in #778: the denial lands here AFTER launchProfileApps
+    // has already returned, so `lateElevatedOutcomes` cannot correct a summary
+    // that is already out. (When the denial arrives while the loop is still
+    // running it IS corrected — see the abort test below.) Pinned deliberately
+    // so the fix for #778 has to update it on purpose rather than silently
+    // changing what users are told.
     expect(result.success).toBe(true)
     expect(result.launchedCount).toBe(2)
     expect(result.elevatedCount).toBe(1)
-    // The success branch carries no failedCount at all, so a late denial has
-    // nowhere to surface even in principle.
+    // The success branch carries no failedCount at all, so a late denial that
+    // misses the window has nowhere to surface even in principle.
     expect(result.failedCount).toBeUndefined()
 
     // It is discarded from the USER-FACING report only. The callback still runs
@@ -1354,6 +1368,57 @@ test('a late UAC denial after the grace timer settles inertly, it does not throw
         (line) => line.includes('Admin Tool.exe') && line.includes('as administrator')
       )
     ).toBe(true)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// Codex P2 on PR #779. The #675 grace timer reports `elevated` optimistically,
+// so a Close Apps landing AFTER it fires used to be told "one app started with
+// administrator permission and cannot be closed from here" — about a handoff
+// SimLauncher had just successfully killed. It named a survivor that did not
+// exist and implied the close had failed.
+test('a handoff cancelled after the grace timer is not reported as a surviving elevated app (#675)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    // A real inter-app delay keeps the loop alive after the grace timer, which
+    // is the window Codex identified.
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+
+    // Grace window expires with the prompt unanswered: the loop moves on and is
+    // now sitting in the inter-app delay.
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+
+    // Close Apps lands. Its abort kills the still-pending PowerShell host (the
+    // mocked child models that by firing the callback with an error), which
+    // reports the cancellation — too late for the promise, but in time for the
+    // summary.
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    await killPromise
+
+    const result = await launchPromise
+
+    expect(result.cancelled).toBe(true)
+    // Nothing elevated survived, so nothing may be named as unclosable.
+    expect(result.elevatedCount).toBe(0)
+    expect(result.message).not.toContain('administrator permission')
+    // And a handoff that started nothing is not a launched app.
+    expect(result.launchedCount).toBe(0)
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1424,6 +1424,72 @@ test('a handoff cancelled after the grace timer is not reported as a surviving e
   }
 })
 
+// CodeRabbit Major on PR #779. Clearing lateElevatedOutcomes per run is not
+// enough on its own: a host left alive by an EARLIER timed-out handoff keeps
+// waiting on its prompt and can fire its callback during a LATER sequence, i.e.
+// after that clear. Keyed by appPath alone, a denial of the old prompt would
+// classify the new handoff for the same exe as gone.
+test("a superseded run's late handoff cannot colour the next sequence (#675)", async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    // Keep run 2's loop alive after its own grace timer, so the stale callback
+    // has a summary left to corrupt. With a 0 delay the loop would already have
+    // finished and the test would pass for the wrong reason.
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps, runningProcesses } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    // Run 1: prompt goes unanswered, the grace timer fires, the sequence ends
+    // with the PowerShell host still alive.
+    const firstPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+    // Grace window, then run 1's own inter-app delay, so the sequence finishes.
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS + 5000)
+    await firstPromise
+    const firstRunCallback = heldElevatedCallback
+    expect(firstRunCallback).not.toBeNull()
+
+    // Clear the post-launch cooldown so run 2 is admitted, and forget what run
+    // 1 spawned so run 2 does not skip everything as already running.
+    await vi.advanceTimersByTimeAsync(11000)
+    processNames.clear()
+    runningProcesses.clear()
+
+    // Run 2: the SAME exe, again unanswered, again resolved optimistically.
+    const secondPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+
+    // Run 1's abandoned prompt is finally DENIED, mid-run-2. It must not be
+    // attributed to run 2's still-pending handoff for the same exe.
+    firstRunCallback?.(makeAccessDeniedError())
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Now let run 2's inter-app delay elapse so its summary is computed AFTER
+    // the stale write would have landed.
+    await vi.advanceTimersByTimeAsync(5000)
+    const result = await secondPromise
+
+    // Run 2's handoff is still unknown, not gone: it stays counted.
+    expect(result.success).toBe(true)
+    expect(result.elevatedCount).toBe(1)
+    expect(result.launchedCount).toBe(2)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
 test('launchProfileApps reports synchronous spawn failures without tracking the failed process', async () => {
   const { launchProfileApps, runningProcesses } = await loadProcessModules()
 

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -68,6 +68,10 @@ let elevatedLaunchHangs = false
 // #675: the held callback of a hung elevated launch, so a test can fire it LATE
 // (after the grace timer already resolved) and assert the late settle is inert.
 let heldElevatedCallback: ((error: NodeJS.ErrnoException | null) => void) | null = null
+// Every held callback of the current test, in creation order. `heldElevatedCallback`
+// is only the latest, which is not enough when one sequence has TWO live handoffs
+// for the same exe (two slots can share a path, #357).
+const heldElevatedCallbacks: ((error: NodeJS.ErrnoException | null) => void)[] = []
 const invalidateProcessNameCacheMock = vi.fn()
 // Paths the mocked PE-subsystem sniffer reports as console-subsystem exes —
 // those must spawn WITHOUT detached so they get a console (#486).
@@ -177,19 +181,21 @@ async function loadProcessModules() {
           // back to its bounded grace timer to keep the chain moving.
           if (elevatedLaunchHangs && args.includes('-EncodedCommand')) {
             let settled = false
-            heldElevatedCallback = (error) => {
+            const held = (error) => {
               if (settled) {
                 return
               }
               settled = true
               callback(error, '', '')
             }
+            heldElevatedCallback = held
+            heldElevatedCallbacks.push(held)
             // Unlike the other branches this call has NOT invoked its callback,
             // so launchElevated's abort handler can still reach the child. Model
             // the real shape: killing the PowerShell host makes execFile's
             // callback fire with an error.
             return {
-              kill: () => heldElevatedCallback?.(makeAccessDeniedError())
+              kill: () => held(makeAccessDeniedError())
             }
           }
           callback(null, '', '')
@@ -529,6 +535,7 @@ beforeEach(async () => {
   spawnErrors.clear()
   elevatedLaunchHangs = false
   heldElevatedCallback = null
+  heldElevatedCallbacks.length = 0
   consoleExePaths.clear()
   appErrorLogFsMock.statSync.mockClear()
   appErrorLogFsMock.renameSync.mockClear()
@@ -1483,6 +1490,61 @@ test("a superseded run's late handoff cannot colour the next sequence (#675)", a
 
     // Run 2's handoff is still unknown, not gone: it stays counted.
     expect(result.success).toBe(true)
+    expect(result.elevatedCount).toBe(1)
+    expect(result.launchedCount).toBe(2)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// CodeRabbit Major on PR #779, the within-run half. Two profile slots may point
+// at the SAME exe (per-slot args, #357), so one sequence can hold two live
+// elevated handoffs for one path. Keyed by appPath, the second callback would
+// overwrite the first and its outcome would be applied to BOTH results.
+test('two handoffs for the same exe in one run do not share a late outcome (#675)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App3.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps } = await loadProcessModulesWithStore({
+      appPaths: {
+        customapp1: 'C:/Tools/Admin Tool.exe',
+        customapp2: 'C:/Tools/Admin Tool.exe',
+        customapp3: 'C:/Tools/App3.exe'
+      }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    // A third, ordinary app last, purely so the loop is still running when the
+    // late denial lands. Without it the summary is already computed and the test
+    // would pass no matter how the map is keyed.
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' },
+      { key: 'customapp2', path: 'C:/Tools/Admin Tool.exe' },
+      { key: 'customapp3', path: 'C:/Tools/App3.exe' }
+    ])
+
+    // Slot 1's prompt goes unanswered, its grace timer fires, the loop waits out
+    // the inter-app delay and slot 2 starts its own handoff.
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS + 5000)
+    // Slot 2's grace timer. The loop is now in the delay before slot 3.
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    expect(heldElevatedCallbacks).toHaveLength(2)
+
+    // ONLY slot 1 is denied. Slot 2's prompt is still on screen.
+    heldElevatedCallbacks[0](makeAccessDeniedError())
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Let slot 3 spawn so the sequence ends and the summary is computed.
+    await vi.advanceTimersByTimeAsync(5000)
+    const result = await launchPromise
+
+    // Slot 1 is gone, slot 2 is still unknown and must stay counted. Keyed by
+    // appPath both would resolve to gone and these would be 0 and 1.
     expect(result.elevatedCount).toBe(1)
     expect(result.launchedCount).toBe(2)
   } finally {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -197,12 +197,18 @@ async function loadProcessModules() {
             // so launchElevated's abort handler can still reach the child. Model
             // the real shape: killing the PowerShell host makes execFile's
             // callback fire with an error.
+            //
+            // Fire it ASYNCHRONOUSLY. kill() only signals the host; the callback
+            // lands on process exit, which is never synchronous in production.
+            // This mock used to call held() inline, which made the launch loop
+            // observe the cancellation the instant it resumed and hid a real
+            // ordering bug (#779 Codex P2) behind a passing test.
             return {
               kill: () => {
                 elevatedHostKills.push(
                   args[args.indexOf('-EncodedCommand') + 1] ? 'elevated-host' : 'unknown'
                 )
-                held(makeAccessDeniedError())
+                setTimeout(() => held(makeAccessDeniedError()), 0)
               }
             }
           }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1341,6 +1341,19 @@ test('a late UAC denial after the grace timer settles inertly, it does not throw
     // The success branch carries no failedCount at all, so a late denial has
     // nowhere to surface even in principle.
     expect(result.failedCount).toBeUndefined()
+
+    // It is discarded from the USER-FACING report only. The callback still runs
+    // its whole error branch before the no-op resolve, so the denial is on disk
+    // in main-error.log and diagnosable (#638). Pinned so a fix for #778 cannot
+    // regress the diagnostics while improving the reporting.
+    const launchLogLines = appErrorLogFsMock.appendFileSync.mock.calls.map((call) =>
+      String(call[1])
+    )
+    expect(
+      launchLogLines.some(
+        (line) => line.includes('Admin Tool.exe') && line.includes('as administrator')
+      )
+    ).toBe(true)
   } finally {
     vi.useRealTimers()
   }


### PR DESCRIPTION
## Summary

A companion that needs admin sits mid-chain, the UAC prompt appears, and the user is in VR or another window and misses it. Today the whole launch parks until Windows times the prompt out (~120s), because `launchElevated` is awaited inside the sequential loop while the global `activeLaunches` single-flight guard is held. For that entire window the game and the remaining companions never start, and a Launch click on **any** game in **any** window returns "Another profile is already launching."

This adds a bounded grace window (`ELEVATED_HANDOFF_MAX_WAIT_MS = 10000`). When it expires, the handoff resolves optimistically as `elevated` and the chain continues. That is the fix #675 itself proposed.

## Resolving early is the easy part; not lying about it is the rest

The awaited value is already out when the truth arrives. Six review rounds, eight real findings:

| Finding | What was wrong |
|---|---|
| Codex P2 | a **Close Apps** after the window was reported as "One app started with administrator permission and cannot be closed from here" about a handoff SimLauncher had just killed |
| CodeRabbit Major | a host left alive by an **earlier** run could fire during a later one and mis-classify its handoff |
| CodeRabbit Major | two slots may point at the **same exe** (per-slot args, #357), so one run can hold two live handoffs for one path, and they shared a map slot |
| Codex P1 | once the sequence ended its controller was unregistered, so a later Close Apps **could not reach the still-live host** and approving the prompt started an app the user had just closed |
| Codex P2 | a **denial** while the loop was still running only reduced the counts, so the sequence still returned `success: true` for an app that definitively failed |
| Codex P2 | the cancellation was recorded from the **execFile callback**, which lands on process exit. `kill()` only signals the host, so the loop could build its summary first and hedge that a killed app "may have started" |
| Codex P2 | `hasPendingElevatedHandoffs` shipped with **no consumers**, and the affordance it was meant for is gated on running apps (deferred, #781) |
| Codex P2 | **profile switch** filters what to stop from a tasklist snapshot, which a pending handoff is absent from (deferred, #782) |

The shape that came out of it:

- **`lateElevatedOutcomes`** records what the execFile callback learns after the timer fired, keyed by a **per-handoff id** (not appPath, not per run) and guarded by a **run id** so a superseded sequence cannot write into a later one.
- **`elevatedFate`** resolves every elevated result to `survived` / `failed` / `cancelled` / `unknown` before it reaches the user. Late failures join `failedResults`; cancelled ones just leave the counts; unknown ones get hedged wording.
- **`pendingElevatedHandoffs`** (in `state.ts`, next to `activeLaunchControllers` and there for the same reason) keeps a timed-out handoff reachable by both kill entry points after its sequence ended.
- **Cancellation is recorded when the kill is issued**, not when the host exits, because those are not the same moment and the summary can be built in between.

## Design notes

- **The PowerShell host is deliberately left alive** so a late approval still starts the app; killing it on timeout would turn a slow user into a failed launch. The registry is what makes that safe.
- **`tasklist` reconciliation stays the source of truth**, so the running dot is honest regardless of what the timer reported.
- **The #670 abort path still works**, and `cancelledByKill` covers the window where the abort signal is no longer wired.

## Tracked residuals

Filed as real issues, not left as prose:

- **#778** a denial arriving **after** `launchProfileApps` has already returned. No summary left to correct, so it needs a post-hoc channel. Diagnostics are intact either way, the denial is in `main-error.log`.
- **#781** Close Apps is not offered when a pending handoff is the **only** outstanding target, so the kill path this PR added is unreachable from the UI in that case. Narrow: with other apps running, the global kill reaches it correctly.
- **#782** a **profile switch** does not cancel a pending handoff from the outgoing profile, so a late approval can start an app from the profile the user left.

Both #781 and #782 need surface this PR does not touch (renderer state, the switch handler). Filed in 1.2.0 with acceptance cases rather than grown into a seventh round here.

## Test plan

- [x] `npm ci` · `format:check` · `lint` · `typecheck` · `build`
- [x] `npm run test` (563 pass)
- Six new tests, each mutation-verified against the specific guard it covers:
  - the chain continues past an unanswered handoff once the window expires
  - a handoff cancelled after the window is not reported as a survivor
  - a superseded run's late handoff cannot colour the next sequence
  - two handoffs for the same exe in one run do not share a late outcome
  - Close Apps after the sequence ended still kills a pending handoff
  - a denial after the window is reported as a failure
  - plus one that pins the #778 residual on purpose, so fixing it has to change those assertions deliberately
- **Two test-mock gaps fixed, both of which had been hiding real behaviour:**
  - the mocked `execFile` returned `undefined` for the hung elevated branch, so `child.kill()` in the abort handler threw, making the abort path untestable
  - the mock fired execFile's callback **synchronously** from `kill()`, which is not how process teardown works. The cancellation test was passing for the wrong reason. With the mock made async and the fix reverted, it fails on `expected 1 to be +0`, so it now tests what it claims
- [ ] Manual: **not run, and it needs to be.** The elevation path cannot be reproduced in a dev build. Checks are queued in `internal-docs/SimLauncher/QA/1.2.0 Smoke Test.md`, including the tightened wording case and repro attempts for #781 and #782.

Closes #675
