### PR TITLE
fix(launch): explain the consent prompt a cancelled handoff leaves behind (#809)

### DIFF
--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -308,7 +308,8 @@ export function registerLaunchHandlers(): void {
               launchedCount: 0,
               skippedCount: 0,
               failedCount: killResult?.failedCount,
-              killFailures: killResult?.failures
+              killFailures: killResult?.failures,
+              strandedConsentPrompts: killResult?.strandedConsentPrompts
             }
           }
 
@@ -318,7 +319,8 @@ export function registerLaunchHandlers(): void {
             launchedCount: 0,
             skippedCount: 0,
             failedCount: killResult?.failedCount,
-            killFailures: killResult?.failures
+            killFailures: killResult?.failures,
+            strandedConsentPrompts: killResult?.strandedConsentPrompts
           }
         }
 
@@ -333,7 +335,11 @@ export function registerLaunchHandlers(): void {
         return {
           ...launchResult,
           failedCount: (launchResult.failedCount || 0) + (killResult?.failedCount || 0),
-          killFailures: killResult?.failures
+          killFailures: killResult?.failures,
+          // The kill phase of a switch can cancel a pending elevated handoff,
+          // which strands its consent prompt. Without this the count dies here
+          // with killResult and the user is never told (#809).
+          strandedConsentPrompts: killResult?.strandedConsentPrompts
         }
       } finally {
         unregisterActiveLaunch(gameKey, launchController)

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -20,7 +20,6 @@ import {
 import {
   abortActiveLaunches,
   cancelPendingElevatedHandoffs,
-  describeStrandedConsentPrompts,
   drainStrandedConsentPrompts,
   processNameMismatchWarnings,
   runningProcesses,
@@ -600,23 +599,23 @@ function getProfileCompanionTargets(gameKey?: string) {
 }
 
 /**
- * Append the stranded-consent-prompt sentence to a kill result, if this kill
- * left any consent prompt on screen (#809).
+ * Attach the stranded-consent-prompt count to a kill result (#809).
  *
- * Drains a counter written by spawn.ts rather than counting here, because the
- * two ways a pending host dies do not line up with either caller: the abort
- * signal reaches it at any point in the sequence, the registry only after its
- * grace window expired. Counting at this level missed the first case entirely
- * and reported the second twice.
+ * A COUNT, not a sentence. Pre-baking the copy into `message` looked simpler
+ * and was wrong: the profile-switch flow discards `message` entirely and the
+ * renderer ignores it on a failed kill, so the explanation was produced
+ * correctly and never shown. The renderer composes the wording, next to
+ * `formatKillFailures` and `formatSkippedLaunchEntries`.
  *
- * Both `abortActiveLaunches` and `cancelPendingElevatedHandoffs` run
- * synchronously at the top of each entry point, so the counter is settled by
- * the time the result is built. Applied at the entry points rather than inside
- * finalizeKillAttempts, which is also reached from paths that cancelled nothing.
+ * Drained in each entry point's PROLOGUE, not here: `abortActiveLaunches` and
+ * `cancelPendingElevatedHandoffs` both run synchronously before any await, so
+ * taking the count there attributes it to the kill that caused it even when a
+ * second kill overlaps this one's async work.
  */
-function withStrandedConsentNote(result: KillResult): KillResult {
-  const note = describeStrandedConsentPrompts(drainStrandedConsentPrompts())
-  return note ? { ...result, message: `${result.message}${note}` } : result
+function withStrandedConsentPrompts(result: KillResult, strandedPromptCount: number): KillResult {
+  return strandedPromptCount > 0
+    ? { ...result, strandedConsentPrompts: strandedPromptCount }
+    : result
 }
 
 export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
@@ -630,6 +629,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // or approving the prompt afterwards starts an app the user just closed
   // (Codex P1 on #779).
   cancelPendingElevatedHandoffs(gameKey)
+  const strandedPromptCount = drainStrandedConsentPrompts()
 
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
@@ -667,7 +667,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
   const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
   await publishRunningApps('kill')
-  return withStrandedConsentNote(result)
+  return withStrandedConsentPrompts(result, strandedPromptCount)
 }
 
 /**
@@ -758,6 +758,7 @@ export async function killProfileApps(
   // through the abort signal once its sequence ended (#779 Codex P1). And the
   // same consequence: each one killed leaves its consent prompt behind (#809).
   cancelPendingElevatedHandoffs(gameKey)
+  const strandedPromptCount = drainStrandedConsentPrompts()
 
   const { processNames } = await readRunningProcessNames()
 
@@ -802,5 +803,5 @@ export async function killProfileApps(
 
   const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
   await publishRunningApps('kill')
-  return withStrandedConsentNote(result)
+  return withStrandedConsentPrompts(result, strandedPromptCount)
 }

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -20,6 +20,7 @@ import {
 import {
   abortActiveLaunches,
   cancelPendingElevatedHandoffs,
+  describeStrandedConsentPrompts,
   processNameMismatchWarnings,
   runningProcesses,
   suppressProcessNameMismatchWarning,
@@ -597,6 +598,20 @@ function getProfileCompanionTargets(gameKey?: string) {
   return companionTargets
 }
 
+/**
+ * Append the stranded-consent-prompt sentence to a kill result, if this kill
+ * cancelled any pending elevated handoff (#809).
+ *
+ * Applied at the entry points rather than inside finalizeKillAttempts, because
+ * the count belongs to the cancellation that happens BEFORE the kill work
+ * starts, and finalizeKillAttempts is also reached from paths that never
+ * cancelled anything.
+ */
+function withStrandedConsentNote(result: KillResult, cancelledCount: number): KillResult {
+  const note = describeStrandedConsentPrompts(cancelledCount)
+  return note ? { ...result, message: `${result.message}${note}` } : result
+}
+
 export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // Cancel any in-flight launchProfileApps sequence for this gameKey (or all
   // of them, for the gameKey-less tray/global kill) before touching the
@@ -607,7 +622,9 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // (#675), so aborting is not enough: kill the still-live PowerShell host too,
   // or approving the prompt afterwards starts an app the user just closed
   // (Codex P1 on #779).
-  cancelPendingElevatedHandoffs(gameKey)
+  // Each one killed strands its consent prompt on screen, which the result
+  // message has to explain (#809).
+  const strandedPromptCount = cancelPendingElevatedHandoffs(gameKey)
 
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
@@ -645,7 +662,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
   const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
   await publishRunningApps('kill')
-  return result
+  return withStrandedConsentNote(result, strandedPromptCount)
 }
 
 /**
@@ -733,8 +750,9 @@ export async function killProfileApps(
   // `except`, so it still cancels a switch's launch as before.
   abortActiveLaunches(gameKey, options)
   // Same reason as killLaunchedApps: a timed-out handoff is not reachable
-  // through the abort signal once its sequence ended (#779 Codex P1).
-  cancelPendingElevatedHandoffs(gameKey)
+  // through the abort signal once its sequence ended (#779 Codex P1). And the
+  // same consequence: each one killed leaves its consent prompt behind (#809).
+  const strandedPromptCount = cancelPendingElevatedHandoffs(gameKey)
 
   const { processNames } = await readRunningProcessNames()
 
@@ -779,5 +797,5 @@ export async function killProfileApps(
 
   const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
   await publishRunningApps('kill')
-  return result
+  return withStrandedConsentNote(result, strandedPromptCount)
 }

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -21,6 +21,7 @@ import {
   abortActiveLaunches,
   cancelPendingElevatedHandoffs,
   describeStrandedConsentPrompts,
+  drainStrandedConsentPrompts,
   processNameMismatchWarnings,
   runningProcesses,
   suppressProcessNameMismatchWarning,
@@ -600,15 +601,21 @@ function getProfileCompanionTargets(gameKey?: string) {
 
 /**
  * Append the stranded-consent-prompt sentence to a kill result, if this kill
- * cancelled any pending elevated handoff (#809).
+ * left any consent prompt on screen (#809).
  *
- * Applied at the entry points rather than inside finalizeKillAttempts, because
- * the count belongs to the cancellation that happens BEFORE the kill work
- * starts, and finalizeKillAttempts is also reached from paths that never
- * cancelled anything.
+ * Drains a counter written by spawn.ts rather than counting here, because the
+ * two ways a pending host dies do not line up with either caller: the abort
+ * signal reaches it at any point in the sequence, the registry only after its
+ * grace window expired. Counting at this level missed the first case entirely
+ * and reported the second twice.
+ *
+ * Both `abortActiveLaunches` and `cancelPendingElevatedHandoffs` run
+ * synchronously at the top of each entry point, so the counter is settled by
+ * the time the result is built. Applied at the entry points rather than inside
+ * finalizeKillAttempts, which is also reached from paths that cancelled nothing.
  */
-function withStrandedConsentNote(result: KillResult, cancelledCount: number): KillResult {
-  const note = describeStrandedConsentPrompts(cancelledCount)
+function withStrandedConsentNote(result: KillResult): KillResult {
+  const note = describeStrandedConsentPrompts(drainStrandedConsentPrompts())
   return note ? { ...result, message: `${result.message}${note}` } : result
 }
 
@@ -622,9 +629,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // (#675), so aborting is not enough: kill the still-live PowerShell host too,
   // or approving the prompt afterwards starts an app the user just closed
   // (Codex P1 on #779).
-  // Each one killed strands its consent prompt on screen, which the result
-  // message has to explain (#809).
-  const strandedPromptCount = cancelPendingElevatedHandoffs(gameKey)
+  cancelPendingElevatedHandoffs(gameKey)
 
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
@@ -662,7 +667,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
   const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
   await publishRunningApps('kill')
-  return withStrandedConsentNote(result, strandedPromptCount)
+  return withStrandedConsentNote(result)
 }
 
 /**
@@ -752,7 +757,7 @@ export async function killProfileApps(
   // Same reason as killLaunchedApps: a timed-out handoff is not reachable
   // through the abort signal once its sequence ended (#779 Codex P1). And the
   // same consequence: each one killed leaves its consent prompt behind (#809).
-  const strandedPromptCount = cancelPendingElevatedHandoffs(gameKey)
+  cancelPendingElevatedHandoffs(gameKey)
 
   const { processNames } = await readRunningProcessNames()
 
@@ -797,5 +802,5 @@ export async function killProfileApps(
 
   const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
   await publishRunningApps('kill')
-  return withStrandedConsentNote(result, strandedPromptCount)
+  return withStrandedConsentNote(result)
 }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -17,7 +17,7 @@ import {
 
 import {
   consumeProcessNameMismatchWarningSuppression,
-  describeStrandedConsentPrompts,
+  noteStrandedConsentPrompt,
   hasOtherActiveLaunchControllers,
   processNameMismatchWarnings,
   registerActiveLaunch,
@@ -394,16 +394,10 @@ export async function launchProfileApps(
           : unknownCount > 1
             ? ` ${unknownCount} apps may have started with administrator permission and could not be closed from here.`
             : ''
-      // A handoff this very abort killed leaves its consent prompt on screen
-      // (#809). survivedNote and unknownNote cover apps that did or might have
-      // started; this covers the one case where we know nothing started and the
-      // dialog is now inert, which is exactly the case the user cannot tell
-      // apart from a failure.
-      const strandedNote = describeStrandedConsentPrompts(cancelledElevatedCount)
       return {
         success: false,
         cancelled: true,
-        message: `Launch cancelled — closed apps instead.${survivedNote}${unknownNote}${strandedNote}`,
+        message: `Launch cancelled — closed apps instead.${survivedNote}${unknownNote}`,
         launchedCount,
         skippedCount,
         elevatedCount: survivedCount + unknownCount,
@@ -667,9 +661,29 @@ function launchElevated(
     // unblocks the launch sequence immediately instead of leaving it parked
     // until the user answers a prompt they no longer want.
     let handoffPending = true
+    /**
+     * Killing the host does not remove the consent prompt, so whoever reports
+     * the cancellation has to explain the dialog left behind (#809). Noted here
+     * rather than at the caller because this is the moment we know a prompt was
+     * pending, which also covers the window before the grace timer, where the
+     * pending-handoff registry is still empty.
+     *
+     * Once per handoff, deliberately. A Close Apps arriving after the grace
+     * window reaches the SAME handoff through both mechanisms, the abort signal
+     * and the registry, and without this guard one prompt gets counted twice
+     * and described in the plural.
+     */
+    let strandedPromptNoted = false
+    const noteStrandedPromptOnce = () => {
+      if (!strandedPromptNoted) {
+        strandedPromptNoted = true
+        noteStrandedConsentPrompt()
+      }
+    }
     const onAbort = () => {
       if (handoffPending) {
         noteHandoffCancelled()
+        noteStrandedPromptOnce()
         child.kill()
       }
     }
@@ -726,6 +740,9 @@ function launchElevated(
         cancel: () => {
           cancelledByKill = true
           noteHandoffCancelled()
+          // Same reason as onAbort (#809), and the same guard: mid-sequence
+          // both this and the abort fire for this one handoff.
+          noteStrandedPromptOnce()
           child.kill()
         }
       })

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -17,6 +17,7 @@ import {
 
 import {
   consumeProcessNameMismatchWarningSuppression,
+  describeStrandedConsentPrompts,
   hasOtherActiveLaunchControllers,
   processNameMismatchWarnings,
   registerActiveLaunch,
@@ -393,10 +394,16 @@ export async function launchProfileApps(
           : unknownCount > 1
             ? ` ${unknownCount} apps may have started with administrator permission and could not be closed from here.`
             : ''
+      // A handoff this very abort killed leaves its consent prompt on screen
+      // (#809). survivedNote and unknownNote cover apps that did or might have
+      // started; this covers the one case where we know nothing started and the
+      // dialog is now inert, which is exactly the case the user cannot tell
+      // apart from a failure.
+      const strandedNote = describeStrandedConsentPrompts(cancelledElevatedCount)
       return {
         success: false,
         cancelled: true,
-        message: `Launch cancelled — closed apps instead.${survivedNote}${unknownNote}`,
+        message: `Launch cancelled — closed apps instead.${survivedNote}${unknownNote}${strandedNote}`,
         launchedCount,
         skippedCount,
         elevatedCount: survivedCount + unknownCount,

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -55,14 +55,46 @@ export function unregisterPendingElevatedHandoff(handoffId: number): void {
  * `gameKey` is undefined (the global "close everything" kill). Each entry
  * removes itself as its callback settles, so this is safe to call on every kill.
  */
-export function cancelPendingElevatedHandoffs(gameKey?: string): void {
+export function cancelPendingElevatedHandoffs(gameKey?: string): number {
+  let cancelledCount = 0
   pendingElevatedHandoffs.forEach((entry, handoffId) => {
     if (gameKey !== undefined && entry.gameKey !== gameKey) {
       return
     }
     pendingElevatedHandoffs.delete(handoffId)
+    cancelledCount += 1
     entry.cancel()
   })
+  return cancelledCount
+}
+
+/**
+ * The sentence appended when a cancellation killed a pending elevated handoff.
+ *
+ * Killing the PowerShell host stops the app from starting, but it does NOT
+ * remove the Windows consent prompt: that UI belongs to the AppInfo service on
+ * the secure desktop and is not ours to close. Verified on a real machine
+ * (#809): after the kill the prompt stayed up, and answering Yes started
+ * nothing. Without this line the user's only readings are "elevation is broken"
+ * or "SimLauncher failed to start it", and neither is true.
+ *
+ * Two things it deliberately does not say: that the app started (it did not),
+ * and that SimLauncher closed the prompt (it cannot). It also stays silent at
+ * zero, so the ordinary cancellation reads exactly as it does today.
+ *
+ * Lives here rather than in spawn.ts because both cancellation paths need the
+ * same words and kill.ts does not import spawn.ts: the mid-sequence abort
+ * (spawn.ts's own summary) and the post-sequence kill (kill.ts, via the
+ * registry above) must not describe the same event differently.
+ */
+export function describeStrandedConsentPrompts(cancelledCount: number): string {
+  if (cancelledCount === 1) {
+    return ' A Windows permission prompt may still be on screen. Answering it will not start the app.'
+  }
+  if (cancelledCount > 1) {
+    return ' Windows permission prompts may still be on screen. Answering them will not start those apps.'
+  }
+  return ''
 }
 
 /**

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -85,48 +85,19 @@ export function noteStrandedConsentPrompt(): void {
 }
 
 /**
- * Take the pending count and reset it, so exactly one message reports it.
+ * Take the pending count and reset it, so exactly one result reports it.
  *
  * Drained by the kill entry points because every stranded prompt originates
  * from one: the abort signal is only ever raised by `abortActiveLaunches`, and
  * the registry is only ever drained by `cancelPendingElevatedHandoffs`, both of
- * which are called from kill.ts and both synchronously, before the kill result
- * is built. The launch summary deliberately stays out of it: mid-sequence, both
- * it and the kill result are delivered, and the user should hear this once.
+ * which are called from kill.ts and both synchronously, in the prologue before
+ * any await. The count travels to the renderer as a number; the sentence is
+ * composed there, next to formatKillFailures.
  */
 export function drainStrandedConsentPrompts(): number {
   const count = strandedConsentPrompts
   strandedConsentPrompts = 0
   return count
-}
-
-/**
- * The sentence appended when a cancellation killed a pending elevated handoff.
- *
- * Killing the PowerShell host stops the app from starting, but it does NOT
- * remove the Windows consent prompt: that UI belongs to the AppInfo service on
- * the secure desktop and is not ours to close. Verified on a real machine
- * (#809): after the kill the prompt stayed up, and answering Yes started
- * nothing. Without this line the user's only readings are "elevation is broken"
- * or "SimLauncher failed to start it", and neither is true.
- *
- * Two things it deliberately does not say: that the app started (it did not),
- * and that SimLauncher closed the prompt (it cannot). It also stays silent at
- * zero, so the ordinary cancellation reads exactly as it does today.
- *
- * Lives here rather than in spawn.ts because both cancellation paths need the
- * same words and kill.ts does not import spawn.ts: the mid-sequence abort
- * (spawn.ts's own summary) and the post-sequence kill (kill.ts, via the
- * registry above) must not describe the same event differently.
- */
-export function describeStrandedConsentPrompts(cancelledCount: number): string {
-  if (cancelledCount === 1) {
-    return ' A Windows permission prompt may still be on screen. Answering it will not start the app.'
-  }
-  if (cancelledCount > 1) {
-    return ' Windows permission prompts may still be on screen. Answering them will not start those apps.'
-  }
-  return ''
 }
 
 /**

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -55,17 +55,49 @@ export function unregisterPendingElevatedHandoff(handoffId: number): void {
  * `gameKey` is undefined (the global "close everything" kill). Each entry
  * removes itself as its callback settles, so this is safe to call on every kill.
  */
-export function cancelPendingElevatedHandoffs(gameKey?: string): number {
-  let cancelledCount = 0
+export function cancelPendingElevatedHandoffs(gameKey?: string): void {
   pendingElevatedHandoffs.forEach((entry, handoffId) => {
     if (gameKey !== undefined && entry.gameKey !== gameKey) {
       return
     }
     pendingElevatedHandoffs.delete(handoffId)
-    cancelledCount += 1
     entry.cancel()
   })
-  return cancelledCount
+}
+
+/**
+ * Consent prompts left on screen by a host SimLauncher killed (#809).
+ *
+ * Counted here, at the one fact that matters, rather than at either caller.
+ * There are two ways a pending host gets killed and they do not overlap
+ * cleanly: the abort signal reaches it at any point in the sequence, while the
+ * registry above only holds it AFTER its grace window expired. Counting at the
+ * callers therefore both missed cancellations (before the grace window, the
+ * registry is empty and the abort path was silent) and double-counted them
+ * (after it, both mechanisms fire for the same handoff, so the user was told
+ * twice, once by the kill result and once by the launch summary).
+ */
+let strandedConsentPrompts = 0
+
+/** Called wherever a host is killed while its consent prompt is still pending. */
+export function noteStrandedConsentPrompt(): void {
+  strandedConsentPrompts += 1
+}
+
+/**
+ * Take the pending count and reset it, so exactly one message reports it.
+ *
+ * Drained by the kill entry points because every stranded prompt originates
+ * from one: the abort signal is only ever raised by `abortActiveLaunches`, and
+ * the registry is only ever drained by `cancelPendingElevatedHandoffs`, both of
+ * which are called from kill.ts and both synchronously, before the kill result
+ * is built. The launch summary deliberately stays out of it: mid-sequence, both
+ * it and the kill result are delivered, and the user should hear this once.
+ */
+export function drainStrandedConsentPrompts(): number {
+  const count = strandedConsentPrompts
+  strandedConsentPrompts = 0
+  return count
 }
 
 /**

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -45,6 +45,12 @@ export interface LaunchResult {
   elevatedCount?: number
   failedCount?: number
   killFailures?: KillFailure[]
+  /**
+   * Consent prompts left on screen because this operation killed a pending
+   * elevated handoff (#809). A count, not a sentence: the renderer composes the
+   * copy, like it does for killFailures and skipped.
+   */
+  strandedConsentPrompts?: number
   /** Entries excluded before spawn for an invalid/missing exe path (#639). NOT counted by `skippedCount`. */
   skipped?: SkippedLaunchEntry[]
   /**
@@ -62,6 +68,12 @@ export interface KillResult {
   closedCount: number
   failedCount: number
   failures: KillFailure[]
+  /**
+   * Consent prompts left on screen because this operation killed a pending
+   * elevated handoff (#809). A count, not a sentence: the renderer composes the
+   * copy, like it does for killFailures and skipped.
+   */
+  strandedConsentPrompts?: number
 }
 
 /**

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -159,6 +159,13 @@ export interface LaunchResult {
    * renderer should show a neutral "cancelled" toast, not an error toast.
    */
   cancelled?: boolean
+  /**
+   * Consent prompts left on screen because this operation killed a pending
+   * elevated handoff (#809). A count, not a sentence: the renderer composes the
+   * wording via `formatStrandedConsentPrompts`, as it does for `killFailures`
+   * and `skipped`.
+   */
+  strandedConsentPrompts?: number
 }
 
 export interface KillResult {
@@ -168,6 +175,8 @@ export interface KillResult {
   closedCount: number
   failedCount: number
   failures: KillFailure[]
+  /** See `LaunchResult.strandedConsentPrompts` (#809). */
+  strandedConsentPrompts?: number
 }
 
 export interface ConfigFileResult {

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -15,6 +15,7 @@ import {
   relaunchMissingProfile
 } from '../../lib/electron'
 import { formatKillFailures } from '../../lib/killFailures'
+import { formatStrandedConsentPrompts } from '../../lib/strandedConsentPrompts'
 import { formatSkippedLaunchEntries } from '../../lib/skippedLaunchEntries'
 import { useGameProfile } from '../../hooks/useGameProfile'
 import { useProfileMenu } from '../../hooks/useProfileMenu'
@@ -306,6 +307,14 @@ export function GameRow({
           if (result.warning) {
             switchWarnings.push(result.warning)
           }
+          // A switch's kill phase can cancel a pending elevated handoff, which
+          // leaves its consent prompt on screen. This flow never displays
+          // `result.message`, so without an entry here the user gets a plain
+          // "Switched to X" and an unexplained dialog (#809).
+          const strandedNote = formatStrandedConsentPrompts(result.strandedConsentPrompts)
+          if (strandedNote) {
+            switchWarnings.push(strandedNote)
+          }
           switchWarning = switchWarnings.length > 0 ? switchWarnings.join(' ') : undefined
         }
 
@@ -443,13 +452,25 @@ export function GameRow({
       const result = await killLaunchedApps(game.key)
       await onRunningStateRefresh()
 
+      // A cancelled elevated handoff strands its consent prompt whether the
+      // rest of the kill succeeded or not, so this is appended on BOTH paths
+      // (#809). The failure path is the likelier of the two: access-denied is
+      // the canonical kill failure for exactly the elevated-tool profiles that
+      // can produce a pending handoff in the first place.
+      const strandedNote = formatStrandedConsentPrompts(result.strandedConsentPrompts)
+
       if (!result.success) {
         const message = result.error || formatKillFailures(result.failures)
-        notify(message, 'warn', 6000)
+        notify([message, strandedNote].filter(Boolean).join(' '), 'warn', 6000)
         return
       }
 
-      notify(result.message || `Closing companion apps for ${game.name}`, 'warn')
+      notify(
+        [result.message || `Closing companion apps for ${game.name}`, strandedNote]
+          .filter(Boolean)
+          .join(' '),
+        'warn'
+      )
     } catch (err) {
       notify('Failed to close companion apps', 'error')
       console.error(err)

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -276,11 +276,21 @@ export function GameRow({
 
           onLaunchStart(game.key)
           const result = await switchProfileApps(game.key, currentProfile.id, nextProfile.id)
+          // The kill phase runs before the switch can cancel or fail, so a
+          // stranded consent prompt has to be reported on every one of the
+          // three exits below — main already drained the count to build this
+          // result, so whichever branch drops it drops it for good (#809).
+          const strandedNote = formatStrandedConsentPrompts(result.strandedConsentPrompts)
           // Close Apps mid-switch cancels the new profile's launch sequence
           // (#670) — the user asked to stop, so this is neither a success nor
           // an error; the switch is not saved and can simply be retried.
           if (result.cancelled) {
-            notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+            notify(
+              [result.message || 'Launch cancelled — closed apps instead.', strandedNote]
+                .filter(Boolean)
+                .join(' '),
+              'warn'
+            )
             onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
             return
           }
@@ -289,7 +299,12 @@ export function GameRow({
               result.skipped && result.skipped.length > 0
                 ? ` ${formatSkippedLaunchEntries(result.skipped, { gameKey: game.key, gameName: game.name })}`
                 : ''
-            notify(`${result.error || 'Failed to switch profile'}${failedSkippedDetail}`, 'error')
+            notify(
+              [`${result.error || 'Failed to switch profile'}${failedSkippedDetail}`, strandedNote]
+                .filter(Boolean)
+                .join(' '),
+              'error'
+            )
             onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
             return
           }
@@ -307,11 +322,9 @@ export function GameRow({
           if (result.warning) {
             switchWarnings.push(result.warning)
           }
-          // A switch's kill phase can cancel a pending elevated handoff, which
-          // leaves its consent prompt on screen. This flow never displays
-          // `result.message`, so without an entry here the user gets a plain
-          // "Switched to X" and an unexplained dialog (#809).
-          const strandedNote = formatStrandedConsentPrompts(result.strandedConsentPrompts)
+          // The success path never displays `result.message`, so without an
+          // entry here the user gets a plain "Switched to X" and an
+          // unexplained dialog (#809).
           if (strandedNote) {
             switchWarnings.push(strandedNote)
           }

--- a/src/renderer/src/lib/strandedConsentPrompts.ts
+++ b/src/renderer/src/lib/strandedConsentPrompts.ts
@@ -1,0 +1,31 @@
+/**
+ * User-facing wording for consent prompts left on screen by a cancelled
+ * elevated handoff (#809).
+ *
+ * When SimLauncher cancels a pending elevated launch it kills the PowerShell
+ * host. That stops the app from starting, but it does NOT remove the Windows
+ * consent prompt: that dialog belongs to the AppInfo service on the secure
+ * desktop and is not ours to close. Verified on a real machine, the prompt
+ * stayed up and answering Yes started nothing, silently. Without this sentence
+ * the readings available to the user are "elevation is broken" or "SimLauncher
+ * failed to start it", and neither is true.
+ *
+ * Two things it deliberately does not say: that the app started (it did not),
+ * and that SimLauncher closed the prompt (it cannot).
+ *
+ * Lives in the renderer, like formatKillFailures and formatSkippedLaunchEntries:
+ * the main process reports a count, the wording is composed here. An earlier
+ * version of this baked the sentence into the kill result's `message` string in
+ * the main process, which the profile-switch flow discards outright and the
+ * renderer ignores on a failed kill, so it was produced correctly and never
+ * shown to anyone.
+ */
+export function formatStrandedConsentPrompts(count: number | undefined): string | undefined {
+  if (!count || count < 1) {
+    return undefined
+  }
+
+  return count === 1
+    ? 'A Windows permission prompt may still be on screen. Answering it will not start the app.'
+    : 'Windows permission prompts may still be on screen. Answering them will not start those apps.'
+}

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1772,15 +1772,59 @@ test('a Close Apps that cancels a pending handoff mid-sequence explains the stra
 
     const killPromise = killLaunchedApps('ac')
     await vi.advanceTimersByTimeAsync(0)
-    await killPromise
+    const killResult = await killPromise
 
     const result = await launchPromise
 
     expect(result.cancelled).toBe(true)
-    expect(result.message).toContain(STRANDED_PROMPT_NOTE)
+    // Said exactly ONCE. Mid-sequence the user gets both messages, and an
+    // earlier version of this fix counted the same handoff at both callers, so
+    // the sentence appeared twice for a single prompt.
+    expect(killResult.message).toContain(STRANDED_PROMPT_NOTE)
+    expect(result.message).not.toContain('still be on screen')
     // The #779 guarantee must survive: we killed it, so it must not be
     // described as something that started or that we failed to close.
     expect(result.message).not.toContain('administrator permission')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The window this fix originally missed. Before the grace timer fires the
+// handoff is not in the pending registry yet (it is only registered when the
+// timer expires), so counting cancellations at the kill entry points saw
+// nothing here — even though the abort had killed the host and the prompt was
+// left on screen exactly as in the documented case. A user who clicks Close
+// Apps promptly, within 10s, lands here rather than in the case the issue
+// describes.
+test('a Close Apps BEFORE the grace window expires still explains the stranded prompt (#809)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+    })
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+    // Well inside the grace window: the prompt is up, the sequence is parked on
+    // it, and nothing has been registered as pending yet.
+    await vi.advanceTimersByTimeAsync(10)
+
+    const killResult = await killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    await launchPromise
+
+    // The host really was killed, which is what strands the prompt.
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(killResult.message).toContain(STRANDED_PROMPT_NOTE)
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1952,6 +1952,55 @@ test('an ordinary Close Apps with no pending handoff says nothing about a prompt
   expect(result.strandedConsentPrompts).toBeUndefined()
 })
 
+// The other kill entry point, and the one a profile switch actually goes
+// through. It carries the same drain + attach prologue as killLaunchedApps, so
+// without this every #809 test would prove the feature on the path the user
+// reaches by clicking Close Apps and none of it on the path they reach by
+// switching profile.
+test('a profile switch that cancels a pending handoff explains the stranded prompt (#809)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // The switch stops the outgoing profile's apps, not the elevated one whose
+    // prompt is still up. The handoff is cancelled by gameKey either way, so
+    // the count must survive a kill that targets something else entirely.
+    const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('an ordinary profile switch with no pending handoff says nothing about a prompt (#809)', async () => {
+  markExistingPath('C:/Tools/App2.exe')
+  processNames.add('app2.exe')
+  registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+
+  const { killProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+
+  expect(result.strandedConsentPrompts).toBeUndefined()
+})
+
 // Codex P2 on PR #779. A denial arriving while the loop is still running was
 // only subtracted from the counts, so the sequence still returned success:true
 // with "All profile applications launched." and no failedCount.

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1901,6 +1901,42 @@ test('two cancelled handoffs are described in the plural (#809)', async () => {
   }
 })
 
+test('a later Close Apps does not repeat the prompt warning for an old cancellation (#809)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    const firstKill = await killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(firstKill.message).toContain(STRANDED_PROMPT_NOTE)
+
+    // Same session, nothing pending any more. The count is consumed by the
+    // message that reported it, so a later kill must not resurrect it and warn
+    // about a dialog that is not there.
+    const secondKill = await killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(secondKill.message).not.toContain('still be on screen')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
 test('an ordinary Close Apps with no pending handoff says nothing about a prompt (#809)', async () => {
   markExistingPath('C:/Tools/App2.exe')
   processNames.add('app2.exe')

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1747,8 +1747,9 @@ test('Close Apps after the sequence ended still kills a pending elevated handoff
 // only readings left to the user are "elevation is broken" or "SimLauncher
 // failed to start it", neither of which is true.
 
-const STRANDED_PROMPT_NOTE =
-  'A Windows permission prompt may still be on screen. Answering it will not start the app.'
+// The main process reports a COUNT. The sentence itself is composed in the
+// renderer and asserted in tests/renderer/gameRowStrandedConsentPrompt.test.tsx,
+// which is where it can be proven to actually reach the user.
 
 test('a Close Apps that cancels a pending handoff mid-sequence explains the stranded prompt (#809)', async () => {
   vi.useFakeTimers()
@@ -1780,8 +1781,9 @@ test('a Close Apps that cancels a pending handoff mid-sequence explains the stra
     // Said exactly ONCE. Mid-sequence the user gets both messages, and an
     // earlier version of this fix counted the same handoff at both callers, so
     // the sentence appeared twice for a single prompt.
-    expect(killResult.message).toContain(STRANDED_PROMPT_NOTE)
-    expect(result.message).not.toContain('still be on screen')
+    expect(killResult.strandedConsentPrompts).toBe(1)
+    // Reported once: the launch summary must not carry it as well.
+    expect(result.strandedConsentPrompts).toBeUndefined()
     // The #779 guarantee must survive: we killed it, so it must not be
     // described as something that started or that we failed to close.
     expect(result.message).not.toContain('administrator permission')
@@ -1824,7 +1826,7 @@ test('a Close Apps BEFORE the grace window expires still explains the stranded p
 
     // The host really was killed, which is what strands the prompt.
     expect(elevatedHostKills).toHaveLength(1)
-    expect(killResult.message).toContain(STRANDED_PROMPT_NOTE)
+    expect(killResult.strandedConsentPrompts).toBe(1)
   } finally {
     vi.useRealTimers()
   }
@@ -1858,7 +1860,7 @@ test('a Close Apps that cancels a pending handoff after the sequence ended expla
     const result = await killPromise
 
     expect(elevatedHostKills).toHaveLength(1)
-    expect(result.message).toContain(STRANDED_PROMPT_NOTE)
+    expect(result.strandedConsentPrompts).toBe(1)
   } finally {
     vi.useRealTimers()
   }
@@ -1893,9 +1895,7 @@ test('two cancelled handoffs are described in the plural (#809)', async () => {
     const result = await killPromise
 
     expect(elevatedHostKills).toHaveLength(2)
-    expect(result.message).toContain(
-      'Windows permission prompts may still be on screen. Answering them will not start those apps.'
-    )
+    expect(result.strandedConsentPrompts).toBe(2)
   } finally {
     vi.useRealTimers()
   }
@@ -1924,14 +1924,14 @@ test('a later Close Apps does not repeat the prompt warning for an old cancellat
 
     const firstKill = await killLaunchedApps('ac')
     await vi.advanceTimersByTimeAsync(0)
-    expect(firstKill.message).toContain(STRANDED_PROMPT_NOTE)
+    expect(firstKill.strandedConsentPrompts).toBe(1)
 
     // Same session, nothing pending any more. The count is consumed by the
     // message that reported it, so a later kill must not resurrect it and warn
     // about a dialog that is not there.
     const secondKill = await killLaunchedApps('ac')
     await vi.advanceTimersByTimeAsync(0)
-    expect(secondKill.message).not.toContain('still be on screen')
+    expect(secondKill.strandedConsentPrompts).toBeUndefined()
   } finally {
     vi.useRealTimers()
   }
@@ -1949,8 +1949,7 @@ test('an ordinary Close Apps with no pending handoff says nothing about a prompt
   const result = await killLaunchedApps('ac')
 
   // The unchanged case must read exactly as it did before this issue.
-  expect(result.message).not.toContain('permission prompt')
-  expect(result.message).not.toContain('still be on screen')
+  expect(result.strandedConsentPrompts).toBeUndefined()
 })
 
 // Codex P2 on PR #779. A denial arriving while the loop is still running was

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1739,6 +1739,140 @@ test('Close Apps after the sequence ended still kills a pending elevated handoff
   }
 })
 
+// --- #809: a cancelled handoff strands its consent prompt on screen ---
+//
+// Killing the PowerShell host stops the app from starting but does NOT remove
+// the Windows consent prompt (verified on a real machine: it stayed up, and
+// answering Yes started nothing). Both cancellation paths have to say so, or the
+// only readings left to the user are "elevation is broken" or "SimLauncher
+// failed to start it", neither of which is true.
+
+const STRANDED_PROMPT_NOTE =
+  'A Windows permission prompt may still be on screen. Answering it will not start the app.'
+
+test('a Close Apps that cancels a pending handoff mid-sequence explains the stranded prompt (#809)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    await killPromise
+
+    const result = await launchPromise
+
+    expect(result.cancelled).toBe(true)
+    expect(result.message).toContain(STRANDED_PROMPT_NOTE)
+    // The #779 guarantee must survive: we killed it, so it must not be
+    // described as something that started or that we failed to close.
+    expect(result.message).not.toContain('administrator permission')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('a Close Apps that cancels a pending handoff after the sequence ended explains it too (#809)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // The sequence is over, so its summary is already delivered. The kill result
+    // is the only message left that can explain the prompt.
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.message).toContain(STRANDED_PROMPT_NOTE)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('two cancelled handoffs are described in the plural (#809)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/Admin Two.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    spawnErrors.set('C:/Tools/Admin Two.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/Admin Two.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/Admin Two.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS * 2)
+    await launchPromise
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    expect(elevatedHostKills).toHaveLength(2)
+    expect(result.message).toContain(
+      'Windows permission prompts may still be on screen. Answering them will not start those apps.'
+    )
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('an ordinary Close Apps with no pending handoff says nothing about a prompt (#809)', async () => {
+  markExistingPath('C:/Tools/App2.exe')
+  processNames.add('app2.exe')
+  registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    appPaths: { customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const result = await killLaunchedApps('ac')
+
+  // The unchanged case must read exactly as it did before this issue.
+  expect(result.message).not.toContain('permission prompt')
+  expect(result.message).not.toContain('still be on screen')
+})
+
 // Codex P2 on PR #779. A denial arriving while the loop is still running was
 // only subtracted from the counts, so the sequence still returned success:true
 // with "All profile applications launched." and no failedCount.

--- a/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
+++ b/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
@@ -343,7 +343,13 @@ describe('profile switch stranded consent prompt toast (#809)', () => {
     expect(allToastText()).toContain('Failed to start Race apps')
   })
 
-  test('a successful switch explains it alongside the switch confirmation', async () => {
+  // Pins the pre-existing contract rather than proposing a new one: a warned
+  // switch reports the warning INSTEAD of "Switched to X", and has since the
+  // row was decomposed (f3d4088). That applies equally to kill failures,
+  // skipped apps and `result.warning`, so the stranded note behaves like its
+  // three siblings. Whether a warned switch should still confirm the change is
+  // a real question, but it is one for all four and is tracked in #817.
+  test('a successful switch reports the prompt in place of the plain confirmation', async () => {
     switchProfileAppsMock.mockResolvedValue({
       success: true,
       launchedCount: 1,
@@ -356,6 +362,9 @@ describe('profile switch stranded consent prompt toast (#809)', () => {
     await switchToProfile('Race')
 
     expect(allToastText()).toContain(PLURAL)
+    expect(allToastText()).not.toContain('Switched to Race')
+    // Warned switches are shown as a warning, not as a success.
+    expect(notifyMock.mock.calls.some((call) => call[1] === 'warn')).toBe(true)
   })
 
   test('an ordinary switch says nothing about a prompt', async () => {

--- a/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
+++ b/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * #809: when SimLauncher cancels a pending elevated handoff it kills the
+ * PowerShell host, which stops the app starting but leaves the Windows consent
+ * prompt on screen. The user answers it, nothing happens, and nothing explains
+ * why.
+ *
+ * These tests exist because the FIRST attempt at that fix composed the sentence
+ * in the main process and appended it to `KillResult.message`. It was correct
+ * copy, and it was invisible: the renderer ignores `message` entirely on a
+ * failed kill. Every test then passed, because every test asserted on the
+ * main-process return value rather than on what reached a toast.
+ *
+ * So the assertions here are deliberately at the notification layer. Main
+ * reports a count; this is where it is proven a human would actually read it.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const notifyMock = vi.fn()
+const killLaunchedAppsMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: vi.fn(),
+  killLaunchedApps: (...args: unknown[]) => killLaunchedAppsMock(...args),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+
+const SINGULAR =
+  'A Windows permission prompt may still be on screen. Answering it will not start the app.'
+const PLURAL =
+  'Windows permission prompts may still be on screen. Answering them will not start those apps.'
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRunningRow(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          // Running, so the primary action becomes Close Apps.
+          isRunning={true}
+          isGameRunning={false}
+          // canKill is runningAppIcons.length > 0 && killControlsEnabled, so the
+          // Close Apps affordance needs a visible companion here.
+          runningAppIcons={[
+            { appPath: 'C:/Tools/AdminTool.exe', icon: 'assets/admin.png', name: 'AdminTool' }
+          ]}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+async function clickCloseApps(): Promise<void> {
+  const button = container.querySelector(
+    'button[aria-label="Close companion apps for Assetto Corsa"]'
+  ) as HTMLButtonElement | null
+  expect(button).not.toBeNull()
+  await act(async () => {
+    button!.click()
+  })
+}
+
+/** Everything the toast said, across however many notify() calls. */
+function allToastText(): string {
+  return notifyMock.mock.calls.map((call) => String(call[0])).join(' | ')
+}
+
+beforeEach(() => {
+  notifyMock.mockClear()
+  killLaunchedAppsMock.mockReset()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('GameRow stranded consent prompt toast (#809)', () => {
+  test('a successful close that stranded a prompt explains it', async () => {
+    killLaunchedAppsMock.mockResolvedValue({
+      success: true,
+      closedCount: 1,
+      failedCount: 0,
+      failures: [],
+      message: 'Closed 1 companion app.',
+      strandedConsentPrompts: 1
+    })
+
+    await renderRunningRow()
+    await clickCloseApps()
+
+    expect(allToastText()).toContain(SINGULAR)
+    // The existing message is kept, not replaced.
+    expect(allToastText()).toContain('Closed 1 companion app.')
+  })
+
+  test('a FAILED close that stranded a prompt still explains it', async () => {
+    // The likelier of the two: access-denied is the canonical kill failure for
+    // exactly the elevated-tool profiles that can strand a prompt at all. This
+    // path ignores `message` entirely, which is how the first version of this
+    // fix lost the sentence.
+    killLaunchedAppsMock.mockResolvedValue({
+      success: false,
+      closedCount: 0,
+      failedCount: 1,
+      failures: [
+        { appName: 'AdminTool.exe', appPath: 'C:/Tools/AdminTool.exe', reason: 'access_denied' }
+      ],
+      strandedConsentPrompts: 1
+    })
+
+    await renderRunningRow()
+    await clickCloseApps()
+
+    expect(allToastText()).toContain(SINGULAR)
+    // And the failure itself is still reported.
+    expect(allToastText()).toContain('AdminTool.exe')
+  })
+
+  test('two stranded prompts are described in the plural', async () => {
+    killLaunchedAppsMock.mockResolvedValue({
+      success: true,
+      closedCount: 0,
+      failedCount: 0,
+      failures: [],
+      message: 'No running companion apps to close.',
+      strandedConsentPrompts: 2
+    })
+
+    await renderRunningRow()
+    await clickCloseApps()
+
+    expect(allToastText()).toContain(PLURAL)
+  })
+
+  test('an ordinary close says nothing about a prompt', async () => {
+    killLaunchedAppsMock.mockResolvedValue({
+      success: true,
+      closedCount: 2,
+      failedCount: 0,
+      failures: [],
+      message: 'Closed 2 companion apps.'
+    })
+
+    await renderRunningRow()
+    await clickCloseApps()
+
+    expect(allToastText()).not.toContain('permission prompt')
+    expect(allToastText()).toContain('Closed 2 companion apps.')
+  })
+
+  test('a close that reports no message at all does not render "undefined"', async () => {
+    // finalizeKillAttempts returns `message: undefined` whenever kill attempts
+    // were made but nothing closed. An earlier version interpolated that
+    // straight into a string, producing a literal "undefined ..." toast.
+    killLaunchedAppsMock.mockResolvedValue({
+      success: true,
+      closedCount: 0,
+      failedCount: 0,
+      failures: [],
+      strandedConsentPrompts: 1
+    })
+
+    await renderRunningRow()
+    await clickCloseApps()
+
+    expect(allToastText()).toContain(SINGULAR)
+    expect(allToastText()).not.toContain('undefined')
+  })
+})

--- a/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
+++ b/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
@@ -20,13 +20,15 @@ import { createRoot, type Root } from 'react-dom/client'
 
 const notifyMock = vi.fn()
 const killLaunchedAppsMock = vi.fn()
+const switchProfileAppsMock = vi.fn()
+const getProfileSwitchDiffMock = vi.fn()
 
 vi.mock('../../src/renderer/src/lib/electron', () => ({
   launchProfile: vi.fn(),
   killLaunchedApps: (...args: unknown[]) => killLaunchedAppsMock(...args),
   relaunchMissingProfile: vi.fn(),
-  getProfileSwitchDiff: vi.fn(),
-  switchProfileApps: vi.fn()
+  getProfileSwitchDiff: (...args: unknown[]) => getProfileSwitchDiffMock(...args),
+  switchProfileApps: (...args: unknown[]) => switchProfileAppsMock(...args)
 }))
 
 vi.mock('../../src/renderer/src/lib/store', () => ({
@@ -49,10 +51,20 @@ vi.mock('../../src/renderer/src/components/Notify', () => ({
   NotifyProvider: ({ children }: { children: React.ReactNode }) => children
 }))
 
+// Two profiles, so the menu has something to switch *to*. The kill tests only
+// ever needed one, but the switch flow returns early when the clicked profile
+// is already active.
 const PROFILE_SET = {
   activeProfileId: 'default',
-  profiles: [{ id: 'default', name: 'Default' }]
+  profiles: [
+    { id: 'default', name: 'Default' },
+    { id: 'race', name: 'Race' }
+  ]
 }
+
+// Read at render time, not when the mock factory is built, so a test can open
+// the profile menu before mounting.
+let profileMenuOpen = false
 
 vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
   useGameProfile: () => ({
@@ -66,7 +78,7 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
 
 vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
   useProfileMenu: () => ({
-    profileMenuOpen: false,
+    profileMenuOpen,
     setProfileMenuOpen: vi.fn(),
     openProfileMenu: vi.fn(),
     closeProfileMenu: vi.fn(),
@@ -144,14 +156,44 @@ async function clickCloseApps(): Promise<void> {
   })
 }
 
+/**
+ * Click a profile in the open menu, then confirm the "switch while running"
+ * dialog. Both steps are required: the first only stages the confirmation,
+ * and it is the confirmed call that actually runs the kill-then-launch.
+ */
+async function switchToProfile(name: string): Promise<void> {
+  const option = Array.from(container.querySelectorAll('button[role="menuitemradio"]')).find(
+    (button) => button.textContent?.includes(name)
+  ) as HTMLButtonElement | undefined
+  expect(option).toBeDefined()
+  await act(async () => {
+    option!.click()
+  })
+
+  // ConfirmDialog portals to document.body, so it is outside `container`.
+  const confirm = Array.from(document.body.querySelectorAll('button')).find(
+    (button) => button.textContent?.trim() === 'Switch Profile'
+  ) as HTMLButtonElement | undefined
+  expect(confirm).toBeDefined()
+  await act(async () => {
+    confirm!.click()
+  })
+}
+
 /** Everything the toast said, across however many notify() calls. */
 function allToastText(): string {
   return notifyMock.mock.calls.map((call) => String(call[0])).join(' | ')
 }
 
 beforeEach(() => {
+  profileMenuOpen = false
   notifyMock.mockClear()
   killLaunchedAppsMock.mockReset()
+  switchProfileAppsMock.mockReset()
+  getProfileSwitchDiffMock.mockReset()
+  // Non-zero counts are what make the switch prompt for confirmation rather
+  // than silently doing nothing.
+  getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 1, toStartCount: 1 })
 })
 
 afterEach(() => {
@@ -250,5 +292,104 @@ describe('GameRow stranded consent prompt toast (#809)', () => {
 
     expect(allToastText()).toContain(SINGULAR)
     expect(allToastText()).not.toContain('undefined')
+  })
+})
+
+/**
+ * The switch flow kills the outgoing profile's apps *before* it can cancel or
+ * fail, so all three of its exits can be carrying a stranded prompt. The first
+ * version of this fix only handled the success exit, which is the same defect
+ * as #809 itself one layer up: main drains the count to build the result, so
+ * whichever branch drops it drops it permanently, and the user's next Close
+ * Apps is silent too.
+ */
+describe('profile switch stranded consent prompt toast (#809)', () => {
+  const DIALOG_PROMPT = 'Switch to "Race" while the game is running?'
+
+  test('a switch cancelled by Close Apps still explains the stranded prompt', async () => {
+    switchProfileAppsMock.mockResolvedValue({
+      success: false,
+      cancelled: true,
+      message: 'Launch cancelled, closed apps instead.',
+      launchedCount: 0,
+      skippedCount: 0,
+      strandedConsentPrompts: 1
+    })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+    await switchToProfile('Race')
+
+    expect(allToastText()).toContain(SINGULAR)
+    // The cancellation is still reported; the note is appended, not swapped in.
+    expect(allToastText()).toContain('Launch cancelled')
+    expect(allToastText()).not.toContain('undefined')
+  })
+
+  test('a FAILED switch still explains the stranded prompt', async () => {
+    switchProfileAppsMock.mockResolvedValue({
+      success: false,
+      error: 'Failed to start Race apps',
+      launchedCount: 0,
+      skippedCount: 0,
+      strandedConsentPrompts: 1
+    })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+    await switchToProfile('Race')
+
+    expect(allToastText()).toContain(SINGULAR)
+    expect(allToastText()).toContain('Failed to start Race apps')
+  })
+
+  test('a successful switch explains it alongside the switch confirmation', async () => {
+    switchProfileAppsMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skippedCount: 0,
+      strandedConsentPrompts: 2
+    })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+    await switchToProfile('Race')
+
+    expect(allToastText()).toContain(PLURAL)
+  })
+
+  test('an ordinary switch says nothing about a prompt', async () => {
+    switchProfileAppsMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skippedCount: 0
+    })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+    await switchToProfile('Race')
+
+    expect(allToastText()).not.toContain('permission prompt')
+    expect(allToastText()).toContain('Switched to Race')
+  })
+
+  // Guards the harness itself: if the menu or the dialog ever stops rendering,
+  // switchToProfile() would throw rather than pass vacuously, but this pins the
+  // reason the confirmation step exists at all.
+  test('the switch is only attempted after the running-profile dialog is confirmed', async () => {
+    switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 1, skippedCount: 0 })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+
+    const option = Array.from(container.querySelectorAll('button[role="menuitemradio"]')).find(
+      (button) => button.textContent?.includes('Race')
+    ) as HTMLButtonElement
+    await act(async () => {
+      option.click()
+    })
+
+    expect(document.body.textContent).toContain(DIALOG_PROMPT)
+    expect(switchProfileAppsMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

When SimLauncher cancels a pending elevated handoff it kills the PowerShell host. That does stop the app from starting, but it does **not** remove the Windows consent prompt: that UI belongs to the AppInfo service on the secure desktop and is not ours to close. Verified on a real machine on 2026-08-05 (recorded in the issue) - after the kill the prompt stayed up, and answering **Yes** started nothing, silently.

The readings left to the user were "elevation is broken" or "SimLauncher failed to start it". Neither is true.

Both cancellation paths now say the same thing, in the same words:

- **mid-sequence** Close Apps, through the launch summary in `spawn.ts`
- **post-sequence** Close Apps, through the kill result in `kill.ts`, which needed `cancelPendingElevatedHandoffs` to report how many handoffs it actually cancelled

Copy:

> A Windows permission prompt may still be on screen. Answering it will not start the app.

## What it deliberately does not say

Both constraints are from the issue's acceptance and both are pinned by tests:

- **Not** that the app started. It did not, and #779 exists precisely to stop us claiming otherwise about a handoff we killed ourselves.
- **Not** that SimLauncher closed the prompt. It cannot.
- Nothing at all when no handoff was cancelled, so an ordinary cancellation reads exactly as it does today.

## Mutation verification

Six mutations, each anchored so it cannot silently no-op. The point is not just that the tests fail, but that each one fails by the *right* count, which is what shows they discriminate rather than all watching the same thing:

| Mutation | Tests failing | Reading |
|---|---|---|
| sentence never renders | 3 of 4 | the three positive tests catch it, the negative one correctly still passes |
| mid-sequence path drops it | 1 | only the `spawn.ts` test |
| post-sequence path drops it | 2 | the `kill.ts` test and the plural one, both of which route through it |
| plural collapses to singular | 1 | only the plural test |
| note fires even at zero | 2 | the negative test, plus plural (the early return shadows it) |
| cancellation count never increments | 2 | the two `kill.ts`-routed tests; mid-sequence uses its own counter and correctly survives |

## Noted while here, not fixed

`Launch cancelled — closed apps instead.` uses an em dash, against the repo's own copy rule for user-facing strings. It is pinned by four test files and three source sites, so it is not a drive-by. Filed separately rather than smuggled in.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, 0 warnings)
- [x] `npm run typecheck`
- [x] `npm test` (77 files, 577 tests, 4 new)
- [x] `npm run build`
- [x] Mutation matrix above
- [ ] **Manual, and it needs a specific fixture:** on the installed build, in a session where **SimLauncher is NOT running as administrator** (otherwise `launchElevated` is never entered and none of this can fire), launch a profile with an admin-manifest companion, leave the consent prompt unanswered past the 10s grace window, then hit Close Apps. The toast must mention the prompt, must not claim the app started, and the prompt itself is expected to still be on screen. Recorded in the 1.2.0 smoke doc.

Closes #809


<!-- auto-closes -->
Closes #809
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings when cancelling launches, switching profiles, or closing the app may leave Windows permission prompts visible.
  * Clarified that accepting these stranded prompts will not start the app.
  * Added accurate singular and plural messaging for multiple cancelled prompts.
  * Preserved existing messages when no pending permission prompts are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update: two defects found by self-review, before any bot saw it

Both were found by printing the actual toast strings rather than by reading the code, and neither was caught by the first test set.

**1. A cancellation BEFORE the grace window said nothing at all.** The pending-handoff registry is only populated when the grace timer fires, so counting cancellations at the kill entry points saw zero here, even though the abort had already killed the host and left the prompt on screen. Probe output: `killMsg="No running companion apps to close." launchMsg="Launch cancelled — closed apps instead." hostKills=1`. The host died, the prompt stayed, nothing explained it. This is the likelier window of the two: it is what a user who clicks Close Apps within 10s hits.

**2. A cancellation AFTER the grace window said it twice.** Mid-sequence the user receives both the kill result and the launch summary, and both were carrying the sentence for one prompt.

### The fix

Count the fact that matters, once: **a host killed while its consent prompt was pending**. `spawn.ts` notes it at both kill points, guarded to once per handoff (a post-grace Close Apps reaches the same handoff through the abort signal *and* the registry, which is what produced the plural for a single prompt). `kill.ts` drains the counter, so exactly one message reports it, and the launch summary no longer mentions it at all.

### Mutation matrix, re-run on the final shape

| Mutation | Tests failing |
|---|---|
| sentence never renders | 5 of 6 |
| abort path stops noting | 1 |
| registry path stops noting | 3 |
| once-per-handoff guard removed | 1 (the plural test) |
| drain stops resetting | 1 |
| kill result stops appending | 5 |
| launch summary repeats it | 2 |

The drain-reset row is worth calling out: it initially survived with **no** test behind it, meaning the counter would never clear and every later Close Apps in the session would warn about a prompt that was not there. That is the same lie this issue removes, pointed the other way. Test added in 6ed7d14.

579 tests, 6 new.
---

## Update 2: Fable review found the note was invisible on two of four paths

The redesign above still composed the sentence in the main process and put it in `KillResult.message`. Wrong shape, and the consequence was this issue's own defect one layer up: correct copy, produced reliably, shown to nobody.

| Path | Before |
|---|---|
| Close Apps, kill succeeds | shown |
| Close Apps, kill **fails** | **lost.** `GameRow` reads `error`/`failures` there, never `message`. The likelier case, since access-denied is the canonical kill failure for exactly the elevated-tool profiles that can strand a prompt |
| **Profile switch** | **lost.** `ipc/launch.ts` spreads `launchResult` without `message`, and the switch toast is built from `killFailures` / `skipped` / `warning` only |
| Tray Close Apps | shown |

The switch case was the worst: the drain had already consumed the count, so the user's next Close Apps was silent too. "Dropped here" became "dropped everywhere".

Plus a literal bug. `finalizeKillAttempts` returns `message: undefined` when attempts were made and nothing closed, so interpolation produced `"undefined A Windows permission prompt..."`.

### Root cause, and it is not subtle

I invented a shape instead of reading the neighbours. This repo returns structured data from main and composes user-facing copy in the renderer, which is exactly what `formatKillFailures` and `formatSkippedLaunchEntries` already do. Nothing wrote that down, so it is now proposed as a rule in #805, along with the second half: **a test for user-facing copy belongs at the surface that renders it.** All six original tests asserted a main-process return value, which is why all six passed while two delivery paths dropped the string.

### Final shape

- `KillResult` and `LaunchResult` carry `strandedConsentPrompts?: number`
- the switch flow threads it through all three of its returns
- wording lives in `renderer/src/lib/strandedConsentPrompts.ts`
- both `GameRow` kill paths and the switch's `switchWarnings` render it
- the count is drained in each kill entry point's **prologue**, which also closes the window where an overlapping kill's async work could take another kill's count

### Known gap, stated rather than papered over

The switch toast composition in `GameRow` has **no test**. The IPC half is covered (the handler returns the count), but the last step into the component is not: no renderer test in this repo drives a profile switch, they all stub it, so that harness does not exist yet. If a reviewer wants it before merge, say so and I will build it.

## Test plan (updated)

- [x] `npm run format:check`, `lint`, `typecheck`, `build`
- [x] `npm test` — **584 tests**, 78 files
- [x] Main tests assert the count; new `tests/renderer/gameRowStrandedConsentPrompt.test.tsx` asserts the sentence reaches a toast on the success path, the failure path, in the plural, and never as `"undefined"`
- [ ] Manual, needs the non-admin fixture described above


---

## Update 3: the declared gap was real, and a reviewer walked straight into it

Update 2 shipped with the switch toast composition untested, on the grounds that no renderer test in this repo drives a profile switch. CodeRabbit then found a defect in exactly that untested code, which is about as direct a verdict on "declared gap" as it gets. Five review threads in total, three valid.

| Finding | Source | Verdict |
|---|---|---|
| Switch drops the note on the cancelled and failed exits | CodeRabbit | **Valid.** Fixed |
| `killProfileApps` has identical wiring and no coverage | review-bot | **Valid.** Fixed |
| Success-path test named as though the toast confirms the switch | CodeRabbit | **Valid.** Test corrected, behaviour change split out |
| Pre-grace cancellation is never counted | review-bot | Already fixed, this is what moved the count into `state.ts` |
| TSDoc for `cancelPendingElevatedHandoffs` returning a count | CodeRabbit | Stale, it returns `void` again |

### The switch defect

Same shape as the one Update 2 fixed, one layer up. The kill phase runs before the switch can cancel or fail, so all three exits can carry a stranded prompt, and only the success exit reported it. Main drains the count to build the result, so the branch that dropped it dropped it permanently and the user's next Close Apps was silent too.

`formatStrandedConsentPrompts` now runs once above the three branches, matching what `handleKill` already does.

### The harness that did not exist

It does now. Open the menu, click the profile, confirm the running-profile dialog. Five switch tests: cancelled, failed, success, the untouched case, and one pinning that the switch is not attempted before the dialog is confirmed.

### Held, with the reason

CodeRabbit also asked that a successful switch compose the confirmation and the warning rather than replacing it. Declined here: that replacement predates this issue (f3d4088) and applies equally to kill failures, skipped entries and `result.warning`. Changing it for the stranded note alone would leave the other three inconsistent. Filed as #817 for all four together, and the corrected test pins today's behaviour so that issue has something to change.

## Test plan (updated)

- [x] `format:check`, `lint`, `typecheck`, `build`
- [x] `npm test` <- **591 tests**, 78 files
- [x] Mutation verified: neutering each of the three switch branches, and `killProfileApps`' return, each turns the suite red
- [ ] Manual, needs the non-admin fixture described above
