### PR TITLE
fix(settings): write the login item on save, not on toggle (#676)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -462,8 +462,20 @@ export function registerConfigHandlers(): void {
       // app start re-applied it (window.ts). Read back through getStoredBoolean
       // rather than trusting the patch, so this is the same spelling as the two
       // startup call sites and cannot drift from what was actually persisted.
+      //
+      // The OS write must not be able to fail the save. The store is the source
+      // of truth and window.ts re-applies it from there on every window
+      // creation, so a failed write converges on the next app start; that repair
+      // path is exactly why this bug was one unexpected boot rather than a
+      // permanent one. Letting it reject instead would report "failed to save"
+      // for a patch that did persist, and leave the renderer dirty against a
+      // store that already agrees with it (CodeRabbit on #831).
       if (changedKeys.includes('startWithWindows')) {
-        app.setLoginItemSettings({ openAtLogin: getStoredBoolean('startWithWindows') })
+        try {
+          app.setLoginItemSettings({ openAtLogin: getStoredBoolean('startWithWindows') })
+        } catch (err) {
+          console.error('Failed to apply the login item setting:', err)
+        }
       }
       notifyStoreConfigChanged({ reason: 'save-settings', keys: changedKeys })
     }

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -15,6 +15,7 @@ import {
   formatConfigRecoveryNotice,
   getDroppedSettingsEntries,
   getSupportedConfigValues,
+  getStoredBoolean,
   getStoredZoomFactor,
   requireSafeZoomFactor,
   sanitizeImportedConfig,
@@ -428,11 +429,6 @@ export function registerConfigHandlers(): void {
     return notice ? formatConfigRecoveryNotice(notice) : null
   })
 
