### PR TITLE
fix(ui): stop the phantom dot claiming a game is running when we cannot tell (#737)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -884,6 +884,17 @@ button:focus-visible,
     box-shadow: none !important;
   }
 
+  /* The unknown-state dot (#737: the game may have exited, or handed off to a
+     child process we cannot see) differs from the confirmed-running dot ONLY by
+     colour, and the rule above deletes colour as a carrier here. Carry it as a
+     shape instead: a hollow ring rather than a filled disc. Must stay AFTER
+     .status-dot — same specificity, both !important, so source order decides.
+     tests/renderer/gameIconDismiss.test.tsx pins the class pairing. */
+  .status-dot-unknown {
+    background: Canvas !important;
+    border: 2px solid CanvasText !important;
+  }
+
   /* Don't dim inactive game rows below contrast — keep every title fully legible. */
   .game-row-container {
     opacity: 1 !important;

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -20,8 +20,17 @@ interface GameIconProps {
   tracked?: boolean
 }
 
-const STATUS_DOT_CLASS =
-  'status-dot absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-(--status-running) shadow-[0_0_8px_var(--status-running)]'
+const STATUS_DOT_BASE_CLASS = 'status-dot absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full'
+const STATUS_DOT_CLASS = `${STATUS_DOT_BASE_CLASS} bg-(--status-running) shadow-[0_0_8px_var(--status-running)]`
+// "We cannot tell", not "running" (#737). A mismatch-warning entry is surfaced
+// only when the launched exe is ABSENT from the tasklist (running.ts), and at
+// that point both readings are live at once: the game exited, or it handed off
+// to a child process under a name nothing here can see. Green asserts the
+// second; nothing asserts the first; neither is known. `--status-warning` is
+// the amber already used for the strip's elevated-companion triangle, and it
+// aliases `--warning-text`, so it follows the theme without a per-theme entry
+// (same as --status-danger / --status-success).
+const STATUS_DOT_UNKNOWN_CLASS = `${STATUS_DOT_BASE_CLASS} bg-(--status-warning) shadow-[0_0_8px_var(--status-warning)]`
 
 export function GameIcon({
   game,
@@ -83,7 +92,15 @@ export function GameIcon({
             {...dismissMenu.getTriggerProps()}
           >
             {iconContent}
-            <span aria-hidden="true" className={STATUS_DOT_CLASS} />
+            {/* Only the UNTRACKED warning is the unknown state. This branch also
+                serves a tracked one: a game exe that failed to close and is
+                still running, surfaced from `unclosedProcesses` only while its
+                image IS in the tasklist. That one genuinely is running, so
+                amber would downgrade a fact to a guess. */}
+            <span
+              aria-hidden="true"
+              className={tracked ? STATUS_DOT_CLASS : STATUS_DOT_UNKNOWN_CLASS}
+            />
           </button>
         </Tooltip>
         {dismissMenu.menu}

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -30,7 +30,11 @@ const STATUS_DOT_CLASS = `${STATUS_DOT_BASE_CLASS} bg-(--status-running) shadow-
 // the amber already used for the strip's elevated-companion triangle, and it
 // aliases `--warning-text`, so it follows the theme without a per-theme entry
 // (same as --status-danger / --status-success).
-const STATUS_DOT_UNKNOWN_CLASS = `${STATUS_DOT_BASE_CLASS} bg-(--status-warning) shadow-[0_0_8px_var(--status-warning)]`
+// `status-dot-unknown` carries no styling of its own outside Windows High
+// Contrast, where App.css turns it into a hollow ring: that mode strips every
+// status dot to one system colour, which would otherwise make this state
+// indistinguishable from a running one (Codex P2 on #829).
+const STATUS_DOT_UNKNOWN_CLASS = `${STATUS_DOT_BASE_CLASS} status-dot-unknown bg-(--status-warning) shadow-[0_0_8px_var(--status-warning)]`
 
 export function GameIcon({
   game,

--- a/tests/renderer/gameIconDismiss.test.tsx
+++ b/tests/renderer/gameIconDismiss.test.tsx
@@ -162,6 +162,50 @@ describe('GameIcon dismiss menu (#737)', () => {
     expect(container.querySelector('button')).toBeNull()
   })
 
+  // The dot's colour is the only thing a sighted user reads off the icon, and
+  // for a mismatch-warning entry "running" is not a fact we have: the entry is
+  // surfaced precisely because the launched exe is gone from the tasklist, which
+  // means either it exited or it handed off to a child under another name.
+  // Pinned here because nothing else can catch it: the class is the whole fix.
+  const dotClass = () => container.querySelector('.status-dot')!.className
+
+  test('an untracked mismatch warning does not claim the game is running (#737)', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    expect(dotClass()).toContain('bg-(--status-warning)')
+    expect(dotClass()).not.toContain('bg-(--status-running)')
+  })
+
+  test('a tracked kill-failed warning keeps the running dot (#737)', async () => {
+    // This one IS running: `unclosedProcesses` entries surface only while the
+    // image is still in the tasklist. Amber here would turn a fact into a guess.
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+        tracked={true}
+      />
+    )
+    expect(dotClass()).toContain('bg-(--status-running)')
+    expect(dotClass()).not.toContain('bg-(--status-warning)')
+  })
+
+  test('a plain running game keeps the running dot (#737)', async () => {
+    await render(<GameIcon game={GAME} isRunning={true} iconUrl={ICON} />)
+    expect(dotClass()).toContain('bg-(--status-running)')
+    expect(dotClass()).not.toContain('bg-(--status-warning)')
+  })
+
   test('a failed dismiss notifies the user instead of failing silently', async () => {
     // The menu closes optimistically, so a rejected dismiss would otherwise
     // leave the dot in place with no feedback (#764 CodeRabbit).

--- a/tests/renderer/gameIconDismiss.test.tsx
+++ b/tests/renderer/gameIconDismiss.test.tsx
@@ -6,6 +6,8 @@
  * icon stays inert (plain dot, no menu).
  */
 
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
 import { act, type ReactElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -204,6 +206,35 @@ describe('GameIcon dismiss menu (#737)', () => {
     await render(<GameIcon game={GAME} isRunning={true} iconUrl={ICON} />)
     expect(dotClass()).toContain('bg-(--status-running)')
     expect(dotClass()).not.toContain('bg-(--status-warning)')
+  })
+
+  // Windows High Contrast strips every `.status-dot` to a single system colour,
+  // so amber cannot carry the distinction there (Codex P2 on #829). A shape
+  // does, via a forced-colors rule keyed on `status-dot-unknown`. Both ends are
+  // pinned here because a class name in a component and a selector in a
+  // stylesheet drift apart silently, and no rendering assertion can catch it:
+  // jsdom applies no media queries, so the dot renders identically either way.
+  test('the unknown dot keeps a non-colour distinction in forced-colors (#737)', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    expect(dotClass()).toContain('status-dot-unknown')
+
+    const css = readFileSync(path.join(process.cwd(), 'src/renderer/src/App.css'), 'utf8')
+    const forcedColorsAt = css.indexOf('@media (forced-colors: active)')
+    expect(forcedColorsAt).toBeGreaterThan(-1)
+    const statusDotAt = css.indexOf('.status-dot {', forcedColorsAt)
+    const unknownAt = css.indexOf('.status-dot-unknown {', forcedColorsAt)
+    expect(unknownAt).toBeGreaterThan(-1)
+    // Same specificity and both !important, so source order is what decides
+    // which background wins. The override has to come second.
+    expect(unknownAt).toBeGreaterThan(statusDotAt)
   })
 
   test('a failed dismiss notifies the user instead of failing silently', async () => {


### PR DESCRIPTION
## Summary

- A mismatch-warning entry surfaces only when the launched exe is **absent** from the tasklist (`running.ts`), so at that moment both readings are live at once: the game exited, or it handed off to a child process under a name nothing in the process layer can see. The dot rendered green regardless, which asserts the second, and the entry never expires, so it kept asserting it for the rest of the session.
- Render that state in amber (`--status-warning`) instead. Per the 2026-08-05 decision: no liveness derivation, no child tracking. There is nothing to compute, because the entry being a mismatch warning **is** the state.
- The entry itself is untouched: not deleted, no `expiresAt`. It is also the adoption marker feeding `launchedGameKeys`, so #360 and the companion strip it keeps alive are unaffected.

### One refinement on the decision, worth a look

The decision says "a surfaced mismatch-warning entry no longer renders the green running dot", and names the `isDismissible` branch. That branch serves **two** warning kinds, so implementing it literally would repaint both:

| Source | `tracked` | Is it running? |
|---|---|---|
| `processNameMismatchWarnings` (this issue) | `false` | Unknown. Surfaced only when the image is **gone** from the tasklist. |
| `unclosedProcesses` (kill-failed game exe) | `true` | **Yes.** Filtered on the image still being **in** the tasklist. |

Only the untracked one changes. Amber on the tracked one would downgrade a fact to a guess. Both directions are pinned by tests and mutation-verified below.

### The light-theme entry the decision asked for is not needed

The decision's step 2 said to add `--status-warning` to the light block "or the light theme falls back to nothing". It does not. `--status-warning` is declared once, in the base `:root`, as an alias of `--warning-text`, and the light block overrides `--warning-text` on the **same element**, so substitution resolves to the light value. Verified three ways: the built CSS declares `--status-warning` once and `--warning-text` twice; `--status-danger` and `--status-success` have shipped on that exact shape and are consumed today by the toast progress bar; and both new utilities are emitted (`.bg-\(--status-warning\)`, `.shadow-\[0_0_8px_var\(--status-warning\)\]`).

That last check matters more than it looks: the renderer test asserts a class name, so a class Tailwind never generated would have left a transparent dot and a green test.

### Mutation-verified

| Injection | Result |
|---|---|
| dot always green (the behavior before this PR) | the untracked test fails |
| whole branch amber (the decision read literally) | the tracked test fails |

## Acceptance (from the 2026-08-05 decision)

- [x] A surfaced mismatch-warning entry no longer renders the green running dot
- [x] It renders a warning-state dot via `--status-warning`, effective in both themes (via the alias, verified above)
- [x] The Dismiss menu, tooltip and accessible name from #764 keep working unchanged (7 existing tests untouched and green)
- [x] The entry is neither deleted nor given an `expiresAt`; the companion strip still surfaces
- [x] The #360 guardrail (`process mismatch warnings persist until manually dismissed`) still passes
- [x] A renderer test pins that a warning-backed entry does not get the running dot, mutation-verified

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (671 passed, was 668)
- [x] Manual, and this one was a taste call rather than a checkbox: `npm run dev` on this branch, stuck dot reproduced on BeamNG. David confirms the amber reads correctly, so the v1 treatment stands and no token change is needed.

Closes #737


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game status indicators so untracked warnings display in amber, while tracked warnings and normally running games remain green.
  * Clarified warning states for dismissible game alerts.

* **Tests**
  * Added coverage for untracked warnings, tracked warnings, and normal running states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- auto-closes -->
Closes #737
<!-- auto-closes -->