### PR TITLE
feat(processes): ask companion apps to close before forcing them (#659)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -249,6 +249,7 @@ function getPersistedSettings() {
     minimizeToTray: store.get('minimizeToTray'),
     showTrayIcon: store.get('showTrayIcon'),
     autoCheckUpdates: store.get('autoCheckUpdates'),
+    gracefulCloseEnabled: store.get('gracefulCloseEnabled'),
     zoomFactor: getStoredZoomFactor()
   }
 }

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -592,32 +592,45 @@ async function requestGracefulCloseForTargets(
   trackedChildren: ChildProcess[],
   pathTargets: { processName: string; appPath: string }[]
 ): Promise<void> {
-  const discovered = await Promise.all(
+  // Each path target is asked the moment ITS OWN lookup resolves, never after
+  // the slowest one. Every WMI query is bounded by WMI_LOOKUP_TIMEOUT_MS, so
+  // collecting all the results first left an already-discovered PID unsignalled
+  // for up to that long, and a number that stale may no longer mean the same
+  // process: if that companion exited on its own in the gap, Windows can hand
+  // its number to something we never launched, and `/T` would take that
+  // stranger's whole tree (Codex on #823). A raw PID carries no way to notice,
+  // so the only defence is to not hold it.
+  const askedByPath = await Promise.all(
     pathTargets.map(async ({ processName, appPath }) => {
       const { processIds } = await findProcessIdsByExecutablePath(processName, appPath)
-      return processIds
+      if (processIds.length === 0) {
+        return false
+      }
+      await requestGracefulClose(processIds)
+      return true
     })
   )
 
-  // Resolved AFTER the lookups above, never before. Each WMI query is bounded by
-  // WMI_LOOKUP_TIMEOUT_MS, so this function can sit here for seconds, and a
-  // tracked child that exits in that time releases its PID for Windows to reuse.
-  // Holding the handle rather than the number is what lets us notice
-  // (Codex on #823) — capturing `child.pid` up front would carry a number that
-  // may no longer mean the same process by the time it is signalled.
+  // A tracked child is the one thing that may be held across the lookups, for
+  // the same reason: we keep the ChildProcess, not the number, so the wait buys
+  // fresher evidence instead of decaying it. The liveness check therefore sits
+  // HERE, after the lookups, and a child that died while they were in flight is
+  // dropped rather than signalled by a number it no longer owns.
   const trackedPids = trackedChildren
     .filter((child) => !hasChildExited(child))
     .map((child) => child.pid)
     .filter((pid): pid is number => typeof pid === 'number')
 
-  const processIds = Array.from(new Set([...trackedPids, ...discovered.flat()]))
+  if (trackedPids.length > 0) {
+    await requestGracefulClose(trackedPids)
+  }
+
   // Nothing answered, so there is nothing to wait for. Skipping the window here
   // keeps "close with nothing running" instant even with the toggle on.
-  if (processIds.length === 0) {
+  if (trackedPids.length === 0 && !askedByPath.some(Boolean)) {
     return
   }
 
-  await requestGracefulClose(processIds)
   await wait(GRACEFUL_CLOSE_WINDOW_MS)
 }
 

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -6,8 +6,8 @@ import {
   getStoredProfiles,
   isUtilityEnabled
 } from '../profiles'
-import { getStoredStringRecord } from '../store'
-import { getExeName, isValidExePath, normalizePathForComparison, pathsEqual } from '../utils'
+import { getStoredBoolean, getStoredStringRecord } from '../store'
+import { getExeName, isValidExePath, normalizePathForComparison, pathsEqual, wait } from '../utils'
 
 import {
   abortActiveLaunches,
@@ -29,11 +29,13 @@ import type {
   KillResult
 } from './types'
 import {
+  GRACEFUL_CLOSE_WINDOW_MS,
   findProcessIdsByExecutablePath,
   isFullExePath,
   isPathScopedExe,
   killProcessByImageName,
-  killProcessTree
+  killProcessTree,
+  requestGracefulClose
 } from './win32KillUtils'
 
 // Hardcoded list of companion process names for utilities that spawn background
@@ -565,6 +567,47 @@ function withStrandedConsentPrompts(result: KillResult, strandedPromptCount: num
     : result
 }
 
+/**
+ * The opt-in graceful phase (#659): ask everything we are about to close to
+ * close itself, then wait once, then let the caller force-kill whatever is left.
+ *
+ * There is deliberately NO re-check of who survived. The force kill IS the
+ * re-check: `taskkill` on a process that already exited reports `notFound`,
+ * which the existing accounting already treats as closed rather than failed. A
+ * separate survivor scan would add a TOCTOU window (exit between scan and kill)
+ * and, if it used the name-scoped `readRunningProcessNames`, would answer wrong
+ * for two same-named exes at different paths, which is the class #772 and #674
+ * are about.
+ *
+ * NOT used by `killProfileApps`. A profile switch already contains close-then-
+ * relaunch pairs today: identity is `{key, path}` (`ipc/launch.ts:31`) while
+ * `appArgs` is global per slot key, so moving one exe between slots stops and
+ * restarts it (`ipc/launch.ts:283-290`). Waiting politely for an app that is
+ * about to be started again is latency spent on nothing, and it would put a new
+ * timing phase into the handler #715 and #782 are about to restructure.
+ */
+async function requestGracefulCloseForTargets(
+  trackedPids: number[],
+  pathTargets: { processName: string; appPath: string }[]
+): Promise<void> {
+  const discovered = await Promise.all(
+    pathTargets.map(async ({ processName, appPath }) => {
+      const { processIds } = await findProcessIdsByExecutablePath(processName, appPath)
+      return processIds
+    })
+  )
+
+  const processIds = Array.from(new Set([...trackedPids, ...discovered.flat()]))
+  // Nothing answered, so there is nothing to wait for. Skipping the window here
+  // keeps "close with nothing running" instant even with the toggle on.
+  if (processIds.length === 0) {
+    return
+  }
+
+  await requestGracefulClose(processIds)
+  await wait(GRACEFUL_CLOSE_WINDOW_MS)
+}
+
 export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // Cancel any in-flight launchProfileApps sequence for this gameKey (or all
   // of them, for the gameKey-less tray/global kill) before touching the
@@ -581,7 +624,13 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
   const companionTargets = getProfileCompanionTargets(gameKey)
-  const killTasks: Promise<KillAttemptResult>[] = []
+  // Thunks, not promises. A `killProcessTree(...)` expression starts the kill
+  // the moment it is evaluated, so building the list eagerly would force-kill
+  // everything before the graceful phase below ever ran (#659). Nothing starts
+  // until these are called.
+  const killTasks: (() => Promise<KillAttemptResult>)[] = []
+  const gracefulPids: number[] = []
+  const gracefulPathTargets: { processName: string; appPath: string }[] = []
 
   runningProcesses.forEach((appProcess, runningKey) => {
     const { process: child, path: appPath } = appProcess
@@ -606,7 +655,10 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
     if (processNames.has(processName)) {
       suppressProcessNameMismatchWarning(appPath)
-      killTasks.push(killProcessTree(child, appPath, appProcess.gameKey))
+      if (child.pid) {
+        gracefulPids.push(child.pid)
+      }
+      killTasks.push(() => killProcessTree(child, appPath, appProcess.gameKey))
     } else {
       runningProcesses.delete(runningKey)
     }
@@ -614,7 +666,14 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
   companionTargets.forEach((target) => {
     if (processNames.has(target.processName)) {
-      killTasks.push(
+      // Only a full path can be asked to close politely. A bare-name target
+      // would have to go through `/IM`, which is not path-scoped, and asking
+      // every same-named process to close would break the same guarantee the
+      // force kill upholds.
+      if (isFullExePath(target.appPath)) {
+        gracefulPathTargets.push({ processName: target.processName, appPath: target.appPath })
+      }
+      killTasks.push(() =>
         killProcessByImageName(
           target.processName,
           target.appPath,
@@ -624,7 +683,16 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
     }
   })
 
-  const result = await finalizeKillAttempts(await Promise.all(killTasks), gameKey)
+  // Ask first, then force. Only ever from here: `killProfileApps` (the profile
+  // switch) deliberately does not opt in, see requestGracefulCloseForTargets.
+  if (getStoredBoolean('gracefulCloseEnabled')) {
+    await requestGracefulCloseForTargets(gracefulPids, gracefulPathTargets)
+  }
+
+  const result = await finalizeKillAttempts(
+    await Promise.all(killTasks.map((startKill) => startKill())),
+    gameKey
+  )
   await publishRunningApps('kill')
   return withStrandedConsentPrompts(result, strandedPromptCount)
 }

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'child_process'
 import path from 'path'
 
 import {
@@ -31,6 +32,7 @@ import type {
 import {
   GRACEFUL_CLOSE_WINDOW_MS,
   findProcessIdsByExecutablePath,
+  hasChildExited,
   isFullExePath,
   isPathScopedExe,
   killProcessByImageName,
@@ -587,7 +589,7 @@ function withStrandedConsentPrompts(result: KillResult, strandedPromptCount: num
  * timing phase into the handler #715 and #782 are about to restructure.
  */
 async function requestGracefulCloseForTargets(
-  trackedPids: number[],
+  trackedChildren: ChildProcess[],
   pathTargets: { processName: string; appPath: string }[]
 ): Promise<void> {
   const discovered = await Promise.all(
@@ -596,6 +598,17 @@ async function requestGracefulCloseForTargets(
       return processIds
     })
   )
+
+  // Resolved AFTER the lookups above, never before. Each WMI query is bounded by
+  // WMI_LOOKUP_TIMEOUT_MS, so this function can sit here for seconds, and a
+  // tracked child that exits in that time releases its PID for Windows to reuse.
+  // Holding the handle rather than the number is what lets us notice
+  // (Codex on #823) — capturing `child.pid` up front would carry a number that
+  // may no longer mean the same process by the time it is signalled.
+  const trackedPids = trackedChildren
+    .filter((child) => !hasChildExited(child))
+    .map((child) => child.pid)
+    .filter((pid): pid is number => typeof pid === 'number')
 
   const processIds = Array.from(new Set([...trackedPids, ...discovered.flat()]))
   // Nothing answered, so there is nothing to wait for. Skipping the window here
@@ -629,7 +642,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // everything before the graceful phase below ever ran (#659). Nothing starts
   // until these are called.
   const killTasks: (() => Promise<KillAttemptResult>)[] = []
-  const gracefulPids: number[] = []
+  const gracefulChildren: ChildProcess[] = []
   const gracefulPathTargets: { processName: string; appPath: string }[] = []
 
   runningProcesses.forEach((appProcess, runningKey) => {
@@ -655,9 +668,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 
     if (processNames.has(processName)) {
       suppressProcessNameMismatchWarning(appPath)
-      if (child.pid) {
-        gracefulPids.push(child.pid)
-      }
+      gracefulChildren.push(child)
       killTasks.push(() => killProcessTree(child, appPath, appProcess.gameKey))
     } else {
       runningProcesses.delete(runningKey)
@@ -686,7 +697,7 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // Ask first, then force. Only ever from here: `killProfileApps` (the profile
   // switch) deliberately does not opt in, see requestGracefulCloseForTargets.
   if (getStoredBoolean('gracefulCloseEnabled')) {
-    await requestGracefulCloseForTargets(gracefulPids, gracefulPathTargets)
+    await requestGracefulCloseForTargets(gracefulChildren, gracefulPathTargets)
   }
 
   const result = await finalizeKillAttempts(

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -259,6 +259,23 @@ export async function killProcessTree(
 ): Promise<KillAttemptResult> {
   const processName = getExeName(appPath)
 
+  // The child already exited, so there is nothing to signal. Bailing out here is
+  // not an optimisation, it is a safety check: once a process exits, Node
+  // releases its handle and Windows is free to hand that PID to something else,
+  // and `/T` would then take an unrelated process tree with it.
+  //
+  // Cheap before #659, load-bearing after it: the graceful phase deliberately
+  // opens a window in which a well-behaved app is expected to exit, so the gap
+  // between "decide to kill" and "kill" went from microseconds to seconds
+  // (CodeRabbit on #823).
+  //
+  // Reports exactly what `taskkill` would have reported had it been called and
+  // found nothing (`success: notFound`), so no downstream accounting has to
+  // learn a new shape.
+  if (typeof child.exitCode === 'number' || typeof child.signalCode === 'string') {
+    return { processName, appPath, gameKey, success: true, notFound: true }
+  }
+
   if (process.platform === 'win32' && child.pid) {
     const result = await runTaskkill(
       ['/PID', String(child.pid), '/T', '/F'],

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -36,7 +36,41 @@ function isStaleTaskMessage(message: string) {
   return /no running instance/i.test(message)
 }
 
-function runTaskkill(args: string[], description: string) {
+/**
+ * How long the whole graceful phase may take, once, for the entire batch (#659).
+ *
+ * Shared rather than per app on purpose: a per-target wait would make the close
+ * action take this long multiplied by the number of apps that ignore it, and the
+ * issue requires the total to stay bounded no matter how many do.
+ */
+export const GRACEFUL_CLOSE_WINDOW_MS = 3000
+
+/**
+ * Ask processes to close themselves. `taskkill` WITHOUT `/F` posts `WM_CLOSE`
+ * to a process's top-level windows, which is what lets an app run its own
+ * shutdown path and flush a layout, dashboard or device handle before it goes.
+ *
+ * Best effort by design, so this reports nothing. A console app with no message
+ * loop, an app that ignores the request, and an elevated app that denies it are
+ * all normal here; the force kill that follows is what decides the outcome, and
+ * it re-reports everything. That is also why the failures are not logged: at
+ * this stage they are expected, not errors.
+ *
+ * Takes PIDs rather than an image name so the request cannot broaden to a
+ * same-named process the user started outside SimLauncher, matching the
+ * guarantee the force-kill path already makes.
+ */
+export async function requestGracefulClose(processIds: number[]): Promise<void> {
+  await Promise.all(
+    processIds.map((processId) =>
+      runTaskkill(['/PID', String(processId), '/T'], `ask process ${processId} to close`, {
+        quiet: true
+      })
+    )
+  )
+}
+
+function runTaskkill(args: string[], description: string, options?: { quiet?: boolean }) {
   return new Promise<{
     success: boolean
     detail?: string
@@ -55,7 +89,7 @@ function runTaskkill(args: string[], description: string) {
       const staleTask = isStaleTaskMessage(detail)
       const accessDenied = isAccessDeniedMessage(detail)
 
-      if (!notFound) {
+      if (!notFound && !options?.quiet) {
         console.error(`Failed to ${description}: ${detail}`)
         writeAppErrorLog('kill', `Failed to ${description}: ${detail}`)
       }

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -37,6 +37,25 @@ function isStaleTaskMessage(message: string) {
 }
 
 /**
+ * Whether a child we spawned has already exited, judged on POSITIVE evidence
+ * only. A live `ChildProcess` reports `null` for both; `undefined` means we are
+ * not looking at a real handle and must not be read as "gone".
+ *
+ * This is the guard on signalling a PID at all. Once a process exits Node
+ * releases its handle and Windows may hand that number to something else, so a
+ * `taskkill /PID` issued afterwards can hit a stranger, and `/T` takes that
+ * stranger's children too. While the handle reports neither an exit code nor a
+ * signal it is open, and the PID cannot have been recycled.
+ *
+ * Exported so the force kill and the graceful phase share one definition. They
+ * are separated by seconds of awaited work, so a second copy of this rule would
+ * drift (Codex on #823).
+ */
+export function hasChildExited(child: ChildProcess): boolean {
+  return typeof child.exitCode === 'number' || typeof child.signalCode === 'string'
+}
+
+/**
  * How long the whole graceful phase may take, once, for the entire batch (#659).
  *
  * Shared rather than per app on purpose: a per-target wait would make the close
@@ -272,7 +291,7 @@ export async function killProcessTree(
   // Reports exactly what `taskkill` would have reported had it been called and
   // found nothing (`success: notFound`), so no downstream accounting has to
   // learn a new shape.
-  if (typeof child.exitCode === 'number' || typeof child.signalCode === 'string') {
+  if (hasChildExited(child)) {
     return { processName, appPath, gameKey, success: true, notFound: true }
   }
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -60,6 +60,7 @@ const STORE_OPTIONS = {
     minimizeToTray: { type: 'boolean', default: false },
     showTrayIcon: { type: 'boolean', default: true },
     autoCheckUpdates: { type: 'boolean', default: true },
+    gracefulCloseEnabled: { type: 'boolean', default: false },
     zoomFactor: { type: 'number', default: DEFAULT_ZOOM_FACTOR },
     windowBounds: { type: 'object', default: {} },
     profileUtilityOrderMigrated: { type: 'boolean', default: false },
@@ -283,6 +284,7 @@ export const EXPECTED_CONFIG_KEYS = new Set([
   'minimizeToTray',
   'showTrayIcon',
   'autoCheckUpdates',
+  'gracefulCloseEnabled',
   'zoomFactor',
   'windowBounds',
   'profileUtilityOrderMigrated',
@@ -303,6 +305,7 @@ const BOOLEAN_CONFIG_KEYS = new Set([
   'minimizeToTray',
   'showTrayIcon',
   'autoCheckUpdates',
+  'gracefulCloseEnabled',
   'profileUtilityOrderMigrated',
   'profileSetsMigrated',
   'migrated'

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -17,6 +17,7 @@ export interface Settings {
   minimizeToTray: boolean
   showTrayIcon: boolean
   autoCheckUpdates: boolean
+  gracefulCloseEnabled: boolean
   zoomFactor: number
 }
 

--- a/src/renderer/src/components/settings/BehaviorContext.tsx
+++ b/src/renderer/src/components/settings/BehaviorContext.tsx
@@ -5,11 +5,13 @@ export interface BehaviorContextValue {
   startMinimized: boolean
   minimizeToTray: boolean
   showTrayIcon: boolean
+  gracefulCloseEnabled: boolean
   launchDelayMs: number
   onStartWithWindowsChange: (checked: boolean) => void
   onStartMinimizedChange: (checked: boolean) => void
   onMinimizeToTrayChange: (checked: boolean) => void
   onShowTrayIconChange: (checked: boolean) => void
+  onGracefulCloseEnabledChange: (checked: boolean) => void
   onLaunchDelayMsChange: (delayMs: number) => void
 }
 

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -15,17 +15,20 @@ export function BehaviorSection(): ReactNode {
   const showTrayIconId = useId()
   const startMinimizedId = useId()
   const minimizeToTrayId = useId()
+  const gracefulCloseId = useId()
 
   const {
     startWithWindows,
     startMinimized,
     minimizeToTray,
     showTrayIcon,
+    gracefulCloseEnabled,
     launchDelayMs,
     onStartWithWindowsChange,
     onStartMinimizedChange,
     onMinimizeToTrayChange,
     onShowTrayIconChange,
+    onGracefulCloseEnabledChange,
     onLaunchDelayMsChange
   } = useBehaviorSettings()
   const isPreset = DELAY_PRESETS.some((p) => p.value === launchDelayMs)
@@ -82,6 +85,21 @@ export function BehaviorSection(): ReactNode {
           checked={minimizeToTray}
           onChange={onMinimizeToTrayChange}
           disabled={!showTrayIcon}
+        />
+      </div>
+      <div className="settings-row">
+        <div className="settings-label-group">
+          <label htmlFor={gracefulCloseId} className="settings-label">
+            Close apps gracefully
+          </label>
+          <span className="settings-sublabel">
+            Ask apps to close and save first, then force-close anything still running
+          </span>
+        </div>
+        <Toggle
+          id={gracefulCloseId}
+          checked={gracefulCloseEnabled}
+          onChange={onGracefulCloseEnabledChange}
         />
       </div>
       <div className="settings-row settings-row-responsive">

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -93,7 +93,8 @@ export function BehaviorSection(): ReactNode {
             Close apps gracefully
           </label>
           <span className="settings-sublabel">
-            Ask apps to close and save first, then force-close anything still running
+            When you use Close Apps, ask them to save and close first, then force-close anything
+            still running
           </span>
         </div>
         <Toggle

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -59,6 +59,7 @@ export function SettingsProvider({
       startMinimized,
       minimizeToTray,
       showTrayIcon,
+      gracefulCloseEnabled,
       autoCheckUpdates,
       zoomFactor,
       isCustomColor,
@@ -85,6 +86,7 @@ export function SettingsProvider({
       setStartMinimized,
       setMinimizeToTray,
       setShowTrayIcon,
+      setGracefulCloseEnabled,
       setAutoCheckUpdates,
       setZoomFactor,
       setIsCustomColor,
@@ -116,6 +118,7 @@ export function SettingsProvider({
         'startMinimized',
         'minimizeToTray',
         'showTrayIcon',
+        'gracefulCloseEnabled',
         'launchDelayMs'
       ]),
       games: getDirtySubset(['gamePaths']),
@@ -151,6 +154,7 @@ export function SettingsProvider({
     setStartMinimized,
     setMinimizeToTray,
     setShowTrayIcon,
+    setGracefulCloseEnabled,
     setAutoCheckUpdates,
     setZoomFactor,
     setIsCustomColor,
@@ -362,6 +366,7 @@ export function SettingsProvider({
     startMinimized,
     minimizeToTray,
     showTrayIcon,
+    gracefulCloseEnabled,
     autoCheckUpdates,
     startWithWindows,
     zoomFactor,
@@ -465,11 +470,13 @@ export function SettingsProvider({
       startMinimized,
       minimizeToTray,
       showTrayIcon,
+      gracefulCloseEnabled,
       launchDelayMs,
       onStartWithWindowsChange: handleStartWithWindowsChange,
       onStartMinimizedChange: setStartMinimized,
       onMinimizeToTrayChange: setMinimizeToTray,
       onShowTrayIconChange: setShowTrayIcon,
+      onGracefulCloseEnabledChange: setGracefulCloseEnabled,
       onLaunchDelayMsChange: setLaunchDelayMs
     }),
     [
@@ -477,11 +484,13 @@ export function SettingsProvider({
       startMinimized,
       minimizeToTray,
       showTrayIcon,
+      gracefulCloseEnabled,
       launchDelayMs,
       handleStartWithWindowsChange,
       setStartMinimized,
       setMinimizeToTray,
       setShowTrayIcon,
+      setGracefulCloseEnabled,
       setLaunchDelayMs
     ]
   )

--- a/src/renderer/src/components/settings/useSettingsLoad.ts
+++ b/src/renderer/src/components/settings/useSettingsLoad.ts
@@ -42,6 +42,7 @@ interface UseSettingsLoadArgs {
   setStartMinimized: (startMinimized: boolean) => void
   setMinimizeToTray: (minimizeToTray: boolean) => void
   setShowTrayIcon: (showTrayIcon: boolean) => void
+  setGracefulCloseEnabled: (gracefulCloseEnabled: boolean) => void
   setAutoCheckUpdates: (autoCheckUpdates: boolean) => void
   setZoomFactor: (zoomFactor: number) => void
   setIsCustomColor: (isCustomColor: boolean) => void
@@ -71,6 +72,7 @@ export function useSettingsLoad({
   setStartMinimized,
   setMinimizeToTray,
   setShowTrayIcon,
+  setGracefulCloseEnabled,
   setAutoCheckUpdates,
   setZoomFactor,
   setIsCustomColor,
@@ -109,6 +111,8 @@ export function useSettingsLoad({
       startMinimized: settings.startMinimized || false,
       minimizeToTray: settings.minimizeToTray || false,
       showTrayIcon: settings.showTrayIcon ?? true,
+      // Opt-in, so anything other than an explicit true stays off (#659).
+      gracefulCloseEnabled: settings.gracefulCloseEnabled === true,
       autoCheckUpdates: settings.autoCheckUpdates !== false,
       zoomFactor: Number.isFinite(settings.zoomFactor) ? settings.zoomFactor : 1.0
     }
@@ -137,6 +141,7 @@ export function useSettingsLoad({
     setStartMinimized(snapshot.startMinimized)
     setMinimizeToTray(snapshot.minimizeToTray)
     setShowTrayIcon(snapshot.showTrayIcon)
+    setGracefulCloseEnabled(snapshot.gracefulCloseEnabled)
     setAutoCheckUpdates(snapshot.autoCheckUpdates)
     setZoomFactor(snapshot.zoomFactor)
 
@@ -201,6 +206,7 @@ export function useSettingsLoad({
     setLoading,
     setMinimizeToTray,
     setShowTrayIcon,
+    setGracefulCloseEnabled,
     setProfiles,
     setStartMinimized,
     setStartWithWindows,

--- a/src/renderer/src/components/settings/useSettingsSave.ts
+++ b/src/renderer/src/components/settings/useSettingsSave.ts
@@ -80,6 +80,7 @@ interface SettingsStateSnapshot {
   startMinimized: boolean
   minimizeToTray: boolean
   showTrayIcon: boolean
+  gracefulCloseEnabled: boolean
   autoCheckUpdates: boolean
   zoomFactor: number
 }
@@ -117,6 +118,7 @@ interface UseSettingsSaveArgs {
   startMinimized: boolean
   minimizeToTray: boolean
   showTrayIcon: boolean
+  gracefulCloseEnabled: boolean
   autoCheckUpdates: boolean
   startWithWindows: boolean
   zoomFactor: number
@@ -146,6 +148,7 @@ export function useSettingsSave({
   startMinimized,
   minimizeToTray,
   showTrayIcon,
+  gracefulCloseEnabled,
   autoCheckUpdates,
   startWithWindows,
   zoomFactor,
@@ -190,6 +193,7 @@ export function useSettingsSave({
           startMinimized,
           minimizeToTray,
           showTrayIcon,
+          gracefulCloseEnabled,
           autoCheckUpdates,
           startWithWindows,
           zoomFactor
@@ -248,6 +252,7 @@ export function useSettingsSave({
     focusActiveTitle,
     gamePaths,
     launchDelayMs,
+    gracefulCloseEnabled,
     minimizeToTray,
     showTrayIcon,
     notify,

--- a/src/renderer/src/components/settings/useSettingsState.ts
+++ b/src/renderer/src/components/settings/useSettingsState.ts
@@ -35,6 +35,7 @@ export interface SettingsStateBundle {
     startMinimized: boolean
     minimizeToTray: boolean
     showTrayIcon: boolean
+    gracefulCloseEnabled: boolean
     autoCheckUpdates: boolean
     zoomFactor: number
     isCustomColor: boolean
@@ -65,6 +66,7 @@ export interface SettingsStateBundle {
     setStartMinimized: Dispatch<SetStateAction<boolean>>
     setMinimizeToTray: Dispatch<SetStateAction<boolean>>
     setShowTrayIcon: Dispatch<SetStateAction<boolean>>
+    setGracefulCloseEnabled: Dispatch<SetStateAction<boolean>>
     setAutoCheckUpdates: Dispatch<SetStateAction<boolean>>
     setZoomFactor: Dispatch<SetStateAction<number>>
     setIsCustomColor: Dispatch<SetStateAction<boolean>>
@@ -97,6 +99,7 @@ export interface SettingsStateBundle {
     startMinimized: boolean
     minimizeToTray: boolean
     showTrayIcon: boolean
+    gracefulCloseEnabled: boolean
     autoCheckUpdates: boolean
     zoomFactor: number
   }
@@ -126,6 +129,7 @@ export function useSettingsState(): SettingsStateBundle {
   const [startMinimized, setStartMinimized] = useState<boolean>(false)
   const [minimizeToTray, setMinimizeToTray] = useState<boolean>(false)
   const [showTrayIcon, setShowTrayIcon] = useState<boolean>(true)
+  const [gracefulCloseEnabled, setGracefulCloseEnabled] = useState<boolean>(false)
   const [autoCheckUpdates, setAutoCheckUpdates] = useState<boolean>(true)
   const [zoomFactor, setZoomFactor] = useState<number>(1.0)
 
@@ -185,6 +189,7 @@ export function useSettingsState(): SettingsStateBundle {
       startMinimized,
       minimizeToTray,
       showTrayIcon,
+      gracefulCloseEnabled,
       autoCheckUpdates,
       zoomFactor
     }),
@@ -205,6 +210,7 @@ export function useSettingsState(): SettingsStateBundle {
       startMinimized,
       minimizeToTray,
       showTrayIcon,
+      gracefulCloseEnabled,
       autoCheckUpdates,
       zoomFactor
     ]
@@ -229,6 +235,7 @@ export function useSettingsState(): SettingsStateBundle {
       startMinimized,
       minimizeToTray,
       showTrayIcon,
+      gracefulCloseEnabled,
       autoCheckUpdates,
       zoomFactor,
       isCustomColor,
@@ -255,6 +262,7 @@ export function useSettingsState(): SettingsStateBundle {
       setStartMinimized,
       setMinimizeToTray,
       setShowTrayIcon,
+      setGracefulCloseEnabled,
       setAutoCheckUpdates,
       setZoomFactor,
       setIsCustomColor,

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2308,7 +2308,7 @@ test('a child that exits while the lookup is in flight is dropped from the reque
 
     // A tracked child, alive at the moment the close starts.
     const trackedChild = { pid: 1234, exitCode: null as number | null, signalCode: null }
-    runningProcesses.set('c:\tools\perplexity.exe', {
+    runningProcesses.set(String.raw`c:\tools\perplexity.exe`, {
       process: trackedChild as never,
       path: 'C:/Tools/Perplexity.exe',
       name: 'Perplexity.exe',

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -64,6 +64,10 @@ let storeReadShouldThrow = false
 // promise does — models a slow tasklist scan so a test can prove ordering
 // against it (#670). Consumed once, then cleared.
 let tasklistReadBlocker: Promise<void> | null = null
+// When set, the NEXT WMI path lookup resolves only after `promise` does. Models
+// a slow Get-CimInstance so a test can land an event inside the graceful
+// phase's await window (#659, #823). Consumed once, then cleared.
+let wmiLookupBlocker: Promise<void> | null = null
 // When set, the `atCall`-th isConsoleExecutable call (1-based) resolves only
 // after `promise` does — models a slow PE-subsystem probe so the abort-point
 // sweep can land a kill inside spawnDetachedApp's pre-spawn window for a
@@ -330,7 +334,17 @@ async function loadProcessModules() {
         if (processName && processNamesGoneAfterWmiLookup.has(processName)) {
           processNames.delete(processName)
         }
-        callback(null, pids.length ? JSON.stringify(pids.map(Number)) : '', '')
+        const emitLookup = () =>
+          callback(null, pids.length ? JSON.stringify(pids.map(Number)) : '', '')
+        // One-shot, same shape as tasklistReadBlocker: only the lookup it was
+        // armed for is delayed, so every other call keeps its exact timing.
+        if (wmiLookupBlocker) {
+          const blocker = wmiLookupBlocker
+          wmiLookupBlocker = null
+          void blocker.then(emitLookup)
+          return
+        }
+        emitLookup()
         return
       }
       // A `/PID` taskkill WITHOUT `/F` is the graceful request (#659): it posts
@@ -646,6 +660,7 @@ beforeEach(async () => {
   tasklistReadShouldFail = false
   storeReadShouldThrow = false
   tasklistReadBlocker = null
+  wmiLookupBlocker = null
   consoleProbeBlocker = null
   consoleProbeCallCount = 0
   failTasklistAfterAccessDeniedPids.clear()
@@ -2260,6 +2275,70 @@ test('nothing running means no grace window at all (#659)', async () => {
     const result = await killPromise
     expect(gracefulRequests()).toHaveLength(0)
     expect(result.closedCount).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// Codex P1 on #823. The graceful phase awaits a WMI lookup per path target,
+// each bounded by WMI_LOOKUP_TIMEOUT_MS, so it can sit there for seconds. A
+// tracked child that exits during that wait releases its PID, and Windows may
+// hand the number to something else before the polite request goes out. Holding
+// the ChildProcess handle instead of the raw number is what makes the exit
+// visible; capturing `child.pid` up front cannot notice.
+test('a child that exits while the lookup is in flight is dropped from the request (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Perplexity.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    processNames.add('perplexity.exe')
+    processNames.add('app2.exe')
+    registerProcess('C:/Tools/App2.exe', 'app2.exe', '5555')
+
+    const { killLaunchedApps, runningProcesses } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe' }
+    })
+
+    // A tracked child, alive at the moment the close starts.
+    const trackedChild = { pid: 1234, exitCode: null as number | null, signalCode: null }
+    runningProcesses.set('c:\tools\perplexity.exe', {
+      process: trackedChild as never,
+      path: 'C:/Tools/Perplexity.exe',
+      name: 'Perplexity.exe',
+      gameKey: 'ac',
+      isGame: false
+    })
+
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    // Park the App2 path lookup, so the graceful phase is stuck awaiting it.
+    let releaseLookup: () => void = () => {}
+    wmiLookupBlocker = new Promise<void>((resolve) => {
+      releaseLookup = resolve
+    })
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The tracked child dies on its own while the lookup is still parked, which
+    // releases PID 1234 for Windows to hand to somebody else.
+    trackedChild.exitCode = 0
+    releaseLookup()
+
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    await killPromise
+
+    const askedPids = gracefulRequests().map((call) => call.args[call.args.indexOf('/PID') + 1])
+    // The companion that is still running is asked; the released number is not.
+    expect(askedPids).toContain('5555')
+    expect(askedPids).not.toContain('1234')
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -397,6 +397,11 @@ async function loadProcessModules() {
       const handlers = new Map<string, (...args: unknown[]) => void>()
       const child = {
         pid: 1234,
+        // A live ChildProcess reports null on both until it exits. Present so a
+        // test can model "the app exited during the grace window" (#659), and
+        // so the exit check reads real values rather than undefined.
+        exitCode: null as number | null,
+        signalCode: null as string | null,
         once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
           handlers.set(event, handler)
           if (event === 'error' && spawnErrors.has(appPath)) {
@@ -2223,26 +2228,67 @@ test('the grace window is one shared wait, not one per app (#659)', async () => 
 })
 
 test('nothing running means no grace window at all (#659)', async () => {
-  // Real timers on purpose. If this waited, the test would hang rather than
-  // fail an assertion, which is a stronger statement than advancing a fake
-  // clock and finding the result already there.
-  markExistingPath('C:/Tools/App2.exe')
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/App2.exe')
 
-  const { killLaunchedApps } = await loadProcessModulesWithStore({
-    gracefulCloseEnabled: true,
-    profiles: {
-      ac: {
-        activeProfileId: 'default',
-        profiles: [{ id: 'default', name: 'Default', customapp2: true }]
-      }
-    },
-    appPaths: { customapp2: 'C:/Tools/App2.exe' }
-  })
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe' }
+    })
 
-  const result = await killLaunchedApps('ac')
+    let settled = false
+    const killPromise = killLaunchedApps('ac').then((value) => {
+      settled = true
+      return value
+    })
 
-  expect(gracefulRequests()).toHaveLength(0)
-  expect(result.closedCount).toBe(0)
+    // The assertion that matters is the clock NOT moving. Advancing by zero
+    // only drains microtasks, so settling here proves the close returned
+    // without entering the window at all. An earlier version used real timers
+    // and would have passed just as happily while waiting the full three
+    // seconds, pinning nothing (CodeRabbit on #823).
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(true)
+
+    const result = await killPromise
+    expect(gracefulRequests()).toHaveLength(0)
+    expect(result.closedCount).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The grace window is a window in which a well-behaved app is expected to exit,
+// which is exactly when a PID stops being a safe thing to signal: Node releases
+// the handle on exit and Windows may hand that number to something else, and
+// `/T` would take that stranger's whole tree. Tested directly against
+// win32KillUtils, which is the seam #773 extracted for precisely this.
+test('a child that already exited is never signalled again (#659)', async () => {
+  await loadProcessModules()
+  const { killProcessTree } = await import('../../src/main/processes/win32KillUtils')
+
+  const exitedChild = {
+    pid: 4321,
+    exitCode: 0,
+    signalCode: null,
+    kill: vi.fn()
+  } as unknown as Parameters<typeof killProcessTree>[0]
+
+  const result = await killProcessTree(exitedChild, 'C:/Tools/App2.exe', 'ac')
+
+  // No taskkill at all, not even a failed one: the PID is never put on the wire.
+  expect(execFileCalls.filter((call) => call.command === 'taskkill')).toHaveLength(0)
+  // Reported exactly as taskkill would have reported finding nothing, so the
+  // accounting downstream needs no special case.
+  expect(result).toMatchObject({ success: true, notFound: true, processName: 'app2.exe' })
+  expect(result.targetConfirmed).toBeUndefined()
 })
 
 test('a bare-name target is never asked politely, to keep the phase path-scoped (#659)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2344,6 +2344,61 @@ test('a child that exits while the lookup is in flight is dropped from the reque
   }
 })
 
+// The same Codex P1, for the half a handle cannot cover. A discovered PID is
+// just a number, so the defence is not to hold it: collecting every lookup
+// before asking anyone left the first answer sitting unused for as long as the
+// slowest lookup took, up to WMI_LOOKUP_TIMEOUT_MS, and that companion could
+// exit and hand its number to a stranger inside that gap.
+test('a discovered PID is asked as soon as its own lookup answers (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/App2.exe')
+    markExistingPath('C:/Tools/App3.exe')
+    processNames.add('app2.exe')
+    processNames.add('app3.exe')
+    registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+    registerProcess('C:/Tools/App3.exe', 'app3.exe', '5555')
+
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true, customapp3: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe', customapp3: 'C:/Tools/App3.exe' }
+    })
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    // One-shot, so it parks whichever lookup goes out first and leaves the
+    // other one answering at its normal speed.
+    let releaseLookup: () => void = () => {}
+    wmiLookupBlocker = new Promise<void>((resolve) => {
+      releaseLookup = resolve
+    })
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Exactly one: the target that already answered has been asked, while the
+    // parked lookup has not delayed it. Batching every result first would make
+    // this zero.
+    expect(gracefulRequests()).toHaveLength(1)
+
+    releaseLookup()
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    await killPromise
+
+    const askedPids = gracefulRequests()
+      .map((call) => call.args[call.args.indexOf('/PID') + 1])
+      .sort()
+    expect(askedPids).toEqual(['4321', '5555'])
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
 // The grace window is a window in which a well-behaved app is expected to exit,
 // which is exactly when a PID stops being a safe thing to signal: Node releases
 // the handle on exit and Windows may hand that number to something else, and

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -17,6 +17,10 @@ const accessDeniedPids = new Set<string>()
 const accessDeniedImageNames = new Set<string>()
 const inaccessibleExecutablePathProcesses = new Set<string>()
 const nullExecutablePathPids = new Set<string>()
+// #659: PIDs whose process actually honours a graceful (non-`/F`) close
+// request. Everything else ignores it and is still there for the force kill,
+// which is the realistic default (console apps, apps with no message loop).
+const gracefulClosePids = new Set<string>()
 const staleTaskkillPids = new Set<string>()
 // "Process exited cleanly BEFORE the kill ran" — when a name is in this set,
 // the path-scoped WMI lookup removes it from `processNames` so the post-kill
@@ -329,6 +333,22 @@ async function loadProcessModules() {
         callback(null, pids.length ? JSON.stringify(pids.map(Number)) : '', '')
         return
       }
+      // A `/PID` taskkill WITHOUT `/F` is the graceful request (#659): it posts
+      // WM_CLOSE rather than terminating, so it only removes a process that
+      // chose to honour it. Modelling this separately is what makes "the app
+      // ignored us and had to be force-killed" expressible at all.
+      if (command === 'taskkill' && args.includes('/PID') && !args.includes('/F')) {
+        const pid = args[args.indexOf('/PID') + 1]
+        if (gracefulClosePids.has(pid)) {
+          const entry = findRegistryEntryByPid(pid)
+          if (entry) {
+            processNames.delete(entry.processName)
+          }
+          nullExecutablePathPids.delete(pid)
+        }
+        callback(null, '', '')
+        return
+      }
       if (command === 'taskkill' && args.includes('/PID')) {
         const pid = args[args.indexOf('/PID') + 1]
         if (staleTaskkillPids.has(pid)) {
@@ -466,6 +486,14 @@ async function loadProcessModules() {
         )
       )
     },
+    // #659: the graceful-close toggle is read straight from the store by
+    // killLaunchedApps. Mirrors the real signature (opt-in, so anything that is
+    // not an explicit true is false) rather than hardcoding false, so a test can
+    // switch it on by writing `storeData.gracefulCloseEnabled = true`.
+    getStoredBoolean: (key: string, fallback = false) => {
+      const value = storeData[key]
+      return typeof value === 'boolean' ? value : fallback
+    },
     store: {
       store: storeData,
       get: (key: string) => storeData[key],
@@ -600,6 +628,7 @@ beforeEach(async () => {
   accessDeniedImageNames.clear()
   inaccessibleExecutablePathProcesses.clear()
   nullExecutablePathPids.clear()
+  gracefulClosePids.clear()
   staleTaskkillPids.clear()
   processNamesGoneAfterWmiLookup.clear()
   processNamesGoneAfterKill.clear()
@@ -2002,6 +2031,271 @@ test('an ordinary Close Apps with no pending handoff says nothing about a prompt
 
   // The unchanged case must read exactly as it did before this issue.
   expect(result.strandedConsentPrompts).toBeUndefined()
+})
+
+// ---------------------------------------------------------------------------
+// #659 graceful close. Every test here drives killLaunchedApps, the path both
+// explicit Close Apps affordances (tray item and row button) go through.
+// ---------------------------------------------------------------------------
+
+// A polite request is a `/PID` taskkill WITHOUT `/F`: that posts WM_CLOSE
+// instead of terminating. The force kill keeps its `/F`, so the two are told
+// apart by the flag alone.
+function gracefulRequests() {
+  return execFileCalls.filter(
+    (call) => call.command === 'taskkill' && call.args.includes('/PID') && !call.args.includes('/F')
+  )
+}
+
+function forceKills() {
+  return execFileCalls.filter(
+    (call) => call.command === 'taskkill' && call.args.includes('/PID') && call.args.includes('/F')
+  )
+}
+
+test('graceful close is off by default, so the close path is unchanged (#659)', async () => {
+  markExistingPath('C:/Tools/App2.exe')
+  processNames.add('app2.exe')
+  registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+      }
+    },
+    appPaths: { customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const result = await killLaunchedApps('ac')
+
+  // Not merely "no delay": nothing is even asked. The default close stays the
+  // single force kill it has always been.
+  expect(gracefulRequests()).toHaveLength(0)
+  expect(forceKills()).toHaveLength(1)
+  expect(result.closedCount).toBe(1)
+})
+
+test('with the toggle on, a target is asked to close before anything is forced (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/App2.exe')
+    processNames.add('app2.exe')
+    registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    await killPromise
+
+    // Asked by PID, not by image name: an `/IM` request would reach every
+    // same-named process, including one the user started themselves.
+    expect(gracefulRequests()).toEqual([
+      expect.objectContaining({ command: 'taskkill', args: ['/PID', '4321', '/T'] })
+    ])
+    // And the ordering is the entire feature.
+    const askedAt = execFileCalls.indexOf(gracefulRequests()[0])
+    const forcedAt = execFileCalls.indexOf(forceKills()[0])
+    expect(askedAt).toBeLessThan(forcedAt)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('an app that honours the request is reported closed, not failed (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/App2.exe')
+    processNames.add('app2.exe')
+    registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+    // This one saves its state and exits on its own.
+    gracefulClosePids.add('4321')
+
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    const result = await killPromise
+
+    // It left during the grace window, so the force kill finds nothing. That
+    // has to read as "closed", never as a failure the user must act on.
+    expect(result.success).toBe(true)
+    expect(result.closedCount).toBe(1)
+    expect(result.failures).toEqual([])
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('an app that ignores the request is still force-killed (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/App2.exe')
+    processNames.add('app2.exe')
+    registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+    // Deliberately not in gracefulClosePids: a console app, or one that simply
+    // ignores WM_CLOSE.
+
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    const result = await killPromise
+
+    expect(forceKills()).toEqual([expect.objectContaining({ args: ['/PID', '4321', '/T', '/F'] })])
+    expect(result.closedCount).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('the grace window is one shared wait, not one per app (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/App2.exe')
+    markExistingPath('C:/Tools/App3.exe')
+    processNames.add('app2.exe')
+    processNames.add('app3.exe')
+    registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+    registerProcess('C:/Tools/App3.exe', 'app3.exe', '5555')
+
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', customapp2: true, customapp3: true }]
+        }
+      },
+      appPaths: { customapp2: 'C:/Tools/App2.exe', customapp3: 'C:/Tools/App3.exe' }
+    })
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    let settled = false
+    const killPromise = killLaunchedApps('ac').then((value) => {
+      settled = true
+      return value
+    })
+
+    // Two apps, both ignoring the request. Advancing ONE window must be
+    // enough: a per-app wait would need two, and the issue requires the total
+    // to stay bounded however many apps ignore it.
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    await killPromise
+
+    expect(settled).toBe(true)
+    expect(gracefulRequests()).toHaveLength(2)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('nothing running means no grace window at all (#659)', async () => {
+  // Real timers on purpose. If this waited, the test would hang rather than
+  // fail an assertion, which is a stronger statement than advancing a fake
+  // clock and finding the result already there.
+  markExistingPath('C:/Tools/App2.exe')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    gracefulCloseEnabled: true,
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', customapp2: true }]
+      }
+    },
+    appPaths: { customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const result = await killLaunchedApps('ac')
+
+  expect(gracefulRequests()).toHaveLength(0)
+  expect(result.closedCount).toBe(0)
+})
+
+test('a bare-name target is never asked politely, to keep the phase path-scoped (#659)', async () => {
+  vi.useFakeTimers()
+  try {
+    // The garage61 companion agent is a hardcoded bare process name with no
+    // configured path, so it can only be reached by `/IM`. Asking by name
+    // would broaden the request to every same-named process, breaking the
+    // guarantee the force-kill path already refuses to break.
+    processNames.add('garage61 telemetry agent.exe')
+    markExistingPath('C:/Tools/Garage61.exe')
+
+    const { killLaunchedApps } = await loadProcessModulesWithStore({
+      gracefulCloseEnabled: true,
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', garage61: true }]
+        }
+      },
+      appPaths: { garage61: 'C:/Tools/Garage61.exe' }
+    })
+    const { GRACEFUL_CLOSE_WINDOW_MS } = await import('../../src/main/processes/win32KillUtils')
+
+    const killPromise = killLaunchedApps('ac')
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CLOSE_WINDOW_MS)
+    await killPromise
+
+    expect(gracefulRequests()).toHaveLength(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The scope decision, pinned. A profile switch already contains close-then-
+// relaunch pairs (a slot-key move of the same exe, see ipc/launch.ts), so a
+// grace window there is latency spent on an app that is about to be started
+// again moments later. If someone later routes the switch through the graceful
+// phase, this is the test that should stop them and send them to #659 first.
+test('a profile switch never runs the graceful phase, toggle or not (#659)', async () => {
+  markExistingPath('C:/Tools/App2.exe')
+  processNames.add('app2.exe')
+  registerProcess('C:/Tools/App2.exe', 'app2.exe', '4321')
+
+  const { killProfileApps } = await loadProcessModulesWithStore({
+    gracefulCloseEnabled: true,
+    appPaths: { customapp2: 'C:/Tools/App2.exe' }
+  })
+
+  const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+
+  expect(gracefulRequests()).toHaveLength(0)
+  expect(result.closedCount).toBe(1)
 })
 
 // The other kill entry point, and the one a profile switch actually goes

--- a/tests/main/store.test.ts
+++ b/tests/main/store.test.ts
@@ -359,6 +359,7 @@ test('sanitizeSettingsPatch round-trips every settings key with valid values', a
     minimizeToTray: true,
     showTrayIcon: false,
     autoCheckUpdates: false,
+    gracefulCloseEnabled: true,
     zoomFactor: 1.5
   }
 


### PR DESCRIPTION
## Summary

Adds the opt-in graceful close: with the toggle on, everything about to be closed is first asked to close itself (`taskkill /PID <pid> /T`, no `/F`, which posts `WM_CLOSE`), then after one bounded window whatever is still running is force-killed exactly as before. Default is **off**, and with it off nothing is asked and nothing waits.

This is what lets an app like SimHub flush a dashboard, layout or device handle instead of being terminated mid-write.

## Scope: explicit Close Apps only, not the profile switch

The graceful phase runs from `killLaunchedApps`, so both explicit affordances get it (tray item via `closeApps.ts`, row button via `ipc/launch.ts`). `killProfileApps`, the profile switch, never opts in.

That is a deliberate product line, not a limitation. A switch is a transition the user wants to be fast, and **it already contains close-then-relaunch pairs today**: entry identity is `{key, path}` (`ipc/launch.ts:31`) while `appArgs` is global per slot key, so moving one exe between slots stops and restarts it. `ipc/launch.ts:283-290` exists precisely to make that relaunch happen. Waiting politely for an app that is about to be started again moments later is latency spent on nothing. It would also drop a new timing phase into the handler #715 and #782 are about to restructure.

A regression test pins this, so a later change is deliberate rather than accidental. #822 tracks revisiting it, since per-profile argument overrides will make those restart pairs common.

## Two deviations from the issue, both to satisfy its own acceptance criteria

**1. No survivor re-scan. The force kill IS the re-check.**

The issue proposes waiting, then re-reading `readRunningProcessNames()` to see who exited, then escalating only for survivors. Two problems. That function is **name-scoped**, so for two same-named exes at different paths it answers about the wrong one, which is exactly the class #772 and #674 are about, and it would break this issue's own criterion that the phase stay path-scoped. And a separate scan opens a TOCTOU window where an app exits between the scan and the kill.

Instead the force kill runs unconditionally over the same targets. `taskkill` against a process that already exited reports `notFound`, which `finalizeKillAttempts` already treats as closed rather than failed, so an app that took the polite exit is reported as closed and one that ignored it is force-killed and reported exactly as today. No new accounting, no new window.

**2. Bare-name targets are not asked.**

A target with no full path can only be reached by `/IM`, which is not path-scoped, so asking would broadcast `WM_CLOSE` to every same-named process including ones the user started outside SimLauncher. Those skip the polite phase and are force-killed as before. Path-scoping wins over politeness, per the issue's own acceptance list.

## Implementation note worth reading before editing

`killLaunchedApps` now collects **thunks** rather than promises. A `killProcessTree(...)` expression starts the kill the moment it is evaluated, so the previous eager `killTasks.push(killProcessTree(...))` would have force-killed everything before the graceful phase ever ran. Nothing starts until the thunks are called, after the phase.

The window is one shared 3s wait for the whole batch, not one per app, so the total stays bounded however many apps ignore the request. With nothing running the window is skipped entirely, so "close with nothing open" stays instant even with the toggle on.

## Follow-ups filed

Both from the second Codex round, adjudicated in the review threads rather than fixed here.

- #824: a descendant that ignores WM_CLOSE survives when its parent honours it. The `hasChildExited` guard is not the cause, `taskkill /PID <dead> /T /F` reaps nothing either (measured, exit 128), so removing it would only put a released PID back on the wire with `/F`.
- #825: the force phase resolves targets at kill time, so a replacement started inside the window is killed. Pre-existing with the toggle off, widened by the window. The fix is a `Win32_Process.CreationDate` filter, which changes every force kill and needs its own change.
- #822: revisit the profile switch once per-profile argument overrides make close-then-relaunch pairs common.

## Acceptance

- [x] Settings toggle, default OFF (`Close apps gracefully`, Behavior section)
- [x] When ON, targets get a non-`/F` request first, then a force kill only after a bounded window
- [x] When OFF, the close path is unchanged: nothing asked, nothing waited
- [x] The grace phase stays path-scoped (per PID, never `/IM`)
- [x] Apps that exit during the window are reported closed; survivors are force-killed and reported as today
- [x] Total close time bounded regardless of how many apps ignore the request

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, 0 warnings)
- [x] `npm run typecheck`
- [x] `npm test` (79 files, **627 passed**, 11 new)
- [x] `npm run build`

The eleven new tests were **mutation-verified**, since a green test that pins nothing is worse than no test:

| mutation | caught by |
|---|---|
| ignore the toggle and always run the graceful phase | `graceful close is off by default…` |
| smuggle `/F` into the polite request, so it terminates instead of asking | `…asked to close before anything is forced`, `…one shared wait…` |
| wait per app instead of once for the batch | `the grace window is one shared wait, not one per app` |
| signal a tracked child by the PID captured before the lookups | `a child that exits while the lookup is in flight is dropped…` |
| hold every discovered PID until the slowest lookup finishes | `a discovered PID is asked as soon as its own lookup answers` |

The `execFile` mock needed extending for this: its `/PID` branch treated every `taskkill` as lethal, so "the app ignored the request" was previously inexpressible. It now splits on `/F` and only removes a process that opted into honouring the polite request.

- [ ] Manual (smoke): with the toggle on, close a running SimHub from the tray and confirm it saves rather than dying mid-write; with the toggle off, confirm the close is as immediate as it is today.

Closes #659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Close apps gracefully” setting.
  * When enabled, applications receive time to shut down normally before remaining applications are force-closed.
  * The setting is saved, restored, and included in configuration import/export.

* **Bug Fixes**
  * Improved application shutdown handling while preserving force-close fallback behavior.

* **Tests**
  * Expanded coverage for graceful closing, fallback termination, shutdown timing, and settings persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #659
<!-- auto-closes -->


