### PR TITLE
fix(settings): write appNames back after a save, like the other three (#711)

### DIFF
--- a/src/renderer/src/components/settings/SettingsContext.tsx
+++ b/src/renderer/src/components/settings/SettingsContext.tsx
@@ -375,6 +375,7 @@ export function SettingsProvider({
     notify,
     resetDirty,
     setAppPaths,
+    setAppNames,
     setGamePaths,
     setAppArgs,
     setLaunchDelayMs

--- a/src/renderer/src/components/settings/useSettingsSave.ts
+++ b/src/renderer/src/components/settings/useSettingsSave.ts
@@ -127,6 +127,7 @@ interface UseSettingsSaveArgs {
   notify: (message: string, type: 'success' | 'error' | 'warn', duration?: number) => void
   resetDirty: (state?: SettingsStateSnapshot) => void
   setAppPaths: (appPaths: Record<string, string>) => void
+  setAppNames: (appNames: Record<string, string>) => void
   setGamePaths: (gamePaths: Record<string, string>) => void
   setAppArgs: (appArgs: Record<string, string>) => void
   setLaunchDelayMs: (launchDelayMs: number) => void
@@ -157,6 +158,7 @@ export function useSettingsSave({
   notify,
   resetDirty,
   setAppPaths,
+  setAppNames,
   setGamePaths,
   setAppArgs,
   setLaunchDelayMs
@@ -213,6 +215,13 @@ export function useSettingsSave({
       // entry the sanitizer rejected is reflected as gone here too, instead
       // of lingering in the input as if it had been saved. #669
       if (!changedDuringSave.appPaths) setAppPaths(persistedSettings.appPaths)
+      // appNames was the one tracked dictionary with no write-back (#711). Its
+      // absence did not just leave a rejected value on screen: the baseline
+      // below IS built from persistedSettings, so live state kept a key the
+      // baseline lacked and useDirtyTracking re-derived isDirty back to true
+      // immediately after resetDirty cleared it. The panel then stayed dirty
+      // for the rest of the session, through every later save.
+      if (!changedDuringSave.appNames) setAppNames(persistedSettings.appNames)
       if (!changedDuringSave.gamePaths) setGamePaths(persistedSettings.gamePaths)
       if (!changedDuringSave.appArgs) setAppArgs(persistedSettings.appArgs)
 
@@ -264,6 +273,7 @@ export function useSettingsSave({
     zoomFactor,
     settingsObjectEditVersions,
     setAppPaths,
+    setAppNames,
     setGamePaths,
     setAppArgs,
     setLaunchDelayMs

--- a/tests/renderer/useSettingsSave.test.tsx
+++ b/tests/renderer/useSettingsSave.test.tsx
@@ -43,6 +43,7 @@ vi.mock('../../src/renderer/src/lib/store', () => ({
 const notifyMock = vi.fn()
 const resetDirtyMock = vi.fn()
 const setAppPathsMock = vi.fn()
+const setAppNamesMock = vi.fn()
 const setGamePathsMock = vi.fn()
 const setAppArgsMock = vi.fn()
 const setLaunchDelayMsMock = vi.fn()
@@ -96,6 +97,7 @@ function buildArgs(overrides: Partial<SaveArgs> = {}): SaveArgs {
     notify: notifyMock,
     resetDirty: resetDirtyMock,
     setAppPaths: setAppPathsMock,
+    setAppNames: setAppNamesMock,
     setGamePaths: setGamePathsMock,
     setAppArgs: setAppArgsMock,
     setLaunchDelayMs: setLaunchDelayMsMock,
@@ -409,6 +411,108 @@ describe('useSettingsSave (#645)', () => {
 
       expect(notifyMock).toHaveBeenCalledWith(expect.stringContaining('path is too long'), 'warn')
       expect(notifyMock).not.toHaveBeenCalledWith(expect.stringContaining('.exe path'), 'warn')
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // #711: appNames was the one tracked dictionary with no write-back. The
+  // visible symptom was not the stale input but a permanently dirty panel: the
+  // resetDirty baseline IS built from persistedSettings, so live state kept a
+  // key the baseline lacked and useDirtyTracking re-derived isDirty back to
+  // true straight after resetDirty cleared it, for the rest of the session.
+  test('#711: a rejected name is written back so live state matches the baseline', async () => {
+    saveSettingsMock.mockImplementation((patch: Record<string, unknown>) =>
+      Promise.resolve({
+        // The sanitizer omits the rejected key entirely.
+        settings: { ...patch, appNames: {} },
+        dropped: [{ field: 'appNames', key: 'simhub', reason: 'too-long' }]
+      })
+    )
+
+    const harness = await renderSave(buildArgs())
+    try {
+      await act(async () => {
+        await harness.handleSave()
+      })
+
+      expect(setAppNamesMock).toHaveBeenCalledWith({})
+      // Same record the baseline is built from: that agreement is the fix.
+      expect(resetDirtyMock.mock.calls[0][0].appNames).toEqual({})
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // The path users actually hit: clearing a name to get the default label back.
+  // The sanitizer drops blank entries WITHOUT reporting them, so this reports
+  // nothing dropped and shows a plain success toast. Deliberately a separate
+  // test rather than a second assertion, because gating the write-back on
+  // `saveResult.dropped.length > 0` is a plausible shortcut that the test above
+  // passes and only this one catches.
+  test('#711: a cleared name is written back even though nothing is reported dropped', async () => {
+    saveSettingsMock.mockImplementation((patch: Record<string, unknown>) =>
+      Promise.resolve({ settings: { ...patch, appNames: {} }, dropped: [] })
+    )
+
+    const harness = await renderSave(buildArgs({ appNames: { simhub: '   ' } }))
+    try {
+      await act(async () => {
+        await harness.handleSave()
+      })
+
+      expect(setAppNamesMock).toHaveBeenCalledWith({})
+      expect(resetDirtyMock.mock.calls[0][0].appNames).toEqual({})
+      // And the user is told it saved, because from their side it did.
+      expect(notifyMock).toHaveBeenCalledWith('Settings saved!', 'success', 2500)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // The write-back must obey the same save-race guard as the other three, or it
+  // would clobber a name typed while the IPC write was in flight.
+  test('#711: a name edited during the save is not overwritten by the persisted copy', async () => {
+    const versions = { current: createSettingsObjectVersions() }
+    saveSettingsMock.mockImplementation((patch: Record<string, unknown>) => {
+      // The user types while the write is in flight.
+      versions.current.appNames += 1
+      return Promise.resolve({ settings: { ...patch, appNames: {} }, dropped: [] })
+    })
+
+    const harness = await renderSave(buildArgs({ settingsObjectEditVersions: versions }))
+    try {
+      await act(async () => {
+        await harness.handleSave()
+      })
+
+      expect(setAppNamesMock).not.toHaveBeenCalled()
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // Pins a caveat the #711 brief flagged as unenforced: the dropped-entry
+  // warning is built from the PRE-SAVE appNames on purpose, so it can name the
+  // value the user typed. "Tidying" it to persistedSettings.appNames alongside
+  // the new write-back reads as consistent and silently degrades the warning to
+  // the slot's default label, which tells the user nothing about what they lost.
+  test('#711: the drop warning names the typed value, not the slot default', async () => {
+    saveSettingsMock.mockImplementation((patch: Record<string, unknown>) =>
+      Promise.resolve({
+        settings: { ...patch, appNames: {} },
+        dropped: [{ field: 'appNames', key: 'customapp1', reason: 'too-long' }]
+      })
+    )
+
+    const harness = await renderSave(buildArgs({ appNames: { customapp1: 'Left Rig Overlay' } }))
+    try {
+      await act(async () => {
+        await harness.handleSave()
+      })
+
+      expect(notifyMock).toHaveBeenCalledWith(expect.stringContaining('Left Rig Overlay'), 'warn')
+      expect(notifyMock).not.toHaveBeenCalledWith(expect.stringContaining('Custom App 1'), 'warn')
     } finally {
       harness.unmount()
     }


### PR DESCRIPTION
## Summary

- `useSettingsSave` pushes the persisted (post-sanitizer) values back into renderer state for `appPaths`, `gamePaths` and `appArgs`. `appNames` was tracked as a save-race field but never written back, so the guard existed for a write-back that was never wired.
- Four lines thread it through. The setter already existed and was already handed to `useSettingsLoad` and `useCustomSlots`, so there is no new plumbing.

### The symptom is not the stale input

The `resetDirty` baseline **is** built from `persistedSettings`, so live state kept a key the baseline lacked, and `useDirtyTracking` re-derived `isDirty` back to true immediately after `resetDirty` optimistically cleared it. The Utility Apps section dot and the sticky save bar then stayed lit for the rest of the session, through every later save. That dot is the panel's only signal for "you have unsaved work", so once stuck it stops being informative for everything the user does afterwards.

### The reachable path is not the one the issue was filed for

The original report was a name over the 100-character cap, which needs a paste and is essentially audit-only. The same root cause fires on **clearing a name** to get the default "Custom App N" label back: the sanitizer trims before the empty check, and `getDroppedSettingsEntries` skips blank values, so nothing is reported as dropped and the user gets a plain green "Settings saved!" with nothing on screen explaining the stuck dots. A leading or trailing space does it too.

That is why one of the tests is a separate cleared-name case rather than a second assertion: gating the write-back on `saveResult.dropped.length > 0` is a plausible shortcut that the too-long test passes and only the cleared-name test catches.

### Expect the data loss to become visible. It is not a regression from this PR

Today the rejected value stays in the input, so the user cannot tell that the previously saved name was erased from disk. After this write-back the input reconciles to the persisted state and falls back to the default label, so the loss becomes apparent while the toast still says "Not saved". That erasure is [#806](https://github.com/Stashpeak/SimLauncher/issues/806) (1.3.0), split out per this issue's own instruction not to smuggle it in: it is a main-process change to `setStoreEntries` and affects every sanitized dictionary, not just `appNames`.

### One caveat now enforced that was not before

The brief flagged that `buildDroppedEntriesWarning(saveResult.dropped, appNames, customSlots)` passes the **pre-save** closure deliberately, so the warning can name the value the user typed, and that no test enforced it. Adding a write-back right above it makes "tidying" that argument to `persistedSettings.appNames` look consistent, and it would silently degrade the warning from "Left Rig Overlay" to "Custom App 1". There is a test for it now.

### Mutation-verified

| Injection | Fails |
|---|---|
| write-back deleted | the too-long and cleared-name tests |
| gated on `dropped.length > 0` | **only** the cleared-name test |
| save-race guard dropped | the mid-flight-edit test |
| warning switched to `persistedSettings.appNames` | the drop-warning-label test |

Each fails exactly the test it should and nothing else.

### Deliberately out of scope

`maxLength={100}` on the name input. It does nothing for the cleared-name path, which is the one users hit, and would silently truncate a paste rather than explain anything. Recorded in the issue's 2026-08-05 decision, not an oversight.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (679 passed, was 675)
- [ ] Manual, about 30 seconds: Settings > Utility Apps, clear a slot's custom name, Save Changes. The green toast appears **and the section dot plus the save bar clear**, where before they stayed lit for the rest of the session.

Closes #711


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application names now remain synchronized between saved settings and the interface.
  * Preserved user-entered names in warnings, including rejected or cleared names.
  * Prevented save operations from overwriting names edited during the save process.
* **Tests**
  * Added coverage for name persistence, clearing names, rejected names, and concurrent edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->