### PR TITLE
docs: record the approaches that keep arriving as PRs and keep getting closed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,28 @@ Electron desktop app for simracing enthusiasts — React + TypeScript + Tailwind
 - Comment the WHY, not the WHAT — explain non-obvious decisions, constraints, invariants, gotchas, and security-sensitive steps; never write comments that restate the code.
 - Doc-comment public/exported items (TS JSDoc) where applicable. English only.
 - Applies to AI agents too.
+
+## Tooling facts that get guessed wrong
+
+- The package manager is **npm**. There is no pnpm and no yarn; `package-lock.json` is the only lockfile. Never generate a `pnpm-lock.yaml`.
+- Dependency pins live in the `overrides` block of [`package.json`](package.json), which is npm-specific. `npm audit --omit=dev` runs inside the required `build` job, so a stale override fails CI for the whole repo, not just one PR.
+- This is a fixed-size desktop window, not a website. Skip-to-content links, breadcrumbs, viewport breakpoints and mobile responsive behaviour do not apply.
+- There is no database, no HTTP API and no server. N+1 queries, indexes, pagination, connection pooling and payload compression have nothing to point at here.
+- Do not create `.jules/` or `.Jules/` scratch files. They are gitignored, so they only add noise to a diff.
+
+## Rejected approaches
+
+Do not re-propose these. Each was tried and closed, and the reasoning is recorded on the linked issue.
+
+- **`React.memo` on `GameList` rows or `RunningAppsStrip`.** Proposed five times (PRs #650, #744, #786, #791, #807) and closed every time. The memos cannot bail out, because `GameList` rebuilds `runningAppIcons` and the row callbacks on every render, so the shallow prop comparison always fails. Stabilizing those props is the actual fix and is tracked in #651, behind a profiling gate. `React.memo` on its own is inert here.
+- **A descriptive `alt` on an icon that sits next to its own name.** The name is already adjacent text, so a descriptive `alt` makes a screen reader announce it twice. Use `alt=""`. The named form (`alt={game.name}`) is only for an icon that _is_ the label, with no adjacent text repeating it. See `AppsSection.tsx` versus `GameIcon.tsx`.
+- **Running a formatter across files you touched.** Prettier already runs with its own config, and a reformat buries the real change in noise.
+
+## Work that automated agents should not open a PR for
+
+Comment on the issue instead. Nothing here can be satisfied by reading code:
+
+- profiling, benchmarks, or any before/after measurement
+- verification with a real screen reader
+- a copy, product, or design decision
+- anything gated on a smoke test or a check against an installed build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,7 @@ Three-process Electron app:
 ## Code documentation
 
 Comment the WHY, not the WHAT — explain non-obvious decisions, constraints, invariants, gotchas, and security-sensitive steps; never write comments that restate the code. Doc-comment public/exported items (TS JSDoc) where applicable. English only. Applies to AI agents too.
+
+## Rejected approaches
+
+[`AGENTS.md`](AGENTS.md) carries a **Rejected approaches** section plus a list of work no agent can settle by reading code (anything needing a profiler, a screen reader, or a product decision). Read it before proposing an optimization or an a11y change; it exists because the same handful of ideas kept arriving as PRs and getting closed for the same reasons.


### PR DESCRIPTION
## Summary

Adds a **Rejected approaches** section to `AGENTS.md`, plus two shorter lists: tooling facts that automated agents keep guessing wrong, and the kinds of work no agent can settle by reading code.

The trigger is a measurable pattern. Of 15 PRs opened here by Google Jules, 3 merged and 11 were closed. The single worst case is "wrap the `GameList` rows in `React.memo`", which arrived **five separate times** (#650, #744, #786, #791, #807) and was closed five times for the same reason: the memos cannot bail out while the parent rebuilds `runningAppIcons` and the row callbacks every render. #651 already records the real fix behind a profiling gate, but nothing in the repo told an agent that, so the reasoning only existed in closed-PR threads nobody reads.

Two more entries come from the same place. A descriptive `alt` on an icon that sits next to its own name makes a screen reader say the name twice, which is why #808 uses `alt=""`. And a formatter run across touched files fights Prettier and buries the actual change.

The tooling list is the cheap half. `.gitignore` already notes that Jules "has more than once produced a pnpm lockfile in this npm repo"; this states the rule in the file agents are told to read, rather than only cleaning up after it. The same list rules out the web and backend checklists (breadcrumbs, viewport breakpoints, N+1 queries, connection pooling) that have nothing to point at in a fixed-size Electron window with no server.

`CLAUDE.md` gets a pointer rather than a copy, so the two files cannot drift.

## Test plan

- [x] `npx prettier --check AGENTS.md CLAUDE.md`
- [x] `npm run format:check`
- [x] Documentation only: no source file, test, or config is touched, so lint, test and build are unaffected

Refs #805


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for automated contributors on tooling assumptions, rejected approaches, and changes that should not be proposed automatically.
  * Documented when to consult project guidance before suggesting optimization or accessibility updates.
  * Clarified decisions that require context beyond the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->