### PR TITLE
refactor(processes): put the launch's cancellation check where the process starts (#715)

### DIFF
--- a/src/main/processes/guardedStart.ts
+++ b/src/main/processes/guardedStart.ts
@@ -1,0 +1,79 @@
+// The launch path's cancellation invariant, in one place (#715).
+//
+// A kill (Close Apps) aborts the active launch's signal before doing its own
+// work (#670). The kill's snapshot cannot include a process that has not
+// started yet, so anything the launch starts after that abort is an app the
+// user just asked to close and that nothing is going to close.
+//
+// Before this module the invariant was enforced by a separate `signal.aborted`
+// check at every suspension point in the launch sequence. All five review
+// findings on #714 were the same check-flag-vs-suspend TOCTOU landing at
+// different suspension points, because a check only holds until the next one:
+// every new one was a new race window that had to remember its own check.
+//
+// Here the check sits in the same synchronous block as the process start, so it
+// is re-evaluated at the last instant a process can still be prevented. That is
+// what makes the suspension points BEFORE it stop being race windows: the
+// launch sequence can suspend wherever it likes, however many times, and still
+// start nothing once the signal is aborted. Callers therefore do not check the
+// signal to protect a start; they check it only to decide what to tell the user.
+//
+// Two properties keep that true, and tests/main/guardedStart.test.ts asserts
+// both rather than leaving them as rules to remember:
+//   1. this module is entirely synchronous, so nothing can suspend between the
+//      check and the start,
+//   2. no other main-process module starts a process on the user's behalf.
+
+import {
+  execFile,
+  spawn,
+  type ChildProcess,
+  type ExecFileException,
+  type ExecFileOptions,
+  type SpawnOptions
+} from 'child_process'
+
+// Only the error matters to the launch path — the elevation host's stdout and
+// stderr are never read — so the callback is narrowed to it rather than
+// re-deriving execFile's encoding-dependent overloads.
+type ExecFileErrorCallback = (error: ExecFileException | null) => void
+
+/**
+ * Start a detached profile application unless the launch has been cancelled.
+ *
+ * Returns null when the signal was already aborted — nothing was started, and
+ * the caller reports the attempt as cancelled.
+ */
+export function spawnUnlessAborted(
+  signal: AbortSignal | undefined,
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions
+): ChildProcess | null {
+  if (signal?.aborted) {
+    return null
+  }
+  return spawn(command, args, options)
+}
+
+/**
+ * Start the elevation host (the PowerShell process that raises the UAC prompt)
+ * unless the launch has been cancelled.
+ *
+ * Returns null when the signal was already aborted. This is the one start where
+ * "too late" is unrecoverable rather than merely untidy: once the consent prompt
+ * is up, killing the host does not take it back down (#809), so the app can
+ * still be started by a user answering a dialog for a launch they cancelled.
+ */
+export function execFileUnlessAborted(
+  signal: AbortSignal | undefined,
+  file: string,
+  args: readonly string[],
+  options: ExecFileOptions,
+  callback: ExecFileErrorCallback
+): ChildProcess | null {
+  if (signal?.aborted) {
+    return null
+  }
+  return execFile(file, args, options, callback)
+}

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -284,11 +284,26 @@ export async function launchProfileApps(
 
     const launchResults: AppLaunchResult[] = []
 
-    // The loop deliberately has no `signal.aborted` check of its own. Whichever
-    // of its suspension points a kill lands in — the wait below, the probe
-    // inside spawnDetachedApp, or one a later feature adds (#625, #626) —
-    // spawnDetachedApp starts nothing and answers 'cancelled' (#715).
     for (let index = 0; index < appsToLaunch.length; index += 1) {
+      // PROMPTNESS, not prevention (#715). Whichever suspension point a kill
+      // lands in — the wait below, the probe inside spawnDetachedApp, or one a
+      // later feature adds (#625, #626) — spawnUnlessAborted starts nothing and
+      // spawnDetachedApp answers 'cancelled'. Deleting this check cannot make a
+      // cancelled launch spawn something; it can only make it slower to admit
+      // it, by entering spawnDetachedApp for an app it will never start and
+      // paying that app's PE-subsystem probe first (Codex P2 on #828). That
+      // probe has no timeout, and the process-wide launch guard is held until
+      // this whole sequence returns, so every window's Launch waits on it.
+      //
+      // Which is why it is a check about latency, not correctness, and why the
+      // features queued behind this refactor must not copy it as protection.
+      // The difference is visible in the tests: remove this and one test slows
+      // down and asserts an extra probe; remove the guarded start and eleven
+      // fail.
+      if (launchController.signal.aborted) {
+        break
+      }
+
       const launchResult = await spawnDetachedApp(
         sender,
         gameKey,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -1,4 +1,3 @@
-import { execFile, spawn } from 'child_process'
 import type { WebContents } from 'electron'
 import fs from 'fs'
 import path from 'path'
@@ -15,6 +14,7 @@ import {
   wait
 } from '../utils'
 
+import { execFileUnlessAborted, spawnUnlessAborted } from './guardedStart'
 import {
   consumeProcessNameMismatchWarningSuppression,
   noteStrandedConsentPrompt,
@@ -242,9 +242,10 @@ export async function launchProfileApps(
       return true
     })
 
-    // A kill can land during the pre-loop awaits (the tasklist scan above) —
-    // the early returns below must report the cancellation like the loop
-    // paths do, not a plain success/error the user's Close Apps contradicts.
+    // REPORTING, not prevention (#715). Nothing has been started yet and the
+    // guarded start would refuse to start anything now anyway — but the early
+    // returns below would otherwise answer a Close Apps with a plain
+    // success/error that contradicts it, so the cancellation is named here.
     if (launchController.signal.aborted) {
       return {
         success: false,
@@ -283,16 +284,11 @@ export async function launchProfileApps(
 
     const launchResults: AppLaunchResult[] = []
 
+    // The loop deliberately has no `signal.aborted` check of its own. Whichever
+    // of its suspension points a kill lands in — the wait below, the probe
+    // inside spawnDetachedApp, or one a later feature adds (#625, #626) —
+    // spawnDetachedApp starts nothing and answers 'cancelled' (#715).
     for (let index = 0; index < appsToLaunch.length; index += 1) {
-      // Checked at the TOP of every iteration, not just after the wait below:
-      // a kill can land in the gap between spawnDetachedApp resolving and the
-      // wait call starting, and an already-aborted signal resolves wait()
-      // immediately — without this check the loop would still spawn one more
-      // app on that immediate resolution (#670).
-      if (launchController.signal.aborted) {
-        break
-      }
-
       const launchResult = await spawnDetachedApp(
         sender,
         gameKey,
@@ -300,8 +296,7 @@ export async function launchProfileApps(
         gamePath,
         launchController.signal
       )
-      // The abort landed during spawnDetachedApp's pre-spawn probe — nothing
-      // was spawned, so don't count it (and don't arm the post-launch
+      // Nothing was started, so don't count it (and don't arm the post-launch
       // cooldown for an attempt that never happened).
       if (launchResult.status === 'cancelled') {
         break
@@ -362,10 +357,12 @@ export async function launchProfileApps(
     // Neither a failed nor a cancelled handoff started anything.
     const launchedCount = launchResults.length - failedResults.length - cancelledElevatedCount
 
-    // A kill (Close Apps) mid-sequence aborts launchController before doing its
-    // own work (#670) — report this as neither success nor failure, and stop
-    // before the failure/success branches below account for apps that were
-    // deliberately never spawned.
+    // REPORTING, not prevention (#715): the loop has already ended and the
+    // guarded start decided what did and did not start. A kill (Close Apps)
+    // mid-sequence aborts launchController before doing its own work (#670) —
+    // report that as neither success nor failure, and stop before the
+    // failure/success branches below account for apps deliberately never
+    // started.
     if (launchController.signal.aborted) {
       // Elevated apps that completed their UAC handoff before (or despite)
       // the abort survive the kill — SimLauncher cannot close them (#670
@@ -680,11 +677,16 @@ function launchElevated(
         noteStrandedConsentPrompt()
       }
     }
+    // `child` is null only when the abort beat the host's start, and that path
+    // returns below without arming the timer or attaching this listener — so
+    // the optional call here and in the timer's cancel is never the reason
+    // nothing gets killed. It is declared above the start because the callback
+    // execFile is given references it, and that callback can fire synchronously.
     const onAbort = () => {
       if (handoffPending) {
         noteHandoffCancelled()
         noteStrandedPromptOnce()
-        child.kill()
+        child?.kill()
       }
     }
 
@@ -743,7 +745,7 @@ function launchElevated(
           // Same reason as onAbort (#809), and the same guard: mid-sequence
           // both this and the abort fire for this one handoff.
           noteStrandedPromptOnce()
-          child.kill()
+          child?.kill()
         }
       })
       resolve({
@@ -755,7 +757,8 @@ function launchElevated(
       })
     }, ELEVATED_HANDOFF_MAX_WAIT_MS)
 
-    const child = execFile(
+    const child = execFileUnlessAborted(
+      signal,
       'powershell.exe',
       [
         '-NoProfile',
@@ -819,6 +822,18 @@ function launchElevated(
         })
       }
     )
+
+    if (!child) {
+      // The launch was cancelled before the elevation host started. No consent
+      // prompt was ever raised, so there is no host to kill and nothing
+      // stranded on screen for the caller to explain (#809) — unlike every
+      // later cancellation point in this function.
+      handoffPending = false
+      clearTimeout(handoffTimer)
+      resolve({ status: 'cancelled', appPath })
+      return
+    }
+
     signal?.addEventListener('abort', onAbort, { once: true })
   })
 }
@@ -836,16 +851,13 @@ export async function spawnDetachedApp(
   // executing, #486). Spawned non-detached they allocate their own console,
   // and children outlive the parent on Windows either way. GUI apps keep the
   // long-standing detached behavior.
+  //
+  // A kill (Close Apps) can land while this PE-subsystem probe is in flight —
+  // and while anything else the launch sequence awaits before reaching here is
+  // in flight. None of those windows needs its own check: spawnUnlessAborted
+  // re-reads the signal in the same synchronous block as spawn() (#715).
   const consoleApp = await isConsoleExecutable(appPath)
 
-  // A kill (Close Apps) can land while the PE-subsystem probe above is in
-  // flight. The kill's snapshot cannot include a process that hasn't spawned
-  // yet, so spawning now would leave an app running that the user just asked
-  // to close (#670). There is no further await between this check and spawn()
-  // below, so the window is fully closed.
-  if (signal?.aborted) {
-    return { status: 'cancelled', appPath }
-  }
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined
@@ -867,11 +879,17 @@ export async function spawnDetachedApp(
       // Apps that resolve assets relative to their CWD (e.g. iOverlay's WIC
       // sprite loads) break — and can leak memory until OOM — when they
       // inherit SimLauncher's CWD instead (#483).
-      const child = spawn(appPath, args, {
+      const child = spawnUnlessAborted(signal, appPath, args, {
         cwd: path.dirname(appPath),
         detached: !consoleApp,
         stdio: 'ignore'
       })
+      if (!child) {
+        // The launch was cancelled before this app started. Nothing to
+        // register, nothing to unwind, nothing running for the kill to miss.
+        resolveOnce({ status: 'cancelled', appPath })
+        return
+      }
       const runningKey = normalizePathForComparison(appPath)
       runningProcesses.set(runningKey, {
         process: child,
@@ -910,15 +928,10 @@ export async function spawnDetachedApp(
         // A UAC elevation request is a handoff, not a failure — don't write a
         // failure entry for it; launchElevated logs its own genuine failures.
         if (isElevatedLaunchError(err)) {
-          // A kill (Close Apps) can land between spawn() and this error event.
-          // Handing off now would pop a UAC prompt right after the user's
-          // Close Apps click — and start an elevated app the kill's snapshot
-          // can never include (#670). Nothing is running (the spawn failed),
-          // so report the attempt as cancelled instead.
-          if (signal?.aborted) {
-            resolveOnce({ status: 'cancelled', appPath })
-            return
-          }
+          // A kill (Close Apps) can land between spawn() and this error event,
+          // in which case launchElevated starts nothing and reports the attempt
+          // as cancelled — its own start is guarded (#715). Nothing is running
+          // here either way: this spawn failed.
           resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey, signal))
           return
         }

--- a/tests/main/guardedStart.test.ts
+++ b/tests/main/guardedStart.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const spawnCalls: { command: string }[] = []
+const execFileCalls: { file: string }[] = []
+
+async function loadGuardedStart() {
+  vi.resetModules()
+  spawnCalls.length = 0
+  execFileCalls.length = 0
+
+  vi.doMock('child_process', () => ({
+    spawn: vi.fn((command: string) => {
+      spawnCalls.push({ command })
+      return { pid: 1234 }
+    }),
+    execFile: vi.fn((file: string) => {
+      execFileCalls.push({ file })
+      return { pid: 5678 }
+    })
+  }))
+
+  return await import('../../src/main/processes/guardedStart')
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// --- Behavior of the two primitives (#715) ---
+
+test('spawnUnlessAborted starts the app while the launch is live', async () => {
+  const { spawnUnlessAborted } = await loadGuardedStart()
+  const controller = new AbortController()
+
+  const child = spawnUnlessAborted(controller.signal, 'C:/Tools/SimHub.exe', [], {})
+
+  expect(child).not.toBeNull()
+  expect(spawnCalls).toEqual([{ command: 'C:/Tools/SimHub.exe' }])
+})
+
+test('spawnUnlessAborted starts nothing once the launch is aborted', async () => {
+  const { spawnUnlessAborted } = await loadGuardedStart()
+  const controller = new AbortController()
+  controller.abort()
+
+  const child = spawnUnlessAborted(controller.signal, 'C:/Tools/SimHub.exe', [], {})
+
+  expect(child).toBeNull()
+  expect(spawnCalls).toEqual([])
+})
+
+// killLaunchedApps outside a launch, and spawnDetachedApp's direct unit tests,
+// both reach these with no signal at all. An absent signal is "not cancellable",
+// not "already cancelled" — it must still start.
+test('spawnUnlessAborted starts the app when there is no signal', async () => {
+  const { spawnUnlessAborted } = await loadGuardedStart()
+
+  expect(spawnUnlessAborted(undefined, 'C:/Tools/SimHub.exe', [], {})).not.toBeNull()
+  expect(spawnCalls).toHaveLength(1)
+})
+
+test('execFileUnlessAborted starts the elevation host while the launch is live', async () => {
+  const { execFileUnlessAborted } = await loadGuardedStart()
+  const controller = new AbortController()
+
+  const host = execFileUnlessAborted(controller.signal, 'powershell.exe', [], {}, () => {})
+
+  expect(host).not.toBeNull()
+  expect(execFileCalls).toEqual([{ file: 'powershell.exe' }])
+})
+
+test('execFileUnlessAborted starts no elevation host once the launch is aborted', async () => {
+  const { execFileUnlessAborted } = await loadGuardedStart()
+  const controller = new AbortController()
+  controller.abort()
+
+  const host = execFileUnlessAborted(controller.signal, 'powershell.exe', [], {}, () => {})
+
+  expect(host).toBeNull()
+  expect(execFileCalls).toEqual([])
+})
+
+test('execFileUnlessAborted starts the elevation host when there is no signal', async () => {
+  const { execFileUnlessAborted } = await loadGuardedStart()
+
+  expect(execFileUnlessAborted(undefined, 'powershell.exe', [], {}, () => {})).not.toBeNull()
+  expect(execFileCalls).toHaveLength(1)
+})
+
+// --- Structural properties the primitives depend on (#715) ---
+//
+// The behavioral tests above prove the check works. These prove it cannot be
+// bypassed, which is the actual point of centralizing it: the old per-await
+// checks were correct too, and still lost to every await someone forgot.
+// Asserted against the source text because that is where both properties live —
+// no runtime observation can tell you an await was NOT added, or that some
+// other module did not call spawn() directly.
+
+const root = process.cwd()
+
+function readSource(relativePath: string) {
+  return readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+// Comments in these files talk about spawn(), execFile() and awaits at length,
+// so the assertions below have to look at code only.
+function stripComments(source: string) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+function listSourceFiles(directory: string): string[] {
+  return readdirSync(path.join(root, directory)).flatMap((entry) => {
+    const relativePath = path.posix.join(directory, entry)
+    return statSync(path.join(root, relativePath)).isDirectory()
+      ? listSourceFiles(relativePath)
+      : relativePath.endsWith('.ts')
+        ? [relativePath]
+        : []
+  })
+}
+
+// Main-process modules that start a process for a reason OTHER than launching
+// the user's apps, and so are correctly outside the launch guard. Adding a file
+// here is a deliberate claim that it never starts anything on the user's behalf.
+const NON_LAUNCH_PROCESS_STARTERS = [
+  // Reads the process list. Starts nothing the user could be asked to close.
+  'src/main/processes/tasklist.ts',
+  // taskkill — the kill side, which the abort exists to serve in the first place.
+  'src/main/processes/win32KillUtils.ts'
+]
+
+test('the launch path starts processes only through the guarded primitives (#715)', () => {
+  const startsAProcess = listSourceFiles('src/main').filter((file) =>
+    /\b(spawn|execFile|exec|fork|execFileSync|spawnSync|execSync)\s*\(/.test(
+      stripComments(readSource(file))
+    )
+  )
+
+  expect(startsAProcess.sort()).toEqual(
+    ['src/main/processes/guardedStart.ts', ...NON_LAUNCH_PROCESS_STARTERS].sort()
+  )
+})
+
+test('nothing can suspend between the abort check and the start (#715)', () => {
+  const source = readSource('src/main/processes/guardedStart.ts')
+  const code = stripComments(source)
+
+  // The whole module is synchronous, so there is no suspension point for an
+  // abort to slip through — and no way to add one without failing here.
+  expect(code).not.toMatch(/\b(await|async)\b/)
+
+  // And the check is the statement immediately before the start, in both.
+  const collapsed = code.replace(/\s+/g, ' ')
+  expect(collapsed).toContain('if (signal?.aborted) { return null } return spawn(')
+  expect(collapsed).toContain('if (signal?.aborted) { return null } return execFile(')
+})

--- a/tests/main/guardedStart.test.ts
+++ b/tests/main/guardedStart.test.ts
@@ -131,14 +131,30 @@ const NON_LAUNCH_PROCESS_STARTERS = [
   'src/main/processes/win32KillUtils.ts'
 ]
 
+// Both signals are required, and each covers the other's blind spot. The call
+// pattern alone matches `someRegex.exec(...)`, which would fail this test for a
+// file that starts nothing — and the remedy a future reader reaches for is
+// adding it to the list above, quietly exempting a real file from the check
+// forever. The import alone would clear `kill.ts` and `types.ts`, which import
+// only the ChildProcess *type* and so cannot start anything. Requiring both
+// also keeps namespace imports (`cp.spawn(...)`) in scope.
+function startsAProcess(source: string): boolean {
+  const code = stripComments(source)
+  const importsChildProcessAtRuntime = /^\s*import\s+(?!type\s)[^;]*from\s+'child_process'/m.test(
+    code
+  )
+  return (
+    importsChildProcessAtRuntime &&
+    /\b(spawn|execFile|exec|fork|execFileSync|spawnSync|execSync)\s*\(/.test(code)
+  )
+}
+
 test('the launch path starts processes only through the guarded primitives (#715)', () => {
-  const startsAProcess = listSourceFiles('src/main').filter((file) =>
-    /\b(spawn|execFile|exec|fork|execFileSync|spawnSync|execSync)\s*\(/.test(
-      stripComments(readSource(file))
-    )
+  const processStarters = listSourceFiles('src/main').filter((file) =>
+    startsAProcess(readSource(file))
   )
 
-  expect(startsAProcess.sort()).toEqual(
+  expect(processStarters.sort()).toEqual(
     ['src/main/processes/guardedStart.ts', ...NON_LAUNCH_PROCESS_STARTERS].sort()
   )
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -4398,13 +4398,21 @@ test('a throw during launch prep releases the launch guard instead of wedging it
   })
 })
 
-// Abort-point sweep (#670): the "nothing spawns after a kill's abort" invariant
-// is enforced by a separate check at EVERY await in the launch path — each
-// suspension point is its own race window, and all five #714 review findings
-// were instances of this one class landing at different points. The sweep
-// drives the full launch sequence through each suspension point in turn, lands
-// the abort while the launch is provably parked there, and asserts nothing
-// further spawned. Adding a new await to the launch path? Add a row here.
+// Abort-point sweep (#670): the "nothing spawns after a kill's abort"
+// invariant, exercised through the real launch sequence. Each row parks the
+// launch at one suspension point, lands the abort while it is provably parked
+// there, and asserts nothing further spawned.
+//
+// Since #715 the rows are no longer the enforcement. The invariant lives in
+// spawnUnlessAborted, which re-reads the signal in the same synchronous block
+// as spawn(), so a suspension point with no row of its own is covered anyway —
+// which is the whole point, because the five #714 findings were all a
+// suspension point nobody had thought to add a check for. What these rows still
+// buy is end-to-end evidence that the primitive is actually reached through the
+// launch path (remove its check and all of them fail), and that the launch
+// REPORTS an abort at each point the way the user is told it does. So a new
+// await does not need a row; a new user-visible cancellation path does.
+// The structural half of the guarantee is in tests/main/guardedStart.test.ts.
 // (The post-spawn EACCES elevation handoff is the one abortable point this
 // table can't reach — it has its own test right below.)
 const abortPointSweep: {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -4503,6 +4503,34 @@ test.each(abortPointSweep)(
   }
 )
 
+// The loop-top check is about promptness, not prevention (#715): the guarded
+// start already makes it impossible for the app below to spawn. What it buys is
+// that a cancelled launch does not first walk into spawnDetachedApp and pay an
+// unbounded PE-subsystem probe for an app it will never start — while holding
+// the process-wide launch guard that every window's Launch waits on (Codex P2
+// on #828). Asserted on the probe count, because that is the cost, and because
+// a check no test can distinguish from its own absence is decoration.
+test('a cancelled launch does not probe the app it will never start (#715)', async () => {
+  markExistingPath('C:/Tools/App1.exe')
+  markExistingPath('C:/Tools/App2.exe')
+  storeData.launchDelayMs = 5000
+  const { launchProfileApps, killLaunchedApps } = await loadProcessModules()
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
+  await flushMicrotasks()
+  // App1 has spawned and the loop is parked on the inter-app wait, which the
+  // abort below releases.
+  expect(spawnCalls.length).toBe(1)
+  expect(consoleProbeCallCount).toBe(1)
+
+  await killLaunchedApps('ac')
+
+  await expect(launchPromise).resolves.toMatchObject({ cancelled: true, launchedCount: 1 })
+  expect(spawnCalls.length).toBe(1)
+  // The point: App2 was never probed, not merely never spawned.
+  expect(consoleProbeCallCount).toBe(1)
+})
+
 // The abort can also land AFTER spawn() was attempted: the child fails with
 // EACCES (asynchronously, some time after spawn returns) and the error handler
 // hands off to an elevated launch — which would pop a UAC prompt right after


### PR DESCRIPTION
## Summary

- The "nothing starts after a kill's abort" invariant lived at every suspension point in the launch path. All five review findings on #714 were the same check-flag-vs-suspend TOCTOU landing at different points: a check only holds until the next suspension, so every new `await` was a new race window that had to remember its own check.
- New `src/main/processes/guardedStart.ts` holds the check in the same synchronous block as the two places a process actually starts: `spawn` in `spawnDetachedApp`, `execFile` in `launchElevated`. Re-reading the signal at the last instant a process can still be prevented is what makes the suspension points *before* it stop being race windows.
- Removed the three per-await checks that only existed to protect a start: the loop-top check, `spawnDetachedApp`'s pre-spawn re-check, and the EACCES elevation-handoff re-check. The pre-loop and post-loop checks stay, relabelled: they decide what the user is told, not what starts.
- No behavior change. Every existing cancellation test passes untouched.

### Why not the shapes the issue proposed

The issue floated `abortable(signal, promise)` at every await, or a step pipeline whose runner checks between steps. Both are still "remember to use the helper" at every new suspension point, which is the same whack-a-mole in a nicer shape. Guarding the start instead means a suspension point cannot be wrong, because it is not where the decision is made. That matters for the two features queued behind this one: #625 waits for a process to be confirmed running and #626 waits for the user, and neither now needs a cancellation check of its own.

### Enforcement, not just correction

The old sweep only covered suspension points someone remembered to add a row for. Two tests now hold the invariant structurally:

- `guardedStart.ts` is asserted to be entirely synchronous, with the abort check as the statement immediately before each start, so nothing can suspend in between.
- `src/main` is asserted to start processes nowhere else, with the two non-launch starters (`tasklist.ts`, `win32KillUtils.ts`) named explicitly. Adding a file to that list is a deliberate claim that it never starts anything on the user's behalf.

The abort-point sweep in `processes.test.ts` keeps all its rows and its comment now says what they are still for: end-to-end evidence that the primitive is reached through the real launch path, and that each point reports the cancellation the way the user is told it does.

### Verified by injection, not by a green run

The refactor passed all 659 existing tests on the first run, which proves nothing on its own. Each guard was broken on purpose to confirm the tests fail:

| Injection | Result |
|---|---|
| abort check removed from `spawnUnlessAborted` | 11 tests fail, including every sweep row |
| abort check removed from `execFileUnlessAborted` | the EACCES handoff test fails |
| a direct `spawn()` added to the launch path | the "starts only through the primitives" test fails |
| `spawnUnlessAborted` made `async` | the synchronous-module test fails |
| a statement inserted between the check and the start | the adjacency test fails |

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (667 passed, was 659)
- [x] Injection harness above: every guard and every structural assertion proven to fail when violated
- [ ] Manual: covered by the batched 1.2.0 smoke run, Close Apps mid-launch with a multi-app profile

Closes #715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process launch cancellation to prevent applications or elevation prompts from starting after cancellation.
  * Improved cancellation handling and reporting for processes that were never started or did not complete elevation.

* **Tests**
  * Added coverage for cancellation-aware process startup and launch-path reporting.
  * Expanded validation to ensure cancellation checks occur immediately before launching processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #715
<!-- auto-closes -->