### PR TITLE
refactor(processes): extract the low-level Win32 kill helpers (#773)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -1,7 +1,5 @@
-import { execFile, type ChildProcess } from 'child_process'
 import path from 'path'
 
-import { writeAppErrorLog } from '../errorLog'
 import {
   getActiveStoredProfile,
   getProfileTrackablePaths,
@@ -9,13 +7,7 @@ import {
   isUtilityEnabled
 } from '../profiles'
 import { getStoredStringRecord } from '../store'
-import {
-  getErrorMessage,
-  getExeName,
-  isValidExePath,
-  normalizePathForComparison,
-  pathsEqual
-} from '../utils'
+import { getExeName, isValidExePath, normalizePathForComparison, pathsEqual } from '../utils'
 
 import {
   abortActiveLaunches,
@@ -29,33 +21,20 @@ import {
 } from './state'
 import { publishRunningApps } from './running'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
-import type { KillFailure, KillFailureReason, KillProfileAppsOptions, KillResult } from './types'
-
-// Generous for a healthy system (the query usually returns in tens of ms) but
-// bounded so a wedged WMI service cannot hang a kill request forever.
-const WMI_LOOKUP_TIMEOUT_MS = 3000
-
-export interface KillAttemptResult {
-  processName: string
-  success: boolean
-  appPath?: string
-  gameKey?: string
-  error?: string
-  accessDenied?: boolean
-  notFound?: boolean
-  staleTask?: boolean
-  stillRunning?: boolean
-  /**
-   * Set only when this attempt positively observed a process under
-   * `processName`: PIDs discovered at its path, a tracked child that was really
-   * there, or an `/IM` taskkill that found something to act on.
-   *
-   * Deliberately NOT the inverse of `notFound`. A WMI lookup that errors out
-   * returns neither, and treating that absence as evidence would let a failed
-   * lookup vouch for a sibling it never looked at (CodeRabbit on #818).
-   */
-  targetConfirmed?: boolean
-}
+import type {
+  KillAttemptResult,
+  KillFailure,
+  KillFailureReason,
+  KillProfileAppsOptions,
+  KillResult
+} from './types'
+import {
+  findProcessIdsByExecutablePath,
+  isFullExePath,
+  isPathScopedExe,
+  killProcessByImageName,
+  killProcessTree
+} from './win32KillUtils'
 
 // Hardcoded list of companion process names for utilities that spawn background
 // agents under a name that differs from (or is not derived from) their
@@ -64,287 +43,6 @@ export interface KillAttemptResult {
 // need an entry here.
 const UTILITY_COMPANION_PROCESS_NAMES: Record<string, string[]> = {
   garage61: ['Garage61 telemetry agent.exe']
-}
-
-function isAccessDeniedMessage(message: string) {
-  return /(access is denied|permission denied|administrator|elevat)/i.test(message)
-}
-
-function isNotFoundMessage(message: string) {
-  return /not found|no running instance/i.test(message)
-}
-
-function isStaleTaskMessage(message: string) {
-  return /no running instance/i.test(message)
-}
-
-function runTaskkill(args: string[], description: string) {
-  return new Promise<{
-    success: boolean
-    detail?: string
-    accessDenied?: boolean
-    notFound?: boolean
-    staleTask?: boolean
-  }>((resolve) => {
-    execFile('taskkill', args, { windowsHide: true }, (error, stdout, stderr) => {
-      if (!error) {
-        resolve({ success: true })
-        return
-      }
-
-      const detail = stderr.trim() || stdout.trim() || error.message
-      const notFound = isNotFoundMessage(detail)
-      const staleTask = isStaleTaskMessage(detail)
-      const accessDenied = isAccessDeniedMessage(detail)
-
-      if (!notFound) {
-        console.error(`Failed to ${description}: ${detail}`)
-        writeAppErrorLog('kill', `Failed to ${description}: ${detail}`)
-      }
-
-      resolve({
-        success: notFound,
-        detail,
-        accessDenied,
-        notFound,
-        staleTask
-      })
-    })
-  })
-}
-
-/**
- * Guard that distinguishes a fully-qualified exe path (e.g.
- * `C:\Tools\app.exe`) from a bare process name (e.g. `app.exe`). Only full
- * paths are eligible for path-scoped kills via WMI `ExecutablePath` matching —
- * bare names fall back to the less precise `/IM` image-name kill to avoid
- * refusing to kill a process whose path we cannot verify.
- */
-function isFullExePath(appPath: string | undefined): appPath is string {
-  return (
-    typeof appPath === 'string' && path.basename(appPath) !== appPath && isValidExePath(appPath)
-  )
-}
-
-/**
- * True when `appPath` is a directory-qualified exe path (has a parent dir),
- * judged by SHAPE ALONE. Unlike {@link isFullExePath} it does NOT stat the
- * filesystem. Use this to decide whether basename fallback cleanup is allowed:
- * scoping must not depend on the exe still being present, or a full-path game
- * whose exe was removed or is momentarily inaccessible mid-close would fall back
- * to matching by image name and delete a DIFFERENT game's same-named companion
- * tracked at another path (#677).
- */
-function isPathScopedExe(appPath: string | undefined): appPath is string {
-  return typeof appPath === 'string' && path.basename(appPath) !== appPath
-}
-
-function parseProcessIds(output: string) {
-  const trimmedOutput = output.trim()
-
-  if (!trimmedOutput) {
-    return []
-  }
-
-  try {
-    const parsed = JSON.parse(trimmedOutput) as unknown
-    const values = Array.isArray(parsed) ? parsed : [parsed]
-
-    return values
-      .map((value) => (typeof value === 'number' ? value : Number(value)))
-      .filter((value) => Number.isSafeInteger(value) && value > 0)
-  } catch {
-    return trimmedOutput
-      .split(/\r?\n/)
-      .map((line) => Number(line.trim()))
-      .filter((value) => Number.isSafeInteger(value) && value > 0)
-  }
-}
-
-function findProcessIdsByExecutablePath(processName: string, appPath: string) {
-  return new Promise<{
-    processIds: number[]
-    detail?: string
-    accessDenied?: boolean
-  }>((resolve) => {
-    const script = [
-      // Both the target path and the process name are injected via environment
-      // variables rather than interpolated into the script string. This prevents
-      // a value containing single-quotes or PowerShell metacharacters from
-      // breaking out of a string literal or injecting arbitrary commands.
-      '$target = $env:SIMLAUNCHER_TARGET_PROCESS_PATH',
-      '$name = $env:SIMLAUNCHER_TARGET_PROCESS_NAME',
-      '$targetPath = [System.IO.Path]::GetFullPath($target)',
-      // Match the process name in PowerShell with -ieq rather than in a WQL
-      // `Name = '...'` filter. WQL string-literal quote escaping is ambiguous and
-      // version-dependent (SQL-style doubling vs backslash), and getting it wrong
-      // silently breaks the lookup for exe names containing a single quote — the
-      // exact case this guards (#531). Comparing $_.Name to the env-injected $name
-      // in the host language sidesteps WQL escaping entirely and handles any
-      // character. The (rare, user-initiated) full-process enumeration is bounded
-      // by WMI_LOOKUP_TIMEOUT_MS; precision still comes from the ExecutablePath match.
-      'Get-CimInstance Win32_Process |',
-      '  Where-Object { $_.Name -ieq $name -and $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
-      '  Select-Object -ExpandProperty ProcessId |',
-      '  ConvertTo-Json -Compress'
-    ].join('\n')
-
-    execFile(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
-      {
-        windowsHide: true,
-        // A hung or slow WMI query (slow disk, process-heavy system) must not
-        // stall the kill pipeline indefinitely. On timeout this surfaces as a
-        // clean kill failure — deliberately NOT a `taskkill /IM` fallback,
-        // which would break the path-scoping safety guarantee and kill
-        // same-named processes the user started outside SimLauncher (#503).
-        timeout: WMI_LOOKUP_TIMEOUT_MS,
-        env: {
-          ...process.env,
-          SIMLAUNCHER_TARGET_PROCESS_PATH: path.resolve(appPath),
-          SIMLAUNCHER_TARGET_PROCESS_NAME: processName
-        }
-      },
-      (error, stdout, stderr) => {
-        if (error) {
-          // execFile sets `killed` when it terminated the child itself —
-          // with a plain timeout option that means the deadline elapsed.
-          const detail = error.killed
-            ? `Process lookup timed out after ${WMI_LOOKUP_TIMEOUT_MS / 1000} seconds.`
-            : stderr.trim() || stdout.trim() || error.message
-          console.error(`Failed to find process IDs for ${appPath}: ${detail}`)
-          writeAppErrorLog('kill', `Failed to find process IDs for ${appPath}: ${detail}`)
-          resolve({ processIds: [], detail, accessDenied: isAccessDeniedMessage(detail) })
-          return
-        }
-
-        resolve({ processIds: parseProcessIds(stdout) })
-      }
-    )
-  })
-}
-
-async function killProcessTree(
-  child: ChildProcess,
-  appPath: string,
-  gameKey?: string
-): Promise<KillAttemptResult> {
-  const processName = getExeName(appPath)
-
-  if (process.platform === 'win32' && child.pid) {
-    const result = await runTaskkill(
-      ['/PID', String(child.pid), '/T', '/F'],
-      `kill process tree for ${appPath}`
-    )
-    return {
-      processName,
-      appPath,
-      gameKey,
-      success: result.success,
-      error: result.detail,
-      accessDenied: result.accessDenied,
-      notFound: result.notFound,
-      staleTask: result.staleTask,
-      // A tracked child we hold a PID for was a real target unless taskkill
-      // reports it had already exited.
-      targetConfirmed: !result.notFound
-    }
-  }
-
-  try {
-    child.kill()
-    return { processName, appPath, gameKey, success: true, targetConfirmed: true }
-  } catch (err) {
-    const error = getErrorMessage(err)
-    console.error(`Error killing ${appPath}:`, err)
-    writeAppErrorLog('kill', `Error killing ${appPath}: ${error}`)
-    return {
-      processName,
-      appPath,
-      gameKey,
-      success: false,
-      error,
-      accessDenied: isAccessDeniedMessage(error)
-    }
-  }
-}
-
-async function killProcessByImageName(
-  processName: string,
-  appPath?: string,
-  gameKey?: string
-): Promise<KillAttemptResult> {
-  if (process.platform !== 'win32') {
-    return { processName, appPath, gameKey, success: true }
-  }
-
-  if (isFullExePath(appPath)) {
-    const targetAppPath = appPath
-    const { processIds, detail, accessDenied } = await findProcessIdsByExecutablePath(
-      processName,
-      targetAppPath
-    )
-
-    if (detail) {
-      return {
-        processName,
-        appPath: targetAppPath,
-        gameKey,
-        success: false,
-        error: detail,
-        accessDenied
-      }
-    }
-
-    if (processIds.length === 0) {
-      // Elevated processes can expose null ExecutablePath in WMI, so they are silently
-      // filtered out by the Where-Object clause; treat this as notFound rather than error.
-      return { processName, appPath: targetAppPath, gameKey, success: true, notFound: true }
-    }
-
-    const results = await Promise.all(
-      processIds.map((processId) =>
-        runTaskkill(
-          ['/PID', String(processId), '/T', '/F'],
-          `kill companion process ${targetAppPath}`
-        )
-      )
-    )
-    const failedResult = results.find((result) => !result.success && !result.notFound)
-
-    return {
-      processName,
-      appPath: targetAppPath,
-      gameKey,
-      success: !failedResult,
-      error: failedResult?.detail,
-      accessDenied: failedResult?.accessDenied,
-      notFound: results.every((result) => result.notFound),
-      staleTask: results.every((result) => result.staleTask),
-      // PIDs were discovered at this exact path, so a process under this image
-      // name demonstrably existed.
-      targetConfirmed: true
-    }
-  }
-
-  const result = await runTaskkill(
-    ['/IM', processName, '/T', '/F'],
-    `kill companion process ${processName}`
-  )
-  return {
-    processName,
-    appPath,
-    gameKey,
-    success: result.success,
-    error: result.detail,
-    accessDenied: result.accessDenied,
-    notFound: result.notFound,
-    staleTask: result.staleTask,
-    // taskkill either killed something or was denied by something. Any other
-    // failure is ambiguous, so it does not count as evidence.
-    targetConfirmed: result.success || result.accessDenied === true
-  }
 }
 
 function clearUnclosedProcess(

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -16,6 +16,36 @@ export interface KillFailure {
 }
 
 /**
+ * The outcome of one kill attempt against one process name.
+ *
+ * Lives here rather than in `kill.ts` because it is the contract BETWEEN the two
+ * halves of the kill path: `win32KillUtils.ts` produces these, `kill.ts`
+ * interprets them. Declaring it in either half would make the other import from
+ * its own consumer (#773).
+ */
+export interface KillAttemptResult {
+  processName: string
+  success: boolean
+  appPath?: string
+  gameKey?: string
+  error?: string
+  accessDenied?: boolean
+  notFound?: boolean
+  staleTask?: boolean
+  stillRunning?: boolean
+  /**
+   * Set only when this attempt positively observed a process under
+   * `processName`: PIDs discovered at its path, a tracked child that was really
+   * there, or an `/IM` taskkill that found something to act on.
+   *
+   * Deliberately NOT the inverse of `notFound`. A WMI lookup that errors out
+   * returns neither, and treating that absence as evidence would let a failed
+   * lookup vouch for a sibling it never looked at (CodeRabbit on #818).
+   */
+  targetConfirmed?: boolean
+}
+
+/**
  * `invalid` — the configured path failed the .exe path-shape check
  * (isValidExePath). `missing` — the path is a well-formed .exe path but the
  * file no longer exists on disk (moved after a game update, or uninstalled).

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -1,0 +1,306 @@
+/**
+ * Low-level Win32 process helpers: everything that shells out to `taskkill` or
+ * queries WMI, with no knowledge of profiles, tracking state, or the store.
+ *
+ * Extracted verbatim from `kill.ts` (#773) to give #659 a directly testable
+ * seam for the force/graceful `taskkill` flag. All three `/F` call sites live
+ * here; against the old 1076-line `kill.ts` they were reachable from tests only
+ * through `killLaunchedApps` plus a package-level `child_process` mock.
+ *
+ * The boundary is the point: nothing in this file may read the store or the
+ * tracking sets (`runningProcesses`, `unclosedProcesses`,
+ * `processNameMismatchWarnings`). Adding such a read collapses the seam and
+ * makes these helpers untestable in isolation again.
+ */
+import { execFile, type ChildProcess } from 'child_process'
+import path from 'path'
+
+import { writeAppErrorLog } from '../errorLog'
+import { getErrorMessage, getExeName, isValidExePath } from '../utils'
+
+import type { KillAttemptResult } from './types'
+
+// Generous for a healthy system (the query usually returns in tens of ms) but
+// bounded so a wedged WMI service cannot hang a kill request forever.
+const WMI_LOOKUP_TIMEOUT_MS = 3000
+
+function isAccessDeniedMessage(message: string) {
+  return /(access is denied|permission denied|administrator|elevat)/i.test(message)
+}
+
+function isNotFoundMessage(message: string) {
+  return /not found|no running instance/i.test(message)
+}
+
+function isStaleTaskMessage(message: string) {
+  return /no running instance/i.test(message)
+}
+
+function runTaskkill(args: string[], description: string) {
+  return new Promise<{
+    success: boolean
+    detail?: string
+    accessDenied?: boolean
+    notFound?: boolean
+    staleTask?: boolean
+  }>((resolve) => {
+    execFile('taskkill', args, { windowsHide: true }, (error, stdout, stderr) => {
+      if (!error) {
+        resolve({ success: true })
+        return
+      }
+
+      const detail = stderr.trim() || stdout.trim() || error.message
+      const notFound = isNotFoundMessage(detail)
+      const staleTask = isStaleTaskMessage(detail)
+      const accessDenied = isAccessDeniedMessage(detail)
+
+      if (!notFound) {
+        console.error(`Failed to ${description}: ${detail}`)
+        writeAppErrorLog('kill', `Failed to ${description}: ${detail}`)
+      }
+
+      resolve({
+        success: notFound,
+        detail,
+        accessDenied,
+        notFound,
+        staleTask
+      })
+    })
+  })
+}
+
+/**
+ * Guard that distinguishes a fully-qualified exe path (e.g.
+ * `C:\Tools\app.exe`) from a bare process name (e.g. `app.exe`). Only full
+ * paths are eligible for path-scoped kills via WMI `ExecutablePath` matching —
+ * bare names fall back to the less precise `/IM` image-name kill to avoid
+ * refusing to kill a process whose path we cannot verify.
+ */
+export function isFullExePath(appPath: string | undefined): appPath is string {
+  return (
+    typeof appPath === 'string' && path.basename(appPath) !== appPath && isValidExePath(appPath)
+  )
+}
+
+/**
+ * True when `appPath` is a directory-qualified exe path (has a parent dir),
+ * judged by SHAPE ALONE. Unlike {@link isFullExePath} it does NOT stat the
+ * filesystem. Use this to decide whether basename fallback cleanup is allowed:
+ * scoping must not depend on the exe still being present, or a full-path game
+ * whose exe was removed or is momentarily inaccessible mid-close would fall back
+ * to matching by image name and delete a DIFFERENT game's same-named companion
+ * tracked at another path (#677).
+ */
+export function isPathScopedExe(appPath: string | undefined): appPath is string {
+  return typeof appPath === 'string' && path.basename(appPath) !== appPath
+}
+
+function parseProcessIds(output: string) {
+  const trimmedOutput = output.trim()
+
+  if (!trimmedOutput) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(trimmedOutput) as unknown
+    const values = Array.isArray(parsed) ? parsed : [parsed]
+
+    return values
+      .map((value) => (typeof value === 'number' ? value : Number(value)))
+      .filter((value) => Number.isSafeInteger(value) && value > 0)
+  } catch {
+    return trimmedOutput
+      .split(/\r?\n/)
+      .map((line) => Number(line.trim()))
+      .filter((value) => Number.isSafeInteger(value) && value > 0)
+  }
+}
+
+export function findProcessIdsByExecutablePath(processName: string, appPath: string) {
+  return new Promise<{
+    processIds: number[]
+    detail?: string
+    accessDenied?: boolean
+  }>((resolve) => {
+    const script = [
+      // Both the target path and the process name are injected via environment
+      // variables rather than interpolated into the script string. This prevents
+      // a value containing single-quotes or PowerShell metacharacters from
+      // breaking out of a string literal or injecting arbitrary commands.
+      '$target = $env:SIMLAUNCHER_TARGET_PROCESS_PATH',
+      '$name = $env:SIMLAUNCHER_TARGET_PROCESS_NAME',
+      '$targetPath = [System.IO.Path]::GetFullPath($target)',
+      // Match the process name in PowerShell with -ieq rather than in a WQL
+      // `Name = '...'` filter. WQL string-literal quote escaping is ambiguous and
+      // version-dependent (SQL-style doubling vs backslash), and getting it wrong
+      // silently breaks the lookup for exe names containing a single quote — the
+      // exact case this guards (#531). Comparing $_.Name to the env-injected $name
+      // in the host language sidesteps WQL escaping entirely and handles any
+      // character. The (rare, user-initiated) full-process enumeration is bounded
+      // by WMI_LOOKUP_TIMEOUT_MS; precision still comes from the ExecutablePath match.
+      'Get-CimInstance Win32_Process |',
+      '  Where-Object { $_.Name -ieq $name -and $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $targetPath) } |',
+      '  Select-Object -ExpandProperty ProcessId |',
+      '  ConvertTo-Json -Compress'
+    ].join('\n')
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
+      {
+        windowsHide: true,
+        // A hung or slow WMI query (slow disk, process-heavy system) must not
+        // stall the kill pipeline indefinitely. On timeout this surfaces as a
+        // clean kill failure — deliberately NOT a `taskkill /IM` fallback,
+        // which would break the path-scoping safety guarantee and kill
+        // same-named processes the user started outside SimLauncher (#503).
+        timeout: WMI_LOOKUP_TIMEOUT_MS,
+        env: {
+          ...process.env,
+          SIMLAUNCHER_TARGET_PROCESS_PATH: path.resolve(appPath),
+          SIMLAUNCHER_TARGET_PROCESS_NAME: processName
+        }
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          // execFile sets `killed` when it terminated the child itself —
+          // with a plain timeout option that means the deadline elapsed.
+          const detail = error.killed
+            ? `Process lookup timed out after ${WMI_LOOKUP_TIMEOUT_MS / 1000} seconds.`
+            : stderr.trim() || stdout.trim() || error.message
+          console.error(`Failed to find process IDs for ${appPath}: ${detail}`)
+          writeAppErrorLog('kill', `Failed to find process IDs for ${appPath}: ${detail}`)
+          resolve({ processIds: [], detail, accessDenied: isAccessDeniedMessage(detail) })
+          return
+        }
+
+        resolve({ processIds: parseProcessIds(stdout) })
+      }
+    )
+  })
+}
+
+export async function killProcessTree(
+  child: ChildProcess,
+  appPath: string,
+  gameKey?: string
+): Promise<KillAttemptResult> {
+  const processName = getExeName(appPath)
+
+  if (process.platform === 'win32' && child.pid) {
+    const result = await runTaskkill(
+      ['/PID', String(child.pid), '/T', '/F'],
+      `kill process tree for ${appPath}`
+    )
+    return {
+      processName,
+      appPath,
+      gameKey,
+      success: result.success,
+      error: result.detail,
+      accessDenied: result.accessDenied,
+      notFound: result.notFound,
+      staleTask: result.staleTask,
+      // A tracked child we hold a PID for was a real target unless taskkill
+      // reports it had already exited.
+      targetConfirmed: !result.notFound
+    }
+  }
+
+  try {
+    child.kill()
+    return { processName, appPath, gameKey, success: true, targetConfirmed: true }
+  } catch (err) {
+    const error = getErrorMessage(err)
+    console.error(`Error killing ${appPath}:`, err)
+    writeAppErrorLog('kill', `Error killing ${appPath}: ${error}`)
+    return {
+      processName,
+      appPath,
+      gameKey,
+      success: false,
+      error,
+      accessDenied: isAccessDeniedMessage(error)
+    }
+  }
+}
+
+export async function killProcessByImageName(
+  processName: string,
+  appPath?: string,
+  gameKey?: string
+): Promise<KillAttemptResult> {
+  if (process.platform !== 'win32') {
+    return { processName, appPath, gameKey, success: true }
+  }
+
+  if (isFullExePath(appPath)) {
+    const targetAppPath = appPath
+    const { processIds, detail, accessDenied } = await findProcessIdsByExecutablePath(
+      processName,
+      targetAppPath
+    )
+
+    if (detail) {
+      return {
+        processName,
+        appPath: targetAppPath,
+        gameKey,
+        success: false,
+        error: detail,
+        accessDenied
+      }
+    }
+
+    if (processIds.length === 0) {
+      // Elevated processes can expose null ExecutablePath in WMI, so they are silently
+      // filtered out by the Where-Object clause; treat this as notFound rather than error.
+      return { processName, appPath: targetAppPath, gameKey, success: true, notFound: true }
+    }
+
+    const results = await Promise.all(
+      processIds.map((processId) =>
+        runTaskkill(
+          ['/PID', String(processId), '/T', '/F'],
+          `kill companion process ${targetAppPath}`
+        )
+      )
+    )
+    const failedResult = results.find((result) => !result.success && !result.notFound)
+
+    return {
+      processName,
+      appPath: targetAppPath,
+      gameKey,
+      success: !failedResult,
+      error: failedResult?.detail,
+      accessDenied: failedResult?.accessDenied,
+      notFound: results.every((result) => result.notFound),
+      staleTask: results.every((result) => result.staleTask),
+      // PIDs were discovered at this exact path, so a process under this image
+      // name demonstrably existed.
+      targetConfirmed: true
+    }
+  }
+
+  const result = await runTaskkill(
+    ['/IM', processName, '/T', '/F'],
+    `kill companion process ${processName}`
+  )
+  return {
+    processName,
+    appPath,
+    gameKey,
+    success: result.success,
+    error: result.detail,
+    accessDenied: result.accessDenied,
+    notFound: result.notFound,
+    staleTask: result.staleTask,
+    // taskkill either killed something or was denied by something. Any other
+    // failure is ambiguous, so it does not count as evidence.
+    targetConfirmed: result.success || result.accessDenied === true
+  }
+}

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -119,6 +119,27 @@ function parseProcessIds(output: string) {
   }
 }
 
+/**
+ * Resolve the PIDs of running processes named `processName` whose WMI
+ * `ExecutablePath` resolves to the same file as `appPath`. This is what makes a
+ * kill path-scoped instead of name-scoped.
+ *
+ * ⚠️ **An empty `processIds` does NOT mean "nothing is running there."** On any
+ * failure this resolves `{ processIds: [], detail }`, so zero PIDs means either
+ * "nothing was there" or "we could not look". Branch on `detail` BEFORE reading
+ * `processIds.length`; reading the absence of a signal as a signal is what
+ * produced two separate defects on #818.
+ *
+ * Two further reasons a genuinely running process yields zero PIDs:
+ * - an elevated process can expose a null `ExecutablePath`, so the
+ *   `Where-Object` clause filters it out while it is very much alive
+ *   (#390/#399)
+ * - the query is bounded by `WMI_LOOKUP_TIMEOUT_MS` and a timeout arrives as a
+ *   failure with `detail` set, deliberately NOT as an `/IM` fallback, which
+ *   would kill same-named processes the user started outside SimLauncher (#503)
+ *
+ * `accessDenied` is set when the failure text says Windows refused the query.
+ */
 export function findProcessIdsByExecutablePath(processName: string, appPath: string) {
   return new Promise<{
     processIds: number[]
@@ -183,6 +204,20 @@ export function findProcessIdsByExecutablePath(processName: string, appPath: str
   })
 }
 
+/**
+ * Kill a process SimLauncher spawned and still holds a `ChildProcess` handle
+ * for, by PID. `/T` takes its children with it, which is what catches launchers
+ * that re-exec into a second process.
+ *
+ * Preferred over {@link killProcessByImageName} whenever a handle exists: a PID
+ * cannot be ambiguous, so this needs neither a WMI lookup nor path scoping.
+ * Off win32 there is no `taskkill`, so it falls back to `child.kill()`.
+ *
+ * `targetConfirmed` holds unless taskkill reported the process had already
+ * exited: a PID we were tracking is positive evidence that this target was
+ * real, which callers use to tell "closed nothing" apart from "closed
+ * something" (#818).
+ */
 export async function killProcessTree(
   child: ChildProcess,
   appPath: string,
@@ -228,6 +263,24 @@ export async function killProcessTree(
   }
 }
 
+/**
+ * Kill a process we have no handle for, which is the normal case for a
+ * companion that re-execed or that was already running when SimLauncher
+ * started.
+ *
+ * Two very different behaviours hide behind one name, decided by `appPath`:
+ *
+ * - **path-scoped** when `appPath` is a full exe path: PIDs are resolved with
+ *   {@link findProcessIdsByExecutablePath} first and killed individually, so a
+ *   same-named process at a different path is never touched
+ * - **image-scoped** when `appPath` is a bare name or absent: falls back to
+ *   `taskkill /IM`, which kills EVERY process with that image name, including
+ *   instances the user started outside SimLauncher. This is the imprecise path
+ *   and the reason {@link isFullExePath} gates it
+ *
+ * Off win32 it reports success without doing anything, so callers on other
+ * platforms are not failed for a Windows-only capability.
+ */
 export async function killProcessByImageName(
   processName: string,
   appPath?: string,


### PR DESCRIPTION
## Summary

Moves the ten low-level Win32 helpers out of `kill.ts` into a new `src/main/processes/win32KillUtils.ts`. No logic edits, no test changes, no behavior change: `kill.ts` goes 1076 → 759 lines and the moved band is byte-identical to what it replaced.

**All three `/F` call sites #659 needs are now in the new module, and zero remain in `kill.ts`** (`win32KillUtils.ts:195`, `:267`, `:290`). That was the whole point of doing this inside 1.2.0 rather than leaving it in the #530 queue: against the old file those sites were reachable from a test only through `killLaunchedApps` plus a package-level `child_process` mock, interleaved with the 140-line `finalizeKillAttempts` body. The new module imports nothing but `child_process`, `path`, `../errorLog`, `../utils` and one type, so a test can drive it directly.

Exported: `isFullExePath`, `isPathScopedExe`, `findProcessIdsByExecutablePath`, `killProcessTree`, `killProcessByImageName`. The other five (`isAccessDeniedMessage`, `isNotFoundMessage`, `isStaleTaskMessage`, `runTaskkill`, `parseProcessIds`) have no consumer outside the band and stay module-private.

### Two things the issue did not account for

The issue described this as "pure move plus one import line". Two symbols sat above the band and were used inside it, so the cut is not quite that clean:

- **`WMI_LOOKUP_TIMEOUT_MS`** (old `kill.ts:36`) is used only inside the band, at three places, so it moved with it.
- **`KillAttemptResult`** (old `kill.ts:38`) is used on *both* sides: the band produces it, and `finalizeKillAttempts`, `registerUnclosedProcess`, `getKillFailureReason` and the two `killTasks` arrays consume it. Leaving it in `kill.ts` would have made the new module import from its own consumer. It moved to `types.ts` instead, next to `KillFailure`, `KillResult` and `KillProfileAppsOptions`, which is where its siblings already live. Nothing outside `kill.ts` imported it (the only other mention in the repo is a comment in `processes.test.ts`), so this is a relocation with no importer churn.

The issue also names the three message predicates as `isAccessDenied` / `isNotFound` / `isStaleTask`; the real names carry a `Message` suffix. Moved under their real names.

Four imports in `kill.ts` (`execFile`, `ChildProcess`, `writeAppErrorLog`, `getErrorMessage`) were orphaned by the move and are removed.

## Coupling check (precondition 1 on the issue)

Re-run against the band immediately before cutting, as the issue requires. The 2026-07-25 measurement still holds, and the band's line numbers have moved since it was written (`:57-328` then, `:69-348` now, because #772 added `targetConfirmed` to `killProcessTree` and `killProcessByImageName`):

| symbol | occurrences in band |
|---|---|
| `getStoredStringRecord` | 0 |
| `getStoredProfiles` | 0 |
| `getActiveStoredProfile` | 0 |
| `isUtilityEnabled` | 0 |
| `getProfileTrackablePaths` | 0 |
| `runningProcesses` | 0 |
| `unclosedProcesses` | 0 |
| `processNameMismatchWarnings` | 0 |

Clean, so the cut proceeded rather than being parked back under #530.

## Verbatim proof

The move was done by extracting the byte range rather than retyping it, then verified by diffing the extracted band against the new file with the five added `export` keywords normalized out:

```
orig band: 280 lines / new band: 280 lines
diff -> no output
```

That proof covers `fa5c3f9`, the extraction itself. A second commit `6c83a4a` then answers a Codex P1 by adding JSDoc to the three helpers this PR newly exported (`findProcessIdsByExecutablePath`, `killProcessTree`, `killProcessByImageName`). It is comments only, and mechanically so:

```
lines removed by the docs commit:            0
added lines that are not comment lines:      0
1 file changed, 53 insertions(+)
```

Splitting it that way keeps the verbatim claim checkable in history rather than resting on the PR description.

The finding was fair. `isFullExePath` and `isPathScopedExe` already carried doc comments, so leaving the other three bare made the new module internally inconsistent, and these three are precisely the seam #659 is meant to build on. The docs record the contracts that are easy to get wrong rather than restating the signatures: that `findProcessIdsByExecutablePath` returns an empty `processIds` on failure too, so callers must read `detail` first (the ambiguity behind two defects on #818, plus the elevated-null-`ExecutablePath` case from #390/#399 and the #503 no-`/IM`-fallback-on-timeout rule); that `killProcessTree` is the handle-based path and why `targetConfirmed` holds; and that `killProcessByImageName` is path-scoped with a full path but kills every same-named process when given a bare name.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, 0 warnings)
- [x] `npm run typecheck` (renderer + node projects + preload types)
- [x] `npm test` (79 files, **616 passed**)
- [x] `npm run build`
- [x] **Zero test files changed.** The suite reaches these helpers only through `kill.ts`'s public entry points; every mention of a moved function in `processes.test.ts` is in a comment, so not even an import path needed updating.

Closes #773