-  ipcMain.handle('set-login-item', (_event, openAtLogin: unknown) => {
-    if (typeof openAtLogin !== 'boolean') return
-    app.setLoginItemSettings({ openAtLogin })
-  })
-
   ipcMain.handle('set-zoom', (_event, factor: unknown) => {
     const zoomFactor = requireSafeZoomFactor(factor)
     const webContents = getMainWindow()?.webContents
@@ -459,6 +455,15 @@ export function registerConfigHandlers(): void {
       setStoreEntries(safe)
       if (changedKeys.includes('showTrayIcon')) {
         applyTrayVisibility(store.get('showTrayIcon') !== false)
+      }
+      // Applied on SAVE, not on toggle (#676). The renderer used to write this
+      // straight to the OS when the switch moved, so a Discard left an HKCU Run
+      // entry behind that contradicted both the UI and the store until the next
+      // app start re-applied it (window.ts). Read back through getStoredBoolean
+      // rather than trusting the patch, so this is the same spelling as the two
+      // startup call sites and cannot drift from what was actually persisted.
+      if (changedKeys.includes('startWithWindows')) {
+        app.setLoginItemSettings({ openAtLogin: getStoredBoolean('startWithWindows') })
       }
       notifyStoreConfigChanged({ reason: 'save-settings', keys: changedKeys })
     }

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -293,7 +293,6 @@ export interface ElectronAPI {
   previewImportConfig: () => Promise<ConfigImportPreviewResult>
   applyImportConfig: (token: string) => Promise<ConfigFileResult>
   cancelImportConfig: (token: string) => Promise<ConfigFileResult>
-  setLoginItem: (openAtLogin: boolean) => Promise<void>
   setZoom: (factor: number) => Promise<void>
   getAssetData: (filename: string) => Promise<string | null>
   getFileIcon: (filePath: string) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -111,8 +111,7 @@ const electronAPI: ElectronAPI = {
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
   getUpdateInfo: () => ipcRenderer.invoke('get-update-info'),
 
-  // startup & zoom
-  setLoginItem: (openAtLogin: boolean) => ipcRenderer.invoke('set-login-item', openAtLogin),
+  // zoom
   setZoom: (factor: number) => ipcRenderer.invoke('set-zoom', factor),
 
   // typed store channels

--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { useDirtyTracking } from '../../hooks/useDirtyTracking'
 import { getUtilities } from '../../lib/config'
-import {
-  browsePath,
-  getFileIcon,
-  setLoginItem,
-  setPendingMinimizeToTray,
-  setZoom
-} from '../../lib/electron'
+import { browsePath, getFileIcon, setPendingMinimizeToTray, setZoom } from '../../lib/electron'
 import type { ThemeMode } from '../../lib/theme'
 import { useTheme } from '../../contexts/ThemeContext'
 import { useNotify } from '../Notify'
@@ -227,10 +221,16 @@ export function SettingsProvider({
     [setZoomFactor]
   )
 
+  // Unlike the other eager-apply handlers here, this one only moves renderer
+  // state: the OS write happens in `save-settings` (#676). Every other eager
+  // side effect on this screen lives in the main process and dies with it, so
+  // Discard reverting renderer state is enough. An HKCU Run entry is not: it
+  // outlives a crash or a power loss between the toggle and the Discard, so
+  // applying it before the user has committed makes the registry disagree with
+  // both the UI and the store until the next app start repairs it.
   const handleStartWithWindowsChange = useCallback(
     (checked: boolean) => {
       setStartWithWindows(checked)
-      setLoginItem(checked)
     },
     [setStartWithWindows]
   )

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -30,7 +30,6 @@ export const onUpdateError = window.electronAPI.onUpdateError
 export const installUpdate = () => window.electronAPI.installUpdate()
 export const checkForUpdates = () => window.electronAPI.checkForUpdates()
 export const getUpdateInfo = () => window.electronAPI.getUpdateInfo()
-export const setLoginItem = window.electronAPI.setLoginItem
 export const setZoom = window.electronAPI.setZoom
 export const getAssetData = window.electronAPI.getAssetData
 export const getFileIcon = window.electronAPI.getFileIcon

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -270,16 +270,11 @@ test('save-settings stores sanitized patch values only', async () => {
   expect(storeModule.store.set).toHaveBeenCalledWith('appArgs', { customapp1: '--safe' })
 })
 
-test('set-login-item ignores non-boolean runtime values', async () => {
-  await loadConfigModule()
-  const { app } = await import('electron')
-
-  await invokeConfigHandler('set-login-item', {}, 'true')
-  expect(app.setLoginItemSettings).not.toHaveBeenCalled()
-
-  await invokeConfigHandler('set-login-item', {}, true)
-  expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true })
-})
+// The `set-login-item` channel and its runtime type guard were deleted with the
+// eager apply (#676): the login item is now written from the store during
+// `save-settings`, where getStoredBoolean already guarantees a boolean, so there
+// is no untrusted renderer value left to reject. Coverage for the new call site
+// lives in configSaveSettings.test.ts.
 
 test('save-profile widens customSlots when profile references a slot beyond the stored count', async () => {
   await loadConfigModule()

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -125,3 +125,43 @@ test('save-settings returns settings + dropped: [] even for a non-object patch',
   expect(result.dropped).toEqual([])
   expect(result.settings).toBeDefined()
 })
+
+/**
+ * #676: the login item used to be written to the OS by the renderer the moment
+ * the switch moved, so Discard left an HKCU Run entry contradicting both the UI
+ * and the store until the next app start repaired it. It is applied on SAVE
+ * now, which makes Discard correct by construction rather than by remembering
+ * to compensate for it.
+ */
+test('save-settings applies the login item when startWithWindows changes (#676)', async () => {
+  await loadConfigModule()
+  const { app } = await import('electron')
+
+  await invokeSaveSettings({ startWithWindows: true, customSlots: 1 })
+
+  expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true })
+})
+
+// Deliberately a SECOND save rather than a second assertion on the first: any
+// truthiness shortcut (applying `true` whenever the key is present) passes the
+// test above and fails only here.
+test('save-settings applies a later startWithWindows: false too (#676)', async () => {
+  await loadConfigModule()
+  const { app } = await import('electron')
+
+  await invokeSaveSettings({ startWithWindows: true, customSlots: 1 })
+  await invokeSaveSettings({ startWithWindows: false, customSlots: 1 })
+
+  expect(app.setLoginItemSettings).toHaveBeenLastCalledWith({ openAtLogin: false })
+})
+
+// Hoisting the apply out of the changedKeys guard would re-write the registry
+// on every unrelated save, which is how the eager-apply version behaved.
+test('save-settings leaves the login item alone when startWithWindows is absent (#676)', async () => {
+  await loadConfigModule()
+  const { app } = await import('electron')
+
+  await invokeSaveSettings({ appPaths: { simhub: 'C:/Tools/SimHub.exe' }, customSlots: 1 })
+
+  expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+})

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -175,9 +175,13 @@ test('save-settings leaves the login item alone when startWithWindows is absent 
 // creation, so the registry converges on the next start. Rejecting instead
 // would tell the user the save failed while it persisted, and leave the
 // renderer dirty against a store that already agrees with it.
-test('save-settings survives a throwing login-item write (#676)', async () => {
+// The log is asserted, not just tolerated: swallowing is the whole point of the
+// catch, so the log is the only trace a failed write leaves. Drop it and the
+// failure becomes invisible with nothing to notice (CodeRabbit on #831).
+test('save-settings survives a throwing login-item write, and says so (#676)', async () => {
   await loadConfigModule()
   const { app } = await import('electron')
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
   vi.mocked(app.setLoginItemSettings).mockImplementationOnce(() => {
     throw new Error('registry write refused')
   })
@@ -186,4 +190,9 @@ test('save-settings survives a throwing login-item write (#676)', async () => {
 
   expect(result.settings.startWithWindows).toBe(true)
   expect(result.dropped).toEqual([])
+  expect(consoleError).toHaveBeenCalledWith(
+    'Failed to apply the login item setting:',
+    expect.objectContaining({ message: 'registry write refused' })
+  )
+  consoleError.mockRestore()
 })

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -12,7 +12,11 @@ import { expect, test, vi, beforeEach } from 'vitest'
 
 type MockIpcHandler = (...args: unknown[]) => unknown
 interface SaveSettingsResult {
-  settings: { appPaths: Record<string, string>; gamePaths: Record<string, string> }
+  settings: {
+    appPaths: Record<string, string>
+    gamePaths: Record<string, string>
+    startWithWindows?: boolean
+  }
   dropped: { field: string; key: string; reason: string }[]
 }
 
@@ -164,4 +168,22 @@ test('save-settings leaves the login item alone when startWithWindows is absent 
   await invokeSaveSettings({ appPaths: { simhub: 'C:/Tools/SimHub.exe' }, customSlots: 1 })
 
   expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+})
+
+// A failing OS write must not fail the save (CodeRabbit on #831). The store is
+// already written by this point and window.ts re-applies it on every window
+// creation, so the registry converges on the next start. Rejecting instead
+// would tell the user the save failed while it persisted, and leave the
+// renderer dirty against a store that already agrees with it.
+test('save-settings survives a throwing login-item write (#676)', async () => {
+  await loadConfigModule()
+  const { app } = await import('electron')
+  vi.mocked(app.setLoginItemSettings).mockImplementationOnce(() => {
+    throw new Error('registry write refused')
+  })
+
+  const result = await invokeSaveSettings({ startWithWindows: true, customSlots: 1 })
+
+  expect(result.settings.startWithWindows).toBe(true)
+  expect(result.dropped).toEqual([])
 })


### PR DESCRIPTION
## Summary

- The renderer wrote the HKCU `Run` entry the moment the switch moved, and the discard path never took it back. Discard left the registry saying "start with Windows" while both the UI and the store said otherwise. SimLauncher then autostarted once on the next boot and repaired itself on the launch after that (`window.ts` re-applies from the store on window creation).
- Apply it in `save-settings` instead. That makes Discard correct **by construction** rather than by remembering to compensate for it.
- Read back through `getStoredBoolean` rather than trusting the patch, so this is the same spelling as the two startup call sites and cannot drift from what was actually persisted.

### Why defer to save when this screen's convention is eager-apply

Eager-apply-then-revert is genuinely the convention here: theme, accent, zoom and the pending minimize-to-tray flag all apply before save. So "it applies early" is not the defect and this needs an argument, not an assumption.

The difference is **where the side effect lives**. Every one of those is main-process state that dies with the process. A registry value outlives a crash or a power loss between the toggle and the Discard, so the only way eager-apply stays honest for this one is a compensating write on a path that has to remember it exists. Removing the early write removes the need to remember.

### `set-login-item` is deleted across the whole chain, and that is not cleanup

`tests/electronApiSurface.test.ts` asserts every `export const` in the renderer wrapper is referenced from some non-wrapper renderer file. `SettingsContext.tsx` was the only consumer of `setLoginItem`, so removing the call while keeping the wrapper fails that gate. The handler, the preload binding, the API type and the wrapper export all go together.

Its runtime type guard (`typeof openAtLogin !== 'boolean'`) goes with it, and nothing is lost: the value now comes from `getStoredBoolean`, which returns a boolean by construction. There is no untrusted renderer value left to reject. The test that covered that guard is replaced by a comment pointing at where the new coverage lives, rather than deleted silently.

### Mutation-verified

| Injection | Result |
|---|---|
| the `startWithWindows` branch deleted | tests 1 and 2 fail |
| a truthiness shortcut (`openAtLogin: true`) | **only** test 2 fails, which is why it is a second save rather than a second assertion |
| apply hoisted out of the `changedKeys` guard | test 3 fails |

### One deviation from the issue's implementation brief, flagged deliberately

The brief's Ordering section says to land #711 first, because it is additive to `SettingsContext.tsx` while this deletes an import and would move its import block. That rationale applies to two changes drafted in parallel. Nothing for #711 is in flight, so this landing first simply means #711 gets written against the updated file. Whoever picks up #711 should re-derive its line references rather than trusting the brief's.

Everything else follows the brief as written, including its correction that the zoom half of this issue is dead: `ThemeContext` already re-applies zoom from the store on discard, and no `setZoom` was added here.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (674 passed)
- [ ] Manual: toggle "Start with Windows" on, click Discard, then run the check below. It must report clean, where before it reported the value present. Then toggle on, **Save**, and confirm it reports present.

```powershell
if ((Get-Item 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run').Property -contains 'electron.app.SimLauncher') { 'ANO - zapsano' } else { 'NE - cisto' }
```

Closes #676


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The “Start with Windows” preference now synchronizes with the operating system when settings are saved.
  - Both enabling and disabling startup behavior are supported.

- **Bug Fixes**
  - Changing the preference no longer applies system startup changes before settings are saved.
  - Settings remain saved even if the operating system update cannot be completed.

- **Tests**
  - Added coverage for startup behavior and unrelated settings saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #676
<!-- auto-closes -->