### PR TITLE
feat(processes): close a profile's companions when its game exits (#204)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import { closeAppsFromTray } from './closeApps'
 import { installMainProcessErrorLogging, writeMainErrorLog } from './errorLog'
 import { registerHandlers } from './ipc'
 import { migrateProfilesToNamedSets } from './migrator'
+import { initAutoClose } from './processes'
 import { registerContentSecurityPolicy } from './security'
 import { store } from './store'
 import { configureTray, createTray } from './tray'
@@ -51,6 +52,11 @@ if (!gotTheLock) {
         console.error('Profile migration failed; leaving stored profiles unchanged.', error)
       }
       registerHandlers()
+      // Registers an observer on the process scan (#204). Cheap and inert until
+      // some profile opts in, and registered here rather than at import time so
+      // it cannot observe anything before the migration above has settled the
+      // profile shape it reads.
+      initAutoClose()
       configureTray({
         getIconPath: getAppIconPath,
         showMainWindow,

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -1,3 +1,4 @@
+export { AUTO_CLOSE_GRACE_MS, initAutoClose } from './processes/autoClose'
 export { hasClosableLaunchedApps, killLaunchedApps, killProfileApps } from './processes/kill'
 export {
   getRunningApps,

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -1,16 +1,13 @@
+import { performance } from 'perf_hooks'
+
 import { writeAppErrorLog } from '../errorLog'
 import { getActiveStoredProfile, getStoredProfiles, type StoredProfile } from '../profiles'
 import { getStoredStringRecord } from '../store'
-import { getExeName, isValidExePath, normalizePathForComparison } from '../utils'
+import { getExeName, isValidExePath } from '../utils'
 
 import { killLaunchedApps } from './kill'
 import { registerProcessScanObserver, type ProcessScanObserver } from './running'
-import {
-  gamesSeenRunning,
-  getLaunchGeneration,
-  isLaunchActiveForGame,
-  processNameMismatchWarnings
-} from './state'
+import { gamesSeenRunning, getLaunchGeneration, isLaunchActiveForGame } from './state'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { RunningProcessNamesResult } from './tasklist'
 
@@ -33,6 +30,25 @@ import type { RunningProcessNamesResult } from './tasklist'
  * has both hands on the wheel and cannot intervene.
  */
 export const AUTO_CLOSE_GRACE_MS = 15000
+
+/**
+ * How long a game must have been seen running before its disappearance counts
+ * as the end of a session (#204).
+ *
+ * Launcher stubs are the reason. Steam and EA App style entry points show up
+ * under the configured game name, hand off to a differently-named child and
+ * exit, all within seconds. Their disappearance is not an exit, it is the
+ * session starting, and closing the user's overlays there lands mid-race.
+ *
+ * A duration rather than provenance: the alternative was to trust only games
+ * SimLauncher launched itself, since only those produce a mismatch warning, and
+ * that silently excluded everyone who starts their sim from Steam (Codex on
+ * #826). This rule needs no evidence about who started the game.
+ *
+ * Two minutes costs nothing real. A session shorter than that had no telemetry
+ * worth flushing and no overlays worth closing on a timer.
+ */
+export const MIN_SESSION_MS = 120000
 
 // A game only becomes a close candidate by leaving `gamesSeenRunning`, so the
 // first observation after startup (or after the observer is re-registered) can
@@ -65,19 +81,13 @@ function isAutoCloseArmed(gameKey: string): boolean {
     return false
   }
 
-  // A mismatch warning means this exe exited right after launch and the real
-  // game is running under a different name, which is the launcher-stub case
-  // (Steam, EA App). The game exe's absence is then meaningless, so refuse,
-  // BUT only while it is the only thing we could watch. Once the user has
-  // followed the warning and configured a secondary executable, we have a
-  // signal that is not lying and the refusal would be permanent for no reason
-  // (Codex on #826). The secondary is what `getArmedGameExeNames` then watches.
-  if (
-    getDistinctSecondaryExeNames(gameKey, profile).size === 0 &&
-    processNameMismatchWarnings.has(normalizePathForComparison(gamePath))
-  ) {
-    return false
-  }
+  // NOTE: there is deliberately no launcher-stub check here any more. It used
+  // to refuse whenever `processNameMismatchWarnings` held this game path, but
+  // that warning is written in exactly one place, spawn.ts' child exit handler,
+  // so it only ever exists for a game SimLauncher launched itself. A stub
+  // started from Steam never produced one, and its brief appearance read as a
+  // whole session (Codex on #826). MIN_SESSION_MS covers both cases with one
+  // rule that needs no evidence about who started the game.
 
   // Watching is by process name, so if another configured game is a different
   // copy of the same exe, one process satisfies both profiles at once: both
@@ -130,28 +140,6 @@ function getSecondaryGamePaths(profile: StoredProfile | undefined): string[] {
 }
 
 /**
- * Secondary executables that contribute a process name the primary does not.
- *
- * Only these may lift the mismatch refusal (CodeRabbit on #826). Watching is by
- * process NAME, so a secondary that is the game path again, or a same-named exe
- * from another install, collapses into the primary's name and adds no signal.
- * Counting it would grant the bypass and then arm on the very name the warning
- * says is unreliable, which is the destructive false close the refusal exists
- * to prevent. `getExeName` lowercases, so this comparison is case-safe.
- */
-function getDistinctSecondaryExeNames(
-  gameKey: string,
-  profile: StoredProfile | undefined
-): Set<string> {
-  const primaryExeName = getExeName(getStoredStringRecord('gamePaths')[gameKey])
-  return new Set(
-    getSecondaryGamePaths(profile)
-      .map(getExeName)
-      .filter((exeName) => exeName.length > 0 && exeName !== primaryExeName)
-  )
-}
-
-/**
  * Every process whose presence means this game's session is still going: the
  * configured game exe plus any "Secondary executables to watch".
  *
@@ -183,13 +171,17 @@ interface ArmedSnapshot {
   profileId: string | undefined
   exeNames: Set<string>
   launchGeneration: number
+  // Carried so the failed-read path can put the streak back exactly as it was,
+  // rather than restarting the clock and demanding another MIN_SESSION_MS.
+  seenRunningSince: number
 }
 
-function captureArming(gameKey: string): ArmedSnapshot {
+function captureArming(gameKey: string, seenRunningSince: number): ArmedSnapshot {
   return {
     profileId: getActiveProfileId(gameKey),
     exeNames: getArmedGameExeNames(gameKey),
-    launchGeneration: getLaunchGeneration(gameKey)
+    launchGeneration: getLaunchGeneration(gameKey),
+    seenRunningSince
   }
 }
 
@@ -278,7 +270,7 @@ async function runAutoClose(gameKey: string, armed: ArmedSnapshot): Promise<void
     // putting it back would resurrect the previous session's evidence for a
     // later scan to arm on (CodeRabbit on #826).
     if (isSameArming(gameKey, armed)) {
-      gamesSeenRunning.add(gameKey)
+      gamesSeenRunning.set(gameKey, armed.seenRunningSince)
     }
     return
   }
@@ -286,7 +278,7 @@ async function runAutoClose(gameKey: string, armed: ArmedSnapshot): Promise<void
   // Any one of them still up means the session is not over: a relaunch, or a
   // restart we never saw stop in a scan. Not an exit.
   if (isAnyRunning(exeNames, processNames)) {
-    gamesSeenRunning.add(gameKey)
+    gamesSeenRunning.set(gameKey, armed.seenRunningSince)
     return
   }
 
@@ -367,7 +359,12 @@ export const observeProcessScan: ProcessScanObserver = ({
     }
 
     if (isAnyRunning(exeNames, processNames)) {
-      gamesSeenRunning.add(gameKey)
+      // First read of a streak starts its clock; later ones leave it alone, so
+      // the value is how long the game has been up rather than how long ago the
+      // last scan was.
+      if (!gamesSeenRunning.has(gameKey)) {
+        gamesSeenRunning.set(gameKey, performance.now())
+      }
       cancelPendingAutoClose(gameKey)
       return
     }
@@ -377,8 +374,19 @@ export const observeProcessScan: ProcessScanObserver = ({
     // the game gone, gets false and does not push the window out again. A
     // separate `!pendingAutoCloses.has(...)` check would look like the guard
     // doing that work and never once decide anything.
-    if (gamesSeenRunning.delete(gameKey)) {
-      const armed = captureArming(gameKey)
+    const seenRunningSince = gamesSeenRunning.get(gameKey)
+    if (seenRunningSince !== undefined) {
+      gamesSeenRunning.delete(gameKey)
+
+      // Seen, but never for long enough to have been a session: a launcher stub
+      // that flickered through a scan or two and handed off to its child. The
+      // streak is consumed either way, so this cannot arm later on the strength
+      // of it.
+      if (performance.now() - seenRunningSince < MIN_SESSION_MS) {
+        return
+      }
+
+      const armed = captureArming(gameKey, seenRunningSince)
       pendingAutoCloses.set(
         gameKey,
         setTimeout(() => {

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -93,17 +93,28 @@ function isAutoCloseArmed(gameKey: string): boolean {
 }
 
 /**
- * Whether any process name this game would watch is also the configured game
- * exe of a DIFFERENT game key. Covers the secondary names too, since those are
- * matched by name exactly like the primary.
+ * Whether any process name this game would watch is also watched by a DIFFERENT
+ * game key.
+ *
+ * Compares whole watched sets, not this game's set against the others' primary
+ * exes. Secondaries are matched by name exactly like primaries, so two profiles
+ * naming the same secondary collide in the same way and with the same
+ * consequence: one process marks both games as seen, and its exit closes the
+ * companions of a profile the user never played (Codex on #826).
+ *
+ * Contested by ANY configured game, armed or not. The other profile does not
+ * have to arm for its process to be the one we mistake for ours.
  */
 function hasContestedExeName(gameKey: string): boolean {
   const watched = getArmedGameExeNames(gameKey)
-  return Object.entries(getStoredStringRecord('gamePaths')).some(
-    ([otherGameKey, otherGamePath]) =>
-      otherGameKey !== gameKey &&
-      isValidExePath(otherGamePath) &&
-      watched.has(getExeName(otherGamePath))
+  const otherGameKeys = new Set([
+    ...Object.keys(getStoredProfiles()),
+    ...Object.keys(getStoredStringRecord('gamePaths'))
+  ])
+  otherGameKeys.delete(gameKey)
+
+  return [...otherGameKeys].some((otherGameKey) =>
+    [...getArmedGameExeNames(otherGameKey)].some((exeName) => watched.has(exeName))
   )
 }
 

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -42,7 +42,7 @@ const pendingAutoCloses = new Map<string, ReturnType<typeof setTimeout>>()
  * time passes, and the user can change any of this inside it.
  */
 function isAutoCloseArmed(gameKey: string): boolean {
-  const profileEntry = getStoredProfiles()?.[gameKey]
+  const profileEntry = getStoredProfiles()[gameKey]
   const profile = profileEntry ? getActiveStoredProfile(profileEntry) : undefined
 
   // The only profile boolean that is opt-in, so `=== true`: absent
@@ -57,7 +57,7 @@ function isAutoCloseArmed(gameKey: string): boolean {
     return false
   }
 
-  const gamePath = getStoredStringRecord('gamePaths')?.[gameKey]
+  const gamePath = getStoredStringRecord('gamePaths')[gameKey]
   if (!isValidExePath(gamePath)) {
     return false
   }
@@ -76,7 +76,7 @@ function isAutoCloseArmed(gameKey: string): boolean {
 }
 
 function getArmedGameExeName(gameKey: string): string | undefined {
-  const gamePath = getStoredStringRecord('gamePaths')?.[gameKey]
+  const gamePath = getStoredStringRecord('gamePaths')[gameKey]
   return isValidExePath(gamePath) ? getExeName(gamePath) : undefined
 }
 
@@ -109,9 +109,17 @@ async function runAutoClose(gameKey: string): Promise<void> {
   invalidateProcessNameCache()
   const { processNames, succeeded } = await readRunningProcessNames()
 
-  // "We could not look" is not "it is gone". Skip this close entirely rather
-  // than acting on a read that told us nothing; the next scan re-observes.
+  // "We could not look" is not "it is gone". Skip this close rather than act on
+  // a read that told us nothing.
+  //
+  // Putting the evidence back is what makes that a skip rather than a permanent
+  // opt-out (CodeRabbit on #826): arming consumed the `gamesSeenRunning` entry,
+  // so without this the next scan, which still finds the game absent, gets
+  // `false` from the delete and never arms again. One transient tasklist
+  // failure at the wrong moment would disable auto-close for the rest of the
+  // session.
   if (!succeeded) {
+    gamesSeenRunning.add(gameKey)
     return
   }
 
@@ -119,6 +127,15 @@ async function runAutoClose(gameKey: string): Promise<void> {
   // in a scan). Not an exit.
   if (processNames.has(exeName)) {
     gamesSeenRunning.add(gameKey)
+    return
+  }
+
+  // Eligibility is re-read here too, not just before the await. The presence
+  // check above is deliberately adjacent to the kill; leaving the permission
+  // check on the far side of an I/O boundary would be the same mistake in the
+  // other half, and a game path edited mid-read would kill against an exe name
+  // we no longer target (CodeRabbit on #826).
+  if (!isAutoCloseArmed(gameKey) || getArmedGameExeName(gameKey) !== exeName) {
     return
   }
 
@@ -142,7 +159,7 @@ export const observeProcessScan: ProcessScanObserver = ({
     return
   }
 
-  const profiles = getStoredProfiles() || {}
+  const profiles = getStoredProfiles()
 
   Object.keys(profiles).forEach((gameKey) => {
     if (!isAutoCloseArmed(gameKey)) {
@@ -187,14 +204,14 @@ export const observeProcessScan: ProcessScanObserver = ({
   })
 }
 
+/**
+ * Subscribe auto-close to the process scan. Inert until some profile opts in,
+ * so registering it costs a Set lookup per scan and nothing else.
+ *
+ * Call AFTER the profile migration has run: every decision here reads the
+ * stored profile shape, and observing a half-migrated one would answer against
+ * data that is about to change.
+ */
 export function initAutoClose(): void {
   registerProcessScanObserver(observeProcessScan)
-}
-
-// Test seam: the module holds cross-scan state by design, so a suite that
-// exercises several scenarios needs a way back to a known one.
-export function resetAutoCloseState(): void {
-  pendingAutoCloses.forEach((timer) => clearTimeout(timer))
-  pendingAutoCloses.clear()
-  gamesSeenRunning.clear()
 }

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -69,7 +69,7 @@ function isAutoCloseArmed(gameKey: string): boolean {
   // signal that is not lying and the refusal would be permanent for no reason
   // (Codex on #826). The secondary is what `getArmedGameExeNames` then watches.
   if (
-    getSecondaryGamePaths(profile).length === 0 &&
+    getDistinctSecondaryExeNames(gameKey, profile).size === 0 &&
     processNameMismatchWarnings.has(normalizePathForComparison(gamePath))
   ) {
     return false
@@ -87,6 +87,28 @@ function getSecondaryGamePaths(profile: StoredProfile | undefined): string[] {
   return Array.isArray(profile?.trackedProcessPaths)
     ? profile.trackedProcessPaths.filter(isValidExePath)
     : []
+}
+
+/**
+ * Secondary executables that contribute a process name the primary does not.
+ *
+ * Only these may lift the mismatch refusal (CodeRabbit on #826). Watching is by
+ * process NAME, so a secondary that is the game path again, or a same-named exe
+ * from another install, collapses into the primary's name and adds no signal.
+ * Counting it would grant the bypass and then arm on the very name the warning
+ * says is unreliable, which is the destructive false close the refusal exists
+ * to prevent. `getExeName` lowercases, so this comparison is case-safe.
+ */
+function getDistinctSecondaryExeNames(
+  gameKey: string,
+  profile: StoredProfile | undefined
+): Set<string> {
+  const primaryExeName = getExeName(getStoredStringRecord('gamePaths')[gameKey])
+  return new Set(
+    getSecondaryGamePaths(profile)
+      .map(getExeName)
+      .filter((exeName) => exeName.length > 0 && exeName !== primaryExeName)
+  )
 }
 
 /**

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -5,7 +5,7 @@ import { getExeName, isValidExePath, normalizePathForComparison } from '../utils
 
 import { killLaunchedApps } from './kill'
 import { registerProcessScanObserver, type ProcessScanObserver } from './running'
-import { isLaunchActiveForGame, processNameMismatchWarnings } from './state'
+import { gamesSeenRunning, isLaunchActiveForGame, processNameMismatchWarnings } from './state'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { RunningProcessNamesResult } from './tasklist'
 
@@ -29,11 +29,10 @@ import type { RunningProcessNamesResult } from './tasklist'
  */
 export const AUTO_CLOSE_GRACE_MS = 15000
 
-// Games whose exe has been SEEN running in a SUCCEEDED read. A game only
-// becomes a close candidate by leaving this set, so the first observation after
-// startup (or after the observer is re-registered) can never look like an exit.
-const gamesSeenRunning = new Set<string>()
-
+// A game only becomes a close candidate by leaving `gamesSeenRunning`, so the
+// first observation after startup (or after the observer is re-registered) can
+// never look like an exit. The set lives in state.ts so that registering a
+// launch can clear it synchronously; see the comment there.
 const pendingAutoCloses = new Map<string, ReturnType<typeof setTimeout>>()
 
 /**
@@ -75,7 +74,32 @@ function isAutoCloseArmed(gameKey: string): boolean {
     return false
   }
 
+  // Watching is by process name, so if another configured game is a different
+  // copy of the same exe, one process satisfies both profiles at once: both
+  // record exit evidence, its exit arms two timers, and the companions of a
+  // profile the user never played get closed (Codex on #826). This is the #674
+  // collision class, and `getExternallyAdoptableGameKeys` already refuses to
+  // adopt on the same ambiguity, so refusing here keeps the two consistent.
+  if (hasContestedExeName(gameKey)) {
+    return false
+  }
+
   return true
+}
+
+/**
+ * Whether any process name this game would watch is also the configured game
+ * exe of a DIFFERENT game key. Covers the secondary names too, since those are
+ * matched by name exactly like the primary.
+ */
+function hasContestedExeName(gameKey: string): boolean {
+  const watched = getArmedGameExeNames(gameKey)
+  return Object.entries(getStoredStringRecord('gamePaths')).some(
+    ([otherGameKey, otherGamePath]) =>
+      otherGameKey !== gameKey &&
+      isValidExePath(otherGamePath) &&
+      watched.has(getExeName(otherGamePath))
+  )
 }
 
 function getActiveProfile(gameKey: string): StoredProfile | undefined {
@@ -289,18 +313,16 @@ export const observeProcessScan: ProcessScanObserver = ({
     // because with `gamePosition: 'last'` the game starts after its utilities
     // and `launchDelayMs` allows up to 30s between entries (Codex on #826).
     //
-    // The seen-marker is dropped as well as the timer, and that second half is
-    // the load-bearing one. Cancelling alone left the PREVIOUS session's
-    // evidence in place whenever the launch began before any absence scan had
-    // consumed it, roughly a two second gap at the FAST cadence. Then a launch
-    // that ends without the game appearing, because `launchAutomatically` is
-    // off for this profile or the spawn failed, hands that stale marker to the
-    // next scan, which arms on it and closes the companions the launch had just
-    // started (Codex on #826). Nothing is lost by dropping it: a launch that
-    // does bring the game up gets the marker re-added by the very next scan.
+    // Only the timer is dropped here. The seen-marker is cleared by
+    // `registerActiveLaunch` instead, because this branch cannot be relied on
+    // to run at all: `publishRunningApps('launch')` is fire-and-forget and a
+    // companion-only or failed sequence can finish before that publish's
+    // tasklist read resolves, so no scan need ever observe an active launch
+    // (Codex on #826). Clearing it a second time here would be dead: every
+    // launch path registers, and this early return means nothing re-adds the
+    // marker for the duration of a launch either.
     if (isLaunchActiveForGame(gameKey)) {
       cancelPendingAutoClose(gameKey)
-      gamesSeenRunning.delete(gameKey)
       return
     }
 

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -288,10 +288,19 @@ export const observeProcessScan: ProcessScanObserver = ({
     // for a new session, and the run-up to it looks exactly like an exit,
     // because with `gamePosition: 'last'` the game starts after its utilities
     // and `launchDelayMs` allows up to 30s between entries (Codex on #826).
-    // Cancelling rather than deferring, because the launch will put the game
-    // back in `gamesSeenRunning` and a later exit arms a fresh window.
+    //
+    // The seen-marker is dropped as well as the timer, and that second half is
+    // the load-bearing one. Cancelling alone left the PREVIOUS session's
+    // evidence in place whenever the launch began before any absence scan had
+    // consumed it, roughly a two second gap at the FAST cadence. Then a launch
+    // that ends without the game appearing, because `launchAutomatically` is
+    // off for this profile or the spawn failed, hands that stale marker to the
+    // next scan, which arms on it and closes the companions the launch had just
+    // started (Codex on #826). Nothing is lost by dropping it: a launch that
+    // does bring the game up gets the marker re-added by the very next scan.
     if (isLaunchActiveForGame(gameKey)) {
       cancelPendingAutoClose(gameKey)
+      gamesSeenRunning.delete(gameKey)
       return
     }
 

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -1,0 +1,200 @@
+import { writeAppErrorLog } from '../errorLog'
+import { getActiveStoredProfile, getStoredProfiles } from '../profiles'
+import { getStoredStringRecord } from '../store'
+import { getExeName, isValidExePath, normalizePathForComparison } from '../utils'
+
+import { killLaunchedApps } from './kill'
+import { registerProcessScanObserver, type ProcessScanObserver } from './running'
+import { processNameMismatchWarnings } from './state'
+import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
+import type { RunningProcessNamesResult } from './tasklist'
+
+/**
+ * How long to wait after the game's exe disappears before closing that
+ * profile's companions (#204).
+ *
+ * NOT a debounce, and not protection against a bad tasklist read: reads report
+ * `succeeded` explicitly and a failed one is never cached, so that risk is
+ * handled deterministically in `observeProcessScan` below. This window exists
+ * because companion apps do their most important work AT the end of a session.
+ * Garage61 uploads telemetry once the session ends; killing it seconds later
+ * risks truncating exactly the data the user ran the session for.
+ *
+ * Until now the only way these apps got closed was a human deciding to close
+ * them, which happens tens of seconds to minutes after the flag drops, so the
+ * absence of reported problems says nothing about closing them immediately.
+ * 15s is deliberately on the safe side: a window that is too long is cosmetic,
+ * a close that is too early destroys data, and it lands while the user still
+ * has both hands on the wheel and cannot intervene.
+ */
+export const AUTO_CLOSE_GRACE_MS = 15000
+
+// Games whose exe has been SEEN running in a SUCCEEDED read. A game only
+// becomes a close candidate by leaving this set, so the first observation after
+// startup (or after the observer is re-registered) can never look like an exit.
+const gamesSeenRunning = new Set<string>()
+
+const pendingAutoCloses = new Map<string, ReturnType<typeof setTimeout>>()
+
+/**
+ * Whether auto-close may act on this game right now. Re-checked immediately
+ * before the kill as well, because the whole point of the grace window is that
+ * time passes, and the user can change any of this inside it.
+ */
+function isAutoCloseArmed(gameKey: string): boolean {
+  const profileEntry = getStoredProfiles()?.[gameKey]
+  const profile = profileEntry ? getActiveStoredProfile(profileEntry) : undefined
+
+  // The only profile boolean that is opt-in, so `=== true`: absent
+  // configuration must never authorise closing a user's apps.
+  if (profile?.closeAppsOnGameExit !== true) {
+    return false
+  }
+
+  // Tracking off means SimLauncher deliberately does not follow this game's
+  // process (#591), so there is no exit to detect and arming would be a lie.
+  if (profile.trackingEnabled === false) {
+    return false
+  }
+
+  const gamePath = getStoredStringRecord('gamePaths')?.[gameKey]
+  if (!isValidExePath(gamePath)) {
+    return false
+  }
+
+  // A mismatch warning means this exe exited right after launch and the real
+  // game is running under a different name, which is the launcher-stub case
+  // (Steam, EA App). For those games EVERY exit signal we have is wrong: the
+  // exe is gone from the tasklist while the session is very much alive. Refuse
+  // to arm rather than act on a signal we already know is lying. The user's
+  // route back is "Secondary executables to watch" in the profile editor.
+  if (processNameMismatchWarnings.has(normalizePathForComparison(gamePath))) {
+    return false
+  }
+
+  return true
+}
+
+function getArmedGameExeName(gameKey: string): string | undefined {
+  const gamePath = getStoredStringRecord('gamePaths')?.[gameKey]
+  return isValidExePath(gamePath) ? getExeName(gamePath) : undefined
+}
+
+function cancelPendingAutoClose(gameKey: string): void {
+  const timer = pendingAutoCloses.get(gameKey)
+  if (timer) {
+    clearTimeout(timer)
+    pendingAutoCloses.delete(gameKey)
+  }
+}
+
+/**
+ * The final check, deliberately adjacent to the destructive action rather than
+ * inherited from the scan that armed it. Fifteen seconds is long enough for the
+ * world to have changed, and the cached read is up to 500ms stale on top, so
+ * the cache is dropped and one fresh read is taken here.
+ */
+async function runAutoClose(gameKey: string): Promise<void> {
+  pendingAutoCloses.delete(gameKey)
+
+  if (!isAutoCloseArmed(gameKey)) {
+    return
+  }
+
+  const exeName = getArmedGameExeName(gameKey)
+  if (!exeName) {
+    return
+  }
+
+  invalidateProcessNameCache()
+  const { processNames, succeeded } = await readRunningProcessNames()
+
+  // "We could not look" is not "it is gone". Skip this close entirely rather
+  // than acting on a read that told us nothing; the next scan re-observes.
+  if (!succeeded) {
+    return
+  }
+
+  // It came back inside the window (a relaunch, or a restart we never saw stop
+  // in a scan). Not an exit.
+  if (processNames.has(exeName)) {
+    gamesSeenRunning.add(gameKey)
+    return
+  }
+
+  // Failures propagate to the scheduler's catch, which is the single place
+  // auto-close reports a problem. Handling it twice would log it twice.
+  await killLaunchedApps(gameKey)
+}
+
+/**
+ * Observe one raw tasklist result and arm, cancel, or leave alone.
+ *
+ * A failed read returns immediately: `processNames` is empty on failure, so
+ * treating it as observation would read one failed read as every game exiting
+ * at once.
+ */
+export const observeProcessScan: ProcessScanObserver = ({
+  processNames,
+  succeeded
+}: RunningProcessNamesResult): void => {
+  if (!succeeded) {
+    return
+  }
+
+  const profiles = getStoredProfiles() || {}
+
+  Object.keys(profiles).forEach((gameKey) => {
+    if (!isAutoCloseArmed(gameKey)) {
+      // Disarming mid-window cancels the close rather than letting a timer the
+      // user just turned off go off anyway.
+      cancelPendingAutoClose(gameKey)
+      gamesSeenRunning.delete(gameKey)
+      return
+    }
+
+    const exeName = getArmedGameExeName(gameKey)
+    if (!exeName) {
+      return
+    }
+
+    if (processNames.has(exeName)) {
+      gamesSeenRunning.add(gameKey)
+      cancelPendingAutoClose(gameKey)
+      return
+    }
+
+    // Absent, and we saw it running. `delete` returning true IS the "arm once"
+    // guarantee: it consumes the evidence, so the next scan, which still finds
+    // the game gone, gets false and does not push the window out again. A
+    // separate `!pendingAutoCloses.has(...)` check would look like the guard
+    // doing that work and never once decide anything.
+    if (gamesSeenRunning.delete(gameKey)) {
+      pendingAutoCloses.set(
+        gameKey,
+        setTimeout(() => {
+          // Caught here rather than left to `void`: a rejection from the read
+          // or the kill would otherwise surface as an unhandled rejection with
+          // no indication which game it came from.
+          runAutoClose(gameKey).catch((err: unknown) => {
+            const detail = err instanceof Error ? err.message : String(err)
+            console.error(`Auto-close failed for ${gameKey}:`, err)
+            writeAppErrorLog('autoClose', `[${gameKey}] Auto-close failed: ${detail}`)
+          })
+        }, AUTO_CLOSE_GRACE_MS)
+      )
+    }
+  })
+}
+
+export function initAutoClose(): void {
+  registerProcessScanObserver(observeProcessScan)
+}
+
+// Test seam: the module holds cross-scan state by design, so a suite that
+// exercises several scenarios needs a way back to a known one.
+export function resetAutoCloseState(): void {
+  pendingAutoCloses.forEach((timer) => clearTimeout(timer))
+  pendingAutoCloses.clear()
+  gamesSeenRunning.clear()
+}

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -1,5 +1,5 @@
 import { writeAppErrorLog } from '../errorLog'
-import { getActiveStoredProfile, getStoredProfiles } from '../profiles'
+import { getActiveStoredProfile, getStoredProfiles, type StoredProfile } from '../profiles'
 import { getStoredStringRecord } from '../store'
 import { getExeName, isValidExePath, normalizePathForComparison } from '../utils'
 
@@ -42,8 +42,7 @@ const pendingAutoCloses = new Map<string, ReturnType<typeof setTimeout>>()
  * time passes, and the user can change any of this inside it.
  */
 function isAutoCloseArmed(gameKey: string): boolean {
-  const profileEntry = getStoredProfiles()[gameKey]
-  const profile = profileEntry ? getActiveStoredProfile(profileEntry) : undefined
+  const profile = getActiveProfile(gameKey)
 
   // The only profile boolean that is opt-in, so `=== true`: absent
   // configuration must never authorise closing a user's apps.
@@ -64,20 +63,66 @@ function isAutoCloseArmed(gameKey: string): boolean {
 
   // A mismatch warning means this exe exited right after launch and the real
   // game is running under a different name, which is the launcher-stub case
-  // (Steam, EA App). For those games EVERY exit signal we have is wrong: the
-  // exe is gone from the tasklist while the session is very much alive. Refuse
-  // to arm rather than act on a signal we already know is lying. The user's
-  // route back is "Secondary executables to watch" in the profile editor.
-  if (processNameMismatchWarnings.has(normalizePathForComparison(gamePath))) {
+  // (Steam, EA App). The game exe's absence is then meaningless, so refuse,
+  // BUT only while it is the only thing we could watch. Once the user has
+  // followed the warning and configured a secondary executable, we have a
+  // signal that is not lying and the refusal would be permanent for no reason
+  // (Codex on #826). The secondary is what `getArmedGameExeNames` then watches.
+  if (
+    getSecondaryGamePaths(profile).length === 0 &&
+    processNameMismatchWarnings.has(normalizePathForComparison(gamePath))
+  ) {
     return false
   }
 
   return true
 }
 
-function getArmedGameExeName(gameKey: string): string | undefined {
+function getActiveProfile(gameKey: string): StoredProfile | undefined {
+  const profileEntry = getStoredProfiles()[gameKey]
+  return profileEntry ? getActiveStoredProfile(profileEntry) : undefined
+}
+
+function getSecondaryGamePaths(profile: StoredProfile | undefined): string[] {
+  return Array.isArray(profile?.trackedProcessPaths)
+    ? profile.trackedProcessPaths.filter(isValidExePath)
+    : []
+}
+
+/**
+ * Every process whose presence means this game's session is still going: the
+ * configured game exe plus any "Secondary executables to watch".
+ *
+ * Deliberately NOT `getProfileTrackablePaths`, which also folds in the enabled
+ * utilities. Those are the very processes auto-close exists to close, so
+ * waiting for them to stop would mean waiting for the thing this is supposed
+ * to cause.
+ *
+ * The trade-off in reusing that user-facing list: it is worded as secondary
+ * executables generally, so a user who files a COMPANION under it turns
+ * auto-close for that profile into a no-op, because that companion is still
+ * running at the moment we ask. That fails safe (nothing is closed) and it is
+ * the price of making the launcher-stub repair path actually work.
+ */
+function getArmedGameExeNames(gameKey: string): Set<string> {
   const gamePath = getStoredStringRecord('gamePaths')[gameKey]
-  return isValidExePath(gamePath) ? getExeName(gamePath) : undefined
+  const paths = [gamePath, ...getSecondaryGamePaths(getActiveProfile(gameKey))].filter(
+    isValidExePath
+  )
+  return new Set(paths.map(getExeName))
+}
+
+// Order-independent, because the identity that matters is WHICH processes are
+// watched, not how the profile happens to list them.
+function sameExeNames(a: Set<string>, b: Set<string>): boolean {
+  return a.size === b.size && [...a].every((name) => b.has(name))
+}
+
+// The session is over only when EVERY watched process is gone. Any survivor
+// means the game is still up under one of its names, which is exactly the
+// launcher-stub case this set exists for.
+function isAnyRunning(exeNames: Set<string>, processNames: Set<string>): boolean {
+  return [...exeNames].some((exeName) => processNames.has(exeName))
 }
 
 function cancelPendingAutoClose(gameKey: string): void {
@@ -101,8 +146,8 @@ async function runAutoClose(gameKey: string): Promise<void> {
     return
   }
 
-  const exeName = getArmedGameExeName(gameKey)
-  if (!exeName) {
+  const exeNames = getArmedGameExeNames(gameKey)
+  if (exeNames.size === 0) {
     return
   }
 
@@ -123,9 +168,9 @@ async function runAutoClose(gameKey: string): Promise<void> {
     return
   }
 
-  // It came back inside the window (a relaunch, or a restart we never saw stop
-  // in a scan). Not an exit.
-  if (processNames.has(exeName)) {
+  // Any one of them still up means the session is not over: a relaunch, or a
+  // restart we never saw stop in a scan. Not an exit.
+  if (isAnyRunning(exeNames, processNames)) {
     gamesSeenRunning.add(gameKey)
     return
   }
@@ -133,9 +178,9 @@ async function runAutoClose(gameKey: string): Promise<void> {
   // Eligibility is re-read here too, not just before the await. The presence
   // check above is deliberately adjacent to the kill; leaving the permission
   // check on the far side of an I/O boundary would be the same mistake in the
-  // other half, and a game path edited mid-read would kill against an exe name
+  // other half, and a profile edited mid-read would kill against a process set
   // we no longer target (CodeRabbit on #826).
-  if (!isAutoCloseArmed(gameKey) || getArmedGameExeName(gameKey) !== exeName) {
+  if (!isAutoCloseArmed(gameKey) || !sameExeNames(getArmedGameExeNames(gameKey), exeNames)) {
     return
   }
 
@@ -170,12 +215,12 @@ export const observeProcessScan: ProcessScanObserver = ({
       return
     }
 
-    const exeName = getArmedGameExeName(gameKey)
-    if (!exeName) {
+    const exeNames = getArmedGameExeNames(gameKey)
+    if (exeNames.size === 0) {
       return
     }
 
-    if (processNames.has(exeName)) {
+    if (isAnyRunning(exeNames, processNames)) {
       gamesSeenRunning.add(gameKey)
       cancelPendingAutoClose(gameKey)
       return

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -5,7 +5,7 @@ import { getExeName, isValidExePath, normalizePathForComparison } from '../utils
 
 import { killLaunchedApps } from './kill'
 import { registerProcessScanObserver, type ProcessScanObserver } from './running'
-import { processNameMismatchWarnings } from './state'
+import { isLaunchActiveForGame, processNameMismatchWarnings } from './state'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { RunningProcessNamesResult } from './tasklist'
 
@@ -134,6 +134,43 @@ function getArmedGameExeNames(gameKey: string): Set<string> {
   return new Set(paths.map(getExeName))
 }
 
+/**
+ * What was true when the window was armed, so the eventual kill can prove it is
+ * still acting on that same intent rather than on whatever is configured 15
+ * seconds later.
+ */
+interface ArmedSnapshot {
+  profileId: string | undefined
+  exeNames: Set<string>
+}
+
+function captureArming(gameKey: string): ArmedSnapshot {
+  return { profileId: getActiveProfileId(gameKey), exeNames: getArmedGameExeNames(gameKey) }
+}
+
+/**
+ * The active profile's id, or undefined for a legacy flat profile entry, which
+ * has only one profile and therefore nothing to switch between.
+ *
+ * Watched exe names alone cannot stand in for this (Codex on #826): two
+ * profiles for the same game necessarily share the game exe, so switching
+ * between them is invisible to a name comparison. The profile switch starts the
+ * incoming profile's companions, and `killLaunchedApps` resolves its targets
+ * from whichever profile is active when it runs, so a stale timer would close
+ * apps that belong to a session the user just started.
+ */
+function getActiveProfileId(gameKey: string): string | undefined {
+  const id = getActiveProfile(gameKey)?.id
+  return typeof id === 'string' ? id : undefined
+}
+
+function isSameArming(gameKey: string, armed: ArmedSnapshot): boolean {
+  return (
+    getActiveProfileId(gameKey) === armed.profileId &&
+    sameExeNames(getArmedGameExeNames(gameKey), armed.exeNames)
+  )
+}
+
 // Order-independent, because the identity that matters is WHICH processes are
 // watched, not how the profile happens to list them.
 function sameExeNames(a: Set<string>, b: Set<string>): boolean {
@@ -161,17 +198,18 @@ function cancelPendingAutoClose(gameKey: string): void {
  * world to have changed, and the cached read is up to 500ms stale on top, so
  * the cache is dropped and one fresh read is taken here.
  */
-async function runAutoClose(gameKey: string): Promise<void> {
+async function runAutoClose(gameKey: string, armed: ArmedSnapshot): Promise<void> {
   pendingAutoCloses.delete(gameKey)
 
-  if (!isAutoCloseArmed(gameKey)) {
+  // An early-out, NOT a correctness guard: the identical check runs after the
+  // read, which is the one that decides. This exists so a timer that is already
+  // moot does not drop everyone else's process-name cache on its way to
+  // deciding nothing, since `invalidateProcessNameCache` is shared state.
+  if (!isAutoCloseArmed(gameKey) || !isSameArming(gameKey, armed)) {
     return
   }
 
-  const exeNames = getArmedGameExeNames(gameKey)
-  if (exeNames.size === 0) {
-    return
-  }
+  const { exeNames } = armed
 
   invalidateProcessNameCache()
   const { processNames, succeeded } = await readRunningProcessNames()
@@ -202,7 +240,16 @@ async function runAutoClose(gameKey: string): Promise<void> {
   // check on the far side of an I/O boundary would be the same mistake in the
   // other half, and a profile edited mid-read would kill against a process set
   // we no longer target (CodeRabbit on #826).
-  if (!isAutoCloseArmed(gameKey) || !sameExeNames(getArmedGameExeNames(gameKey), exeNames)) {
+  if (!isAutoCloseArmed(gameKey) || !isSameArming(gameKey, armed)) {
+    return
+  }
+
+  // An absent game exe is ALSO what a launch in progress looks like, and
+  // `killLaunchedApps` opens by aborting active launches, so firing here would
+  // cancel the session the user just asked for and close the companions it had
+  // already started (Codex on #826). Checked last, so a launch begun during the
+  // read is still caught.
+  if (isLaunchActiveForGame(gameKey)) {
     return
   }
 
@@ -237,6 +284,17 @@ export const observeProcessScan: ProcessScanObserver = ({
       return
     }
 
+    // A launch for this game supersedes any pending close: the user has asked
+    // for a new session, and the run-up to it looks exactly like an exit,
+    // because with `gamePosition: 'last'` the game starts after its utilities
+    // and `launchDelayMs` allows up to 30s between entries (Codex on #826).
+    // Cancelling rather than deferring, because the launch will put the game
+    // back in `gamesSeenRunning` and a later exit arms a fresh window.
+    if (isLaunchActiveForGame(gameKey)) {
+      cancelPendingAutoClose(gameKey)
+      return
+    }
+
     const exeNames = getArmedGameExeNames(gameKey)
     if (exeNames.size === 0) {
       return
@@ -254,13 +312,14 @@ export const observeProcessScan: ProcessScanObserver = ({
     // separate `!pendingAutoCloses.has(...)` check would look like the guard
     // doing that work and never once decide anything.
     if (gamesSeenRunning.delete(gameKey)) {
+      const armed = captureArming(gameKey)
       pendingAutoCloses.set(
         gameKey,
         setTimeout(() => {
           // Caught here rather than left to `void`: a rejection from the read
           // or the kill would otherwise surface as an unhandled rejection with
           // no indication which game it came from.
-          runAutoClose(gameKey).catch((err: unknown) => {
+          runAutoClose(gameKey, armed).catch((err: unknown) => {
             const detail = err instanceof Error ? err.message : String(err)
             console.error(`Auto-close failed for ${gameKey}:`, err)
             writeAppErrorLog('autoClose', `[${gameKey}] Auto-close failed: ${detail}`)

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -5,7 +5,12 @@ import { getExeName, isValidExePath, normalizePathForComparison } from '../utils
 
 import { killLaunchedApps } from './kill'
 import { registerProcessScanObserver, type ProcessScanObserver } from './running'
-import { gamesSeenRunning, isLaunchActiveForGame, processNameMismatchWarnings } from './state'
+import {
+  gamesSeenRunning,
+  getLaunchGeneration,
+  isLaunchActiveForGame,
+  processNameMismatchWarnings
+} from './state'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
 import type { RunningProcessNamesResult } from './tasklist'
 
@@ -166,10 +171,15 @@ function getArmedGameExeNames(gameKey: string): Set<string> {
 interface ArmedSnapshot {
   profileId: string | undefined
   exeNames: Set<string>
+  launchGeneration: number
 }
 
 function captureArming(gameKey: string): ArmedSnapshot {
-  return { profileId: getActiveProfileId(gameKey), exeNames: getArmedGameExeNames(gameKey) }
+  return {
+    profileId: getActiveProfileId(gameKey),
+    exeNames: getArmedGameExeNames(gameKey),
+    launchGeneration: getLaunchGeneration(gameKey)
+  }
 }
 
 /**
@@ -190,6 +200,10 @@ function getActiveProfileId(gameKey: string): string | undefined {
 
 function isSameArming(gameKey: string, armed: ArmedSnapshot): boolean {
   return (
+    // Counts every launch since arming, including one that registered AND
+    // unregistered inside our own tasklist read, which no "is a launch active"
+    // sample can see (CodeRabbit on #826).
+    getLaunchGeneration(gameKey) === armed.launchGeneration &&
     getActiveProfileId(gameKey) === armed.profileId &&
     sameExeNames(getArmedGameExeNames(gameKey), armed.exeNames)
   )
@@ -248,7 +262,13 @@ async function runAutoClose(gameKey: string, armed: ArmedSnapshot): Promise<void
   // failure at the wrong moment would disable auto-close for the rest of the
   // session.
   if (!succeeded) {
-    gamesSeenRunning.add(gameKey)
+    // ...but only if nothing superseded this session while we were looking. A
+    // launch registered during the read cleared the marker on purpose, and
+    // putting it back would resurrect the previous session's evidence for a
+    // later scan to arm on (CodeRabbit on #826).
+    if (isSameArming(gameKey, armed)) {
+      gamesSeenRunning.add(gameKey)
+    }
     return
   }
 
@@ -268,14 +288,12 @@ async function runAutoClose(gameKey: string, armed: ArmedSnapshot): Promise<void
     return
   }
 
-  // An absent game exe is ALSO what a launch in progress looks like, and
-  // `killLaunchedApps` opens by aborting active launches, so firing here would
-  // cancel the session the user just asked for and close the companions it had
-  // already started (Codex on #826). Checked last, so a launch begun during the
-  // read is still caught.
-  if (isLaunchActiveForGame(gameKey)) {
-    return
-  }
+  // No "is a launch active" check here on purpose. It used to sit at this
+  // point, and it was strictly weaker than the generation comparison above: a
+  // timer can never be armed while a launch is active, because the observer
+  // returns before arming, so any launch running now must have registered after
+  // arming and has already moved the generation. Keeping both would leave a
+  // line that cannot decide anything.
 
   // Failures propagate to the scheduler's catch, which is the single place
   // auto-close reports a problem. Handling it twice would log it twice.
@@ -313,14 +331,20 @@ export const observeProcessScan: ProcessScanObserver = ({
     // because with `gamePosition: 'last'` the game starts after its utilities
     // and `launchDelayMs` allows up to 30s between entries (Codex on #826).
     //
-    // Only the timer is dropped here. The seen-marker is cleared by
-    // `registerActiveLaunch` instead, because this branch cannot be relied on
-    // to run at all: `publishRunningApps('launch')` is fire-and-forget and a
-    // companion-only or failed sequence can finish before that publish's
+    // An early cancel, NOT a correctness guard, and the distinction is worth
+    // keeping straight because this branch used to be both.
+    //
+    // Superseding a session is handled entirely by `registerActiveLaunch`: it
+    // clears the seen-marker so nothing can arm, and bumps the generation so an
+    // already-armed timer refuses to act. Neither can be missed. This branch
+    // cannot carry that weight anyway, since `publishRunningApps('launch')` is
+    // fire-and-forget and a companion-only sequence can finish before its
     // tasklist read resolves, so no scan need ever observe an active launch
-    // (Codex on #826). Clearing it a second time here would be dead: every
-    // launch path registers, and this early return means nothing re-adds the
-    // marker for the duration of a launch either.
+    // (Codex on #826).
+    //
+    // What it still buys: a timer that is already doomed does not get to spend
+    // a `tasklist` spawn and drop everyone else's process-name cache on its way
+    // to deciding nothing.
     if (isLaunchActiveForGame(gameKey)) {
       cancelPendingAutoClose(gameKey)
       return

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -19,7 +19,11 @@ import {
   runningProcesses,
   unclosedProcesses
 } from './state'
-import { readRunningProcessNames } from './tasklist'
+import { readRunningProcessNames, type RunningProcessNamesResult } from './tasklist'
+
+export type ProcessScanObserver = (result: RunningProcessNamesResult) => void
+
+const processScanObservers = new Set<ProcessScanObserver>()
 
 export interface RunningApp {
   path: string
@@ -177,8 +181,42 @@ async function getTrackedRunningApps(
   return trackedApps
 }
 
+/**
+ * Register a main-process observer of the RAW tasklist result (#204).
+ *
+ * Deliberately raw rather than the published `RunningApp[]`: the #399 guard
+ * below protects PRUNING only, so on a failed read the empty `processNames`
+ * still flows into `unclosedApps`, `getExternallyAdoptableGameKeys` and
+ * `getTrackedRunningApps`, and an externally adopted game plus every tracked
+ * companion drop out of the published snapshot for that tick. Anything deciding
+ * "the game exited" from that list would read one failed read as an exit. An
+ * observer gets `succeeded` and can treat false as "no observation" instead.
+ *
+ * A registration hook rather than a direct import so this module never has to
+ * know about auto-close, which reaches `killLaunchedApps` and would otherwise
+ * deepen the existing running/kill import cycle.
+ */
+export function registerProcessScanObserver(observer: ProcessScanObserver): void {
+  processScanObservers.add(observer)
+}
+
+export function unregisterProcessScanObserver(observer: ProcessScanObserver): void {
+  processScanObservers.delete(observer)
+}
+
 export async function getRunningApps(): Promise<RunningApp[]> {
-  const { processNames, succeeded: tasklistReadSucceeded } = await readRunningProcessNames()
+  const readResult = await readRunningProcessNames()
+  const { processNames, succeeded: tasklistReadSucceeded } = readResult
+  // Observers run before any derivation below, on every read rather than only
+  // on scan ticks, and never get to break the caller: a throwing observer must
+  // not take the running-apps list down with it.
+  processScanObservers.forEach((observer) => {
+    try {
+      observer(readResult)
+    } catch (err) {
+      console.error('Process scan observer error:', err)
+    }
+  })
   // When the tasklist read failed, processNames is an empty Set with no
   // signal value — skip pruning so we don't silently clear running/unclosed
   // state based on bogus "everything is gone" data (see #399).

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -21,6 +21,14 @@ import {
 } from './state'
 import { readRunningProcessNames, type RunningProcessNamesResult } from './tasklist'
 
+/**
+ * A main-process consumer of one raw tasklist read.
+ *
+ * `succeeded === false` means the read failed and `processNames` is an empty
+ * Set carrying no information. An observer MUST treat that as "no observation"
+ * rather than "nothing is running", or one failed read reads as everything on
+ * the machine having stopped at once.
+ */
 export type ProcessScanObserver = (result: RunningProcessNamesResult) => void
 
 const processScanObservers = new Set<ProcessScanObserver>()
@@ -198,10 +206,6 @@ async function getTrackedRunningApps(
  */
 export function registerProcessScanObserver(observer: ProcessScanObserver): void {
   processScanObservers.add(observer)
-}
-
-export function unregisterProcessScanObserver(observer: ProcessScanObserver): void {
-  processScanObservers.delete(observer)
 }
 
 export async function getRunningApps(): Promise<RunningApp[]> {

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -33,9 +33,26 @@ const activeLaunchControllers = new Map<string, AbortController>()
  */
 export const gamesSeenRunning = new Set<string>()
 
+/**
+ * Monotonic count of launches registered per game (#204).
+ *
+ * "Is a launch active right now" is a point-in-time sample, and a
+ * companion-only or failed sequence can register AND unregister inside a single
+ * tasklist read, so an auto-close that samples it before and after its read can
+ * miss the launch entirely and then close what that launch just started
+ * (CodeRabbit on #826). A counter cannot be missed: a pending close records the
+ * value it was armed against and refuses to act if it has moved.
+ */
+const launchGenerations = new Map<string, number>()
+
+export function getLaunchGeneration(gameKey: string): number {
+  return launchGenerations.get(gameKey) ?? 0
+}
+
 export function registerActiveLaunch(gameKey: string): AbortController {
   const controller = new AbortController()
   activeLaunchControllers.set(gameKey, controller)
+  launchGenerations.set(gameKey, getLaunchGeneration(gameKey) + 1)
   // A new launch supersedes the previous session, so its exit evidence must go
   // at the moment the launch is registered, not whenever a scan next lands.
   gamesSeenRunning.delete(gameKey)

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -125,6 +125,19 @@ export function unregisterActiveLaunch(gameKey: string, controller: AbortControl
  * the caller's own threaded-through controller, so a handler's launch is not
  * blocked by its own registration.
  */
+/**
+ * Whether a launch sequence for this game is in flight right now (#204).
+ *
+ * Auto-close needs this because "the game exe is absent" is also true for the
+ * whole run-up of a launch: with `gamePosition: 'last'` the game starts after
+ * its utilities, and `launchDelayMs` allows up to 30s between entries, so the
+ * exe can legitimately be missing for far longer than the grace window while a
+ * new session is starting.
+ */
+export function isLaunchActiveForGame(gameKey: string): boolean {
+  return activeLaunchControllers.has(gameKey)
+}
+
 export function hasOtherActiveLaunchControllers(except?: AbortController): boolean {
   for (const controller of activeLaunchControllers.values()) {
     if (controller !== except) {

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -19,9 +19,26 @@ export const suppressedProcessNameMismatchWarnings = new Set<string>()
 // import between the two process-lifecycle modules (#670).
 const activeLaunchControllers = new Map<string, AbortController>()
 
+/**
+ * Games whose exe has been seen running in a succeeded tasklist read (#204).
+ *
+ * Auto-close's state, kept HERE rather than in autoClose.ts so that
+ * `registerActiveLaunch` below can clear it synchronously. Clearing it from a
+ * scan instead is not sound: `publishRunningApps('launch')` is fire-and-forget
+ * (spawn.ts), observers only run after that publish's tasklist await, and a
+ * companion-only or failed sequence can finish and unregister before the read
+ * resolves. The scan would then see no active launch, consume the PREVIOUS
+ * session's marker and close the companions the launch had just started
+ * (Codex on #826).
+ */
+export const gamesSeenRunning = new Set<string>()
+
 export function registerActiveLaunch(gameKey: string): AbortController {
   const controller = new AbortController()
   activeLaunchControllers.set(gameKey, controller)
+  // A new launch supersedes the previous session, so its exit evidence must go
+  // at the moment the launch is registered, not whenever a scan next lands.
+  gamesSeenRunning.delete(gameKey)
   return controller
 }
 

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -20,7 +20,14 @@ export const suppressedProcessNameMismatchWarnings = new Set<string>()
 const activeLaunchControllers = new Map<string, AbortController>()
 
 /**
- * Games whose exe has been seen running in a succeeded tasklist read (#204).
+ * Games seen running in a succeeded tasklist read, mapped to the monotonic
+ * timestamp of the FIRST read in the current streak (#204).
+ *
+ * A timestamp rather than a bare marker because auto-close only treats a
+ * disappearance as the end of a session once the game has been running for
+ * long enough to have been one. That is what keeps a launcher stub, which
+ * flickers through a scan or two and hands off to a differently-named child,
+ * from reading as an exit (Codex on #826).
  *
  * Auto-close's state, kept HERE rather than in autoClose.ts so that
  * `registerActiveLaunch` below can clear it synchronously. Clearing it from a
@@ -31,7 +38,7 @@ const activeLaunchControllers = new Map<string, AbortController>()
  * session's marker and close the companions the launch had just started
  * (Codex on #826).
  */
-export const gamesSeenRunning = new Set<string>()
+export const gamesSeenRunning = new Map<string, number>()
 
 /**
  * Monotonic count of launches registered per game (#204).

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -32,6 +32,7 @@ const FORBIDDEN_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 const PROFILE_BOOLEAN_KEYS = [
   'launchAutomatically',
   'trackingEnabled',
+  'closeAppsOnGameExit',
   'killControlsEnabled',
   'relaunchControlsEnabled'
 ]

--- a/src/renderer/src/components/ProfileEditor.tsx
+++ b/src/renderer/src/components/ProfileEditor.tsx
@@ -127,9 +127,11 @@ export function ProfileEditor(props: ProfileEditorProps): ReactNode {
           launchAutomatically={editor.launchAutomatically}
           gamePosition={editor.gamePosition}
           trackingEnabled={editor.trackingEnabled}
+          closeAppsOnGameExit={editor.closeAppsOnGameExit}
           onLaunchAutomaticallyChange={editor.setLaunchAutomatically}
           onGamePositionChange={editor.setGamePosition}
           onTrackingEnabledChange={editor.setTrackingEnabled}
+          onCloseAppsOnGameExitChange={editor.setCloseAppsOnGameExit}
         />
 
         <ProcessTrackingSection

--- a/src/renderer/src/components/profile-editor/ProfileBehaviorSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileBehaviorSection.tsx
@@ -6,9 +6,11 @@ interface ProfileBehaviorSectionProps {
   launchAutomatically: boolean
   gamePosition: GamePosition
   trackingEnabled: boolean
+  closeAppsOnGameExit: boolean
   onLaunchAutomaticallyChange: Dispatch<SetStateAction<boolean>>
   onGamePositionChange: Dispatch<SetStateAction<GamePosition>>
   onTrackingEnabledChange: Dispatch<SetStateAction<boolean>>
+  onCloseAppsOnGameExitChange: Dispatch<SetStateAction<boolean>>
 }
 
 const GAME_POSITION_OPTIONS: { value: GamePosition; label: string }[] = [
@@ -20,9 +22,11 @@ export function ProfileBehaviorSection({
   launchAutomatically,
   gamePosition,
   trackingEnabled,
+  closeAppsOnGameExit,
   onLaunchAutomaticallyChange,
   onGamePositionChange,
-  onTrackingEnabledChange
+  onTrackingEnabledChange,
+  onCloseAppsOnGameExitChange
 }: ProfileBehaviorSectionProps): ReactNode {
   return (
     <div className="border-t border-(--glass-border) pt-4">
@@ -38,6 +42,21 @@ export function ProfileBehaviorSection({
           checked={trackingEnabled}
           onToggle={() => onTrackingEnabledChange((value) => !value)}
           onChange={onTrackingEnabledChange}
+        />
+        {/* Auto-close needs the running indicator: without tracking there is no
+            exit to detect, so the toggle is disabled rather than left settable
+            and silently inert. */}
+        <ProfileToggleRow
+          label="Close apps when the game exits"
+          sublabel={
+            trackingEnabled
+              ? 'Waits a few seconds so tools can finish saving'
+              : 'Needs the running indicator above'
+          }
+          checked={closeAppsOnGameExit}
+          disabled={!trackingEnabled}
+          onToggle={() => onCloseAppsOnGameExitChange((value) => !value)}
+          onChange={onCloseAppsOnGameExitChange}
         />
         {/* Game position is only meaningful when "Launch game with profile" is
             on; dim and disable it via pointer-events-none + opacity rather than

--- a/src/renderer/src/components/profile-editor/ProfileToggleRow.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileToggleRow.tsx
@@ -7,30 +7,43 @@ interface ProfileToggleRowProps {
   checked: boolean
   onToggle: () => void
   onChange: (checked: boolean) => void
+  // Dims and inerts the row while keeping it in the a11y tree as a disabled
+  // switch, so a dependent toggle reads as unavailable rather than missing.
+  disabled?: boolean
+  sublabel?: string
 }
 
 export function ProfileToggleRow({
   label,
   checked,
   onToggle,
-  onChange
+  onChange,
+  disabled = false,
+  sublabel
 }: ProfileToggleRowProps): ReactNode {
   return (
     <div
       role="switch"
       aria-checked={checked ? 'true' : 'false'}
       aria-label={label}
-      tabIndex={0}
-      onClick={onToggle}
+      aria-disabled={disabled ? 'true' : undefined}
+      aria-description={sublabel}
+      tabIndex={disabled ? -1 : 0}
+      onClick={disabled ? undefined : onToggle}
       onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
+        if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
           event.preventDefault()
           onToggle()
         }
       }}
-      className="accent-subtle-hover group flex cursor-pointer items-center justify-between rounded-xl bg-(--glass-bg) p-3"
+      className={`accent-subtle-hover group flex items-center justify-between rounded-xl bg-(--glass-bg) p-3 transition-opacity ${
+        disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'
+      }`}
     >
-      <span className="text-sm font-medium text-(--text-secondary)">{label}</span>
+      <span className="flex min-w-0 flex-col pr-3">
+        <span className="text-sm font-medium text-(--text-secondary)">{label}</span>
+        {sublabel ? <span className="mt-0.5 text-xs text-(--text-muted)">{sublabel}</span> : null}
+      </span>
       {/* The native checkbox is inert (disabled + aria-hidden + tabIndex -1) and
           only drives the visual track. The click bubbles to the row's onToggle,
           so no stopPropagation wrapper and no double toggle. */}

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -60,6 +60,8 @@ export interface UseProfileEditorResult {
   setGamePosition: Dispatch<SetStateAction<GamePosition>>
   trackingEnabled: boolean
   setTrackingEnabled: Dispatch<SetStateAction<boolean>>
+  closeAppsOnGameExit: boolean
+  setCloseAppsOnGameExit: Dispatch<SetStateAction<boolean>>
   killControlsEnabled: boolean
   setKillControlsEnabled: Dispatch<SetStateAction<boolean>>
   relaunchControlsEnabled: boolean
@@ -141,6 +143,9 @@ export function useProfileEditor({
   const [launchAutomatically, setLaunchAutomatically] = useState(true)
   const [gamePosition, setGamePosition] = useState<GamePosition>('first')
   const [trackingEnabled, setTrackingEnabled] = useState(true)
+  // Default OFF, unlike every other profile toggle: this one closes the user's
+  // apps, so it has to be asked for (#204).
+  const [closeAppsOnGameExit, setCloseAppsOnGameExit] = useState(false)
   // Default ON (see useGameProfile getProfileState / #590); the load below uses
   // the same `!== false` rule so only an explicit opt-out reads as off.
   const [killControlsEnabled, setKillControlsEnabled] = useState(true)
@@ -191,6 +196,9 @@ export function useProfileEditor({
       // Anything other than an explicit 'last' means game-first (#471)
       setGamePosition(profile.gamePosition === 'last' ? 'last' : 'first')
       setTrackingEnabled(profile.trackingEnabled !== false)
+      // `=== true`, not the `!== false` its neighbours use: an unset value has
+      // to read as off.
+      setCloseAppsOnGameExit(profile.closeAppsOnGameExit === true)
       setKillControlsEnabled(profile.killControlsEnabled !== false)
       setRelaunchControlsEnabled(profile.relaunchControlsEnabled !== false)
       setTrackedProcessPaths(
@@ -268,6 +276,7 @@ export function useProfileEditor({
       launchAutomatically,
       gamePosition,
       trackingEnabled,
+      closeAppsOnGameExit,
       killControlsEnabled,
       relaunchControlsEnabled,
       trackedProcessPaths
@@ -278,6 +287,7 @@ export function useProfileEditor({
       launchAutomatically,
       gamePosition,
       trackingEnabled,
+      closeAppsOnGameExit,
       killControlsEnabled,
       relaunchControlsEnabled,
       trackedProcessPaths
@@ -538,6 +548,7 @@ export function useProfileEditor({
         launchAutomatically,
         gamePosition,
         trackingEnabled,
+        closeAppsOnGameExit,
         killControlsEnabled,
         relaunchControlsEnabled,
         trackedProcessPaths: trackedProcessPaths.filter(
@@ -594,6 +605,7 @@ export function useProfileEditor({
         launchAutomatically,
         gamePosition,
         trackingEnabled,
+        closeAppsOnGameExit,
         killControlsEnabled,
         relaunchControlsEnabled,
         trackedProcessPaths: trackedProcessPaths.filter(
@@ -702,6 +714,8 @@ export function useProfileEditor({
     setGamePosition,
     trackingEnabled,
     setTrackingEnabled,
+    closeAppsOnGameExit,
+    setCloseAppsOnGameExit,
     killControlsEnabled,
     setKillControlsEnabled,
     relaunchControlsEnabled,

--- a/src/shared/domain/profile.ts
+++ b/src/shared/domain/profile.ts
@@ -28,6 +28,11 @@ export interface Profile {
   launchAutomatically?: boolean
   gamePosition?: GamePosition
   trackingEnabled?: boolean
+  // Opt-in auto-close of this profile's companions when the game exits (#204).
+  // The ONLY profile boolean that defaults to OFF, so every read is `=== true`
+  // rather than the `!== false` the others use: closing a user's apps is
+  // destructive, so absent configuration must never mean "yes".
+  closeAppsOnGameExit?: boolean
   killControlsEnabled?: boolean
   relaunchControlsEnabled?: boolean
   trackedProcessPaths?: string[]

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -14,8 +14,17 @@ const ARMED = { closeAppsOnGameExit: true }
 // Game keys with a launch sequence in flight, mirroring activeLaunchControllers.
 const launchingGames = new Set<string>()
 // The real set lives in state.ts so registerActiveLaunch can clear it.
-const seenRunning = new Set<string>()
+const seenRunning = new Map<string, number>()
 const launchGenerations = new Map<string, number>()
+// perf_hooks is NOT driven by vitest fake timers, so the monotonic clock is
+// mocked and advanced through one helper alongside the timers. Two clocks moved
+// separately would drift, and a drifting clock makes these tests lie.
+let monotonicNow = 0
+
+async function advance(ms: number): Promise<void> {
+  monotonicNow += ms
+  await vi.advanceTimersByTimeAsync(ms)
+}
 
 // Mirrors registerActiveLaunch: registering a launch bumps the generation and
 // drops the previous session's evidence, both synchronously.
@@ -32,10 +41,11 @@ function endLaunch(gameKey: string): void {
 async function loadAutoCloseModule(opts?: {
   profiles?: Record<string, unknown>
   gamePaths?: Record<string, string>
-  mismatchPaths?: string[]
 }) {
   // utils.isValidExePath checks fs.existsSync; pretend every .exe exists so the
   // armed check does not depend on the host filesystem.
+  vi.doMock('perf_hooks', () => ({ performance: { now: () => monotonicNow } }))
+
   vi.doMock('fs', () => ({
     default: {
       existsSync: (filePath: unknown) => typeof filePath === 'string' && /\.exe$/i.test(filePath)
@@ -71,9 +81,6 @@ async function loadAutoCloseModule(opts?: {
   vi.doMock('../../src/main/processes/running.ts', () => runningMock)
 
   const stateMock = {
-    processNameMismatchWarnings: new Map(
-      (opts?.mismatchPaths ?? []).map((warnedPath) => [warnedPath.toLowerCase(), { warning: 'x' }])
-    ),
     // Read live rather than captured, so a test can start a launch part-way
     // through a scenario the way the real registry would.
     isLaunchActiveForGame: (gameKey: string) => launchingGames.has(gameKey),
@@ -127,6 +134,7 @@ beforeEach(() => {
   launchingGames.clear()
   seenRunning.clear()
   launchGenerations.clear()
+  monotonicNow = 0
   readRunningProcessNamesMock.mockReset()
   invalidateProcessNameCacheMock.mockReset()
   killLaunchedAppsMock.mockClear()
@@ -136,10 +144,11 @@ afterEach(() => {
   vi.useRealTimers()
   vi.resetModules()
   vi.doUnmock('fs')
+  vi.doUnmock('perf_hooks')
 })
 
 test('a profile that never opted in is not closed, however the game exits (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: { ac: {} },
     gamePaths: AC_GAME_PATHS
   })
@@ -149,28 +158,30 @@ test('a profile that never opted in is not closed, however the game exits (#204)
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('an armed game closes its companions once the grace window elapses (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
 
   // One millisecond short of the window: still nothing, the whole point being
   // that companions get time to finish their end-of-session work.
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS - 1)
+  await advance(AUTO_CLOSE_GRACE_MS - 1)
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 
-  await vi.advanceTimersByTimeAsync(1)
+  await advance(1)
   expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
   // The confirming read must not be served from the 500ms cache, or the check
   // adjacent to the kill is not actually fresh.
@@ -180,31 +191,34 @@ test('an armed game closes its companions once the grace window elapses (#204)',
 // The landmine. On a failed read processNames is empty, so anything treating it
 // as an observation reads one failed tasklist as every game exiting at once.
 test('a failed tasklist read is not an exit (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(READ_FAILED)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('a game that is back before the window elapses is not closed (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 2)
+  await advance(AUTO_CLOSE_GRACE_MS / 2)
   observeProcessScan(RUNNING)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(MIN_SESSION_MS)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -213,29 +227,31 @@ test('a game that is back before the window elapses is not closed (#204)', async
 // final read can catch it. This is what makes the recheck load-bearing rather
 // than decorative.
 test('a game found running by the final recheck is not closed (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(RUNNING)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('a failed read at the end of the window aborts the close (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(READ_FAILED)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -244,21 +260,22 @@ test('a failed read at the end of the window aborts the close (#204)', async () 
 // that the game was running, so unless the aborted close puts it back, one
 // badly-timed tasklist failure disables auto-close for the rest of the session.
 test('a close aborted by a failed read can still arm again afterwards (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(READ_FAILED)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 
   // tasklist recovers, and the game is still gone.
   readRunningProcessNamesMock.mockResolvedValue(GONE)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
 })
@@ -267,7 +284,7 @@ test('a close aborted by a failed read can still arm again afterwards (#204)', a
 // is. These two pin the far side of that I/O boundary (CodeRabbit on #826).
 test('disarming while the final read is in flight aborts the close (#204)', async () => {
   const profiles: Record<string, Record<string, unknown>> = { ac: { ...ARMED } }
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles,
     gamePaths: AC_GAME_PATHS
   })
@@ -277,15 +294,16 @@ test('disarming while the final read is in flight aborts the close (#204)', asyn
   })
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('repointing the game path while the final read is in flight aborts the close (#204)', async () => {
   const gamePaths: Record<string, string> = { ...AC_GAME_PATHS }
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths
   })
@@ -297,8 +315,9 @@ test('repointing the game path while the final read is in flight aborts the clos
   })
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -309,21 +328,22 @@ test('repointing the game path while the final read is in flight aborts the clos
 // would abort the launch in killLaunchedApps' prologue and close the companions
 // it had just started (Codex on #826).
 test('a launch starting inside the window cancels the pending close (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
 
   // The user has had enough of waiting and starts the profile again. The game
   // itself has not appeared yet, so the scan still sees nothing.
   startLaunch('ac')
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 3)
+  await advance(AUTO_CLOSE_GRACE_MS / 3)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -334,22 +354,23 @@ test('a launch starting inside the window cancels the pending close (#204)', asy
 // cancel, a launch that failed to start its game takes out the utilities the
 // user just watched start.
 test('a launch that ends without the game appearing still cancels the close (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
 
   startLaunch('ac')
-  await vi.advanceTimersByTimeAsync(1000)
+  await advance(1000)
   observeProcessScan(GONE)
   // The sequence gives up (a broken game path, an aborted launch) long before
   // the window would have elapsed.
   endLaunch('ac')
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -360,7 +381,7 @@ test('a launch that ends without the game appearing still cancels the close (#20
 // launch (launchAutomatically off, or a failed spawn) then never overwrites it,
 // and the first post-launch scan closes what the launch just started.
 test('a launch supersedes the previous session rather than deferring it (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -368,13 +389,14 @@ test('a launch supersedes the previous session rather than deferring it (#204)',
 
   // Seen running, then the launch starts before any scan observes the exit.
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   startLaunch('ac')
   observeProcessScan(GONE)
 
   // The sequence starts the utilities but never the game, and finishes.
   endLaunch('ac')
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -386,7 +408,7 @@ test('a launch supersedes the previous session rather than deferring it (#204)',
 // launch is active, and the guard that depends on one never fires. Clearing at
 // registration is what makes this safe.
 test('a launch no scan ever observes still supersedes the session (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -399,7 +421,7 @@ test('a launch no scan ever observes still supersedes the session (#204)', async
   endLaunch('ac')
 
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -409,15 +431,16 @@ test('a launch no scan ever observes still supersedes the session (#204)', async
 // user never played has its companions closed. getExternallyAdoptableGameKeys
 // already refuses to adopt on this same ambiguity.
 test('two configured games sharing an exe name never arm (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: { ac: { ...ARMED }, ams2: { ...ARMED } },
     gamePaths: { ac: 'C:/Games/acs.exe', ams2: 'D:/OtherInstall/acs.exe' }
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -428,7 +451,7 @@ test('two configured games sharing an exe name never arm (#204)', async () => {
 // invisible to it: absent before, absent after, yet it started the very
 // companions this close is about to kill. Only a counter survives that.
 test('a launch that begins and ends inside the confirming read aborts the close (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -439,14 +462,15 @@ test('a launch that begins and ends inside the confirming read aborts the close 
   })
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('a failed read does not resurrect evidence a launch has superseded (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -457,8 +481,9 @@ test('a failed read does not resurrect evidence a launch has superseded (#204)',
   })
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 
   // The failed-read path puts the seen-marker back so a transient failure is a
@@ -466,7 +491,7 @@ test('a failed read does not resurrect evidence a launch has superseded (#204)',
   // it back regardless would hand the previous session's evidence to this scan.
   readRunningProcessNamesMock.mockResolvedValue(GONE)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -476,7 +501,7 @@ test('a failed read does not resurrect evidence a launch has superseded (#204)',
 // secondary collisions open, and a secondary is matched by name exactly like a
 // primary.
 test('two profiles sharing a secondary exe name never arm (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: {
       ac: { ...ARMED, trackedProcessPaths: ['C:/Shared/session.exe'] },
       ams2: { ...ARMED, trackedProcessPaths: ['D:/Other/session.exe'] }
@@ -487,14 +512,15 @@ test('two profiles sharing a secondary exe name never arm (#204)', async () => {
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan({ processNames: new Set(['session.exe']), succeeded: true })
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('a launch starting during the final read aborts the close (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -506,8 +532,9 @@ test('a launch starting during the final read aborts the close (#204)', async ()
   })
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -520,18 +547,19 @@ test('switching the active profile inside the window aborts the close (#204)', a
   const profiles: Record<string, Record<string, unknown>> = {
     ac: { ...ARMED, id: 'practice' }
   }
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
 
   // Same game, same exe, different profile now active.
   profiles.ac.id = 'race'
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -542,125 +570,150 @@ test('switching the active profile inside the window aborts the close (#204)', a
 // exactly how to give us a signal that is not lying.
 const STUB_SECONDARY = 'C:/Games/acs_real.exe'
 const STUB_PROFILES = { ac: { ...ARMED, trackedProcessPaths: [STUB_SECONDARY] } }
-const STUB_MISMATCH = ['c:\\games\\acs.exe']
 const REAL_RUNNING = { processNames: new Set(['acs_real.exe']), succeeded: true }
 
 test('a stub-launched game arms once a secondary executable is configured (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: STUB_PROFILES,
-    gamePaths: AC_GAME_PATHS,
-    mismatchPaths: STUB_MISMATCH
+    gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   // The stub exe is long gone; the real game is what is running.
   observeProcessScan(REAL_RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
 })
 
 test('a secondary executable still running keeps the session open (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: STUB_PROFILES,
-    gamePaths: AC_GAME_PATHS,
-    mismatchPaths: STUB_MISMATCH
+    gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   // The stub exits, which is normal for a stub, while the game plays on.
   observeProcessScan({ processNames: new Set(['acs.exe', 'acs_real.exe']), succeeded: true })
+  await advance(MIN_SESSION_MS)
   observeProcessScan(REAL_RUNNING)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('a secondary found running by the final recheck aborts the close (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: STUB_PROFILES,
-    gamePaths: AC_GAME_PATHS,
-    mismatchPaths: STUB_MISMATCH
+    gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(REAL_RUNNING)
 
   observeProcessScan(REAL_RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  await advance(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
-// A secondary that collapses to the primary's process name adds no signal, and
-// watching is by name (CodeRabbit on #826). Counting it would lift the refusal
-// and then arm on the exact name the warning calls unreliable, producing the
-// destructive false close the refusal exists to prevent.
-test('a same-named secondary does not lift the mismatch refusal (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
-    profiles: { ac: { ...ARMED, trackedProcessPaths: ['D:/SteamLibrary/acs.exe'] } },
-    gamePaths: AC_GAME_PATHS,
-    mismatchPaths: STUB_MISMATCH
-  })
-  readRunningProcessNamesMock.mockResolvedValue(GONE)
-
-  // The stub exits fast, as stubs do, while the real game plays on unseen.
-  observeProcessScan(RUNNING)
-  observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
-
-  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
-})
-
-// Still refused when the warning is the ONLY thing we could go on: the game
-// exe exited right after launch and the real game runs under another name, so
-// "the exe is gone" is already known to be a lie for this game.
-test('a game carrying a process-name mismatch warning never arms (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+// The launcher-stub rule, and the reason it replaced the mismatch-warning
+// refusal rather than joining it (Codex on #826). A stub shows up under the
+// configured game name, hands off to a differently-named child and exits within
+// seconds. That disappearance is the session STARTING.
+test('a game that only flickers is not treated as a session (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
-    gamePaths: AC_GAME_PATHS,
-    mismatchPaths: ['c:\\games\\acs.exe']
+    gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  // One millisecond short of counting as a session.
+  await advance(MIN_SESSION_MS - 1)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The case the old refusal could never cover. `processNameMismatchWarnings` is
+// written in one place, spawn.ts' child exit handler, so a game started from
+// Steam never had one and its stub read as a whole session. Nothing in this
+// test tells auto-close who started the game, which is the point.
+test('a stub started outside SimLauncher is not treated as a session (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  // Caught by two scans, four seconds apart, then gone while the real game runs
+  // on under a name we are not watching.
+  observeProcessScan(RUNNING)
+  await advance(2000)
+  observeProcessScan(RUNNING)
+  await advance(2000)
+  observeProcessScan(GONE)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The streak is what is measured, not the gap since the last scan: a game seen
+// in scan after scan has been up the whole time.
+test('a long session measured across many scans still closes (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  for (let elapsed = 0; elapsed <= MIN_SESSION_MS; elapsed += 2000) {
+    observeProcessScan(RUNNING)
+    await advance(2000)
+  }
+  observeProcessScan(GONE)
+  await advance(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
 })
 
 test('a profile with tracking turned off never arms (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: { ac: { ...ARMED, trackingEnabled: false } },
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('turning the toggle off inside the window cancels the pending close (#204)', async () => {
   const profiles: Record<string, Record<string, unknown>> = { ac: { ...ARMED } }
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 2)
+  await advance(AUTO_CLOSE_GRACE_MS / 2)
 
   // The user disarms it while the window is open. The next scan must take the
   // timer down rather than let a close the user just turned off go ahead.
   profiles.ac.closeAppsOnGameExit = false
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
@@ -669,31 +722,32 @@ test('turning the toggle off inside the window cancels the pending close (#204)'
 // scan of a session (or the first after the observer is re-registered) looks
 // exactly like an exit.
 test('a game absent from the very first scan is not treated as an exit (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(GONE)
-  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
 test('the window is armed once, not restarted by every scan that still finds it gone (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
   observeProcessScan(GONE)
   // Scans keep arriving every 2s while the window is open. If each one re-armed
   // the timer the close would be pushed out forever and never fire.
   for (let elapsed = 0; elapsed < AUTO_CLOSE_GRACE_MS; elapsed += 2000) {
-    await vi.advanceTimersByTimeAsync(2000)
+    await advance(2000)
     observeProcessScan(GONE)
   }
 

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+// #204 auto-close. Every test drives `observeProcessScan` directly with a raw
+// tasklist result, which is the whole point of the design: the detector never
+// sees the derived RunningApp[] list, because a failed read empties that list
+// without meaning anything stopped.
+
+const readRunningProcessNamesMock = vi.fn()
+const invalidateProcessNameCacheMock = vi.fn()
+const killLaunchedAppsMock = vi.fn(async () => ({ success: true, closedCount: 1, failures: [] }))
+
+const ARMED = { closeAppsOnGameExit: true }
+
+async function loadAutoCloseModule(opts?: {
+  profiles?: Record<string, unknown>
+  gamePaths?: Record<string, string>
+  mismatchPaths?: string[]
+}) {
+  // utils.isValidExePath checks fs.existsSync; pretend every .exe exists so the
+  // armed check does not depend on the host filesystem.
+  vi.doMock('fs', () => ({
+    default: {
+      existsSync: (filePath: unknown) => typeof filePath === 'string' && /\.exe$/i.test(filePath)
+    }
+  }))
+
+  const tasklistMock = {
+    readRunningProcessNames: readRunningProcessNamesMock,
+    invalidateProcessNameCache: invalidateProcessNameCacheMock
+  }
+  vi.doMock('./tasklist', () => tasklistMock)
+  vi.doMock('/src/main/processes/tasklist.ts', () => tasklistMock)
+  vi.doMock('../../src/main/processes/tasklist', () => tasklistMock)
+  vi.doMock('../../src/main/processes/tasklist.ts', () => tasklistMock)
+
+  const killMock = {
+    killLaunchedApps: killLaunchedAppsMock,
+    killProfileApps: vi.fn(),
+    hasClosableLaunchedApps: vi.fn(),
+    pruneUnclosedProcesses: vi.fn()
+  }
+  vi.doMock('./kill', () => killMock)
+  vi.doMock('/src/main/processes/kill.ts', () => killMock)
+  vi.doMock('../../src/main/processes/kill', () => killMock)
+  vi.doMock('../../src/main/processes/kill.ts', () => killMock)
+
+  // Only initAutoClose touches running.ts, and these tests call the observer
+  // directly, so the registration seam is stubbed rather than exercised here.
+  const runningMock = {
+    registerProcessScanObserver: vi.fn(),
+    unregisterProcessScanObserver: vi.fn()
+  }
+  vi.doMock('./running', () => runningMock)
+  vi.doMock('/src/main/processes/running.ts', () => runningMock)
+  vi.doMock('../../src/main/processes/running', () => runningMock)
+  vi.doMock('../../src/main/processes/running.ts', () => runningMock)
+
+  const stateMock = {
+    processNameMismatchWarnings: new Map(
+      (opts?.mismatchPaths ?? []).map((warnedPath) => [warnedPath.toLowerCase(), { warning: 'x' }])
+    )
+  }
+  vi.doMock('./state', () => stateMock)
+  vi.doMock('/src/main/processes/state.ts', () => stateMock)
+  vi.doMock('../../src/main/processes/state', () => stateMock)
+  vi.doMock('../../src/main/processes/state.ts', () => stateMock)
+
+  const profilesMock = {
+    getStoredProfiles: vi.fn(() => opts?.profiles ?? {}),
+    // Tests pass a flat profile per game key; profile-set resolution is
+    // profiles.ts' concern and has its own suite.
+    getActiveStoredProfile: vi.fn((entry: unknown) => entry)
+  }
+  vi.doMock('../profiles', () => profilesMock)
+  vi.doMock('/src/main/profiles.ts', () => profilesMock)
+  vi.doMock('../../src/main/profiles', () => profilesMock)
+  vi.doMock('../../src/main/profiles.ts', () => profilesMock)
+
+  const storeMock = {
+    getStoredStringRecord: vi.fn((key: string) =>
+      key === 'gamePaths' ? (opts?.gamePaths ?? {}) : {}
+    )
+  }
+  vi.doMock('../store', () => storeMock)
+  vi.doMock('/src/main/store.ts', () => storeMock)
+  vi.doMock('../../src/main/store', () => storeMock)
+  vi.doMock('../../src/main/store.ts', () => storeMock)
+
+  const errorLogMock = { writeAppErrorLog: vi.fn(), writeMainErrorLog: vi.fn() }
+  vi.doMock('../errorLog', () => errorLogMock)
+  vi.doMock('/src/main/errorLog.ts', () => errorLogMock)
+  vi.doMock('../../src/main/errorLog', () => errorLogMock)
+  vi.doMock('../../src/main/errorLog.ts', () => errorLogMock)
+
+  return import('../../src/main/processes/autoClose')
+}
+
+// The default world: one armed game whose exe is running.
+const AC_PROFILES = { ac: { ...ARMED } }
+const AC_GAME_PATHS = { ac: 'C:/Games/acs.exe' }
+const RUNNING = { processNames: new Set(['acs.exe']), succeeded: true }
+const GONE = { processNames: new Set<string>(), succeeded: true }
+const READ_FAILED = { processNames: new Set<string>(), succeeded: false }
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  readRunningProcessNamesMock.mockReset()
+  invalidateProcessNameCacheMock.mockReset()
+  killLaunchedAppsMock.mockClear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetModules()
+  vi.doUnmock('fs')
+})
+
+test('a profile that never opted in is not closed, however the game exits (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: { ac: {} },
+    gamePaths: AC_GAME_PATHS
+  })
+  // Required, not decoration: without it the final read resolves undefined and
+  // the close throws on destructuring, so the assertion below would hold for a
+  // reason that has nothing to do with the toggle being off.
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('an armed game closes its companions once the grace window elapses (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+
+  // One millisecond short of the window: still nothing, the whole point being
+  // that companions get time to finish their end-of-session work.
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS - 1)
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+
+  await vi.advanceTimersByTimeAsync(1)
+  expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
+  // The confirming read must not be served from the 500ms cache, or the check
+  // adjacent to the kill is not actually fresh.
+  expect(invalidateProcessNameCacheMock).toHaveBeenCalled()
+})
+
+// The landmine. On a failed read processNames is empty, so anything treating it
+// as an observation reads one failed tasklist as every game exiting at once.
+test('a failed tasklist read is not an exit (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(READ_FAILED)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('a game that is back before the window elapses is not closed (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 2)
+  observeProcessScan(RUNNING)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// Distinct from the test above: here no scan ever saw it come back, so only the
+// final read can catch it. This is what makes the recheck load-bearing rather
+// than decorative.
+test('a game found running by the final recheck is not closed (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(RUNNING)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('a failed read at the end of the window aborts the close (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(READ_FAILED)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The launcher-stub case. The exe exited right after launch and the real game
+// runs under another name, so "the exe is gone" is already known to be a lie
+// for this game and must not be acted on.
+test('a game carrying a process-name mismatch warning never arms (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS,
+    mismatchPaths: ['c:\\games\\acs.exe']
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('a profile with tracking turned off never arms (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: { ac: { ...ARMED, trackingEnabled: false } },
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('turning the toggle off inside the window cancels the pending close (#204)', async () => {
+  const profiles: Record<string, Record<string, unknown>> = { ac: { ...ARMED } }
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 2)
+
+  // The user disarms it while the window is open. The next scan must take the
+  // timer down rather than let a close the user just turned off go ahead.
+  profiles.ac.closeAppsOnGameExit = false
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// A game that was never seen running cannot have exited. Without this the first
+// scan of a session (or the first after the observer is re-registered) looks
+// exactly like an exit.
+test('a game absent from the very first scan is not treated as an exit (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('the window is armed once, not restarted by every scan that still finds it gone (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  // Scans keep arriving every 2s while the window is open. If each one re-armed
+  // the timer the close would be pushed out forever and never fire.
+  for (let elapsed = 0; elapsed < AUTO_CLOSE_GRACE_MS; elapsed += 2000) {
+    await vi.advanceTimersByTimeAsync(2000)
+    observeProcessScan(GONE)
+  }
+
+  expect(killLaunchedAppsMock).toHaveBeenCalledTimes(1)
+})

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -15,11 +15,13 @@ const ARMED = { closeAppsOnGameExit: true }
 const launchingGames = new Set<string>()
 // The real set lives in state.ts so registerActiveLaunch can clear it.
 const seenRunning = new Set<string>()
+const launchGenerations = new Map<string, number>()
 
-// Mirrors registerActiveLaunch: registering a launch drops the previous
-// session's evidence synchronously, without waiting for a scan.
+// Mirrors registerActiveLaunch: registering a launch bumps the generation and
+// drops the previous session's evidence, both synchronously.
 function startLaunch(gameKey: string): void {
   launchingGames.add(gameKey)
+  launchGenerations.set(gameKey, (launchGenerations.get(gameKey) ?? 0) + 1)
   seenRunning.delete(gameKey)
 }
 
@@ -75,6 +77,7 @@ async function loadAutoCloseModule(opts?: {
     // Read live rather than captured, so a test can start a launch part-way
     // through a scenario the way the real registry would.
     isLaunchActiveForGame: (gameKey: string) => launchingGames.has(gameKey),
+    getLaunchGeneration: (gameKey: string) => launchGenerations.get(gameKey) ?? 0,
     gamesSeenRunning: seenRunning
   }
   vi.doMock('./state', () => stateMock)
@@ -123,6 +126,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   launchingGames.clear()
   seenRunning.clear()
+  launchGenerations.clear()
   readRunningProcessNamesMock.mockReset()
   invalidateProcessNameCacheMock.mockReset()
   killLaunchedAppsMock.mockClear()
@@ -412,6 +416,55 @@ test('two configured games sharing an exe name never arm (#204)', async () => {
   readRunningProcessNamesMock.mockResolvedValue(GONE)
 
   observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The mirror image of the arming-side hole, on the firing side (CodeRabbit on
+// #826). "Is a launch active" is sampled at one instant, so a companion-only
+// sequence that registers AND unregisters inside the confirming read is
+// invisible to it: absent before, absent after, yet it started the very
+// companions this close is about to kill. Only a counter survives that.
+test('a launch that begins and ends inside the confirming read aborts the close (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockImplementation(async () => {
+    startLaunch('ac')
+    endLaunch('ac')
+    return GONE
+  })
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('a failed read does not resurrect evidence a launch has superseded (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockImplementation(async () => {
+    startLaunch('ac')
+    endLaunch('ac')
+    return READ_FAILED
+  })
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+
+  // The failed-read path puts the seen-marker back so a transient failure is a
+  // skip rather than an opt-out, but the launch cleared it on purpose. Putting
+  // it back regardless would hand the previous session's evidence to this scan.
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
   observeProcessScan(GONE)
   await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
 

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -335,6 +335,31 @@ test('a launch that ends without the game appearing still cancels the close (#20
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
+// The gap the cancel alone could not close: the launch begins before any
+// absence scan has consumed the previous session's evidence, so cancelling the
+// timer leaves that evidence armed for later. A profile whose game does not
+// launch (launchAutomatically off, or a failed spawn) then never overwrites it,
+// and the first post-launch scan closes what the launch just started.
+test('a launch supersedes the previous session rather than deferring it (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  // Seen running, then the launch starts before any scan observes the exit.
+  observeProcessScan(RUNNING)
+  launchingGames.add('ac')
+  observeProcessScan(GONE)
+
+  // The sequence starts the utilities but never the game, and finishes.
+  launchingGames.delete('ac')
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
 test('a launch starting during the final read aborts the close (#204)', async () => {
   const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -333,6 +333,26 @@ test('a secondary found running by the final recheck aborts the close (#204)', a
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
+// A secondary that collapses to the primary's process name adds no signal, and
+// watching is by name (CodeRabbit on #826). Counting it would lift the refusal
+// and then arm on the exact name the warning calls unreliable, producing the
+// destructive false close the refusal exists to prevent.
+test('a same-named secondary does not lift the mismatch refusal (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: { ac: { ...ARMED, trackedProcessPaths: ['D:/SteamLibrary/acs.exe'] } },
+    gamePaths: AC_GAME_PATHS,
+    mismatchPaths: STUB_MISMATCH
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  // The stub exits fast, as stubs do, while the real game plays on unseen.
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
 // Still refused when the warning is the ONLY thing we could go on: the game
 // exe exited right after launch and the real game runs under another name, so
 // "the exe is gone" is already known to be a lie for this game.

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -471,6 +471,28 @@ test('a failed read does not resurrect evidence a launch has superseded (#204)',
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
+// The residual half of the ownership check (Codex on #826): comparing each
+// watched set against the other profiles' PRIMARY exes left secondary-to-
+// secondary collisions open, and a secondary is matched by name exactly like a
+// primary.
+test('two profiles sharing a secondary exe name never arm (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: {
+      ac: { ...ARMED, trackedProcessPaths: ['C:/Shared/session.exe'] },
+      ams2: { ...ARMED, trackedProcessPaths: ['D:/Other/session.exe'] }
+    },
+    // Distinct primaries, so the earlier primary-only check passes both.
+    gamePaths: { ac: 'C:/Games/acs.exe', ams2: 'D:/Games/AMS2.exe' }
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan({ processNames: new Set(['session.exe']), succeeded: true })
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
 test('a launch starting during the final read aborts the close (#204)', async () => {
   const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -46,10 +46,7 @@ async function loadAutoCloseModule(opts?: {
 
   // Only initAutoClose touches running.ts, and these tests call the observer
   // directly, so the registration seam is stubbed rather than exercised here.
-  const runningMock = {
-    registerProcessScanObserver: vi.fn(),
-    unregisterProcessScanObserver: vi.fn()
-  }
+  const runningMock = { registerProcessScanObserver: vi.fn() }
   vi.doMock('./running', () => runningMock)
   vi.doMock('/src/main/processes/running.ts', () => runningMock)
   vi.doMock('../../src/main/processes/running', () => runningMock)
@@ -209,6 +206,69 @@ test('a failed read at the end of the window aborts the close (#204)', async () 
     gamePaths: AC_GAME_PATHS
   })
   readRunningProcessNamesMock.mockResolvedValue(READ_FAILED)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// A skip, not an opt-out (CodeRabbit on #826). Arming consumes the evidence
+// that the game was running, so unless the aborted close puts it back, one
+// badly-timed tasklist failure disables auto-close for the rest of the session.
+test('a close aborted by a failed read can still arm again afterwards (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(READ_FAILED)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+
+  // tasklist recovers, and the game is still gone.
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
+})
+
+// The permission check has to be as adjacent to the kill as the presence check
+// is. These two pin the far side of that I/O boundary (CodeRabbit on #826).
+test('disarming while the final read is in flight aborts the close (#204)', async () => {
+  const profiles: Record<string, Record<string, unknown>> = { ac: { ...ARMED } }
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockImplementation(async () => {
+    profiles.ac.closeAppsOnGameExit = false
+    return GONE
+  })
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('repointing the game path while the final read is in flight aborts the close (#204)', async () => {
+  const gamePaths: Record<string, string> = { ...AC_GAME_PATHS }
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths
+  })
+  readRunningProcessNamesMock.mockImplementation(async () => {
+    // The window is long enough for a user to edit the profile in it, and the
+    // absence we are about to act on was measured against the OLD exe.
+    gamePaths.ac = 'C:/Games/other.exe'
+    return GONE
+  })
 
   observeProcessScan(RUNNING)
   observeProcessScan(GONE)

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -11,6 +11,9 @@ const killLaunchedAppsMock = vi.fn(async () => ({ success: true, closedCount: 1,
 
 const ARMED = { closeAppsOnGameExit: true }
 
+// Game keys with a launch sequence in flight, mirroring activeLaunchControllers.
+const launchingGames = new Set<string>()
+
 async function loadAutoCloseModule(opts?: {
   profiles?: Record<string, unknown>
   gamePaths?: Record<string, string>
@@ -55,7 +58,10 @@ async function loadAutoCloseModule(opts?: {
   const stateMock = {
     processNameMismatchWarnings: new Map(
       (opts?.mismatchPaths ?? []).map((warnedPath) => [warnedPath.toLowerCase(), { warning: 'x' }])
-    )
+    ),
+    // Read live rather than captured, so a test can start a launch part-way
+    // through a scenario the way the real registry would.
+    isLaunchActiveForGame: (gameKey: string) => launchingGames.has(gameKey)
   }
   vi.doMock('./state', () => stateMock)
   vi.doMock('/src/main/processes/state.ts', () => stateMock)
@@ -101,6 +107,7 @@ const READ_FAILED = { processNames: new Set<string>(), succeeded: false }
 
 beforeEach(() => {
   vi.useFakeTimers()
+  launchingGames.clear()
   readRunningProcessNamesMock.mockReset()
   invalidateProcessNameCacheMock.mockReset()
   killLaunchedAppsMock.mockClear()
@@ -272,6 +279,100 @@ test('repointing the game path while the final read is in flight aborts the clos
 
   observeProcessScan(RUNNING)
   observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// An in-flight launch looks exactly like an exit: with the game set to start
+// after its utilities, and up to 30s of launch delay between entries, its exe
+// is legitimately absent for longer than the whole grace window. Firing there
+// would abort the launch in killLaunchedApps' prologue and close the companions
+// it had just started (Codex on #826).
+test('a launch starting inside the window cancels the pending close (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+
+  // The user has had enough of waiting and starts the profile again. The game
+  // itself has not appeared yet, so the scan still sees nothing.
+  launchingGames.add('ac')
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 3)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The case only the observer's guard can catch: the launch is over by the time
+// the timer fires, so the check next to the kill sees no active launch, and the
+// game never appeared so the presence check sees nothing either. Without the
+// cancel, a launch that failed to start its game takes out the utilities the
+// user just watched start.
+test('a launch that ends without the game appearing still cancels the close (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+
+  launchingGames.add('ac')
+  await vi.advanceTimersByTimeAsync(1000)
+  observeProcessScan(GONE)
+  // The sequence gives up (a broken game path, an aborted launch) long before
+  // the window would have elapsed.
+  launchingGames.delete('ac')
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('a launch starting during the final read aborts the close (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  // No scan gets a chance to notice: the launch begins while the confirming
+  // read is in flight, which is why that check sits last.
+  readRunningProcessNamesMock.mockImplementation(async () => {
+    launchingGames.add('ac')
+    return GONE
+  })
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// Two profiles for the same game necessarily share the game exe, so the
+// watched-name comparison cannot see a switch between them. Without the profile
+// id the timer would close the incoming profile's companions on the strength of
+// the outgoing profile's exit (Codex on #826).
+test('switching the active profile inside the window aborts the close (#204)', async () => {
+  const profiles: Record<string, Record<string, unknown>> = {
+    ac: { ...ARMED, id: 'practice' }
+  }
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  observeProcessScan(GONE)
+
+  // Same game, same exe, different profile now active.
+  profiles.ac.id = 'race'
   await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -408,7 +408,7 @@ test('a launch supersedes the previous session rather than deferring it (#204)',
 // launch is active, and the guard that depends on one never fires. Clearing at
 // registration is what makes this safe.
 test('a launch no scan ever observes still supersedes the session (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -644,7 +644,7 @@ test('a game that only flickers is not treated as a session (#204)', async () =>
 // Steam never had one and its stub read as a whole session. Nothing in this
 // test tells auto-close who started the game, which is the point.
 test('a stub started outside SimLauncher is not treated as a session (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })
@@ -722,7 +722,7 @@ test('turning the toggle off inside the window cancels the pending close (#204)'
 // scan of a session (or the first after the observer is re-registered) looks
 // exactly like an exit.
 test('a game absent from the very first scan is not treated as an exit (#204)', async () => {
-  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,
     gamePaths: AC_GAME_PATHS
   })

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -277,9 +277,65 @@ test('repointing the game path while the final read is in flight aborts the clos
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
 })
 
-// The launcher-stub case. The exe exited right after launch and the real game
-// runs under another name, so "the exe is gone" is already known to be a lie
-// for this game and must not be acted on.
+// The launcher-stub repair path, and the reason the refusal below is
+// conditional (Codex on #826). Refusing forever would mean Steam/EA-launched
+// games can never use this feature, while the warning we show tells the user
+// exactly how to give us a signal that is not lying.
+const STUB_SECONDARY = 'C:/Games/acs_real.exe'
+const STUB_PROFILES = { ac: { ...ARMED, trackedProcessPaths: [STUB_SECONDARY] } }
+const STUB_MISMATCH = ['c:\\games\\acs.exe']
+const REAL_RUNNING = { processNames: new Set(['acs_real.exe']), succeeded: true }
+
+test('a stub-launched game arms once a secondary executable is configured (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: STUB_PROFILES,
+    gamePaths: AC_GAME_PATHS,
+    mismatchPaths: STUB_MISMATCH
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  // The stub exe is long gone; the real game is what is running.
+  observeProcessScan(REAL_RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).toHaveBeenCalledWith('ac')
+})
+
+test('a secondary executable still running keeps the session open (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: STUB_PROFILES,
+    gamePaths: AC_GAME_PATHS,
+    mismatchPaths: STUB_MISMATCH
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  // The stub exits, which is normal for a stub, while the game plays on.
+  observeProcessScan({ processNames: new Set(['acs.exe', 'acs_real.exe']), succeeded: true })
+  observeProcessScan(REAL_RUNNING)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+test('a secondary found running by the final recheck aborts the close (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: STUB_PROFILES,
+    gamePaths: AC_GAME_PATHS,
+    mismatchPaths: STUB_MISMATCH
+  })
+  readRunningProcessNamesMock.mockResolvedValue(REAL_RUNNING)
+
+  observeProcessScan(REAL_RUNNING)
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// Still refused when the warning is the ONLY thing we could go on: the game
+// exe exited right after launch and the real game runs under another name, so
+// "the exe is gone" is already known to be a lie for this game.
 test('a game carrying a process-name mismatch warning never arms (#204)', async () => {
   const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -13,6 +13,19 @@ const ARMED = { closeAppsOnGameExit: true }
 
 // Game keys with a launch sequence in flight, mirroring activeLaunchControllers.
 const launchingGames = new Set<string>()
+// The real set lives in state.ts so registerActiveLaunch can clear it.
+const seenRunning = new Set<string>()
+
+// Mirrors registerActiveLaunch: registering a launch drops the previous
+// session's evidence synchronously, without waiting for a scan.
+function startLaunch(gameKey: string): void {
+  launchingGames.add(gameKey)
+  seenRunning.delete(gameKey)
+}
+
+function endLaunch(gameKey: string): void {
+  launchingGames.delete(gameKey)
+}
 
 async function loadAutoCloseModule(opts?: {
   profiles?: Record<string, unknown>
@@ -61,7 +74,8 @@ async function loadAutoCloseModule(opts?: {
     ),
     // Read live rather than captured, so a test can start a launch part-way
     // through a scenario the way the real registry would.
-    isLaunchActiveForGame: (gameKey: string) => launchingGames.has(gameKey)
+    isLaunchActiveForGame: (gameKey: string) => launchingGames.has(gameKey),
+    gamesSeenRunning: seenRunning
   }
   vi.doMock('./state', () => stateMock)
   vi.doMock('/src/main/processes/state.ts', () => stateMock)
@@ -108,6 +122,7 @@ const READ_FAILED = { processNames: new Set<string>(), succeeded: false }
 beforeEach(() => {
   vi.useFakeTimers()
   launchingGames.clear()
+  seenRunning.clear()
   readRunningProcessNamesMock.mockReset()
   invalidateProcessNameCacheMock.mockReset()
   killLaunchedAppsMock.mockClear()
@@ -301,7 +316,7 @@ test('a launch starting inside the window cancels the pending close (#204)', asy
 
   // The user has had enough of waiting and starts the profile again. The game
   // itself has not appeared yet, so the scan still sees nothing.
-  launchingGames.add('ac')
+  startLaunch('ac')
   await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS / 3)
   observeProcessScan(GONE)
   await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
@@ -324,12 +339,12 @@ test('a launch that ends without the game appearing still cancels the close (#20
   observeProcessScan(RUNNING)
   observeProcessScan(GONE)
 
-  launchingGames.add('ac')
+  startLaunch('ac')
   await vi.advanceTimersByTimeAsync(1000)
   observeProcessScan(GONE)
   // The sequence gives up (a broken game path, an aborted launch) long before
   // the window would have elapsed.
-  launchingGames.delete('ac')
+  endLaunch('ac')
   await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
 
   expect(killLaunchedAppsMock).not.toHaveBeenCalled()
@@ -349,11 +364,54 @@ test('a launch supersedes the previous session rather than deferring it (#204)',
 
   // Seen running, then the launch starts before any scan observes the exit.
   observeProcessScan(RUNNING)
-  launchingGames.add('ac')
+  startLaunch('ac')
   observeProcessScan(GONE)
 
   // The sequence starts the utilities but never the game, and finishes.
-  launchingGames.delete('ac')
+  endLaunch('ac')
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The ordering the observer's own guard cannot cover (Codex on #826).
+// `publishRunningApps('launch')` is fire-and-forget, observers only run after
+// that publish's tasklist await, and a companion-only or failed sequence can
+// finish and unregister before the read resolves. So NO scan lands while the
+// launch is active, and the guard that depends on one never fires. Clearing at
+// registration is what makes this safe.
+test('a launch no scan ever observes still supersedes the session (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: AC_PROFILES,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
+  // A utilities-only profile: registers, starts its companions, unregisters,
+  // all inside one tasklist read.
+  startLaunch('ac')
+  endLaunch('ac')
+
+  observeProcessScan(GONE)
+  await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
+// The #674 collision class. Watching is by name, so one process satisfies both
+// profiles: both record evidence, its exit arms two timers, and a profile the
+// user never played has its companions closed. getExternallyAdoptableGameKeys
+// already refuses to adopt on this same ambiguity.
+test('two configured games sharing an exe name never arm (#204)', async () => {
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
+    profiles: { ac: { ...ARMED }, ams2: { ...ARMED } },
+    gamePaths: { ac: 'C:/Games/acs.exe', ams2: 'D:/OtherInstall/acs.exe' }
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  observeProcessScan(RUNNING)
   observeProcessScan(GONE)
   await vi.advanceTimersByTimeAsync(AUTO_CLOSE_GRACE_MS * 2)
 
@@ -368,7 +426,7 @@ test('a launch starting during the final read aborts the close (#204)', async ()
   // No scan gets a chance to notice: the launch begins while the confirming
   // read is in flight, which is why that check sits last.
   readRunningProcessNamesMock.mockImplementation(async () => {
-    launchingGames.add('ac')
+    startLaunch('ac')
     return GONE
   })
 

--- a/tests/main/state.test.ts
+++ b/tests/main/state.test.ts
@@ -153,8 +153,10 @@ test('abortActiveLaunches skips the except controller but still aborts every oth
 // is fire-and-forget and a companion-only or failed sequence can finish before
 // that publish's tasklist read resolves, so no scan ever sees an active launch.
 test('registering a launch clears that game exit evidence (#204)', () => {
-  gamesSeenRunning.add('iracing')
-  gamesSeenRunning.add('ac')
+  // The value is the monotonic timestamp of the first read in the streak; only
+  // its presence matters here.
+  gamesSeenRunning.set('iracing', 0)
+  gamesSeenRunning.set('ac', 0)
 
   const controller = registerActiveLaunch('iracing')
 

--- a/tests/main/state.test.ts
+++ b/tests/main/state.test.ts
@@ -6,6 +6,7 @@ import {
   consumeProcessNameMismatchWarningSuppression,
   dismissAppIcon,
   gamesSeenRunning,
+  getLaunchGeneration,
   getUnclosedProcessKey,
   isLaunchActiveForGame,
   processNameMismatchWarnings,
@@ -175,4 +176,26 @@ test('isLaunchActiveForGame tracks the registration it is named for (#204)', () 
 
   unregisterActiveLaunch('iracing', controller)
   expect(isLaunchActiveForGame('iracing')).toBe(false)
+})
+
+// The counter exists because "is a launch active" is a point-in-time sample: a
+// companion-only sequence can register AND unregister inside one tasklist read,
+// so an auto-close that samples before and after its read misses it entirely
+// and then closes what that launch just started (CodeRabbit on #826).
+test('registering a launch bumps that game launch generation (#204)', () => {
+  const before = getLaunchGeneration('iracing')
+
+  const first = registerActiveLaunch('iracing')
+  expect(getLaunchGeneration('iracing')).toBe(before + 1)
+  // Unregistering must NOT roll it back, or a sequence that finished inside a
+  // pending close's read would become invisible again.
+  unregisterActiveLaunch('iracing', first)
+  expect(getLaunchGeneration('iracing')).toBe(before + 1)
+
+  const second = registerActiveLaunch('iracing')
+  expect(getLaunchGeneration('iracing')).toBe(before + 2)
+  // Per game key, like every other launch registry here.
+  expect(getLaunchGeneration('ac')).toBe(0)
+
+  unregisterActiveLaunch('iracing', second)
 })

--- a/tests/main/state.test.ts
+++ b/tests/main/state.test.ts
@@ -5,7 +5,9 @@ import {
   abortActiveLaunches,
   consumeProcessNameMismatchWarningSuppression,
   dismissAppIcon,
+  gamesSeenRunning,
   getUnclosedProcessKey,
+  isLaunchActiveForGame,
   processNameMismatchWarnings,
   pruneExpiredProcessNameMismatchWarnings,
   pruneStoppedRunningProcesses,
@@ -142,4 +144,35 @@ test('abortActiveLaunches skips the except controller but still aborts every oth
     unregisterActiveLaunch('iracing', ownSwitchController)
     unregisterActiveLaunch('acc', unrelatedController)
   }
+})
+
+// #204. Auto-close's exit evidence lives here rather than in autoClose.ts for
+// exactly this: registering a launch has to drop it SYNCHRONOUSLY. Clearing it
+// from a process scan instead is not sound, because publishRunningApps('launch')
+// is fire-and-forget and a companion-only or failed sequence can finish before
+// that publish's tasklist read resolves, so no scan ever sees an active launch.
+test('registering a launch clears that game exit evidence (#204)', () => {
+  gamesSeenRunning.add('iracing')
+  gamesSeenRunning.add('ac')
+
+  const controller = registerActiveLaunch('iracing')
+
+  expect(gamesSeenRunning.has('iracing')).toBe(false)
+  // Only the launching game: another game's session is none of its business.
+  expect(gamesSeenRunning.has('ac')).toBe(true)
+
+  unregisterActiveLaunch('iracing', controller)
+  gamesSeenRunning.clear()
+})
+
+test('isLaunchActiveForGame tracks the registration it is named for (#204)', () => {
+  expect(isLaunchActiveForGame('iracing')).toBe(false)
+
+  const controller = registerActiveLaunch('iracing')
+  expect(isLaunchActiveForGame('iracing')).toBe(true)
+  // Per game key, so one profile launching says nothing about another.
+  expect(isLaunchActiveForGame('ac')).toBe(false)
+
+  unregisterActiveLaunch('iracing', controller)
+  expect(isLaunchActiveForGame('iracing')).toBe(false)
 })


### PR DESCRIPTION
## Summary

Opt-in per profile: when the game exits, that profile's companion apps are closed. Default off, and disabled unless the running indicator is on for that game, because without tracking there is no exit to detect and the toggle would be settable and silently inert.

How the close happens is not a new decision: it calls `killLaunchedApps(gameKey)`, so it inherits the `Close apps gracefully` setting from #659, never touches a configured game (#519), and reports through the same accounting.

## The exit signal, and the landmine under it

The detector observes the **raw** `{processNames, succeeded}` from `readRunningProcessNames`, never the published `RunningApp[]` list.

That distinction is the whole design. The #399 guard in `getRunningApps` protects **pruning only**. On a failed read `processNames` is empty and still flows into `unclosedApps`, `getExternallyAdoptableGameKeys` and `getTrackedRunningApps`, so an externally adopted game and every tracked companion drop out of the published snapshot for that tick, and the snapshot-diff gate publishes it as a normal change. A detector reading that list would treat one failed tasklist read as "the game exited" and close the user's apps mid-race.

So `succeeded === false` means no observation, never absence. `running.ts` gained a small observer hook for this; it does not import the auto-close module, which would have deepened the existing running/kill import cycle.

## Three refusals to arm

- **Not opted in.** The only profile boolean read with `=== true` rather than `!== false`. Absent configuration must never authorise closing a user's apps.
- **Tracking off.** SimLauncher deliberately does not follow that game's process (#591), so there is no exit to detect.
- **A process-name mismatch warning exists for the game.** That warning is written when the exe exits right after launch and the real game runs under a different name, the launcher-stub case (Steam, EA App). For those games every exit signal is wrong: the exe is gone from the tasklist while the session is alive. The route back is the existing "Secondary executables to watch".

## The 15 second window is not a debounce

Two other justifications were considered and rejected.

A **two-scan debounce against a bad tasklist read** is superstition: reads report `succeeded` explicitly and a failed read is never cached, so the risk is already handled deterministically.

**Protection against a game restarting itself** does not apply: for AC and iRacing a VR/flat switch is a deliberate quit back to the launcher with human interaction in between, so it is neither a short blip nor a false alarm.

What remains is that companion apps do their most important work **at** the end of a session. Garage61 uploads telemetry then. Until now the only thing that ever closed these apps was a human deciding to, which happens tens of seconds to minutes after the flag drops, so the absence of reported problems says nothing about closing them within two seconds. 15s is deliberately on the safe side: a window that is too long is cosmetic, a close that is too early destroys the data the session was run for, and it lands while the user still has both hands on the wheel and cannot intervene.

Immediately before the kill the cache is dropped and one fresh read is taken, so the confirmation sits next to the destructive action rather than two scan ticks earlier. A game that is back, or a read that fails, aborts the close.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors, 0 warnings, read from the output rather than the exit code, which is 0 on warnings)
- [x] `npm run typecheck`
- [x] `npm test` (80 files, **659 passed**, 32 new)
- [x] `npm run build`

The eleven new tests are **mutation-verified**. Seven mutations were applied to the implementation and each had to turn a test red:

| mutation | caught by |
|---|---|
| drop the `succeeded` guard in the observer | `a failed tasklist read is not an exit` |
| drop the `succeeded` guard in the final recheck | `a failed read at the end of the window aborts the close` |
| drop the presence check in the final recheck | `a game found running by the final recheck is not closed` |
| make the toggle default ON | `a profile that never opted in is not closed` |
| drop the mismatch-warning guard | `a game carrying a process-name mismatch warning never arms` |
| drop the `trackingEnabled` guard | `a profile with tracking turned off never arms` |
| arm without having seen the game run | `a game absent from the very first scan is not treated as an exit` |

Two findings came out of that pass rather than from review:

The "never opted in" test was **passing for the wrong reason**. It omitted the final-read mock, so the close threw on destructuring `undefined` and the assertion held whatever the toggle did. It only failed once the mock was added, which also surfaced that a rejection there became an unhandled rejection; the scheduler now catches and logs it with the game key.

A `!pendingAutoCloses.has(gameKey)` clause turned out to be **dead**: consuming the seen-set entry with `delete` already provides the arm-once guarantee, so no mutation of that clause could ever fail a test. Removed rather than left looking load-bearing.

- [ ] Manual (smoke, batched for the 1.2.0 run): arm a profile, play, exit the game, confirm companions close after the window and that SimHub has finished writing. Confirm a profile with the toggle off is untouched.

Deferred, filed rather than left as prose: #827 (the close resolves companion targets at kill time, not from the session that ended).

Closes #204


<!-- auto-closes -->
Closes #204
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional profile setting to automatically close configured companion apps when a tracked game exits.
  * Added a 15-second grace period with safeguards for relaunches, process-scan failures, configuration changes, and secondary executables.
  * Added contextual guidance and disabled-state behavior when tracking is unavailable.
  * Preserved the setting when profiles are saved and migrated.

* **Tests**
  * Added coverage for automatic closing, recovery, cancellation, and process-detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

