### PR TITLE
test: arm the tasklist failure from the kill, not a call index (#751)

### DIFF
--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -65,6 +65,15 @@ let consoleProbeCallCount = 0
 //
 // Keying off the taskkill that the test is actually about makes the injection
 // hit the post-kill recheck by construction, whatever the call ordering is.
+//
+// Deliberately STICKY rather than one-shot, and this matters: a one-shot flag
+// is consumed by whichever read arrives first, so a stray read landing between
+// the taskkill and finalizeKillAttempts' verification read would let the
+// verification succeed. The test would then pass whether or not production
+// still gates on `tasklistReadSucceeded`, i.e. it would silently stop covering
+// #399 — the same "unawaited work reorders the reads" class this change exists
+// to be immune to. Staying armed models the honest scenario anyway: tasklist is
+// broken from the kill onward, however many reads that turns out to be.
 const failTasklistAfterAccessDeniedPids = new Set<string>()
 let tasklistReadFailArmed = false
 const wmiLookupCounts = new Map<string, number>()
@@ -364,11 +373,9 @@ async function loadProcessModules() {
   const tasklistMock = {
     invalidateProcessNameCache: invalidateProcessNameCacheMock,
     readRunningProcessNames: vi.fn(() => {
-      // One-shot: consumed by the first read after the armed taskkill, which
-      // is the post-kill recheck.
-      const armedFailure = tasklistReadFailArmed
-      tasklistReadFailArmed = false
-      const shouldFailNow = tasklistReadShouldFail || armedFailure
+      // Sticky once armed (see the declaration): not consumed here, so a stray
+      // read cannot steal the failure from the verification read.
+      const shouldFailNow = tasklistReadShouldFail || tasklistReadFailArmed
       // Production's readRunningProcessNames swallows tasklist execution
       // errors and resolves with an empty Set + succeeded: false. Modelling
       // the empty-Set here is what lets the regression test distinguish

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -52,12 +52,21 @@ let tasklistReadBlocker: Promise<void> | null = null
 // specific app in the sequence (#670). Consumed once, then cleared.
 let consoleProbeBlocker: { atCall: number; promise: Promise<void> } | null = null
 let consoleProbeCallCount = 0
-// When >0, the mocked readRunningProcessNames returns a successful response
-// for the first N calls, then starts failing. Lets a single test simulate a
-// transient tasklist failure on the post-kill recheck only — without breaking
-// the pre-kill scan that decides which processes to attempt to kill.
-let tasklistReadFailAfterCalls = 0
-let tasklistReadCallCount = 0
+// Arms a transient tasklist failure on the POST-kill recheck only, without
+// breaking the pre-kill scan that decides which processes to attempt to kill.
+//
+// This used to be positional ("succeed for the first N reads, then fail"),
+// which silently mis-targeted itself: the kill path and its neighbours have
+// five readRunningProcessNames call sites, production dedupes via cache and
+// in-flight sharing while this mock counts every raw call, so one extra read
+// landing before the pre-kill scan shifted the numbering by one and made the
+// PRE-kill scan fail instead. killLaunchedApps then took its "nothing to
+// close" early return and the test failed on an unrelated assertion (#751).
+//
+// Keying off the taskkill that the test is actually about makes the injection
+// hit the post-kill recheck by construction, whatever the call ordering is.
+const failTasklistAfterAccessDeniedPids = new Set<string>()
+let tasklistReadFailArmed = false
 const wmiLookupCounts = new Map<string, number>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
@@ -277,6 +286,11 @@ async function loadProcessModules() {
           return
         }
         if (accessDeniedPids.has(pid)) {
+          // Arm the tasklist failure from the kill itself, so it lands on the
+          // post-kill recheck no matter how many reads preceded this (#751).
+          if (failTasklistAfterAccessDeniedPids.has(pid)) {
+            tasklistReadFailArmed = true
+          }
           if (pidsAccessDeniedButImageGone.has(pid)) {
             const entry = findRegistryEntryByPid(pid)
             if (entry) {
@@ -350,10 +364,11 @@ async function loadProcessModules() {
   const tasklistMock = {
     invalidateProcessNameCache: invalidateProcessNameCacheMock,
     readRunningProcessNames: vi.fn(() => {
-      tasklistReadCallCount += 1
-      const shouldFailNow =
-        tasklistReadShouldFail ||
-        (tasklistReadFailAfterCalls > 0 && tasklistReadCallCount > tasklistReadFailAfterCalls)
+      // One-shot: consumed by the first read after the armed taskkill, which
+      // is the post-kill recheck.
+      const armedFailure = tasklistReadFailArmed
+      tasklistReadFailArmed = false
+      const shouldFailNow = tasklistReadShouldFail || armedFailure
       // Production's readRunningProcessNames swallows tasklist execution
       // errors and resolves with an empty Set + succeeded: false. Modelling
       // the empty-Set here is what lets the regression test distinguish
@@ -540,8 +555,8 @@ beforeEach(async () => {
   tasklistReadBlocker = null
   consoleProbeBlocker = null
   consoleProbeCallCount = 0
-  tasklistReadFailAfterCalls = 0
-  tasklistReadCallCount = 0
+  failTasklistAfterAccessDeniedPids.clear()
+  tasklistReadFailArmed = false
   wmiLookupCounts.clear()
   processRegistry.clear()
   execFileCalls.length = 0
@@ -3760,9 +3775,24 @@ test('kill is NOT reported successful when taskkill failed and the post-kill tas
   // then make the POST-kill recheck fail. With the buggy code, the empty Set
   // from the failed recheck satisfied `!processNamesAfterKill.has(...)` and
   // turned the access-denied failure into success: true / closedCount: 1.
-  tasklistReadFailAfterCalls = 1
+  //
+  // Armed off the taskkill for this PID rather than off a call index, so the
+  // failure cannot drift onto the pre-kill scan when an unrelated read slips
+  // in first (#751).
+  failTasklistAfterAccessDeniedPids.add('5555')
 
   const result = await killLaunchedApps('ac')
+
+  // Loud guard, and the reason this test is worth trusting: everything below
+  // asserts how a kill FAILURE is reported, so it is only meaningful if a kill
+  // was dispatched at all. Without this, a killLaunchedApps that bailed early
+  // and never issued a taskkill fails on `result.success` with a message that
+  // says nothing about the real cause (#751).
+  expect(execFileCalls).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ command: 'taskkill', args: ['/PID', '5555', '/T', '/F'] })
+    ])
+  )
 
   expect(result.success).toBe(false)
   expect(result.failedCount).toBe(1)


### PR DESCRIPTION
## Summary

- The #399 kill-failure test injected its tasklist failure **positionally**: `tasklistReadFailAfterCalls = 1` assumed call #1 was the pre-kill scan and everything after it the post-kill recheck. That numbering is not contractual. The kill path and its neighbours have five `readRunningProcessNames` call sites, and production dedupes via cache and in-flight sharing while the mock counts every raw call, so one extra read arriving first shifted the injection onto the **pre-kill** scan. `killLaunchedApps` then took its "nothing to close" early return, returned `success: true`, and the test failed on an assertion that said nothing about the real cause. That is the observed flake on [run 29597226603](https://github.com/Stashpeak/SimLauncher/actions/runs/29597226603).
- Arm the failure from the taskkill the test is actually about, so it lands on the post-kill recheck **by construction** whatever the call ordering is.
- Add the loud guard the issue asks for: assert a `taskkill /PID 5555` was dispatched **before** asserting how its failure is reported, since everything below that point is about failure reporting and is meaningless if no kill happened.
- Remove the positional mechanism and its now-dead call counter.

Fix direction 3 in the issue (root-causing the stray read itself) is deliberately **not** in scope here. That is the floating-promise class tracked in #697, and this change makes the test immune to it rather than waiting on it.

## Why now

The kill path this test guards is about to be rewritten by #772, #773, #674 and #673. A guard that can silently mis-target itself is worth an hour before that, not after.

## Mutation verification

Every claim above was verified by mutation rather than asserted:

| Mutation | Result |
|---|---|
| **Old** test + a stray `readRunningProcessNames()` before the pre-kill scan | **Fails**, reproducing the observed flake message exactly (`expected true to be false`) |
| **New** test + the same stray read | **Passes** |
| New test + the #399 `tasklistReadSucceeded` gate removed from `kill.ts` | **Fails**, so it still guards the behaviour it exists for |
| New test with the failure forced onto the pre-kill scan | **Fails on the new guard** (`expected [] to deeply equal ArrayContaining`) rather than on an unrelated assertion |

The first two rows are the ones that matter: they show the flake was real and is now closed, not merely reworded.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, 0 warnings)
- [x] `npm run typecheck`
- [x] `npm test` (77 files, 573 tests, all passing)
- [x] `npm run build`
- [x] Mutation matrix above
- [ ] Manual: none. Test-only change, no runtime surface, nothing to smoke.

Closes #751


<!-- auto-closes -->
Closes #751
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of task termination failures during post-termination verification.
  * Ensured failed termination results are reported correctly when access is denied.

* **Tests**
  * Added regression coverage confirming the process termination request is issued before failure is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update after Codex review

Codex raised a P2 that was correct: the armed failure was **one-shot**, so a stray `readRunningProcessNames()` landing between the taskkill and `finalizeKillAttempts`' verification read would consume it. The verification read would then succeed, and the test would pass whether or not production still gated on `tasklistReadSucceeded` — silently no longer covering #399, via exactly the reordering this PR exists to be immune to.

Reproduced before fixing (stray read after `invalidateProcessNameCache()` so it actually reaches the mock, plus the #399 gate removed): the test **passed**. Fixed in 17f9bc9 by making the flag sticky once armed. That is also the more faithful fixture: tasklist is broken from the kill onward, not for exactly one read.

Worth recording because it nearly hid the bug: a first attempt to reproduce placed the stray read *before* the invalidate, where production's cache absorbed it so it never reached the mock, and the test failed correctly. That looked like a refutation and was not.

Full matrix re-run on the fix, with every mutation anchor verified unique so none could silently no-op:

| Mutation | Expect | Result |
|---|---|---|
| unmutated | pass | pass |
| #399 `tasklistReadSucceeded` gate removed | fail | fail |
| stray read before the pre-kill scan (the original flake) | pass | pass |
| stray read reaching the mock + gate removed (Codex) | fail | fail |
| stray read reaching the mock, alone | pass | pass |
| failure forced onto the pre-kill scan | fail on the dispatch guard | fails with `expected [] to deeply equal ArrayContaining` |