### PR TITLE
fix(kill): attribute a shared companion to its own profile, or to none (#772)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -546,16 +546,78 @@ function getConfiguredGameExePaths(): Set<string> {
   return gameExePaths
 }
 
+interface CompanionTarget {
+  processName: string
+  appPath: string
+  /**
+   * Every profile that configures this target, in enumeration order. Usually
+   * one. More than one is the case #772 is about: a utility shared across
+   * profiles (Oculus Tray Tool, SimHub, CrewChief) has no single owner, and the
+   * map used to silently keep whichever profile was enumerated last.
+   */
+  gameKeys: string[]
+}
+
+/**
+ * Map key for a companion killed by IMAGE NAME (the curated utility list). The
+ * name is the whole identity: one `taskkill /IM` covers every profile that
+ * enabled it, so the same name from two profiles is one target, not two.
+ */
+function companionTargetNameKey(processName: string): string {
+  return `name:${processName.toLowerCase()}`
+}
+
+/**
+ * Map key for a companion killed by PATH (a tracked companion path). The path
+ * is the identity, not the basename: two profiles pointing at two different
+ * `Overlay.exe` files are two separate processes and both need closing. Keying
+ * by basename collapsed them and closed only one (#772).
+ */
+function companionTargetPathKey(processPath: string): string {
+  return `path:${normalizePathForComparison(processPath)}`
+}
+
+/**
+ * The game a failed close should be filed under, or `undefined` when the target
+ * is configured in more than one profile.
+ *
+ * Undefined is the honest answer, not a fallback. For a companion SimLauncher
+ * launched itself the owner is known and comes from `runningProcesses`, which
+ * never reaches this function. What reaches it is a configured companion that is
+ * merely *running*, and when several profiles configure it there is nothing that
+ * makes one of them its owner. Naming one anyway is exactly the defect: it made
+ * a game the user never started surface as having leftover apps, which is why
+ * the tray Close Apps item was pulled before 1.0.0 (#772, blocks #519).
+ *
+ * The failure is still reported either way. `finalizeKillAttempts` builds
+ * `failures` from the attempts alone, so the toast names the app regardless of
+ * whether anything can be attributed.
+ */
+function resolveCompanionTargetGameKey(target: CompanionTarget): string | undefined {
+  return target.gameKeys.length === 1 ? target.gameKeys[0] : undefined
+}
+
 function getProfileCompanionTargets(gameKey?: string) {
   const profiles = getStoredProfiles()
   const gamePaths = getStoredStringRecord('gamePaths')
   const appPaths = getStoredStringRecord('appPaths')
-  const companionTargets = new Map<
-    string,
-    { processName: string; appPath: string; gameKey: string }
-  >()
+  const companionTargets = new Map<string, CompanionTarget>()
 
   const gameExePaths = getConfiguredGameExePaths()
+
+  // Record `profileGameKey` as an owner of `key`, creating the target on first
+  // sight. Never overwrites: a repeated key means another profile configures the
+  // same target, which is information, not a collision to resolve by last write.
+  const addOwner = (key: string, target: Omit<CompanionTarget, 'gameKeys'>, owner: string) => {
+    const existing = companionTargets.get(key)
+    if (!existing) {
+      companionTargets.set(key, { ...target, gameKeys: [owner] })
+      return
+    }
+    if (!existing.gameKeys.includes(owner)) {
+      existing.gameKeys.push(owner)
+    }
+  }
 
   Object.entries(profiles || {}).forEach(([profileGameKey, profileEntry]) => {
     if (gameKey && profileGameKey !== gameKey) {
@@ -571,11 +633,11 @@ function getProfileCompanionTargets(gameKey?: string) {
       if (isUtilityEnabled(profile, utilityKey)) {
         processNames.forEach((processName) => {
           const normalizedProcessName = processName.toLowerCase()
-          companionTargets.set(normalizedProcessName, {
-            processName: normalizedProcessName,
-            appPath: processName,
-            gameKey: profileGameKey
-          })
+          addOwner(
+            companionTargetNameKey(normalizedProcessName),
+            { processName: normalizedProcessName, appPath: processName },
+            profileGameKey
+          )
         })
       }
     })
@@ -585,12 +647,11 @@ function getProfileCompanionTargets(gameKey?: string) {
         if (gameExePaths.has(normalizePathForComparison(processPath))) {
           return
         }
-        const processName = getExeName(processPath)
-        companionTargets.set(processName, {
-          processName,
-          appPath: processPath,
-          gameKey: profileGameKey
-        })
+        addOwner(
+          companionTargetPathKey(processPath),
+          { processName: getExeName(processPath), appPath: processPath },
+          profileGameKey
+        )
       }
     )
   })
@@ -649,7 +710,13 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
     }
 
     const processName = getExeName(appPath)
