### PR TITLE
docs: correct CLAUDE.md architecture drift and drop a dead helper

### DIFF
--- a/src/renderer/src/lib/config.ts
+++ b/src/renderer/src/lib/config.ts
@@ -147,13 +147,6 @@ export function normalizeProfileUtilities(
   return orderedUtilities
 }
 
-export function getEnabledProfileUtilities(
-  profile: GameProfile | undefined,
-  utilities: Utility[]
-): ProfileUtility[] {
-  return normalizeProfileUtilities(profile, utilities).filter((utility) => utility.enabled)
-}
-
 /**
  * One-time migration that converts a flat-boolean profile (legacy format where
  * each utility is stored as `{ simhub: true, crewchief: false, ... }`) to the


### PR DESCRIPTION
## Summary

Deletes `getEnabledProfileUtilities` from `src/renderer/src/lib/config.ts`. It was added on 2026-04-19 in `c3708dd` and never gained a caller.

Verified dead against the pre-deletion tree, not just the working copy:

- `git grep getEnabledProfileUtilities main` returns exactly one hit: the definition itself.
- No `export *` anywhere in `src/`, so it cannot be reachable through a barrel without being named.
- No dynamic/string access patterns.

## Scope correction

This PR opened claiming a set of `CLAUDE.md` corrections as well. Those are not here, and cannot be: `AGENTS.md` and `CLAUDE.md` are both gitignored under `.gitignore`'s "AI agent context (local only)" section, so no PR can change them. Caught by the review bot. The corrections were applied to the local file instead.

That also means **#698 cannot be closed by a pull request** and is no longer referenced below. Its remaining items are drift in an untracked file; see the issue for the disposition.

## On #699

The issue asked for two things. Only the first is real:

- Remove the dead function. Done here.
- Narrow four "over-broad" exports. Obsolete: `DEFAULT_THEME_MODE` (4 references) and `BUILT_IN_UTILITIES` (12) have genuine external consumers today, and the issue's stated driver, prep for #692, already shipped.

## Test plan

- [x] `format:check` · `lint` · `typecheck` · `build`
- [x] `npm run test` (563 pass)
- [x] `git grep` on `main` confirms the only occurrence was the definition

No runtime behaviour changes, so there is nothing to add to the 1.2.0 smoke test.

Closes #699
