### PR TITLE
a11y: make the HEX text focus its input, and ignore agent scratch files (#762)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,11 @@ vite.config.ts.timestamp-*
 
 # AI agent context is tracked (#784): it carries architecture facts agents act
 # on, so drift has to be catchable in review like any other documentation.
+
+# Agent scratch files. Google Jules writes a "learning" note next to every PR
+# (.jules/, .Jules/, the casing varies), and has more than once produced a
+# pnpm lockfile in this npm repo. Neither belongs here; the tracked agent
+# context above is the only agent-facing documentation we keep.
+.jules/
+.Jules/
+pnpm-lock.yaml

--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -1,4 +1,5 @@
 import {
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -30,6 +31,7 @@ export function ColorPickerPopover({
 }: ColorPickerPopoverProps): ReactNode {
   const popoverRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<CSSProperties | null>(null)
+  const hexInputId = useId()
 
   // This component is only mounted while the picker is open, so active is always true.
   // Focus is trapped here rather than via aria-modal because the popover is
@@ -107,10 +109,17 @@ export function ColorPickerPopover({
         <HexColorPicker color={color} onChange={onChange} />
 
         <div className="flex w-full items-center gap-2 px-1">
-          <span className="text-[10px] font-bold uppercase tracking-wider text-(--text-muted)">
+          {/* "HEX" alone is a poor accessible name, so the input keeps its own
+              aria-label and this only exists to make the text a click target
+              that focuses the field (matches the htmlFor/useId pattern from #765). */}
+          <label
+            htmlFor={hexInputId}
+            className="cursor-pointer text-[10px] font-bold uppercase tracking-wider text-(--text-muted)"
+          >
             HEX
-          </span>
+          </label>
           <input
+            id={hexInputId}
             type="text"
             aria-label="Hex color value"
             value={color.toUpperCase()}

--- a/tests/renderer/colorPickerHexLabel.test.tsx
+++ b/tests/renderer/colorPickerHexLabel.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * The "HEX" text next to the color input must be a real <label> associated with
+ * the <input> (htmlFor/id via useId), so clicking it focuses the field. Mirrors
+ * profileNameSectionLabel.test.tsx (#765), with one deliberate difference: this
+ * input KEEPS its aria-label, because "HEX" on its own is a poor accessible
+ * name. The second test pins that down so nobody removes it while making the
+ * two components look alike.
+ */
+import { afterEach, describe, expect, test } from 'vitest'
+import { act, createRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { ColorPickerPopover } from '../../src/renderer/src/components/ColorPickerPopover'
+
+let root: Root | null = null
+let container: HTMLElement | null = null
+
+async function renderPopover(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const anchor = createRef<HTMLElement>()
+  anchor.current = document.createElement('button')
+  document.body.appendChild(anchor.current)
+
+  await act(async () => {
+    root = createRoot(container as HTMLElement)
+    root.render(
+      <ColorPickerPopover
+        color="#AD46FF"
+        onChange={() => {}}
+        onClose={() => {}}
+        anchorRef={anchor}
+      />
+    )
+  })
+}
+
+// The popover portals to document.body, so it is not inside `container`.
+function hexInput(): HTMLInputElement | null {
+  return document.body.querySelector('input[type="text"]')
+}
+
+function hexLabel(): HTMLLabelElement | null {
+  return document.body.querySelector('label')
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  root = null
+  container?.remove()
+  container = null
+  document.body.innerHTML = ''
+})
+
+describe('ColorPickerPopover HEX label association', () => {
+  test('the HEX text is programmatically associated with the input', async () => {
+    await renderPopover()
+
+    const label = hexLabel()
+    const input = hexInput()
+
+    expect(label?.textContent?.trim()).toBe('HEX')
+    expect(input).not.toBeNull()
+
+    // jsdom resolves HTMLLabelElement.control through htmlFor/id, so this goes
+    // null the moment the pairing breaks. Before this change the text was a
+    // <span> in a <div> and clicking it did nothing.
+    expect(input?.id).toBeTruthy()
+    expect(label?.htmlFor).toBe(input?.id)
+    expect(label?.control).toBe(input)
+  })
+
+  test('the input keeps its own accessible name rather than inheriting "HEX"', async () => {
+    const input = (await renderPopover(), hexInput())
+
+    // Deliberately the opposite of ProfileNameSection (#765), where the visible
+    // label IS the name. "HEX" would be a useless name on its own, so the
+    // aria-label wins the name computation and the label only adds the click
+    // target. Removing it would silently downgrade the announced name.
+    expect(input?.getAttribute('aria-label')).toBe('Hex color value')
+  })
+})


### PR DESCRIPTION
## Summary

Two small things that came out of triaging the open agent-authored PRs.

**1. The HEX caption now focuses the field it labels.** It was a `<span>` inside a `<div>`, so clicking the word "HEX" did nothing. It is now a real `<label>` tied to the input via `htmlFor` + `useId`, which is the pattern #765 established in `ProfileNameSection`.

The input deliberately **keeps** its `aria-label="Hex color value"`. "HEX" alone would be a poor accessible name, so the label contributes the click target while the aria-label still wins the name computation. That is the opposite of #765, where the visible label IS the name, and the second new test pins the difference down so the two components do not get "unified" later. Being honest about scope: screen reader output is unchanged, the win here is the click target.

Adapted from #792, which had the right idea but wrapped the whole row in an implicit `<label>`, introducing a second labelling pattern alongside #765's. #792 is closed in favour of this.

**2. Agent scratch files are now ignored.** Three PRs in this batch each added a Jules "learning" note (`.jules/` in one, `.Jules/` in another), and #787 also produced a 6850-line `pnpm-lock.yaml` in a repo that uses npm. This will recur every batch. The tracked agent context from #784 is untouched: that is deliberate documentation, this is scratch output.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test` (573 passing, 2 new)
- [x] Both new tests verified against three mutations: dropping `htmlFor` fails the association test, dropping `aria-label` fails the name test, and reverting `<label>` to `<span>` fails the association test. Neither test passes for the wrong reason.
- [ ] Manual: open Settings, open the accent color picker, click the word "HEX", confirm the cursor lands in the field.

Refs #762


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the color picker’s HEX field by associating its visible label directly with the input.
  * Preserved the input’s accessible name for assistive technologies.

* **Tests**
  * Added coverage verifying the HEX label and color input relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->