### PR TITLE
fix(launch): stop the launch summary contradicting its own skip warning (#739)

### DIFF
--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -109,6 +109,52 @@ export function isAnyLaunchActive(): boolean {
   return activeLaunches.size > 0
 }
 
+/**
+ * Wording for a sequence that finished with no failures and no kill.
+ *
+ * `skippedCount` and `missingCount` are two different senses of "skipped" (see
+ * LaunchResult): the first is "already running", the second is entries filtered
+ * out before spawn for an invalid or missing path. The renderer concatenates the
+ * skip warning naming those missing entries onto this string, so claiming "All"
+ * while `missingCount > 0` produces a toast that contradicts itself in
+ * consecutive sentences (#739).
+ *
+ * Extracted from the return site, and written as ordered early returns rather
+ * than nested ternaries, because the ordering IS the logic and both review bots
+ * found a wrong branch in the ternary version. Exported for unit tests only, not
+ * part of the processes barrel surface.
+ */
+export function buildLaunchSummaryMessage(
+  launchedCount: number,
+  skippedCount: number,
+  missingCount: number
+): string {
+  // Nothing actually started. Reachable without failing or being cancelled:
+  // launchedCount subtracts elevated handoffs cancelled by a kill that did not
+  // abort this sequence's controller (the `except: launchController` path used
+  // by switch-profile-apps). Both "Started 0 apps" and "All ... launched" are
+  // false here, and the latter is the very contradiction this function fixes.
+  if (launchedCount === 0) {
+    return skippedCount > 0
+      ? `No apps were started; ${skippedCount} ${skippedCount === 1 ? 'was' : 'were'} already running.`
+      : 'No apps were started.'
+  }
+
+  const started = `Started ${launchedCount} app${launchedCount === 1 ? '' : 's'}`
+
+  // Must be tested before `missingCount`, or a launch that both skipped a
+  // running app and filtered out a missing one loses the already-running count.
+  if (skippedCount > 0) {
+    return `${started}; skipped ${skippedCount} already running.`
+  }
+
+  if (missingCount > 0) {
+    return `${started}.`
+  }
+
+  return 'All profile applications launched.'
+}
+
 export async function launchProfileApps(
   sender: WebContents,
   gameKey: string,
@@ -393,17 +439,7 @@ export async function launchProfileApps(
 
     return {
       success: true,
-      // Arm order is load-bearing: the `skippedCount` test must come first, or a
-      // launch that both skipped a running app AND filtered out a missing one
-      // silently loses the already-running count. `launchedCount > 0` guards the
-      // degenerate "Started 0 apps." wording — launchedCount subtracts cancelled
-      // elevated handoffs above, which a kill can zero out without aborting (#739).
-      message:
-        skippedCount > 0
-          ? `Started ${launchedCount} app${launchedCount === 1 ? '' : 's'}; skipped ${skippedCount} already running.`
-          : skipped.length > 0 && launchedCount > 0
-            ? `Started ${launchedCount} app${launchedCount === 1 ? '' : 's'}.`
-            : 'All profile applications launched.',
+      message: buildLaunchSummaryMessage(launchedCount, skippedCount, skipped.length),
       warning: elevatedWarning,
       launchedCount,
       skippedCount,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -218,7 +218,16 @@ export async function launchProfileApps(
     if (appsToLaunch.length === 0) {
       return {
         success: true,
-        message: 'All profile applications are already running.',
+        // Two different meanings of "skipped" meet here (see LaunchResult):
+        // `skippedCount` is "already running", `skipped` is "missing or invalid
+        // path". Saying "All" while `skipped` is non-empty contradicts the skip
+        // warning the renderer concatenates onto this very string (#739) — one
+        // sentence names an app that could not be found, the next claims they
+        // are all running.
+        message:
+          skipped.length > 0
+            ? 'The remaining profile applications are already running.'
+            : 'All profile applications are already running.',
         launchedCount: 0,
         skippedCount,
         skipped
@@ -384,10 +393,17 @@ export async function launchProfileApps(
 
     return {
       success: true,
+      // Arm order is load-bearing: the `skippedCount` test must come first, or a
+      // launch that both skipped a running app AND filtered out a missing one
+      // silently loses the already-running count. `launchedCount > 0` guards the
+      // degenerate "Started 0 apps." wording — launchedCount subtracts cancelled
+      // elevated handoffs above, which a kill can zero out without aborting (#739).
       message:
         skippedCount > 0
           ? `Started ${launchedCount} app${launchedCount === 1 ? '' : 's'}; skipped ${skippedCount} already running.`
-          : 'All profile applications launched.',
+          : skipped.length > 0 && launchedCount > 0
+            ? `Started ${launchedCount} app${launchedCount === 1 ? '' : 's'}.`
+            : 'All profile applications launched.',
       warning: elevatedWarning,
       launchedCount,
       skippedCount,

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1054,6 +1054,86 @@ test('launchProfileApps skips profile apps that are already running', async () =
   })
 })
 
+// #739: the renderer concatenates the skip warning onto `message`, so a summary
+// claiming "All" while `skipped` is non-empty produces a toast that contradicts
+// itself in consecutive sentences. Note the two senses of "skipped" in the
+// payload: `skippedCount` is "already running", `skipped` is "missing/invalid".
+test('nothing left to spawn does not claim ALL apps are running when one was skipped as missing', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  // SimHub exists and is already up; the game exe does not resolve at all.
+  markExistingPath('C:/Tools/SimHub.exe')
+  processNames.add('simhub.exe')
+
+  const result = await launchProfileApps(sender, 'ac', [
+    'C:/Tools/SimHub.exe',
+    'C:/Games/AC/acs.exe'
+  ])
+
+  expect(result).toMatchObject({
+    success: true,
+    message: 'The remaining profile applications are already running.',
+    launchedCount: 0,
+    skippedCount: 1
+  })
+  // Assert the harness really reached this branch rather than bailing out at
+  // the empty-validApps guard above it, which would also produce a plausible
+  // message with no spawn.
+  expect(result.skipped).toHaveLength(1)
+  expect(result.skipped?.[0]).toMatchObject({ path: 'C:/Games/AC/acs.exe', reason: 'missing' })
+  expect(spawnCalls).toHaveLength(0)
+})
+
+test('a launch that skipped a missing app does not report ALL applications launched', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  // SimHub exists and is NOT running, so it launches; the game exe is missing.
+  markExistingPath('C:/Tools/SimHub.exe')
+
+  const result = await launchProfileApps(sender, 'ac', [
+    'C:/Tools/SimHub.exe',
+    'C:/Games/AC/acs.exe'
+  ])
+
+  expect(result).toMatchObject({
+    success: true,
+    message: 'Started 1 app.',
+    launchedCount: 1,
+    skippedCount: 0
+  })
+  expect(result.skipped).toHaveLength(1)
+  // Without this the test passes even if nothing spawned at all.
+  expect(spawnCalls).toHaveLength(1)
+  expect(spawnCalls[0]).toMatchObject({ appPath: 'C:/Tools/SimHub.exe' })
+})
+
+test('an already-running app is still counted when another app was skipped as missing', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  // One running, one launchable, one missing: `skippedCount` and `skipped` are
+  // BOTH non-empty. Pins the arm order — testing `skipped.length` before
+  // `skippedCount` drops the already-running count from the summary.
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('C:/Tools/CrewChief.exe')
+  processNames.add('simhub.exe')
+
+  const result = await launchProfileApps(sender, 'ac', [
+    'C:/Tools/SimHub.exe',
+    'C:/Tools/CrewChief.exe',
+    'C:/Games/AC/acs.exe'
+  ])
+
+  expect(result).toMatchObject({
+    success: true,
+    message: 'Started 1 app; skipped 1 already running.',
+    launchedCount: 1,
+    skippedCount: 1
+  })
+  expect(result.skipped).toHaveLength(1)
+  expect(spawnCalls).toHaveLength(1)
+  expect(spawnCalls[0]).toMatchObject({ appPath: 'C:/Tools/CrewChief.exe' })
+})
+
 test('launchProfileApps parses custom app arguments with quoted paths and escaped quotes', async () => {
   markExistingPath('C:/Tools/Custom Tool.exe')
   const { launchProfileApps } = await loadProcessModulesWithStore({

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1134,6 +1134,35 @@ test('an already-running app is still counted when another app was skipped as mi
   expect(spawnCalls[0]).toMatchObject({ appPath: 'C:/Tools/CrewChief.exe' })
 })
 
+// Both review bots on PR #795 found the same hole in the ternary this replaced:
+// with launchedCount at 0 it either emitted "Started 0 apps" or fell through to
+// "All profile applications launched." while entries had been skipped as
+// missing, which is the #739 contradiction the PR set out to remove.
+const loadSummaryBuilder = async () =>
+  (await import('../../src/main/processes/spawn')).buildLaunchSummaryMessage
+
+test('summary: nothing started and something missing does not claim everything launched', async () => {
+  expect((await loadSummaryBuilder())(0, 0, 1)).toBe('No apps were started.')
+})
+
+test('summary: nothing started never emits a zero count', async () => {
+  const build = await loadSummaryBuilder()
+  expect(build(0, 2, 0)).toBe('No apps were started; 2 were already running.')
+  expect(build(0, 1, 1)).toBe('No apps were started; 1 was already running.')
+})
+
+test('summary: an already-running count survives a missing entry in the same launch', async () => {
+  expect((await loadSummaryBuilder())(1, 1, 1)).toBe('Started 1 app; skipped 1 already running.')
+})
+
+test('summary: a missing entry alone drops the ALL claim but keeps the count', async () => {
+  expect((await loadSummaryBuilder())(2, 0, 1)).toBe('Started 2 apps.')
+})
+
+test('summary: a clean launch is unchanged', async () => {
+  expect((await loadSummaryBuilder())(3, 0, 0)).toBe('All profile applications launched.')
+})
+
 test('launchProfileApps parses custom app arguments with quoted paths and escaped quotes', async () => {
   markExistingPath('C:/Tools/Custom Tool.exe')
   const { launchProfileApps } = await loadProcessModulesWithStore({


### PR DESCRIPTION
## Summary

The renderer joins the skip warning and the launch summary into a single toast (`GameRow.tsx:413-427`), so a summary claiming everything is running lands immediately after a sentence naming an app whose path no longer resolves:

> Assetto Corsa was skipped: its path no longer exists. **All profile applications are already running.**

Both summary strings in `launchProfileApps` could produce that, not just the one the issue names.

- **Nothing-left-to-spawn return:** now says "The remaining profile applications are already running." whenever `skipped` is non-empty.
- **Success return:** the wording moved into `buildLaunchSummaryMessage`, which takes `launchedCount`, `skippedCount` and `missingCount` and picks the string with ordered early returns.

## Why an extracted function rather than another ternary arm

The first version of this fix kept the nested ternary and added a `launchedCount > 0` guard. **Both review bots then found a wrong branch in it, from opposite sides**, and they were right:

- With `skippedCount > 0` and nothing launched it emitted `Started 0 apps; skipped N already running.` (CodeRabbit)
- With only missing entries and nothing launched it fell through to `All profile applications launched.` while `skipped` was non-empty, which is **the exact contradiction this PR removes** (review bot). My guard against the first case is what opened the second.

That state is reachable without failing or being cancelled: everything above the return filters out failures and aborts, but `launchedCount` subtracts cancelled elevated handoffs, and `cancelPendingElevatedHandoffs` sets `cancelledByKill` without touching the abort signal. A kill carrying `except: launchController`, which is the `switch-profile-apps` path, produces it. Narrow, but real.

The ordering is the logic here, and as nested ternaries it was neither readable nor testable on its own, which is how it grew two wrong branches. As early returns the zero-launch case is handled first and explicitly, so neither wrong string is reachable.

## Two details worth keeping

**`skippedCount` before `missingCount`.** A launch that both skipped an already-running app and filtered out a missing one must keep reporting the already-running count.

**The two senses of "skipped".** `skippedCount` is "already running", `missingCount` is "filtered out before spawn for an invalid or missing path". Same word, two meanings, one payload. Documented on the function.

## Deliberately not done

Not fixed in the renderer by dropping `result.message` when `skipped` is non-empty. That concatenation is the #639 guarantee, pinned by `tests/renderer/gameRowLaunchSkipped.test.tsx:197-217`.

`src/main/ipc/launch.ts:138` has a similar string but returns no `skipped[]`, so it cannot contradict itself. Left alone, pinned separately by `tests/main/ipcLaunch.test.ts:176`.

## Follow-up filed

#794, from this issue's Corrections section: a broken **game** path hides that profile's running companions entirely. More user-visible than this copy bug.

## Test plan

- [x] `format:check` · `lint` · `typecheck` · `build`
- [x] `npm run test` (571 pass, 8 new)
- [x] Three integration tests through `launchProfileApps`, each asserting `spawnCalls` as well as the message so none can pass from an early return that never reached the branch
- [x] Five unit tests directly on `buildLaunchSummaryMessage`
- [x] Mutation-verified: deleting the zero-launch branch fails two tests; swapping the `skippedCount` and `missingCount` branches fails two more; reverting the first message fails one; dropping the middle case fails one
- [ ] Manual: string-only change, covered by the 1.2.0 smoke test rather than per-PR

Closes #739
