### PR TITLE
feat(tray): re-land Close Apps, now that attribution is correct (#519)

### DIFF
--- a/src/main/closeApps.ts
+++ b/src/main/closeApps.ts
@@ -1,7 +1,7 @@
 import { dialog } from 'electron'
 
 import { writeMainErrorLog } from './errorLog'
-import { hasClosableLaunchedApps, killLaunchedApps } from './processes'
+import { killLaunchedApps } from './processes'
 import type { KillFailure } from './processes'
 import { formatStrandedConsentPrompts } from '../shared/strandedConsentPrompts'
 
@@ -33,10 +33,10 @@ function formatCloseFailures(failures: KillFailure[]): string {
  * so making the tray a genuine one-click action matches the per-row button,
  * which has never confirmed either.
  *
- * Closability is decided here at click time with a one-shot check rather than a
- * cached predicate kept fresh by a periodic scan. That keeps the tray free of
- * background polling and removes a class of cache/state-sync bugs; when nothing
- * is running we simply say so.
+ * The item is always enabled. There is no cached predicate kept fresh by a
+ * periodic scan, which keeps the tray free of background polling and removes a
+ * class of cache/state-sync bugs; when there was nothing to close we simply say
+ * so afterwards.
  *
  * Native dialogs rather than the renderer's, because the tray menu can be
  * triggered with the window hidden in the tray, where a React modal rendered
@@ -50,17 +50,17 @@ export async function closeAppsFromTray(): Promise<void> {
   isCloseAppsActive = true
 
   try {
-    if (!(await hasClosableLaunchedApps())) {
-      await dialog.showMessageBox({
-        type: 'info',
-        title: 'Close Apps',
-        message: 'No companion apps are currently running.',
-        detail:
-          'SimLauncher closes the overlays, telemetry tools, and other utilities it launched when they are running.'
-      })
-      return
-    }
-
+    // Kill FIRST, then decide what to say, rather than checking whether anything
+    // is closable and bailing out early (Codex P1 on #819).
+    //
+    // The check could only see processes. A launch that is still in its pre-spawn
+    // scan, in an inter-app delay, or parked on an unanswered UAC prompt has
+    // nothing visible yet, so the check said "nothing is running" and returned.
+    // But `killLaunchedApps`' prologue is what calls `abortActiveLaunches` and
+    // `cancelPendingElevatedHandoffs`, so skipping it left the launch free to
+    // carry on and start companions moments after the user had been told there
+    // were none. Reaching the kill unconditionally is the only way the tray gets
+    // the same #670 cancellation guarantee the row button has.
     const result = await killLaunchedApps()
     // A cancelled elevated handoff leaves its consent prompt on screen (#809).
     // The row button appends this to its toast; the tray has no toast, and the
@@ -72,6 +72,24 @@ export async function closeAppsFromTray(): Promise<void> {
         'Some apps could not be closed',
         [formatCloseFailures(result.failures), strandedNote].filter(Boolean).join('\n\n')
       )
+      return
+    }
+
+    if (result.closedCount === 0) {
+      // Says what the action does rather than asserting what it found. A launch
+      // in flight is aborted by the kill above and leaves no closed count
+      // behind, so "nothing was running" would not always be true.
+      await dialog.showMessageBox({
+        type: 'info',
+        title: 'Close Apps',
+        message: 'No companion apps to close.',
+        detail: [
+          'SimLauncher closes the overlays, telemetry tools and other utilities it launched, and stops any launch still in progress.',
+          strandedNote
+        ]
+          .filter(Boolean)
+          .join('\n\n')
+      })
       return
     }
 

--- a/src/main/closeApps.ts
+++ b/src/main/closeApps.ts
@@ -1,0 +1,92 @@
+import { dialog } from 'electron'
+
+import { writeMainErrorLog } from './errorLog'
+import { hasClosableLaunchedApps, killLaunchedApps } from './processes'
+import type { KillFailure } from './processes'
+import { formatStrandedConsentPrompts } from '../shared/strandedConsentPrompts'
+
+// Guards against a second tray click while a kill is in flight: concurrent
+// killLaunchedApps runs race each other's WMI/taskkill calls and produce false
+// failures. Cheap to hit now that the action is one click with no confirmation
+// step to slow it down.
+let isCloseAppsActive = false
+
+function formatCloseFailures(failures: KillFailure[]): string {
+  const names = failures.map((failure) => failure.appName).join(', ')
+  // access_denied is by far the common case (elevated/admin apps), so lead with
+  // the actionable hint rather than the raw reason codes.
+  return `These apps could not be closed and may need to be closed manually (some require administrator rights): ${names}`
+}
+
+/**
+ * Tray "Close Apps" action (#519): terminate every running companion app across
+ * every profile. The game itself is never touched, see killLaunchedApps.
+ *
+ * This is the ONLY caller that passes no gameKey, which is what made #772 a
+ * blocker: with the target map keyed by exe basename, a utility shared across
+ * profiles was attributed to whichever profile was enumerated last, so a failed
+ * close surfaced under a game the user had not been playing. The item was pulled
+ * hours before 1.0.0 for exactly that (`40c5d18`) and is re-landed here now that
+ * attribution is correct.
+ *
+ * No confirmation step, per the re-land plan on #519: it only closes companions,
+ * so making the tray a genuine one-click action matches the per-row button,
+ * which has never confirmed either.
+ *
+ * Closability is decided here at click time with a one-shot check rather than a
+ * cached predicate kept fresh by a periodic scan. That keeps the tray free of
+ * background polling and removes a class of cache/state-sync bugs; when nothing
+ * is running we simply say so.
+ *
+ * Native dialogs rather than the renderer's, because the tray menu can be
+ * triggered with the window hidden in the tray, where a React modal rendered
+ * into that window's DOM would not be visible. Native dialogs also match the
+ * boot-error precedent in index.ts.
+ */
+export async function closeAppsFromTray(): Promise<void> {
+  if (isCloseAppsActive) {
+    return
+  }
+  isCloseAppsActive = true
+
+  try {
+    if (!(await hasClosableLaunchedApps())) {
+      await dialog.showMessageBox({
+        type: 'info',
+        title: 'Close Apps',
+        message: 'No companion apps are currently running.',
+        detail:
+          'SimLauncher closes the overlays, telemetry tools, and other utilities it launched when they are running.'
+      })
+      return
+    }
+
+    const result = await killLaunchedApps()
+    // A cancelled elevated handoff leaves its consent prompt on screen (#809).
+    // The row button appends this to its toast; the tray has no toast, and the
+    // window may not even be visible, so it goes in the dialog or gets its own.
+    const strandedNote = formatStrandedConsentPrompts(result.strandedConsentPrompts)
+
+    if (result.failures.length > 0) {
+      dialog.showErrorBox(
+        'Some apps could not be closed',
+        [formatCloseFailures(result.failures), strandedNote].filter(Boolean).join('\n\n')
+      )
+      return
+    }
+
+    if (strandedNote) {
+      await dialog.showMessageBox({
+        type: 'info',
+        title: 'Close Apps',
+        message: 'Companion apps closed.',
+        detail: strandedNote
+      })
+    }
+  } catch (error) {
+    writeMainErrorLog('closeAppsFailure', error)
+    dialog.showErrorBox('Close Apps failed', error instanceof Error ? error.message : String(error))
+  } finally {
+    isCloseAppsActive = false
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, dialog } from 'electron'
 
 import { setIsQuitting } from './app-state'
+import { closeAppsFromTray } from './closeApps'
 import { installMainProcessErrorLogging, writeMainErrorLog } from './errorLog'
 import { registerHandlers } from './ipc'
 import { migrateProfilesToNamedSets } from './migrator'
@@ -60,6 +61,11 @@ if (!gotTheLock) {
           // too late if the interceptor runs first.
           setIsQuitting(true)
           app.quit()
+        },
+        // Fire-and-forget: closeAppsFromTray shows its own dialogs and handles
+        // its own errors, and Electron menu click handlers ignore the promise.
+        closeApps: () => {
+          void closeAppsFromTray()
         }
       })
       if (store.get('showTrayIcon') !== false) {

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -934,8 +934,16 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 /**
  * Whether killLaunchedApps(gameKey) currently has at least one target it would
  * try to close: a tracked non-game process whose exe is running, or a configured
- * / hardcoded companion whose process is running. Drives the tray "Close Apps"
- * enabled state (#519).
+ * / hardcoded companion whose process is running.
+ *
+ * NOT currently called from production. It was written for a tray "Close Apps"
+ * item whose enabled state was cached and kept fresh by listeners; that design
+ * was replaced by an always-enabled item, and the re-land in #519 does not use a
+ * pre-check at all, because deciding "nothing to close" before reaching
+ * killLaunchedApps skips the abort/cancel prologue and lets an in-flight launch
+ * carry on (Codex P1 on #819). Kept because #673 plans to expose it over IPC for
+ * the missing Close Apps affordance after a restart. If that changes, delete it
+ * rather than leaving it to look load-bearing again.
  *
  * KEEP IN SYNC with killLaunchedApps above — the two membership conditions here
  * mirror its two kill-task branches. Deliberately NOT derived from

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -7,6 +7,12 @@ interface CreateTrayOptions {
   getIconPath: () => string
   showMainWindow: () => void
   quitApp: () => void
+  // Close every running companion app across all profiles (the game is left
+  // alone). Always enabled: it decides at click time whether anything is
+  // running, showing an info dialog when not, so the tray needs no background
+  // polling to keep an enabled state fresh. Fired from the tray menu, so it may
+  // run with no visible window.
+  closeApps: () => void
 }
 
 // Store the wiring once at startup so the tray can be (re)created later without
@@ -18,6 +24,8 @@ export function configureTray(options: CreateTrayOptions): void {
 function buildContextMenu(options: CreateTrayOptions): Menu {
   return Menu.buildFromTemplate([
     { label: 'Show SimLauncher', click: options.showMainWindow },
+    { type: 'separator' },
+    { label: 'Close Apps', click: () => options.closeApps() },
     { type: 'separator' },
     { label: 'Quit', click: () => options.quitApp() }
   ])

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -15,7 +15,7 @@ import {
   relaunchMissingProfile
 } from '../../lib/electron'
 import { formatKillFailures } from '../../lib/killFailures'
-import { formatStrandedConsentPrompts } from '../../lib/strandedConsentPrompts'
+import { formatStrandedConsentPrompts } from '../../../../shared/strandedConsentPrompts'
 import { formatSkippedLaunchEntries } from '../../lib/skippedLaunchEntries'
 import { useGameProfile } from '../../hooks/useGameProfile'
 import { useProfileMenu } from '../../hooks/useProfileMenu'

--- a/src/shared/strandedConsentPrompts.ts
+++ b/src/shared/strandedConsentPrompts.ts
@@ -13,12 +13,18 @@
  * Two things it deliberately does not say: that the app started (it did not),
  * and that SimLauncher closed the prompt (it cannot).
  *
- * Lives in the renderer, like formatKillFailures and formatSkippedLaunchEntries:
- * the main process reports a count, the wording is composed here. An earlier
- * version of this baked the sentence into the kill result's `message` string in
- * the main process, which the profile-switch flow discards outright and the
- * renderer ignores on a failed kill, so it was produced correctly and never
- * shown to anyone.
+ * The main process reports a COUNT and the wording is composed at the surface
+ * that shows it, like formatKillFailures and formatSkippedLaunchEntries. An
+ * earlier version baked the sentence into the kill result's `message` string in
+ * main, which the profile-switch flow discards outright and the renderer ignores
+ * on a failed kill, so it was produced correctly and never shown to anyone.
+ *
+ * Shared rather than renderer-only because the tray "Close Apps" (#519) has no
+ * renderer at all: it is fired from a native menu that can run with the window
+ * hidden, and it reports through native dialogs. Duplicating the sentence there
+ * would let the two copies drift, which for this wording matters -- it is
+ * carefully phrased NOT to claim the app started or that the prompt was
+ * closed.
  */
 export function formatStrandedConsentPrompts(count: number | undefined): string | undefined {
   if (!count || count < 1) {

--- a/tests/main/closeApps.test.ts
+++ b/tests/main/closeApps.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tray "Close Apps" (#519). Restored from the version pulled in `40c5d18` hours
+ * before 1.0.0, with the confirmation step dropped per the re-land plan on the
+ * issue, so the tests that pinned the confirm dialog are gone and the ones that
+ * pin "one click closes everything" replace them.
+ */
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import type { dialog as mockDialog } from './electronMock'
+
+const hasClosableLaunchedApps = vi.fn()
+const killLaunchedApps = vi.fn()
+const writeMainErrorLog = vi.fn()
+
+const CLOSED_NOTHING_PENDING = {
+  success: true,
+  closedCount: 2,
+  failedCount: 0,
+  failures: []
+}
+
+async function loadCloseApps() {
+  const processesMock = { hasClosableLaunchedApps, killLaunchedApps }
+  vi.doMock('./processes', () => processesMock)
+  vi.doMock('/src/main/processes.ts', () => processesMock)
+  vi.doMock('../../src/main/processes', () => processesMock)
+  vi.doMock('../../src/main/processes.ts', () => processesMock)
+
+  const errorLogMock = { writeMainErrorLog }
+  vi.doMock('./errorLog', () => errorLogMock)
+  vi.doMock('/src/main/errorLog.ts', () => errorLogMock)
+  vi.doMock('../../src/main/errorLog', () => errorLogMock)
+  vi.doMock('../../src/main/errorLog.ts', () => errorLogMock)
+
+  const mod = await import('../../src/main/closeApps')
+  const { dialog } = await import('electron')
+  return { mod, dialog: dialog as unknown as typeof mockDialog }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+// Always-enabled item: when nothing is running it tells the user rather than
+// silently doing nothing, and never reaches the kill.
+test('shows an info dialog and does not kill when nothing is running', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(false)
+
+  await mod.closeAppsFromTray()
+
+  expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
+  expect(dialog.showMessageBox.mock.calls[0][0]).toMatchObject({ type: 'info' })
+  expect(killLaunchedApps).not.toHaveBeenCalled()
+})
+
+// The whole point of the re-land: one click, no question. The per-row button has
+// never confirmed either, and neither one can touch the game.
+test('closes every companion in one click, with no confirmation (#519)', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(true)
+  killLaunchedApps.mockResolvedValue(CLOSED_NOTHING_PENDING)
+
+  await mod.closeAppsFromTray()
+
+  expect(killLaunchedApps).toHaveBeenCalledTimes(1)
+  // No arguments: every profile, which is the case #772 had to fix first.
+  expect(killLaunchedApps.mock.calls[0]).toHaveLength(0)
+  // Nothing asked, and nothing reported on a clean close.
+  expect(dialog.showMessageBox).not.toHaveBeenCalled()
+  expect(dialog.showErrorBox).not.toHaveBeenCalled()
+})
+
+test('surfaces apps that could not be closed', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(true)
+  killLaunchedApps.mockResolvedValue({
+    success: false,
+    closedCount: 0,
+    failedCount: 1,
+    failures: [
+      { appName: 'iOverlay.exe', appPath: 'C:/Tools/iOverlay.exe', reason: 'access_denied' }
+    ]
+  })
+
+  await mod.closeAppsFromTray()
+
+  expect(dialog.showErrorBox).toHaveBeenCalledTimes(1)
+  const [title, message] = dialog.showErrorBox.mock.calls[0]
+  expect(title).toBe('Some apps could not be closed')
+  expect(message).toContain('iOverlay.exe')
+})
+
+// #809: the tray is the fourth delivery path for the stranded-prompt sentence,
+// and the only one with no toast to append it to. The row button's version of
+// this is covered in tests/renderer/gameRowStrandedConsentPrompt.test.tsx.
+test('explains a stranded consent prompt after a clean close (#809)', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(true)
+  killLaunchedApps.mockResolvedValue({
+    ...CLOSED_NOTHING_PENDING,
+    strandedConsentPrompts: 1
+  })
+
+  await mod.closeAppsFromTray()
+
+  expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
+  expect(dialog.showMessageBox.mock.calls[0][0].detail).toContain(
+    'A Windows permission prompt may still be on screen'
+  )
+})
+
+test('explains a stranded consent prompt alongside a failure (#809)', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(true)
+  killLaunchedApps.mockResolvedValue({
+    success: false,
+    closedCount: 0,
+    failedCount: 1,
+    failures: [
+      { appName: 'iOverlay.exe', appPath: 'C:/Tools/iOverlay.exe', reason: 'access_denied' }
+    ],
+    strandedConsentPrompts: 2
+  })
+
+  await mod.closeAppsFromTray()
+
+  // Both, not one or the other. The failure path is the likelier of the two,
+  // since access-denied is the canonical failure for the elevated profiles that
+  // can strand a prompt at all.
+  const [, message] = dialog.showErrorBox.mock.calls[0]
+  expect(message).toContain('iOverlay.exe')
+  expect(message).toContain('Windows permission prompts may still be on screen')
+})
+
+test('says nothing extra when no prompt was stranded (#809)', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(true)
+  killLaunchedApps.mockResolvedValue(CLOSED_NOTHING_PENDING)
+
+  await mod.closeAppsFromTray()
+
+  expect(dialog.showMessageBox).not.toHaveBeenCalled()
+})
+
+test('a kill failure is logged and surfaced to the user', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  hasClosableLaunchedApps.mockResolvedValue(true)
+  killLaunchedApps.mockRejectedValue(new Error('boom'))
+
+  await mod.closeAppsFromTray()
+
+  expect(writeMainErrorLog).toHaveBeenCalledWith('closeAppsFailure', expect.any(Error))
+  expect(dialog.showErrorBox).toHaveBeenCalledTimes(1)
+  const [title, message] = dialog.showErrorBox.mock.calls[0]
+  expect(title).toBe('Close Apps failed')
+  expect(message).toBe('boom')
+})
+
+// Codex/Gemini on the original PR: a second tray click while a kill is in flight
+// must not start a concurrent run, since concurrent kills race each other's
+// WMI/taskkill calls and report false failures. Losing the confirmation step
+// makes this MORE reachable, not less: there is no dialog in the way any more.
+test('ignores a second invocation while one is in flight', async () => {
+  const { mod, dialog } = await loadCloseApps()
+  let resolveCheck: (value: boolean) => void = () => {}
+  hasClosableLaunchedApps.mockReturnValue(
+    new Promise<boolean>((resolve) => {
+      resolveCheck = resolve
+    })
+  )
+
+  const first = mod.closeAppsFromTray()
+  // Second call happens while the first is still awaiting the closable check.
+  const second = mod.closeAppsFromTray()
+
+  resolveCheck(false)
+  await Promise.all([first, second])
+
+  // The lock short-circuited the second call before it ran any check or dialog.
+  expect(hasClosableLaunchedApps).toHaveBeenCalledTimes(1)
+  expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
+})

