### PR TITLE
chore(deps): bump the fast-uri override past the new advisory range (#796)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4746,9 +4746,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "overrides": {
     "@electron/asar": "4.2.0",
     "js-yaml": "^4.3.0",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "esbuild": "^0.28.1",
     "form-data": "4.0.6",
     "tar": "7.5.22",


### PR DESCRIPTION
## Summary

`npm audit --omit=dev` is the `build` gate, and it started failing on `main` and on every open PR today:

```
fast-uri  3.0.0 - 3.1.4   high
fast-uri vulnerable to host confusion via backslash authority introducer
```

#769 pinned an override at `^3.1.4` to clear an earlier advisory. The new range is inclusive of `3.1.4`, so the pinned version became the last vulnerable one. Bumped to `^3.1.5`.

**Not dev-only.** It reaches the production tree through a runtime dependency:

```
electron-store@11.0.2 -> conf@15.1.0 -> ajv@8.20.0 -> fast-uri
```

`ajv@8.20.0` asks for `^3.0.1`, so `3.1.5` satisfies it with no other tree movement.

## Edited surgically, on purpose

Only `version`, `resolved` and `integrity` on the single `node_modules/fast-uri` node. Four changed lines in total.

Regenerating the lockfile with local npm 11.x strips the `libc` selectors off ten native optional entries (Rolldown, Tailwind), which would hand glibc CI and dev hosts musl binaries. That was the #769 gotcha and it cost a review round there. The `libc` count is verified still 10 after the edit.

## Not the cause, checked

None of the open Dependabot PRs fixes or causes this. #789 (production-dependencies, 4 updates) does not touch `fast-uri` at all, and Dependabot has no alert for this advisory yet: its only open alerts are `undici`, all dev-scope.

## Test plan

- [x] `npm audit --omit=dev` → **found 0 vulnerabilities** (was 1 high)
- [x] `libc` field count in `package-lock.json` still 10
- [x] `npm ls fast-uri --package-lock-only` resolves to 3.1.5 under both `ajv` paths
- [x] `format:check` · `lint` · `typecheck` · `build`
- [x] `npm run test` (563 pass)
- [ ] The local `node_modules` still holds 3.1.4, so the suite above did not exercise 3.1.5 itself. CI installs fresh from the lockfile, so its green run is the real verification of the new version.

Closes #796