-    companionTargets.delete(processName)
+    // This process is about to be tree-killed, so drop the companion targets that
+    // would hit it again: its own path, and the curated image-name entry, whose
+    // `taskkill /IM` would cover it by name. A same-named companion at a
+    // DIFFERENT path is deliberately left alone now that paths are keyed by path
+    // rather than by basename — it is a separate process and still needs closing.
+    companionTargets.delete(companionTargetPathKey(appPath))
+    companionTargets.delete(companionTargetNameKey(processName))
 
     if (processNames.has(processName)) {
       suppressProcessNameMismatchWarning(appPath)
@@ -661,7 +728,13 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
   companionTargets.forEach((target) => {
     if (processNames.has(target.processName)) {
-      killTasks.push(killProcessByImageName(target.processName, target.appPath, target.gameKey))
+      killTasks.push(
+        killProcessByImageName(
+          target.processName,
+          target.appPath,
+          resolveCompanionTargetGameKey(target)
+        )
+      )
     }
   })
 

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -416,6 +416,26 @@ export async function finalizeKillAttempts(
   invalidateProcessNameCache()
   const { processNames: processNamesAfterKill, succeeded: tasklistReadSucceeded } =
     await readRunningProcessNames()
+
+  // Image names this batch found something real to kill under. Scheduling is
+  // gated on the tasklist, which knows names and not paths, so once two profiles
+  // can configure two same-named executables at different paths (#772) both get
+  // scheduled even when only one of them is running.
+  //
+  // That matters because "0 PIDs at this path while the image is in the
+  // tasklist" is otherwise read as an invisible elevated process (#390). Here
+  // the image's presence is already accounted for by the sibling attempt that
+  // did find PIDs, so inferring a hidden instance at a DIFFERENT path is
+  // unjustified: it invented a leftover under a profile that had nothing
+  // running, and counted an empty attempt as a closed app (Codex P1 on #818).
+  //
+  // Deliberately narrow. With no sibling to explain the image, the ambiguity is
+  // real and stays unresolved; discriminating name from path in the general case
+  // is #674.
+  const imagesWithConfirmedTarget = new Set(
+    attempts.filter((attempt) => attempt.notFound !== true).map((attempt) => attempt.processName)
+  )
+
   const finalizedAttempts = await Promise.all(
     attempts.map(async (attempt) => {
       // Treat the launched exe's absence from the post-kill tasklist as the
@@ -440,6 +460,14 @@ export async function finalizeKillAttempts(
       const appPath = attempt.appPath
       const isFullPathAttempt = isFullExePath(appPath)
 
+      // This attempt found nothing at its own path, and another attempt in the
+      // same batch did find the image elsewhere. So this path was never running:
+      // not a failure to close, and not a close either.
+      const isEmptySameNameTarget =
+        isFullPathAttempt &&
+        attempt.notFound === true &&
+        imagesWithConfirmedTarget.has(attempt.processName)
+
       let stillRunning: boolean
       let isElevatedInconclusive = false
       if (isFullPathAttempt) {
@@ -450,6 +478,7 @@ export async function finalizeKillAttempts(
         // or elevated-invisible, and the empty processNamesAfterKill Set
         // can't distinguish them. Same for the access-denied recheck.
         isElevatedInconclusive =
+          !isEmptySameNameTarget &&
           !imageGoneFromTasklist &&
           attempt.notFound === true &&
           attempt.staleTask !== true &&
@@ -468,6 +497,7 @@ export async function finalizeKillAttempts(
         ...attempt,
         stillRunning,
         imageGoneFromTasklist,
+        isEmptySameNameTarget,
         accessDenied: attempt.accessDenied || isElevatedInconclusive
       }
     })
@@ -507,7 +537,13 @@ export async function finalizeKillAttempts(
       attempt.stillRunning ||
       (!attempt.success && !attempt.notFound && !attempt.imageGoneFromTasklist)
   )
-  const closedCount = finalizedAttempts.length - failedAttempts.length
+  // An attempt that found nothing at its own path while a sibling accounted for
+  // the image closed nothing, so it is neither a success nor a failure. Counting
+  // it as closed reported one app as two.
+  const emptySameNameTargets = finalizedAttempts.filter(
+    (attempt) => attempt.isEmptySameNameTarget
+  ).length
+  const closedCount = finalizedAttempts.length - failedAttempts.length - emptySameNameTargets
   const failures: KillFailure[] = failedAttempts.map((attempt) => {
     const appPath = attempt.appPath || attempt.processName
     return {

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -664,17 +664,47 @@ function getProfileCompanionTargets(gameKey?: string) {
   // in favour of the path-scoped one, which is strictly more precise and hits
   // the same process.
   //
-  // The old basename keying collapsed these too, but by accident: both landed
-  // on the same Map key and the path branch happened to be enumerated second.
-  // Keying by identity separated them, so the collapse now has to be deliberate.
-  const pathScopedNames = new Set<string>()
+  // The old basename keying collapsed these too, but by accident: both landed on
+  // the same Map key and the path branch happened to be enumerated second.
+  // Keying by identity separated them, so the collapse has to be deliberate --
+  // and, unlike the accident, it has to be narrow.
+  //
+  // Matching on the process name alone is NOT enough. `getProfileTrackablePaths`
+  // pulls `appPaths[key]` exactly when that utility is enabled, so a genuine
+  // duplicate always carries the SAME owners on both scopes. A basename shared
+  // by coincidence does not: another profile's freeform `trackedProcessPaths`
+  // entry can happen to be called the same thing. Collapsing that would delete a
+  // target this profile really configured, leaving the survivor looking uniquely
+  // owned by a profile that never enabled the utility -- #772 reintroduced --
+  // and dropping the `/IM` coverage along with it.
+  //
+  // So a name target is only a duplicate if every profile that owns it also
+  // owns a path target for the same process. Merging the owners instead would
+  // fix the attribution but still lose that coverage.
+  const pathTargetsByName = new Map<string, CompanionTarget[]>()
   companionTargets.forEach((target) => {
-    if (target.scope === 'path') {
-      pathScopedNames.add(target.processName)
+    if (target.scope !== 'path') {
+      return
+    }
+    const existing = pathTargetsByName.get(target.processName)
+    if (existing) {
+      existing.push(target)
+    } else {
+      pathTargetsByName.set(target.processName, [target])
     }
   })
   companionTargets.forEach((target, key) => {
-    if (target.scope === 'name' && pathScopedNames.has(target.processName)) {
+    if (target.scope !== 'name') {
+      return
+    }
+    const pathTargets = pathTargetsByName.get(target.processName)
+    if (!pathTargets) {
+      return
+    }
+    const everyOwnerReachableByPath = target.gameKeys.every((owner) =>
+      pathTargets.some((pathTarget) => pathTarget.gameKeys.includes(owner))
+    )
+    if (everyOwnerReachableByPath) {
       companionTargets.delete(key)
     }
   })

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -436,41 +436,51 @@ export async function finalizeKillAttempts(
   const { processNames: processNamesAfterKill, succeeded: tasklistReadSucceeded } =
     await readRunningProcessNames()
 
-  // Image names this batch found something real to kill under. Scheduling is
-  // gated on the tasklist, which knows names and not paths, so once two profiles
-  // can configure two same-named executables at different paths (#772) both get
-  // scheduled even when only one of them is running.
+  // Paths this batch positively located a process at, grouped by image name.
   //
-  // That matters because "0 PIDs at this path while the image is in the
-  // tasklist" is otherwise read as an invisible elevated process (#390). Here
-  // the image's presence is already accounted for by the sibling attempt that
-  // did find PIDs, so inferring a hidden instance at a DIFFERENT path is
-  // unjustified: it invented a leftover under a profile that had nothing
-  // running, and counted an empty attempt as a closed app (Codex P1 on #818).
+  // Scheduling is gated on the tasklist, which knows names and not paths, so
+  // once two profiles can configure two same-named executables at different
+  // paths (#772) both get scheduled even when only one is running. The absent
+  // one then looks exactly like an invisible elevated process (#390): 0 PIDs at
+  // its path while the image IS in the tasklist. Inferring a hidden instance
+  // there invented a leftover for a profile with nothing running, which is
+  // #772's own symptom (Codex P1 on #818).
   //
-  // Deliberately narrow. With no sibling to explain the image, the ambiguity is
-  // real and stays unresolved; discriminating name from path in the general case
-  // is #674.
+  // Only a PATH-SCOPED sibling at a DIFFERENT path counts as evidence:
   //
-  // KNOWN RESIDUAL, recorded on #674: a sibling that found its target and closed
-  // it successfully still counts as confirmation here, even though the image
-  // surviving in the tasklist afterwards can only be something else -- possibly a
-  // genuinely elevated-invisible process at this very path. Distinguishing the
-  // two needs the post-kill state of each sibling, which is what #674 builds.
-  // The trade is deliberate: the false positive this suppresses (a leftover
-  // invented for a profile with nothing running) is #772's own symptom and far
-  // likelier than the false negative it leaves.
-  // Counted, not a Set, because the test is "did ANOTHER attempt confirm this
-  // image". `targetConfirmed` and `notFound` can both hold on one attempt (PIDs
-  // were discovered, then taskkill found them already gone), so membership alone
-  // would let such an attempt vouch for itself.
-  const confirmedTargetsByImage = new Map<string, number>()
+  //   - a bare-name `/IM` confirmation says only that *some* process with this
+  //     name exists, which may be the very process this path is tracking, so it
+  //     cannot establish that this path was empty (Codex P2 on #818)
+  //   - a lookup that errored confirms nothing at all, which is why this reads
+  //     `targetConfirmed` rather than the absence of `notFound` (CodeRabbit)
+  //   - and the differing path is what stops an attempt vouching for itself,
+  //     since `targetConfirmed` and `notFound` can both hold on one attempt when
+  //     PIDs are found and taskkill then reports them already gone
+  //
+  // Deliberately narrow. With no such sibling the ambiguity is real and stays
+  // unresolved; discriminating name from path in general is #674.
+  //
+  // KNOWN RESIDUAL, recorded on #674: a sibling that located its target and
+  // closed it successfully still counts, even though an image surviving in the
+  // tasklist afterwards can only be something else, possibly a genuinely
+  // elevated-invisible process at this very path. Telling those apart needs each
+  // sibling's POST-kill state, which is what #674 builds. The trade is
+  // deliberate: the false positive suppressed here is far likelier than the
+  // false negative left behind.
+  const confirmedPathsByImage = new Map<string, Set<string>>()
   attempts.forEach((attempt) => {
-    if (attempt.targetConfirmed) {
-      confirmedTargetsByImage.set(
-        attempt.processName,
-        (confirmedTargetsByImage.get(attempt.processName) ?? 0) + 1
-      )
+    if (!attempt.targetConfirmed || !isPathScopedExe(attempt.appPath)) {
+      return
+    }
+    const confirmedPath = normalizePathForComparison(attempt.appPath)
+    if (!confirmedPath) {
+      return
+    }
+    const existing = confirmedPathsByImage.get(attempt.processName)
+    if (existing) {
+      existing.add(confirmedPath)
+    } else {
+      confirmedPathsByImage.set(attempt.processName, new Set([confirmedPath]))
     }
   })
 
@@ -498,18 +508,29 @@ export async function finalizeKillAttempts(
       const appPath = attempt.appPath
       const isFullPathAttempt = isFullExePath(appPath)
 
-      // This attempt found nothing at its own path, and another attempt in the
-      // same batch did find the image elsewhere. So this path was never running:
-      // not a failure to close, and not a close either.
-      const siblingsWithConfirmedTarget =
-        (confirmedTargetsByImage.get(attempt.processName) ?? 0) - (attempt.targetConfirmed ? 1 : 0)
-      const isEmptySameNameTarget =
-        isFullPathAttempt && attempt.notFound === true && siblingsWithConfirmedTarget > 0
-
       let stillRunning: boolean
       let isElevatedInconclusive = false
+      // This attempt found nothing at its own path, before the kill and after
+      // it, while another attempt located the image somewhere else. So this path
+      // was never running: not a failure to close, and not a close either.
+      //
+      // The post-kill half matters for the counting below. Without it, a target
+      // absent at lookup time but running by the recheck would be both "failed"
+      // and "empty", and closedCount subtracts each once (Codex P2 on #818).
+      // Requiring 0 PIDs on the recheck makes the two mutually exclusive by
+      // construction rather than by a second filter.
+      let isEmptySameNameTarget = false
       if (isFullPathAttempt) {
         const { processIds } = await findProcessIdsByExecutablePath(attempt.processName, appPath)
+
+        const ownPath = normalizePathForComparison(appPath)
+        const confirmedPaths = confirmedPathsByImage.get(attempt.processName)
+        isEmptySameNameTarget =
+          attempt.notFound === true &&
+          processIds.length === 0 &&
+          !!confirmedPaths &&
+          Array.from(confirmedPaths).some((confirmedPath) => confirmedPath !== ownPath)
+
         // When the post-kill tasklist read failed, treat any unverified
         // "process gone" signal as inconclusive rather than success: a
         // notFound result from WMI/taskkill could mean either truly exited

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -521,12 +521,20 @@ export async function finalizeKillAttempts(
       // construction rather than by a second filter.
       let isEmptySameNameTarget = false
       if (isFullPathAttempt) {
-        const { processIds } = await findProcessIdsByExecutablePath(attempt.processName, appPath)
+        const { processIds, detail: lookupError } = await findProcessIdsByExecutablePath(
+          attempt.processName,
+          appPath
+        )
 
         const ownPath = normalizePathForComparison(appPath)
         const confirmedPaths = confirmedPathsByImage.get(attempt.processName)
         isEmptySameNameTarget =
           attempt.notFound === true &&
+          // A lookup that FAILED also returns zero PIDs, so the count alone
+          // cannot tell "nothing is there" from "could not look". Same mistake
+          // as reading confirmation off an absent `notFound`, one lookup later
+          // (CodeRabbit on #818).
+          lookupError === undefined &&
           processIds.length === 0 &&
           !!confirmedPaths &&
           Array.from(confirmedPaths).some((confirmedPath) => confirmedPath !== ownPath)

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -549,6 +549,8 @@ function getConfiguredGameExePaths(): Set<string> {
 interface CompanionTarget {
   processName: string
   appPath: string
+  /** Whether this target closes by image name (`/IM`) or scoped to its path. */
+  scope: 'name' | 'path'
   /**
    * Every profile that configures this target, in enumeration order. Usually
    * one. More than one is the case #772 is about: a utility shared across
@@ -635,7 +637,7 @@ function getProfileCompanionTargets(gameKey?: string) {
           const normalizedProcessName = processName.toLowerCase()
           addOwner(
             companionTargetNameKey(normalizedProcessName),
-            { processName: normalizedProcessName, appPath: processName },
+            { processName: normalizedProcessName, appPath: processName, scope: 'name' },
             profileGameKey
           )
         })
@@ -649,11 +651,32 @@ function getProfileCompanionTargets(gameKey?: string) {
         }
         addOwner(
           companionTargetPathKey(processPath),
-          { processName: getExeName(processPath), appPath: processPath },
+          { processName: getExeName(processPath), appPath: processPath, scope: 'path' },
           profileGameKey
         )
       }
     )
+  })
+
+  // A curated utility whose executable path is ALSO configured yields both a
+  // name-keyed and a path-keyed target for the same process. Issuing both would
+  // close one app twice and count it twice, so the image-name entry is dropped
+  // in favour of the path-scoped one, which is strictly more precise and hits
+  // the same process.
+  //
+  // The old basename keying collapsed these too, but by accident: both landed
+  // on the same Map key and the path branch happened to be enumerated second.
+  // Keying by identity separated them, so the collapse now has to be deliberate.
+  const pathScopedNames = new Set<string>()
+  companionTargets.forEach((target) => {
+    if (target.scope === 'path') {
+      pathScopedNames.add(target.processName)
+    }
+  })
+  companionTargets.forEach((target, key) => {
+    if (target.scope === 'name' && pathScopedNames.has(target.processName)) {
+      companionTargets.delete(key)
+    }
   })
 
   return companionTargets

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -45,6 +45,16 @@ export interface KillAttemptResult {
   notFound?: boolean
   staleTask?: boolean
   stillRunning?: boolean
+  /**
+   * Set only when this attempt positively observed a process under
+   * `processName`: PIDs discovered at its path, a tracked child that was really
+   * there, or an `/IM` taskkill that found something to act on.
+   *
+   * Deliberately NOT the inverse of `notFound`. A WMI lookup that errors out
+   * returns neither, and treating that absence as evidence would let a failed
+   * lookup vouch for a sibling it never looked at (CodeRabbit on #818).
+   */
+  targetConfirmed?: boolean
 }
 
 // Hardcoded list of companion process names for utilities that spawn background
@@ -235,13 +245,16 @@ async function killProcessTree(
       error: result.detail,
       accessDenied: result.accessDenied,
       notFound: result.notFound,
-      staleTask: result.staleTask
+      staleTask: result.staleTask,
+      // A tracked child we hold a PID for was a real target unless taskkill
+      // reports it had already exited.
+      targetConfirmed: !result.notFound
     }
   }
 
   try {
     child.kill()
-    return { processName, appPath, gameKey, success: true }
+    return { processName, appPath, gameKey, success: true, targetConfirmed: true }
   } catch (err) {
     const error = getErrorMessage(err)
     console.error(`Error killing ${appPath}:`, err)
@@ -308,7 +321,10 @@ async function killProcessByImageName(
       error: failedResult?.detail,
       accessDenied: failedResult?.accessDenied,
       notFound: results.every((result) => result.notFound),
-      staleTask: results.every((result) => result.staleTask)
+      staleTask: results.every((result) => result.staleTask),
+      // PIDs were discovered at this exact path, so a process under this image
+      // name demonstrably existed.
+      targetConfirmed: true
     }
   }
 
@@ -324,7 +340,10 @@ async function killProcessByImageName(
     error: result.detail,
     accessDenied: result.accessDenied,
     notFound: result.notFound,
-    staleTask: result.staleTask
+    staleTask: result.staleTask,
+    // taskkill either killed something or was denied by something. Any other
+    // failure is ambiguous, so it does not count as evidence.
+    targetConfirmed: result.success || result.accessDenied === true
   }
 }
 
@@ -432,9 +451,28 @@ export async function finalizeKillAttempts(
   // Deliberately narrow. With no sibling to explain the image, the ambiguity is
   // real and stays unresolved; discriminating name from path in the general case
   // is #674.
-  const imagesWithConfirmedTarget = new Set(
-    attempts.filter((attempt) => attempt.notFound !== true).map((attempt) => attempt.processName)
-  )
+  //
+  // KNOWN RESIDUAL, recorded on #674: a sibling that found its target and closed
+  // it successfully still counts as confirmation here, even though the image
+  // surviving in the tasklist afterwards can only be something else -- possibly a
+  // genuinely elevated-invisible process at this very path. Distinguishing the
+  // two needs the post-kill state of each sibling, which is what #674 builds.
+  // The trade is deliberate: the false positive this suppresses (a leftover
+  // invented for a profile with nothing running) is #772's own symptom and far
+  // likelier than the false negative it leaves.
+  // Counted, not a Set, because the test is "did ANOTHER attempt confirm this
+  // image". `targetConfirmed` and `notFound` can both hold on one attempt (PIDs
+  // were discovered, then taskkill found them already gone), so membership alone
+  // would let such an attempt vouch for itself.
+  const confirmedTargetsByImage = new Map<string, number>()
+  attempts.forEach((attempt) => {
+    if (attempt.targetConfirmed) {
+      confirmedTargetsByImage.set(
+        attempt.processName,
+        (confirmedTargetsByImage.get(attempt.processName) ?? 0) + 1
+      )
+    }
+  })
 
   const finalizedAttempts = await Promise.all(
     attempts.map(async (attempt) => {
@@ -463,10 +501,10 @@ export async function finalizeKillAttempts(
       // This attempt found nothing at its own path, and another attempt in the
       // same batch did find the image elsewhere. So this path was never running:
       // not a failure to close, and not a close either.
+      const siblingsWithConfirmedTarget =
+        (confirmedTargetsByImage.get(attempt.processName) ?? 0) - (attempt.targetConfirmed ? 1 : 0)
       const isEmptySameNameTarget =
-        isFullPathAttempt &&
-        attempt.notFound === true &&
-        imagesWithConfirmedTarget.has(attempt.processName)
+        isFullPathAttempt && attempt.notFound === true && siblingsWithConfirmedTarget > 0
 
       let stillRunning: boolean
       let isElevatedInconclusive = false

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -467,6 +467,20 @@ export async function finalizeKillAttempts(
   // sibling's POST-kill state, which is what #674 builds. The trade is
   // deliberate: the false positive suppressed here is far likelier than the
   // false negative left behind.
+  // Image names a bare-name `/IM` attempt actually closed. That kill is not
+  // path-scoped, so it takes down whatever was running under the name, including
+  // whatever a same-named path target was aiming at. Such a path attempt then
+  // finds nothing and would otherwise be counted as a second closed app, one
+  // process reported as two (Codex P2 on #818).
+  //
+  // Used ONLY for counting. It cannot decide that the path was empty, since the
+  // process it closed may be exactly the one that path tracks.
+  const imagesClosedByNameKill = new Set(
+    attempts
+      .filter((attempt) => !isPathScopedExe(attempt.appPath) && attempt.success)
+      .map((attempt) => attempt.processName)
+  )
+
   const confirmedPathsByImage = new Map<string, Set<string>>()
   attempts.forEach((attempt) => {
     if (!attempt.targetConfirmed || !isPathScopedExe(attempt.appPath)) {
@@ -520,24 +534,44 @@ export async function finalizeKillAttempts(
       // Requiring 0 PIDs on the recheck makes the two mutually exclusive by
       // construction rather than by a second filter.
       let isEmptySameNameTarget = false
+      let closedNothing = false
       if (isFullPathAttempt) {
         const { processIds, detail: lookupError } = await findProcessIdsByExecutablePath(
           attempt.processName,
           appPath
         )
 
+        // Verifiably nothing at this path: none before the kill, none after, and
+        // both lookups actually ran. A lookup that FAILED also returns zero PIDs,
+        // so the count alone cannot tell "nothing is there" from "could not
+        // look" -- the same mistake as reading confirmation off an absent
+        // `notFound`, one lookup later (CodeRabbit on #818).
+        const verifiablyEmpty =
+          attempt.notFound === true && lookupError === undefined && processIds.length === 0
+
+        // Whether this path was EMPTY is a stronger claim than whether it closed
+        // anything, and it needs stronger evidence: a confirmed sibling at a
+        // DIFFERENT path. A bare-name `/IM` confirmation cannot serve, because
+        // the process it found may be the very one this path tracks (Codex P2).
+        //
+        // The two are separated because they answer different questions. This
+        // one suppresses the elevated-process inference, so being wrong invents
+        // or hides a leftover. `closedNothing` only decides whether to count the
+        // attempt, and an attempt that found nothing closed nothing no matter
+        // what else was running.
         const ownPath = normalizePathForComparison(appPath)
         const confirmedPaths = confirmedPathsByImage.get(attempt.processName)
         isEmptySameNameTarget =
-          attempt.notFound === true &&
-          // A lookup that FAILED also returns zero PIDs, so the count alone
-          // cannot tell "nothing is there" from "could not look". Same mistake
-          // as reading confirmation off an absent `notFound`, one lookup later
-          // (CodeRabbit on #818).
-          lookupError === undefined &&
-          processIds.length === 0 &&
+          verifiablyEmpty &&
           !!confirmedPaths &&
           Array.from(confirmedPaths).some((confirmedPath) => confirmedPath !== ownPath)
+
+        // Either kind of sibling is enough to say this attempt closed nothing.
+        // Without one, a lone empty attempt keeps its long-standing treatment
+        // rather than having its counting quietly changed here.
+        closedNothing =
+          isEmptySameNameTarget ||
+          (verifiablyEmpty && imagesClosedByNameKill.has(attempt.processName))
 
         // When the post-kill tasklist read failed, treat any unverified
         // "process gone" signal as inconclusive rather than success: a
@@ -565,17 +599,18 @@ export async function finalizeKillAttempts(
         stillRunning,
         imageGoneFromTasklist,
         isEmptySameNameTarget,
+        closedNothing,
         accessDenied: attempt.accessDenied || isElevatedInconclusive
       }
     })
   )
 
-  finalizedAttempts.forEach((attempt) => {
-    const failedToClose =
-      attempt.stillRunning ||
-      (!attempt.success && !attempt.notFound && !attempt.imageGoneFromTasklist)
+  const hasFailedToClose = (attempt: (typeof finalizedAttempts)[number]) =>
+    attempt.stillRunning ||
+    (!attempt.success && !attempt.notFound && !attempt.imageGoneFromTasklist)
 
-    if (failedToClose) {
+  finalizedAttempts.forEach((attempt) => {
+    if (hasFailedToClose(attempt)) {
       registerUnclosedProcess(attempt)
       return
     }
@@ -599,18 +634,15 @@ export async function finalizeKillAttempts(
     })
   })
 
-  const failedAttempts = finalizedAttempts.filter(
-    (attempt) =>
-      attempt.stillRunning ||
-      (!attempt.success && !attempt.notFound && !attempt.imageGoneFromTasklist)
-  )
-  // An attempt that found nothing at its own path while a sibling accounted for
-  // the image closed nothing, so it is neither a success nor a failure. Counting
-  // it as closed reported one app as two.
-  const emptySameNameTargets = finalizedAttempts.filter(
-    (attempt) => attempt.isEmptySameNameTarget
+  const failedAttempts = finalizedAttempts.filter(hasFailedToClose)
+  // Counted by filtering rather than by subtracting two overlapping tallies. An
+  // attempt that verifiably found nothing at its path closed nothing, so it is
+  // neither a success nor a failure: counting it reported one process as two
+  // whenever a sibling had already covered it, and subtracting it separately
+  // could deduct the same attempt twice (Codex P2 on #818).
+  const closedCount = finalizedAttempts.filter(
+    (attempt) => !hasFailedToClose(attempt) && !attempt.closedNothing
   ).length
-  const closedCount = finalizedAttempts.length - failedAttempts.length - emptySameNameTargets
   const failures: KillFailure[] = failedAttempts.map((attempt) => {
     const appPath = attempt.appPath || attempt.processName
     return {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2877,6 +2877,40 @@ test('two profiles pointing at same-named exes in different folders close both (
   expect(killedPids).toEqual(expect.arrayContaining(['1111', '2222']))
 })
 
+test('a curated utility with a configured path is closed once, by path (#772)', async () => {
+  // Regression guard on the fix itself rather than on the original bug. The old
+  // basename keying collapsed the curated-name target and the configured-path
+  // target onto one Map key, so only the path-scoped kill ever ran. Keying by
+  // identity separates them, and without a deliberate collapse this would issue
+  // BOTH an /IM and a path-scoped kill for one app, closing it twice and
+  // counting it twice.
+  const garage61Path = 'C:/Tools/Garage61 telemetry agent.exe'
+  markExistingPath(garage61Path)
+  processNames.add('garage61 telemetry agent.exe')
+  registerProcess(garage61Path, 'garage61 telemetry agent.exe', '9090')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    appPaths: { garage61: garage61Path },
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    }
+  })
+
+  await expect(killLaunchedApps()).resolves.toMatchObject({
+    success: true,
+    closedCount: 1,
+    failedCount: 0
+  })
+
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls).toHaveLength(1)
+  // Path-scoped, so it cannot take down a same-named process from elsewhere.
+  expect(killCalls[0].args).toEqual(['/PID', '9090', '/T', '/F'])
+})
+
 test('pruneUnclosedProcesses removes stale entries and keeps running entries', async () => {
   const { pruneUnclosedProcesses, unclosedProcesses } = await loadProcessModules()
   unclosedProcesses.set('ac:c:\\tools\\stale.exe', {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2965,6 +2965,58 @@ test('a coincidental basename does not collapse another profile away (#772)', as
   expect(unclosedProcesses.has('unknown:garage61 telemetry agent.exe')).toBe(false)
 })
 
+test('a path target covering only one of two owners does not collapse the name target (#772)', async () => {
+  // Found by mutation, not by review: with the collapse condition weakened from
+  // `every` to `some` the whole suite stayed green, which meant nothing pinned
+  // the difference. This is the case that does.
+  //
+  // `ac` enables the curated utility AND tracks its executable; `iracing`
+  // enables the same utility with no path of its own. The path target therefore
+  // covers `ac` but not `iracing`, so it is not a duplicate of the name target
+  // and cannot replace it: collapsing would leave `iracing` with no coverage at
+  // all, since a path-scoped kill only ever touches that one file.
+  const acPath = 'C:/Tools/Garage61 telemetry agent.exe'
+  markExistingPath(acPath)
+  processNames.add('garage61 telemetry agent.exe')
+  registerProcess(acPath, 'garage61 telemetry agent.exe', '5555')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [
+          { id: 'default', name: 'Default', garage61: true, trackedProcessPaths: [acPath] }
+        ]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    }
+  })
+  accessDeniedImageNames.add('garage61 telemetry agent.exe')
+  accessDeniedPids.add('5555')
+
+  await killLaunchedApps()
+
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls.map((call) => call.args)).toEqual(
+    expect.arrayContaining([
+      ['/IM', 'garage61 telemetry agent.exe', '/T', '/F'],
+      ['/PID', '5555', '/T', '/F']
+    ])
+  )
+
+  // The name target is owned by both profiles, so it stays unattributed. The
+  // path target is owned by `ac` alone, so it is attributed.
+  expect(unclosedProcesses.get('unknown:garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: ''
+  })
+  expect(unclosedProcesses.get('ac:c:\\tools\\garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: 'ac'
+  })
+})
+
 test('pruneUnclosedProcesses removes stale entries and keeps running entries', async () => {
   const { pruneUnclosedProcesses, unclosedProcesses } = await loadProcessModules()
   unclosedProcesses.set('ac:c:\\tools\\stale.exe', {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -41,6 +41,9 @@ const pathsAppearingAfterKill = new Set<string>()
 const wmiPathLookupCounts = new Map<string, number>()
 // Paths whose lookup succeeds pre-kill and then FAILS on the post-kill recheck.
 const wmiPostKillLookupErrorPaths = new Set<string>()
+// Image names that stay in the tasklist even after a SUCCESSFUL /IM kill: the
+// kill took down the instances it could, and a protected one survived.
+const imageNamesSurvivingImageKill = new Set<string>()
 // "taskkill /PID reports access-denied, but the image is gone from tasklist
 // afterwards" — used to model #390 where the launched exe's actual running
 // process has a different name, so the wrapper's PID kill fails but the app
@@ -363,7 +366,9 @@ async function loadProcessModules() {
           callback(new Error('Access is denied.'), '', 'Access is denied.')
           return
         }
-        processNames.delete(imageName)
+        if (!imageNamesSurvivingImageKill.has(imageName)) {
+          processNames.delete(imageName)
+        }
       }
       callback(null, '', '')
     }),
@@ -602,6 +607,7 @@ beforeEach(async () => {
   pathsAppearingAfterKill.clear()
   wmiPathLookupCounts.clear()
   wmiPostKillLookupErrorPaths.clear()
+  imageNamesSurvivingImageKill.clear()
   pidsAccessDeniedButImageGone.clear()
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
@@ -3156,6 +3162,41 @@ test('an /IM kill that covered the only instance is not counted twice (#772)', a
   // But there was only ever one process.
   expect(result.closedCount).toBe(1)
   expect(result.failedCount).toBe(0)
+})
+
+// Companion to the /IM subsumption above, and the guard that keeps it from
+// swallowing the earlier P2. A successful /IM is enough to say a same-named path
+// attempt CLOSED NOTHING, but not that the path was EMPTY: here the /IM took
+// down what it could while an elevated instance at iracing's path survived, so
+// the leftover is real and must still be reported.
+test('a successful /IM does not prove a same-named path was empty (#772)', async () => {
+  const iracingPath = 'C:/UserApps/Garage61 telemetry agent.exe'
+  markExistingPath(iracingPath)
+  processNames.add('garage61 telemetry agent.exe')
+  // /IM succeeds, but the image survives because one instance is protected.
+  imageNamesSurvivingImageKill.add('garage61 telemetry agent.exe')
+  // That survivor is iracing's, invisible to WMI the way elevated ones are.
+  inaccessibleExecutablePathProcesses.add('garage61 telemetry agent.exe')
+  registerProcess(iracingPath, 'garage61 telemetry agent.exe', '6666')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingPath] }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  expect(unclosedProcesses.get('iracing:c:\\userapps\\garage61 telemetry agent.exe')).toMatchObject(
+    { gameKey: 'iracing', reason: 'access_denied' }
+  )
 })
 
 test('a same-named path that is not running is not counted as closed (#772)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2736,6 +2736,147 @@ test('killLaunchedApps registers elevated utility companion when image-name fall
   })
 })
 
+// #772. The all-profiles close (no gameKey) walks every profile, and the
+// companion target map used to be keyed by exe BASENAME, so a utility shared
+// across profiles was overwritten and the last profile enumerated won. A failed
+// close was then filed under a game the user had not been playing, which made
+// that game surface as having leftover apps. It is the documented reason the
+// tray Close Apps item was pulled before 1.0.0, and the blocker on #519.
+test('an all-profiles close does not attribute a shared utility to an arbitrary game (#772)', async () => {
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    }
+  })
+  processNames.add('garage61 telemetry agent.exe')
+  accessDeniedImageNames.add('garage61 telemetry agent.exe')
+
+  // No gameKey: the tray/global close.
+  const result = await killLaunchedApps()
+
+  // The user is still told, because `failures` is built from the attempts and
+  // never consults gameKey. Only the attribution is withheld.
+  expect(result).toMatchObject({
+    success: false,
+    failedCount: 1,
+    failures: [
+      expect.objectContaining({ appPath: 'Garage61 telemetry agent.exe', reason: 'access_denied' })
+    ]
+  })
+
+  // Neither game may claim it. Before the fix exactly one of these held, chosen
+  // by store insertion order.
+  expect(unclosedProcesses.has('ac:garage61 telemetry agent.exe')).toBe(false)
+  expect(unclosedProcesses.has('iracing:garage61 telemetry agent.exe')).toBe(false)
+  expect(unclosedProcesses.get('unknown:garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: '',
+    reason: 'access_denied'
+  })
+
+  // One kill, not one per owning profile: the image-name kill already covers
+  // every profile that enabled it.
+  expect(
+    execFileCalls.filter(
+      (call) => call.command === 'taskkill' && call.args.includes('garage61 telemetry agent.exe')
+    )
+  ).toHaveLength(1)
+})
+
+test('an all-profiles close still attributes a utility only one profile enables (#772)', async () => {
+  // The complement of the test above, and the reason the fix cannot simply drop
+  // attribution: with a single owner there is nothing ambiguous to withhold.
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default' }]
+      }
+    }
+  })
+  processNames.add('garage61 telemetry agent.exe')
+  accessDeniedImageNames.add('garage61 telemetry agent.exe')
+
+  await killLaunchedApps()
+
+  expect(unclosedProcesses.get('ac:garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: 'ac',
+    reason: 'access_denied'
+  })
+  expect(unclosedProcesses.has('unknown:garage61 telemetry agent.exe')).toBe(false)
+})
+
+test('a per-game close of a shared utility is unchanged (#772)', async () => {
+  // Per-row Close Apps passes a gameKey, which filters the profile loop to one
+  // entry, so the map could never collide and this path stayed shipped. Pinned
+  // so the fix cannot regress it into the unattributed case.
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    }
+  })
+  processNames.add('garage61 telemetry agent.exe')
+  accessDeniedImageNames.add('garage61 telemetry agent.exe')
+
+  await killLaunchedApps('ac')
+
+  expect(unclosedProcesses.get('ac:garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: 'ac',
+    reason: 'access_denied'
+  })
+})
+
+test('two profiles pointing at same-named exes in different folders close both (#772)', async () => {
+  // The second half of the basename-keying defect, and a silently MISSED kill
+  // rather than a misattributed one: `C:/Tools/Overlay.exe` and
+  // `C:/UserApps/Overlay.exe` are two different processes, but one Map key held
+  // them both, so the all-profiles close only ever closed the survivor.
+  const acOverlay = 'C:/Tools/Overlay.exe'
+  const iracingOverlay = 'C:/UserApps/Overlay.exe'
+  markExistingPath(acOverlay)
+  markExistingPath(iracingOverlay)
+  processNames.add('overlay.exe')
+  registerProcess(acOverlay, 'overlay.exe', '1111')
+  registerProcess(iracingOverlay, 'overlay.exe', '2222')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [acOverlay] }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  const killedPids = execFileCalls
+    .filter((call) => call.command === 'taskkill' && call.args[0] === '/PID')
+    .map((call) => call.args[1])
+  expect(killedPids).toEqual(expect.arrayContaining(['1111', '2222']))
+})
+
 test('pruneUnclosedProcesses removes stale entries and keeps running entries', async () => {
   const { pruneUnclosedProcesses, unclosedProcesses } = await loadProcessModules()
   unclosedProcesses.set('ac:c:\\tools\\stale.exe', {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2911,6 +2911,60 @@ test('a curated utility with a configured path is closed once, by path (#772)', 
   expect(killCalls[0].args).toEqual(['/PID', '9090', '/T', '/F'])
 })
 
+test('a coincidental basename does not collapse another profile away (#772)', async () => {
+  // Raised by both review bots on PR #818 against the collapse above. Profile
+  // `ac` enables the curated utility and configures no path for it; profile
+  // `iracing` happens to track a freeform path whose basename is the same.
+  // Those are two configurations, not one duplicate. Collapsing on the name
+  // alone deleted `ac`'s target, which left the surviving path target looking
+  // uniquely owned by `iracing` -- #772 reintroduced through its own fix -- and
+  // silently dropped the /IM coverage `ac` had asked for.
+  const iracingPath = 'C:/Other/Garage61 telemetry agent.exe'
+  markExistingPath(iracingPath)
+  processNames.add('garage61 telemetry agent.exe')
+  registerProcess(iracingPath, 'garage61 telemetry agent.exe', '7777')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingPath] }]
+      }
+    }
+  })
+  // Both must fail, or whichever succeeds first takes the image out of the
+  // tasklist and the other is finalized as a success with nothing to attribute.
+  accessDeniedImageNames.add('garage61 telemetry agent.exe')
+  accessDeniedPids.add('7777')
+
+  await killLaunchedApps()
+
+  // Both survive: ac's curated /IM and iracing's path-scoped kill.
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls.map((call) => call.args)).toEqual(
+    expect.arrayContaining([
+      ['/IM', 'garage61 telemetry agent.exe', '/T', '/F'],
+      ['/PID', '7777', '/T', '/F']
+    ])
+  )
+
+  // And each is attributed to the profile that actually configured it, since
+  // each has exactly one owner. Neither may be filed under the other's game,
+  // and neither may end up unattributed.
+  expect(unclosedProcesses.get('ac:garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: 'ac'
+  })
+  expect(unclosedProcesses.get('iracing:c:\\other\\garage61 telemetry agent.exe')).toMatchObject({
+    gameKey: 'iracing'
+  })
+  expect(unclosedProcesses.has('iracing:garage61 telemetry agent.exe')).toBe(false)
+  expect(unclosedProcesses.has('unknown:garage61 telemetry agent.exe')).toBe(false)
+})
+
 test('pruneUnclosedProcesses removes stale entries and keeps running entries', async () => {
   const { pruneUnclosedProcesses, unclosedProcesses } = await loadProcessModules()
   unclosedProcesses.set('ac:c:\\tools\\stale.exe', {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -30,6 +30,9 @@ const processNamesGoneAfterWmiLookup = new Set<string>()
 // predicate `processNamesAfterKill.has(processName)` must stay true so the
 // staleTask branch is the only thing keeping isElevatedInconclusive false.
 const processNamesGoneAfterKill = new Set<string>()
+// Executable paths whose WMI/PowerShell lookup fails outright. Distinct from
+// "found nothing": the lookup errored, so it learned nothing either way.
+const wmiLookupErrorPaths = new Set<string>()
 // "taskkill /PID reports access-denied, but the image is gone from tasklist
 // afterwards" — used to model #390 where the launched exe's actual running
 // process has a different name, so the wrapper's PID kill fails but the app
@@ -253,6 +256,15 @@ async function loadProcessModules() {
         // whose executable path matches SIMLAUNCHER_TARGET_PROCESS_PATH AND
         // whose process name matches the queried $name. This is what makes
         // findProcessIdsByExecutablePath path-scoped in production.
+        if (wmiLookupErrorPaths.has(normalizeRegistryKey(targetPathEnv))) {
+          callback(
+            new Error('The RPC server is unavailable.'),
+            '',
+            'The RPC server is unavailable.'
+          )
+          return
+        }
+
         const entry = processRegistry.get(normalizeRegistryKey(targetPathEnv))
         const lookupCount = processName ? (wmiLookupCounts.get(processName) ?? 0) + 1 : 0
         if (processName) {
@@ -556,6 +568,7 @@ beforeEach(async () => {
   staleTaskkillPids.clear()
   processNamesGoneAfterWmiLookup.clear()
   processNamesGoneAfterKill.clear()
+  wmiLookupErrorPaths.clear()
   pidsAccessDeniedButImageGone.clear()
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
@@ -2915,6 +2928,48 @@ test('a same-named path that is not running is not reported as a leftover (#772)
   expect(result.failedCount).toBe(1)
   expect(unclosedProcesses.get('ac:c:\\tools\\overlay.exe')).toMatchObject({ gameKey: 'ac' })
   expect(unclosedProcesses.has('iracing:c:\\userapps\\overlay.exe')).toBe(false)
+})
+
+// CodeRabbit on PR #818, against the fix for the Codex P1 above. The sibling
+// rule originally read "confirmed" as `notFound !== true`, but the lookup-error
+// branch of killProcessByImageName returns neither flag, so a lookup that
+// learned nothing was vouching for a sibling it never looked at. That suppressed
+// a real elevated inference and dropped a genuine leftover.
+test('a sibling whose lookup ERRORED does not vouch for a same-named path (#772)', async () => {
+  const acOverlay = 'C:/Tools/Overlay.exe'
+  const iracingOverlay = 'C:/UserApps/Overlay.exe'
+  markExistingPath(acOverlay)
+  markExistingPath(iracingOverlay)
+  processNames.add('overlay.exe')
+  // ac's lookup blows up, so it confirms nothing about anything.
+  wmiLookupErrorPaths.add(normalizeRegistryKey(acOverlay))
+  // iracing's finds no PIDs while the image is in the tasklist, which is exactly
+  // what an elevated process with a null ExecutablePath looks like (#390).
+  inaccessibleExecutablePathProcesses.add('overlay.exe')
+  registerProcess(iracingOverlay, 'overlay.exe', '3333')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [acOverlay] }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  // The elevated inference must survive: nothing established that the image in
+  // the tasklist belongs to anything other than iracing's own invisible process.
+  expect(unclosedProcesses.get('iracing:c:\\userapps\\overlay.exe')).toMatchObject({
+    gameKey: 'iracing',
+    reason: 'access_denied',
+    elevated: true
+  })
 })
 
 test('a same-named path that is not running is not counted as closed (#772)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2877,6 +2877,77 @@ test('two profiles pointing at same-named exes in different folders close both (
   expect(killedPids).toEqual(expect.arrayContaining(['1111', '2222']))
 })
 
+// Codex P1 on PR #818, and a hazard this PR created. Scheduling is gated on the
+// tasklist, which knows image NAMES only, so once two profiles can hold two
+// same-named paths both get scheduled even when only one of them is running.
+// The absent one's WMI lookup returns 0 PIDs, and the image is in the tasklist
+// because of the OTHER profile's instance.
+test('a same-named path that is not running is not reported as a leftover (#772)', async () => {
+  const acOverlay = 'C:/Tools/Overlay.exe'
+  const iracingOverlay = 'C:/UserApps/Overlay.exe'
+  markExistingPath(acOverlay)
+  markExistingPath(iracingOverlay)
+  processNames.add('overlay.exe')
+  // Only ac's instance exists. iracing's path is configured but nothing runs there.
+  registerProcess(acOverlay, 'overlay.exe', '1111')
+  // ac's kill fails, so the image stays in the tasklist afterwards. That is what
+  // used to make iracing's empty lookup look like an invisible elevated process.
+  accessDeniedPids.add('1111')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [acOverlay] }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  const result = await killLaunchedApps()
+
+  // ac's real instance is the only failure. iracing never had anything here, so
+  // it must not be told it has an app it cannot close: that is #772's symptom,
+  // a phantom leftover on a game the user was not playing.
+  expect(result.failedCount).toBe(1)
+  expect(unclosedProcesses.get('ac:c:\\tools\\overlay.exe')).toMatchObject({ gameKey: 'ac' })
+  expect(unclosedProcesses.has('iracing:c:\\userapps\\overlay.exe')).toBe(false)
+})
+
+test('a same-named path that is not running is not counted as closed (#772)', async () => {
+  // The other half of the same finding. With ac's instance actually closing,
+  // the image leaves the tasklist, which finalize reads as success for EVERY
+  // attempt including iracing's empty one, so one app reported as two.
+  const acOverlay = 'C:/Tools/Overlay.exe'
+  const iracingOverlay = 'C:/UserApps/Overlay.exe'
+  markExistingPath(acOverlay)
+  markExistingPath(iracingOverlay)
+  processNames.add('overlay.exe')
+  processNamesGoneAfterKill.add('overlay.exe')
+  registerProcess(acOverlay, 'overlay.exe', '1111')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [acOverlay] }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  await expect(killLaunchedApps()).resolves.toMatchObject({
+    success: true,
+    closedCount: 1
+  })
+})
+
 test('a curated utility with a configured path is closed once, by path (#772)', async () => {
   // Regression guard on the fix itself rather than on the original bug. The old
   // basename keying collapsed the curated-name target and the configured-path

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -39,6 +39,8 @@ const pathsAppearingAfterKill = new Set<string>()
 // Per-PATH lookup counter. wmiLookupCounts is keyed by process name, which two
 // same-named paths share, so it cannot express "first lookup for this path".
 const wmiPathLookupCounts = new Map<string, number>()
+// Paths whose lookup succeeds pre-kill and then FAILS on the post-kill recheck.
+const wmiPostKillLookupErrorPaths = new Set<string>()
 // "taskkill /PID reports access-denied, but the image is gone from tasklist
 // afterwards" — used to model #390 where the launched exe's actual running
 // process has a different name, so the wrapper's PID kill fails but the app
@@ -262,6 +264,22 @@ async function loadProcessModules() {
         // whose executable path matches SIMLAUNCHER_TARGET_PROCESS_PATH AND
         // whose process name matches the queried $name. This is what makes
         // findProcessIdsByExecutablePath path-scoped in production.
+        if (
+          wmiPostKillLookupErrorPaths.has(normalizeRegistryKey(targetPathEnv)) &&
+          (wmiPathLookupCounts.get(normalizeRegistryKey(targetPathEnv)) ?? 0) >= 1
+        ) {
+          wmiPathLookupCounts.set(
+            normalizeRegistryKey(targetPathEnv),
+            (wmiPathLookupCounts.get(normalizeRegistryKey(targetPathEnv)) ?? 0) + 1
+          )
+          callback(
+            new Error('The RPC server is unavailable.'),
+            '',
+            'The RPC server is unavailable.'
+          )
+          return
+        }
+
         if (wmiLookupErrorPaths.has(normalizeRegistryKey(targetPathEnv))) {
           callback(
             new Error('The RPC server is unavailable.'),
@@ -583,6 +601,7 @@ beforeEach(async () => {
   wmiLookupErrorPaths.clear()
   pathsAppearingAfterKill.clear()
   wmiPathLookupCounts.clear()
+  wmiPostKillLookupErrorPaths.clear()
   pidsAccessDeniedButImageGone.clear()
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
@@ -3061,6 +3080,47 @@ test('a same-named path that respawns before the recheck is only counted once (#
   // deducted twice.
   expect(result.closedCount).toBe(0)
   expect(result.failedCount).toBe(2)
+})
+
+// CodeRabbit on PR #818, and the same mistake as its earlier finding one lookup
+// later: findProcessIdsByExecutablePath returns zero PIDs both when nothing is
+// there and when the lookup itself failed, so the count alone cannot tell those
+// apart. Reading a failed POST-kill lookup as "empty" would suppress a real
+// elevated leftover and subtract it from closedCount.
+test('a FAILED post-kill lookup does not make a path count as empty (#772)', async () => {
+  const acOverlay = 'C:/Tools/Overlay.exe'
+  const iracingOverlay = 'C:/UserApps/Overlay.exe'
+  markExistingPath(acOverlay)
+  markExistingPath(iracingOverlay)
+  processNames.add('overlay.exe')
+  // ac is a genuinely confirmed sibling at a different path, and fails to close
+  // so the image stays in the tasklist.
+  registerProcess(acOverlay, 'overlay.exe', '1111')
+  accessDeniedPids.add('1111')
+  // iracing finds nothing pre-kill, then its recheck blows up.
+  wmiPostKillLookupErrorPaths.add(normalizeRegistryKey(iracingOverlay))
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [acOverlay] }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  // Nothing established that iracing's path was empty, so the elevated
+  // inference stands and its leftover is reported.
+  expect(unclosedProcesses.get('iracing:c:\\userapps\\overlay.exe')).toMatchObject({
+    gameKey: 'iracing',
+    reason: 'access_denied'
+  })
 })
 
 test('a same-named path that is not running is not counted as closed (#772)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -33,6 +33,12 @@ const processNamesGoneAfterKill = new Set<string>()
 // Executable paths whose WMI/PowerShell lookup fails outright. Distinct from
 // "found nothing": the lookup errored, so it learned nothing either way.
 const wmiLookupErrorPaths = new Set<string>()
+// Executable paths that report no PIDs on the FIRST (pre-kill) lookup but do on
+// the post-kill recheck: the process started or respawned in between.
+const pathsAppearingAfterKill = new Set<string>()
+// Per-PATH lookup counter. wmiLookupCounts is keyed by process name, which two
+// same-named paths share, so it cannot express "first lookup for this path".
+const wmiPathLookupCounts = new Map<string, number>()
 // "taskkill /PID reports access-denied, but the image is gone from tasklist
 // afterwards" — used to model #390 where the launched exe's actual running
 // process has a different name, so the wrapper's PID kill fails but the app
@@ -275,13 +281,19 @@ async function loadProcessModules() {
         // the post-kill tasklist recheck still reports the image as present.
         const suppressPidsForPostKill =
           !!processName && lookupCount > 1 && processNamesGoneAfterKill.has(processName)
+        const targetPathKey = normalizeRegistryKey(targetPathEnv)
+        const pathLookupCount = (wmiPathLookupCounts.get(targetPathKey) ?? 0) + 1
+        wmiPathLookupCounts.set(targetPathKey, pathLookupCount)
+        const suppressPidsForPreKill =
+          pathLookupCount <= 1 && pathsAppearingAfterKill.has(targetPathKey)
         const pids: string[] = []
         if (
           entry &&
           (!processName || entry.processName === processName) &&
           processNames.has(entry.processName) &&
           !inaccessibleExecutablePathProcesses.has(entry.processName) &&
-          !suppressPidsForPostKill
+          !suppressPidsForPostKill &&
+          !suppressPidsForPreKill
         ) {
           pids.push(entry.pid)
         }
@@ -569,6 +581,8 @@ beforeEach(async () => {
   processNamesGoneAfterWmiLookup.clear()
   processNamesGoneAfterKill.clear()
   wmiLookupErrorPaths.clear()
+  pathsAppearingAfterKill.clear()
+  wmiPathLookupCounts.clear()
   pidsAccessDeniedButImageGone.clear()
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
@@ -2970,6 +2984,83 @@ test('a sibling whose lookup ERRORED does not vouch for a same-named path (#772)
     reason: 'access_denied',
     elevated: true
   })
+})
+
+// Codex P2 on PR #818. A bare-name /IM confirmation says only that SOME process
+// with that name exists, which may be the very process the other profile tracks
+// by path, so it cannot establish that the path was empty. Only a path-scoped
+// sibling at a different path can.
+test('a curated /IM confirmation does not vouch for a tracked path (#772)', async () => {
+  const iracingOverlay = 'C:/UserApps/Garage61 telemetry agent.exe'
+  markExistingPath(iracingOverlay)
+  processNames.add('garage61 telemetry agent.exe')
+  // ac's curated /IM is denied: something by that name exists and is protected.
+  accessDeniedImageNames.add('garage61 telemetry agent.exe')
+  // iracing's tracked copy looks elevated-invisible, which is the same process.
+  inaccessibleExecutablePathProcesses.add('garage61 telemetry agent.exe')
+  registerProcess(iracingOverlay, 'garage61 telemetry agent.exe', '4444')
+
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  // iracing must keep its leftover. Suppressing it would attribute the failure
+  // to ac alone, which is the misattribution this whole PR exists to remove.
+  expect(unclosedProcesses.get('iracing:c:\\userapps\\garage61 telemetry agent.exe')).toMatchObject(
+    {
+      gameKey: 'iracing',
+      reason: 'access_denied'
+    }
+  )
+})
+
+// Codex P2 on PR #818. An attempt absent at lookup time but running by the
+// post-kill recheck used to be both "failed" and "empty", and closedCount
+// subtracts each once, so one attempt was deducted twice and the count could go
+// negative once every attempt failed.
+test('a same-named path that respawns before the recheck is only counted once (#772)', async () => {
+  const acOverlay = 'C:/Tools/Overlay.exe'
+  const iracingOverlay = 'C:/UserApps/Overlay.exe'
+  markExistingPath(acOverlay)
+  markExistingPath(iracingOverlay)
+  processNames.add('overlay.exe')
+  registerProcess(acOverlay, 'overlay.exe', '1111')
+  registerProcess(iracingOverlay, 'overlay.exe', '2222')
+  // ac is a real, confirmed sibling that fails to close.
+  accessDeniedPids.add('1111')
+  // iracing reports nothing pre-kill and is back by the recheck.
+  pathsAppearingAfterKill.add(normalizeRegistryKey(iracingOverlay))
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [acOverlay] }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingOverlay] }]
+      }
+    }
+  })
+
+  const result = await killLaunchedApps()
+
+  // Two attempts, both still running afterwards. Nothing closed, and nothing
+  // deducted twice.
+  expect(result.closedCount).toBe(0)
+  expect(result.failedCount).toBe(2)
 })
 
 test('a same-named path that is not running is not counted as closed (#772)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3123,6 +3123,41 @@ test('a FAILED post-kill lookup does not make a path count as empty (#772)', asy
   })
 })
 
+// Codex P2 on PR #818. When one profile curated-enables a utility and another
+// tracks a same-named path, both targets are deliberately kept so neither loses
+// coverage. If only the tracked instance is running, the /IM kill takes it down
+// and the path attempt then finds nothing, so one process was reported as two.
+test('an /IM kill that covered the only instance is not counted twice (#772)', async () => {
+  const iracingPath = 'C:/UserApps/Garage61 telemetry agent.exe'
+  markExistingPath(iracingPath)
+  processNames.add('garage61 telemetry agent.exe')
+  registerProcess(iracingPath, 'garage61 telemetry agent.exe', '8888')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: [iracingPath] }]
+      }
+    }
+  })
+
+  const result = await killLaunchedApps()
+
+  // Both targets are still attempted, which is the point of keeping them.
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls.map((call) => call.args)).toEqual(
+    expect.arrayContaining([['/IM', 'garage61 telemetry agent.exe', '/T', '/F']])
+  )
+  // But there was only ever one process.
+  expect(result.closedCount).toBe(1)
+  expect(result.failedCount).toBe(0)
+})
+
 test('a same-named path that is not running is not counted as closed (#772)', async () => {
   // The other half of the same finding. With ac's instance actually closing,
   // the image leaves the tasklist, which finalize reads as success for EVERY


### PR DESCRIPTION
## Summary

`getProfileCompanionTargets` keyed its target map by exe **basename** and wrote `gameKey` from whichever profile the loop happened to be on. With a `gameKey` the loop is filtered to one profile so it could never collide, which is why per-row Close Apps stayed shipped. The all-profiles close walks every profile, so a utility shared across profiles (Oculus Tray Tool, SimHub, CrewChief) was overwritten and **the last profile enumerated won**. A failed close was then filed under a game the user had not been playing, and that game surfaced as having leftover apps.

This is the documented reason the tray Close Apps item was pulled hours before the 1.0.0 tag, and the blocker on re-landing it in #519.

## What changed

Targets are keyed by **identity** instead of basename: curated utilities by process name, configured companions by normalized path. Each target carries **every** profile that configures it rather than a single winner.

Attribution then follows from the data instead of from enumeration order:

| Owners | Attributed to |
|---|---|
| one | that game, exactly as before |
| several | nothing |

`undefined` there is the honest answer, not a fallback. A companion SimLauncher launched itself is attributed from `runningProcesses` and never reaches this code. What does reach it is a companion that is merely *running*, and when several profiles configure it there is no fact that makes one of them its owner. **The failure is still reported either way** — `finalizeKillAttempts` builds `failures` from the attempts alone, so the toast names the app regardless of whether anything can be attributed. What is withheld is only the persistent per-game row, which is the part users saw as a phantom.

## Two things that fell out of it

**A silently missed kill, fixed.** Two profiles pointing at same-named exes in different folders are two different processes. One Map key held them both, so the all-profiles close only ever closed the survivor. Keying paths by path closes both.

**A regression I introduced and then closed.** A curated utility whose executable path is *also* configured produced one Map key under the old scheme (the path branch enumerated second, so it won) and two under the new one. That would have issued both an `/IM` and a path-scoped kill for one app, closing it twice and reporting `closedCount` 2. The collapse is now deliberate and keeps the same winner. No existing test covered an enabled utility with a configured path, which is why the suite stayed green through it.

## `hasClosableLaunchedApps`

The issue asks whether the `KEEP IN SYNC` contract needs the same fix. It does not. It reads `target.processName` only, never `gameKey`, so attribution is irrelevant to it. The keying change can only add entries, never remove them, so its answer can move from false to true but never the reverse: a companion previously collapsed away is now correctly reported as closable, which is the direction #519 wants.

## Test plan

- [x] `format:check`, `lint`, `typecheck`, `build`
- [x] `npm test` - **596 tests**, 78 files
- [x] Five new tests: the shared-utility case, single-owner attribution, the per-game path unchanged, both same-named exes closed, and the curated-utility-with-a-path collapse
- [x] The two defect tests **fail against pre-fix `kill.ts`**; the guard tests pass on both, which is what makes them guards
- [x] Mutation verified: never-attribute, always-first-owner and always-last-owner are each caught, as are removing or inverting the collapse
- [ ] Manual: not reachable from the UI today. The path has no caller until #519 re-lands the tray item, so this is unit-level until then

Closes #772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup when utilities or executables share names or appear in different directories.
  * Ensured configured executable paths are respected, preventing unrelated processes from being affected.
  * Preserved accurate game attribution for uniquely owned utilities while avoiding arbitrary attribution for shared utilities.
  * Prevented duplicate cleanup attempts and phantom failures for non-running, missing, or respawning processes.
  * Improved handling of process lookup failures and cleanup across multiple profiles.

* **Tests**
  * Added regression coverage for shared names, per-game closing, path-specific matching, ownership attribution, lookup failures, and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #772
<!-- auto-closes -->

---

## Update: three review findings, all of them defects this PR introduced

None were in the original bug. All three came from broadening the fix past what #772 asked for, and each is now covered.

| Finding | Source | What it was |
|---|---|---|
| The collapse matched on process name alone | CodeRabbit + review-bot | #772 reintroduced through its own fix |
| `every` could be weakened to `some` | mutation, not review | untested boundary in the collapse |
| A never-running path reported as a leftover | Codex `P1` | #772's symptom again, plus a doubled count |

**The collapse was too broad.** Deleting a name-scoped target whenever *any* path target shared its process name works for a real duplicate, since `getProfileTrackablePaths` pulls `appPaths[key]` exactly when the utility is enabled and both scopes end up with the same owners. It does not work for a basename shared by accident with another profile's freeform `trackedProcessPaths`: that deleted a target the first profile really configured, leaving the survivor looking uniquely owned by a profile that never enabled the utility, and dropping its `/IM` coverage. Review-bot's framing was the sharper one, so the condition is now a superset check rather than the owner merge CodeRabbit proposed, which would have fixed the attribution and still lost the coverage.

**Codex's P1 was the same class one layer down.** Scheduling is gated on the tasklist, which knows image names and not paths, so two same-named paths both get scheduled even when only one is running. The absent one returns 0 PIDs while the image *is* in the tasklist, which `finalizeKillAttempts` reads as an invisible elevated process (#390). Both halves were reproduced with failing tests before any code changed: a leftover registered under a profile with nothing running, and one app counted as two.

The discriminator needs no extra lookups. If another attempt in the same batch found real PIDs for that image, its presence in the tasklist is already accounted for, so a hidden instance at a *different* path cannot be inferred, and an attempt that found nothing is neither a close nor a failure. It stays narrow on purpose: with no sibling to explain the image the ambiguity is real, and the general name-versus-path discriminator is #674, which is in this milestone and blocked by this issue.

## Test plan (updated)

- [x] `format:check`, `lint`, `typecheck`, `build`
- [x] `npm test` <- **600 tests**, 78 files
- [x] Nine tests for #772. The defect tests fail against pre-fix `kill.ts`; the guard tests pass on both
- [x] Codex's two cases written as failing tests first, then fixed
- [x] Mutation verified across all three fixes, eleven mutants, all caught. Notably, making the P1 rule unconditional is caught by the existing #390 test, which is what pins it as narrow rather than blanket
- [ ] Manual: not reachable from the UI until #519 re-lands the tray item