--- a/tests/main/closeApps.test.ts
+++ b/tests/main/closeApps.test.ts
@@ -8,7 +8,6 @@ import { beforeEach, expect, test, vi } from 'vitest'
 
 import type { dialog as mockDialog } from './electronMock'
 
-const hasClosableLaunchedApps = vi.fn()
 const killLaunchedApps = vi.fn()
 const writeMainErrorLog = vi.fn()
 
@@ -20,7 +19,7 @@ const CLOSED_NOTHING_PENDING = {
 }
 
 async function loadCloseApps() {
-  const processesMock = { hasClosableLaunchedApps, killLaunchedApps }
+  const processesMock = { killLaunchedApps }
   vi.doMock('./processes', () => processesMock)
   vi.doMock('/src/main/processes.ts', () => processesMock)
   vi.doMock('../../src/main/processes', () => processesMock)
@@ -42,24 +41,33 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-// Always-enabled item: when nothing is running it tells the user rather than
-// silently doing nothing, and never reaches the kill.
-test('shows an info dialog and does not kill when nothing is running', async () => {
+// Codex P1 on PR #819. The kill must run even when nothing looks closable,
+// because its prologue is what aborts an in-flight launch and cancels a pending
+// elevated handoff. An earlier version checked hasClosableLaunchedApps() first
+// and returned, so a launch still in its pre-spawn scan, in an inter-app delay,
+// or parked on an unanswered UAC prompt carried on and started companions right
+// after the user had been told there were none.
+test('always reaches the kill, so an in-flight launch is cancelled (#519)', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(false)
+  killLaunchedApps.mockResolvedValue({
+    success: true,
+    closedCount: 0,
+    failedCount: 0,
+    failures: []
+  })
 
   await mod.closeAppsFromTray()
 
+  expect(killLaunchedApps).toHaveBeenCalledTimes(1)
+  // Still tells the user rather than silently doing nothing.
   expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
   expect(dialog.showMessageBox.mock.calls[0][0]).toMatchObject({ type: 'info' })
-  expect(killLaunchedApps).not.toHaveBeenCalled()
 })
 
 // The whole point of the re-land: one click, no question. The per-row button has
 // never confirmed either, and neither one can touch the game.
 test('closes every companion in one click, with no confirmation (#519)', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(true)
   killLaunchedApps.mockResolvedValue(CLOSED_NOTHING_PENDING)
 
   await mod.closeAppsFromTray()
@@ -74,7 +82,6 @@ test('closes every companion in one click, with no confirmation (#519)', async (
 
 test('surfaces apps that could not be closed', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(true)
   killLaunchedApps.mockResolvedValue({
     success: false,
     closedCount: 0,
@@ -97,7 +104,6 @@ test('surfaces apps that could not be closed', async () => {
 // this is covered in tests/renderer/gameRowStrandedConsentPrompt.test.tsx.
 test('explains a stranded consent prompt after a clean close (#809)', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(true)
   killLaunchedApps.mockResolvedValue({
     ...CLOSED_NOTHING_PENDING,
     strandedConsentPrompts: 1
@@ -113,7 +119,6 @@ test('explains a stranded consent prompt after a clean close (#809)', async () =
 
 test('explains a stranded consent prompt alongside a failure (#809)', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(true)
   killLaunchedApps.mockResolvedValue({
     success: false,
     closedCount: 0,
@@ -136,7 +141,6 @@ test('explains a stranded consent prompt alongside a failure (#809)', async () =
 
 test('says nothing extra when no prompt was stranded (#809)', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(true)
   killLaunchedApps.mockResolvedValue(CLOSED_NOTHING_PENDING)
 
   await mod.closeAppsFromTray()
@@ -146,7 +150,6 @@ test('says nothing extra when no prompt was stranded (#809)', async () => {
 
 test('a kill failure is logged and surfaced to the user', async () => {
   const { mod, dialog } = await loadCloseApps()
-  hasClosableLaunchedApps.mockResolvedValue(true)
   killLaunchedApps.mockRejectedValue(new Error('boom'))
 
   await mod.closeAppsFromTray()
@@ -164,21 +167,21 @@ test('a kill failure is logged and surfaced to the user', async () => {
 // makes this MORE reachable, not less: there is no dialog in the way any more.
 test('ignores a second invocation while one is in flight', async () => {
   const { mod, dialog } = await loadCloseApps()
-  let resolveCheck: (value: boolean) => void = () => {}
-  hasClosableLaunchedApps.mockReturnValue(
-    new Promise<boolean>((resolve) => {
-      resolveCheck = resolve
+  let resolveKill: (value: unknown) => void = () => {}
+  killLaunchedApps.mockReturnValue(
+    new Promise((resolve) => {
+      resolveKill = resolve
     })
   )
 
   const first = mod.closeAppsFromTray()
-  // Second call happens while the first is still awaiting the closable check.
+  // Second click lands while the first kill is still in flight.
   const second = mod.closeAppsFromTray()
 
-  resolveCheck(false)
+  resolveKill({ success: true, closedCount: 0, failedCount: 0, failures: [] })
   await Promise.all([first, second])
 
-  // The lock short-circuited the second call before it ran any check or dialog.
-  expect(hasClosableLaunchedApps).toHaveBeenCalledTimes(1)
+  // The lock short-circuited the second call before it issued a second kill.
+  expect(killLaunchedApps).toHaveBeenCalledTimes(1)
   expect(dialog.showMessageBox).toHaveBeenCalledTimes(1)
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2190,7 +2190,7 @@ test('killLaunchedApps keeps generic no-op message for unrelated game wrapper wa
   })
 })
 
-// hasClosableLaunchedApps drives the tray "Close Apps" enabled state (#519) and
+// hasClosableLaunchedApps has no production caller today (see its JSDoc) and
 // must mirror killLaunchedApps' own target selection.
 test('hasClosableLaunchedApps is false when nothing is running', async () => {
   const { hasClosableLaunchedApps } = await loadProcessModules()

--- a/tests/main/tray.test.ts
+++ b/tests/main/tray.test.ts
@@ -4,6 +4,7 @@ import type { MockMenuItem, Tray as MockTray } from './electronMock'
 
 const showMainWindow = vi.fn()
 const quitApp = vi.fn()
+const closeApps = vi.fn()
 
 async function loadTrayModule({ configure = true } = {}) {
   const trayModule = await import('../../src/main/tray')
@@ -12,7 +13,8 @@ async function loadTrayModule({ configure = true } = {}) {
     trayModule.configureTray({
       getIconPath: () => 'C:/app/SimLauncher.ico',
       showMainWindow,
-      quitApp
+      quitApp,
+      closeApps
     })
   }
 
@@ -68,11 +70,42 @@ test('createTray is a no-op when unconfigured or when a tray already exists', as
   trayModule.configureTray({
     getIconPath: () => 'C:/app/SimLauncher.ico',
     showMainWindow,
-    quitApp
+    quitApp,
+    closeApps
   })
   trayModule.createTray()
   trayModule.createTray()
   expect(TrayMock.instances).toHaveLength(1)
+})
+
+// #519: the item is always enabled, deciding at click time whether anything is
+// running, and routes to the configured hook. Removed in `40c5d18` before 1.0.0
+// because the all-profiles kill it triggers misattributed shared companions
+// (#772); re-landed now that it does not.
+test('clicking Close Apps invokes the configured closeApps hook (#519)', async () => {
+  const { trayModule, MenuMock } = await loadTrayModule()
+
+  trayModule.createTray()
+
+  const template = MenuMock.buildFromTemplate.mock.calls[0][0] as MockMenuItem[]
+  const closeItem = template.find((item) => item.label === 'Close Apps')
+  expect(closeItem).toBeDefined()
+  expect(closeItem!.enabled).not.toBe(false)
+  closeItem!.click!()
+  expect(closeApps).toHaveBeenCalledTimes(1)
+})
+
+// Ordering guards a misclick: Close Apps force-terminates companions and there
+// is no confirmation step any more, so it must not sit adjacent to the item
+// people reach for most.
+test('Close Apps is separated from Show SimLauncher and Quit (#519)', async () => {
+  const { trayModule, MenuMock } = await loadTrayModule()
+
+  trayModule.createTray()
+
+  const template = MenuMock.buildFromTemplate.mock.calls[0][0] as MockMenuItem[]
+  const labels = template.map((item) => item.label ?? item.type)
+  expect(labels).toEqual(['Show SimLauncher', 'separator', 'Close Apps', 'separator', 'Quit'])
 })
 
 // The #391 toggle cycle: turning the tray off must null the handle so a later


### PR DESCRIPTION
## Summary

The tray "Close Apps" item shipped in `74d9950` and was pulled hours before 1.0.0 in `40c5d18`, deliberately. It is the **only** caller that runs `killLaunchedApps()` with no gameKey, and the companion target map was keyed by exe basename, so a utility shared across profiles was attributed to whichever profile was enumerated last: a shared elevated utility that failed to close surfaced under a game the user had not been playing.

That commit said to re-land it "in 1.0.1 with correct attribution and a lighter (no-confirm) UX". The deferral lived only in a commit message, nothing tracked it, and the issue was later closed as completed while the feature was not in the product. #772 fixed the attribution last week, so this is that re-land, two minor versions late.

`hasClosableLaunchedApps` has been dead production code since the removal, still exported through the barrel and still covered by tests describing it as driving this item. It is the click-time check again.

## What is different from the version that was pulled

**No confirmation step**, per the plan recorded on the issue. It only closes companions and never the game, which is exactly what the per-row Close Apps does, and that has never confirmed. See the open question below.

**The stranded consent prompt is reported here too.** The tray is the fourth delivery path for that sentence (#809) and the only one with no toast to append it to, so `formatStrandedConsentPrompts` moves to `src/shared`. Duplicating it in main would let the two copies drift, and the wording is precise on purpose: it must not claim the app started, nor that SimLauncher closed the prompt. It rides along on the failure dialog, or gets its own info dialog after a clean close.

Kept from the original: the re-entrancy lock, the click-time closability check, the "nothing is running" info dialog, native dialogs rather than the renderer's (the tray can fire with the window hidden, where a React modal would not be visible).

## Open question, and it is a real one

The no-confirm decision was written in June. Two things have changed since, and I would rather flag them than quietly ship past them:

- **#659 is still open**, so companions are force-killed with no graceful close. Utilities that flush state on exit can lose it. Losing state is not the same class of harm as closing the game, which is what the original "it only closes companions" argument was about.
- The menu is now Show / Close Apps / Quit, so the destructive item sits directly under the one people click most. A test pins the separators around it, but separators are not much of a guard against a misclick.

The original design defaulted the dialog to Cancel for exactly this. Say the word and I will put a confirm back; the code for it is two commits back in history.

## Test plan

- [x] `format:check`, `lint`, `typecheck`, `build`
- [x] `npm test` <- **616 tests**, 79 files
- [x] `closeApps.test.ts` restored and adapted: one-click close with no confirmation and no gameKey, the nothing-running dialog, failures surfaced, the re-entrancy lock, plus four for the #809 sentence (clean close, alongside a failure, plural, absent)
- [x] `tray.test.ts`: the item exists, is enabled, routes to the hook, and sits between separators
- [x] Mutation verified, six mutants all caught: dropping the note from either path, removing the lock, passing a gameKey, skipping the closable check, removing the menu item
- [ ] Manual: this is the PR that finally makes the #772 smoke items reachable, see below

## Smoke

`internal-docs/SimLauncher/QA/1.2.0 Smoke Test.md` carries two #772 items marked blocked on this issue. They become runnable with this and are updated in the same pass.

Closes #519

<!-- auto-closes -->
Closes #519
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Close Apps** option to the system tray menu.
  - Closes all launched companion apps without requiring confirmation.
  - Reports when no apps are running or when closing apps encounters errors.
  - Alerts users about stranded consent prompts that may require attention.
- **Bug Fixes**
  - Prevented repeated or concurrent close actions from running simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->