### PR TITLE
build: clear the undici advisories and the now-vulnerable brace-expansion pin (#802)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@electron/get/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3339,9 +3339,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "tar": "7.5.22",
     "@babel/core": "7.29.7",
     "postcss": "^8.5.23",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Summary

Clears every open advisory on the repo, both the Dependabot page and plain `npm audit`. Seven lines across two files, no runtime code.

**`undici` 7.28.0 to 7.29.0** under `@electron/get`. That one pin accounts for **all five** open Dependabot alerts (one high, four medium), and 7.29.0 fixes all of them.

Exposure is essentially nil, which is worth saying plainly rather than dressing this up as a security fix. Nothing in this codebase calls `undici`. It arrives as an *optional* dependency of `@electron/get`, the tool that downloads the Electron binary from GitHub releases at install time, so it never reaches a user's machine. Every one of the five advisories needs a hostile server or proxy on the other end; ours is GitHub over HTTPS. This is **alert hygiene**: five permanently red rows is how a real advisory gets missed later.

`@electron/get` declares `undici: "^7.24.4"`, which 7.29.0 already satisfies, so only the pinned version had to move. Two plausible-looking fixes that are **not**:

- **Electron 43 (#780) does not fix this.** Both 42.4.0 and 43.2.0 depend on `@electron/get: ^5.0.0`, and 5.1.0 declares the same `undici: ^7.24.4`.
- **A blanket `undici` override would break the build.** The tree carries three copies: 6.28.0 under `node-gyp` (via electron-builder), 7.28.0 under `@electron/get`, and 8.10.0 under `jsdom`. Only the middle one is in the vulnerable range.

**`brace-expansion` 5.0.8 to 5.0.9** rides along because it is the identical one-line shape and separate ceremony for a three-line lockfile edit is not worth it. The `^5.0.8` override added in #777 cleared the *previous* brace-expansion advisory; the new one (`DoS via unbounded intermediate arrays`, range 4.0.0 - 5.0.8) covers 5.0.8 itself, so our pin had become the thing keeping us vulnerable. Same pattern as `fast-uri` in #796. The override moves to `^5.0.9` too, so a lockfile regeneration cannot fall back.

## Lockfile discipline

Both edits are surgical text replacements, not a regeneration, because `npm install` strips the `libc` selectors from native optional packages (#769). Each patch asserted **exactly one** match before writing.

- The other two `undici` copies are untouched: 6.28.0 and 8.10.0 confirmed after `npm ci`
- `libc` selector count is still 14, verified after `npm ci`
- Integrity hashes are proven by `npm ci` succeeding, which would fail on a wrong hash

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (573 passing)
- [x] `npm run build`
- [x] `npm audit --omit=dev` reports 0
- [x] **plain `npm audit` reports 0** (it reported 1 high before this)
- [x] `npm ci` installs `undici` 7.29.0 under `@electron/get` and `brace-expansion` 5.0.9
- [ ] Manual: none, no runtime code changed. The five Dependabot alerts should close on merge; worth confirming they do.

Closes #802


<!-- auto-closes -->
Closes #802
<!-- auto-closes -->