### PR TITLE
build: raise the js-yaml override past the advisory covering our pin (#812)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5331,9 +5331,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "overrides": {
     "@electron/asar": "4.2.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "fast-uri": "^3.1.5",
     "esbuild": "^0.28.1",
     "form-data": "4.0.6",


### PR DESCRIPTION
## Summary

- `GHSA-5p4m-2wfm-xmqj` lands on `js-yaml` **4.0.0 - 4.3.0**, and our overrides block pinned `^4.3.0`, so the resolved tree sat exactly on the vulnerable floor. Production scope, reached via `electron-updater`.
- That fails `npm audit --omit=dev`, which is a step in the **build** job, so every open PR and main itself were red regardless of their contents. This unblocks all of them.
- Override raised to `^4.3.1`.

Third time an override we added to *fix* an advisory later became the reason we stayed vulnerable (`fast-uri` #796, `brace-expansion` #802). #804 tracks going through all nine.

## Lockfile handling

Patched **surgically, not regenerated.** npm 11.4.2 strips the `libc` selectors from native optional entries when it rewrites the lockfile, which would ship musl binaries to glibc hosts (the #769 gotcha). Only the single `node_modules/js-yaml` node changed:

```
-      "version": "4.3.0",
+      "version": "4.3.1",
```

plus its `resolved` and `integrity`. Verified all **14** `libc` selectors survive.

## Still open, deliberately out of scope here

Full `npm audit` (including the dev tree) reports two more, neither of which touches the `--omit=dev` gate, so neither blocks anything:

- `electron` moderate, range `42.0.0-alpha.1 - 42.5.0`. Relevant to #780, which is held at the release boundary rather than on its merits. Worth re-reading that hold in light of this.
- `nanoid` high, `<3.3.17`, dev-only.

Both belong in the deps batch, not in an unblock PR.

## Test plan

- [x] `npm audit --omit=dev` -> **found 0 vulnerabilities** (was 1 high)
- [x] Lockfile diff touches only the `js-yaml` node
- [x] All 14 `libc` selectors still present
- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, 0 warnings)
- [x] `npm run typecheck`
- [x] `npm test` (77 files, 573 tests)
- [x] `npm run build`
- [ ] Manual: none. `js-yaml` is consumed by `electron-updater`, so the real exercise is the update flow in the batched pre-release smoke run, not this PR.

Closes #812


<!-- auto-closes -->
Closes #812
<!-- auto-closes -->