### PR TITLE
feat(processes): make tracking-off actually mean fire-and-forget (#591)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -23,6 +23,7 @@ import {
   store
 } from '../store'
 import { isRecord } from '../utils'
+import { publishRunningApps } from '../processes'
 import { applyTrayVisibility } from '../tray'
 import { applyRuntimeConfigSettings, getMainWindow, sendToRenderer } from '../window'
 
@@ -499,6 +500,12 @@ export function registerConfigHandlers(): void {
     profiles[gameKey] = sanitizedProfileSet
     store.set('profiles', profiles)
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })
+    // Republish so a tracking toggle takes effect on save rather than on the
+    // next poll (#591). Saving a profile changes which processes are surfaced
+    // at all, and the tasklist scan is the only other thing that would notice,
+    // up to 12s later on the SLOW cadence. This is also what finally gives the
+    // 'config' change reason a producer; it has been declared and unused.
+    void publishRunningApps('config')
   })
 
   ipcMain.handle('save-profiles', (_event, profiles: unknown) => {

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -221,11 +221,20 @@ function applySanitizedConfig(supportedConfig: Record<string, unknown>) {
     applyRuntimeConfigSettings()
     applyTrayVisibility(store.get('showTrayIcon') !== false)
     notifyStoreConfigChanged({ reason: 'import-config', keys: ['*'] })
+    // An import replaces every profile, so it can turn tracking on or off for
+    // any of them (#591). Both branches publish, because a rollback restores a
+    // different set of profiles than the one that was briefly live.
+    publishRunningApps('config').catch((err) => {
+      console.error('Failed to publish running apps after a profile change:', err)
+    })
   } catch (err) {
     store.clear()
     setStoreEntries(snapshot)
     applyRuntimeConfigSettings()
     applyTrayVisibility(store.get('showTrayIcon') !== false)
+    publishRunningApps('config').catch((err) => {
+      console.error('Failed to publish running apps after a profile change:', err)
+    })
     throw err
   }
 }
@@ -505,7 +514,9 @@ export function registerConfigHandlers(): void {
     // at all, and the tasklist scan is the only other thing that would notice,
     // up to 12s later on the SLOW cadence. This is also what finally gives the
     // 'config' change reason a producer; it has been declared and unused.
-    void publishRunningApps('config')
+    publishRunningApps('config').catch((err) => {
+      console.error('Failed to publish running apps after a profile change:', err)
+    })
   })
 
   ipcMain.handle('save-profiles', (_event, profiles: unknown) => {
@@ -513,6 +524,11 @@ export function registerConfigHandlers(): void {
     if (!sanitizedProfiles) return
     store.set('profiles', sanitizedProfiles)
     notifyStoreConfigChanged({ reason: 'save-profiles', keys: ['profiles'] })
+    // Same reason as save-profile above: this is the bulk write, so it can
+    // change tracking for several games at once.
+    publishRunningApps('config').catch((err) => {
+      console.error('Failed to publish running apps after a profile change:', err)
+    })
   })
 
   ipcMain.handle('get-migration-flags', () => {

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -329,7 +329,12 @@ export function registerLaunchHandlers(): void {
         // stop profile B from launching — launchProfileApps checks the same
         // signal before it spawns anything.
         const launchResult = await launchProfileApps(event.sender, gameKey, entriesToStart, {
-          controller: launchController
+          controller: launchController,
+          // The store still says the OUTGOING profile is active at this point:
+          // the renderer saves the new activeProfileId only after this call
+          // returns. Naming the incoming profile is what lets the launch read
+          // ITS tracking setting rather than the one being left behind (#591).
+          profileId: toProfileId
         })
 
         return {

--- a/src/main/processes/autoClose.ts
+++ b/src/main/processes/autoClose.ts
@@ -1,7 +1,12 @@
 import { performance } from 'perf_hooks'
 
 import { writeAppErrorLog } from '../errorLog'
-import { getActiveStoredProfile, getStoredProfiles, type StoredProfile } from '../profiles'
+import {
+  getActiveProfileForGame,
+  getStoredProfiles,
+  isProcessTrackingEnabled,
+  type StoredProfile
+} from '../profiles'
 import { getStoredStringRecord } from '../store'
 import { getExeName, isValidExePath } from '../utils'
 
@@ -62,7 +67,7 @@ const pendingAutoCloses = new Map<string, ReturnType<typeof setTimeout>>()
  * time passes, and the user can change any of this inside it.
  */
 function isAutoCloseArmed(gameKey: string): boolean {
-  const profile = getActiveProfile(gameKey)
+  const profile = getActiveProfileForGame(gameKey)
 
   // The only profile boolean that is opt-in, so `=== true`: absent
   // configuration must never authorise closing a user's apps.
@@ -72,7 +77,7 @@ function isAutoCloseArmed(gameKey: string): boolean {
 
   // Tracking off means SimLauncher deliberately does not follow this game's
   // process (#591), so there is no exit to detect and arming would be a lie.
-  if (profile.trackingEnabled === false) {
+  if (!isProcessTrackingEnabled(profile)) {
     return false
   }
 
@@ -128,11 +133,6 @@ function hasContestedExeName(gameKey: string): boolean {
   )
 }
 
-function getActiveProfile(gameKey: string): StoredProfile | undefined {
-  const profileEntry = getStoredProfiles()[gameKey]
-  return profileEntry ? getActiveStoredProfile(profileEntry) : undefined
-}
-
 function getSecondaryGamePaths(profile: StoredProfile | undefined): string[] {
   return Array.isArray(profile?.trackedProcessPaths)
     ? profile.trackedProcessPaths.filter(isValidExePath)
@@ -156,7 +156,7 @@ function getSecondaryGamePaths(profile: StoredProfile | undefined): string[] {
  */
 function getArmedGameExeNames(gameKey: string): Set<string> {
   const gamePath = getStoredStringRecord('gamePaths')[gameKey]
-  const paths = [gamePath, ...getSecondaryGamePaths(getActiveProfile(gameKey))].filter(
+  const paths = [gamePath, ...getSecondaryGamePaths(getActiveProfileForGame(gameKey))].filter(
     isValidExePath
   )
   return new Set(paths.map(getExeName))
@@ -197,7 +197,7 @@ function captureArming(gameKey: string, seenRunningSince: number): ArmedSnapshot
  * apps that belong to a session the user just started.
  */
 function getActiveProfileId(gameKey: string): string | undefined {
-  const id = getActiveProfile(gameKey)?.id
+  const id = getActiveProfileForGame(gameKey)?.id
   return typeof id === 'string' ? id : undefined
 }
 

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -5,6 +5,7 @@ import {
   getActiveStoredProfile,
   getProfileTrackablePaths,
   getStoredProfiles,
+  isProcessTrackingEnabled,
   isUtilityEnabled
 } from '../profiles'
 import { getStoredBoolean, getStoredStringRecord } from '../store'
@@ -464,6 +465,17 @@ function getProfileCompanionTargets(gameKey?: string) {
     }
 
     const profile = getActiveStoredProfile(profileEntry)
+
+    // Tracking off means SimLauncher does not manage this profile's apps at all
+    // (#591, desired behavior 2). Skipping the recording in spawn.ts is not
+    // enough on its own: this function rebuilds targets from the stored profile
+    // rather than from what was launched, so without this guard the tray's
+    // always-enabled Close Apps would still find and kill apps the user
+    // explicitly opted out of us touching. `hasClosableLaunchedApps` reads the
+    // same map, so this also stops the action being offered for that profile.
+    if (!isProcessTrackingEnabled(profile)) {
+      return
+    }
 
     // The hardcoded list is curated utility process names — never a game — so it
     // needs no game filtering. Only the path-based tracked companions can name a

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -17,6 +17,7 @@ import {
   processNameMismatchWarnings,
   pruneExpiredProcessNameMismatchWarnings,
   pruneStoppedRunningProcesses,
+  pruneUntrackedGames,
   runningProcesses,
   unclosedProcesses
 } from './state'
@@ -230,6 +231,27 @@ export async function getRunningApps(): Promise<RunningApp[]> {
     pruneUnclosedProcesses(processNames)
   }
   pruneExpiredProcessNameMismatchWarnings()
+  // Hoisted above the prune below because it needs the same profiles; the reads
+  // are pure store lookups, so their position carries no other meaning.
+  const profiles = getStoredProfiles()
+  const appPaths = getStoredStringRecord('appPaths')
+  const gamePaths = getStoredStringRecord('gamePaths')
+  // Turning tracking off has to take effect on apps that are ALREADY recorded,
+  // not just on the next launch (#591). `runningProcesses` is written at launch
+  // time and nothing removes an entry until its exe exits, so a profile that was
+  // launched while tracked would otherwise keep its strip icons, its dot and its
+  // Close Apps entry for the rest of the session, contradicting the setting the
+  // user just saved. Forget, never kill: those apps were started deliberately,
+  // and fire-and-forget means they outlive our interest in them.
+  pruneUntrackedGames(
+    new Set(
+      Object.entries(profiles || {})
+        .filter(
+          ([, profileEntry]) => !isProcessTrackingEnabled(getActiveStoredProfile(profileEntry))
+        )
+        .map(([gameKey]) => gameKey)
+    )
+  )
 
   const launchedApps = Array.from(runningProcesses.values()).map((appProcess) => ({
     path: appProcess.path,
@@ -272,9 +294,6 @@ export async function getRunningApps(): Promise<RunningApp[]> {
     )
   )
   const launchedExeNames = new Set(surfacedApps.map((appProcess) => getExeName(appProcess.path)))
-  const profiles = getStoredProfiles()
-  const appPaths = getStoredStringRecord('appPaths')
-  const gamePaths = getStoredStringRecord('gamePaths')
   const launchedGameKeys = new Set(
     [...surfacedApps, ...mismatchWarnings].map((appProcess) => appProcess.gameKey)
   )

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -246,7 +246,7 @@ export function registerProcessScanObserver(observer: ProcessScanObserver): void
 function reconcileUntrackedGames(): void {
   pruneUntrackedGames(
     new Set(
-      Object.entries(getStoredProfiles() || {})
+      Object.entries(getStoredProfiles())
         .filter(
           ([gameKey, profileEntry]) =>
             !isLaunchActiveForGame(gameKey) &&

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -14,6 +14,7 @@ import { getExeName, isValidExePath, normalizePathForComparison } from '../utils
 
 import { pruneUnclosedProcesses } from './kill'
 import {
+  isLaunchActiveForGame,
   processNameMismatchWarnings,
   pruneExpiredProcessNameMismatchWarnings,
   pruneStoppedRunningProcesses,
@@ -210,6 +211,52 @@ export function registerProcessScanObserver(observer: ProcessScanObserver): void
   processScanObservers.add(observer)
 }
 
+/**
+ * Drop every surfaced record belonging to a game whose active profile has
+ * process tracking off (#591).
+ *
+ * Turning tracking off has to take effect on apps that are ALREADY recorded,
+ * not just on the next launch. `runningProcesses` is written at launch time and
+ * nothing removes an entry until its exe exits, so a profile launched while
+ * tracked would otherwise keep its strip icons, its dot and its Close Apps
+ * entry for the rest of the session, contradicting the setting the user just
+ * saved. Forget, never kill: those apps were started deliberately, and
+ * fire-and-forget means they outlive our interest in them.
+ *
+ * Deliberately SYNCHRONOUS, and called from two places for that reason
+ * (CodeRabbit on #834). Doing it only inside `getRunningApps` puts it behind
+ * that function's `tasklist` await, leaving a window after the profile is saved
+ * in which `killLaunchedApps` still finds the stale entries and closes apps the
+ * user just opted out of. `publishRunningApps` runs it at call time instead, so
+ * a save reconciles before it returns; `getRunningApps` keeps its own call for
+ * the paths that reach it without a publish (the `get-running-apps` handler).
+ * Idempotent, so running it twice per publish costs one store read.
+ *
+ * Games with a launch in flight are skipped, and that is load-bearing rather
+ * than an optimisation. This reads the store's ACTIVE profile, which during a
+ * profile switch still names the OUTGOING one: the renderer launches the
+ * incoming profile's apps before saving the new `activeProfileId`. Reconciling
+ * in that window would prune the entries the incoming TRACKED profile just
+ * correctly recorded, on the authority of the outgoing untracked one. It is the
+ * same staleness `LaunchProfileAppsOptions.profileId` exists to defeat, and the
+ * same reason auto-close consults this primitive before reading an absence as
+ * an exit (#204). A toggle saved mid-launch is simply applied by the next
+ * publish, once the sequence has ended and the store agrees with itself.
+ */
+function reconcileUntrackedGames(): void {
+  pruneUntrackedGames(
+    new Set(
+      Object.entries(getStoredProfiles() || {})
+        .filter(
+          ([gameKey, profileEntry]) =>
+            !isLaunchActiveForGame(gameKey) &&
+            !isProcessTrackingEnabled(getActiveStoredProfile(profileEntry))
+        )
+        .map(([gameKey]) => gameKey)
+    )
+  )
+}
+
 export async function getRunningApps(): Promise<RunningApp[]> {
   const readResult = await readRunningProcessNames()
   const { processNames, succeeded: tasklistReadSucceeded } = readResult
@@ -231,27 +278,10 @@ export async function getRunningApps(): Promise<RunningApp[]> {
     pruneUnclosedProcesses(processNames)
   }
   pruneExpiredProcessNameMismatchWarnings()
-  // Hoisted above the prune below because it needs the same profiles; the reads
-  // are pure store lookups, so their position carries no other meaning.
+  reconcileUntrackedGames()
   const profiles = getStoredProfiles()
   const appPaths = getStoredStringRecord('appPaths')
   const gamePaths = getStoredStringRecord('gamePaths')
-  // Turning tracking off has to take effect on apps that are ALREADY recorded,
-  // not just on the next launch (#591). `runningProcesses` is written at launch
-  // time and nothing removes an entry until its exe exits, so a profile that was
-  // launched while tracked would otherwise keep its strip icons, its dot and its
-  // Close Apps entry for the rest of the session, contradicting the setting the
-  // user just saved. Forget, never kill: those apps were started deliberately,
-  // and fire-and-forget means they outlive our interest in them.
-  pruneUntrackedGames(
-    new Set(
-      Object.entries(profiles || {})
-        .filter(
-          ([, profileEntry]) => !isProcessTrackingEnabled(getActiveStoredProfile(profileEntry))
-        )
-        .map(([gameKey]) => gameKey)
-    )
-  )
 
   const launchedApps = Array.from(runningProcesses.values()).map((appProcess) => ({
     path: appProcess.path,
@@ -406,6 +436,21 @@ export function publishRunningApps(
   // settling process set is tracked live even if the window is hidden.
   if (reason !== 'scan') {
     noteRunningAppsActivity()
+  }
+  // Before the chain, not inside it: a `'config'` publish follows the profile
+  // write synchronously, so reconciling here is what makes the tracking toggle
+  // take effect by the time the save handler returns rather than one tasklist
+  // read later (#591).
+  //
+  // Guarded, because running it synchronously moved it onto the CALLER's stack:
+  // `save-profile` calls this right after writing the store, so an exception in
+  // here would now fail the save itself, where the same exception inside the
+  // promise chain below was contained by the caller's `.catch`. Reconciling the
+  // running-apps view must never be able to take down a settings write.
+  try {
+    reconcileUntrackedGames()
+  } catch (err) {
+    console.error('Failed to reconcile untracked games before publishing:', err)
   }
 
   const next = (publishRunningAppsPromise || Promise.resolve(null))

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -6,7 +6,8 @@ import {
   StoredProfileEntry,
   getActiveStoredProfile,
   getProfileTrackablePaths,
-  getStoredProfiles
+  getStoredProfiles,
+  isProcessTrackingEnabled
 } from '../profiles'
 import { getStoredStringRecord } from '../store'
 import { getExeName, isValidExePath, normalizePathForComparison } from '../utils'
@@ -164,7 +165,7 @@ async function getTrackedRunningApps(
 
     const profile = getActiveStoredProfile(profileEntry)
 
-    if (profile?.trackingEnabled === false) {
+    if (!isProcessTrackingEnabled(profile)) {
       return
     }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -484,6 +484,27 @@ export async function launchProfileApps(
     }
     activeLaunches.delete(gameKey)
     unregisterActiveLaunch(gameKey, launchController)
+    // A tracking toggle saved DURING this sequence was skipped by the reconcile,
+    // which refuses to judge a game mid-launch because the store's active
+    // profile is unreliable then (#591). Nothing else publishes when a sequence
+    // ENDS: every per-app publish above runs before this unregister, and the
+    // poll stops outright once the last subscriber goes, so the stale records
+    // and any pending elevated handoff could otherwise outlive the toggle
+    // indefinitely and still be closed by a tray Close Apps (Codex on #834).
+    //
+    // Only when no `profileId` was passed, which is the exact condition: the
+    // caller supplies it precisely when the profile being launched is NOT the
+    // persisted active one, i.e. a switch whose new `activeProfileId` the
+    // renderer has not saved yet. Reconciling there would prune the incoming
+    // profile's records on the authority of the outgoing one, and the switch's
+    // own `save-profile` publish covers it with a store that agrees with itself
+    // by then. Gating on `options.controller` instead is NOT equivalent and the
+    // switch regression test says so: it passes a profileId without one.
+    if (!options?.profileId) {
+      publishRunningApps('config').catch((err) => {
+        console.error('Failed to publish running apps after a launch sequence:', err)
+      })
+    }
   }
 }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -1054,7 +1054,13 @@ export async function spawnDetachedApp(
 
       child.once('exit', () => {
         const processEntry = runningProcesses.get(runningKey)
-        const wasGame = processEntry?.isGame ?? false
+        // Derived the same way as at record time rather than read back off the
+        // entry, because the entry is not guaranteed to still be there: the
+        // untracked reconcile prunes it (#591), and `?? false` then claimed the
+        // game exe was a companion and toasted about it (Codex on #834).
+        // Whether this path IS the game does not depend on whether we recorded
+        // it, so it should not be stored in something prunable.
+        const wasGame = !!gamePath && pathsEqual(appPath, gamePath)
         // Only drop the entry if it is still ours. Two slots can share a
         // canonical key (#357), and a late exit event for an already-killed
         // child must not wipe an entry that a subsequent spawn has just
@@ -1069,7 +1075,23 @@ export async function spawnDetachedApp(
         // nothing to say to a profile that asked not to be tracked (#591). It
         // would also be the one thing still lighting that game's card, which is
         // exactly what fire-and-forget promises not to do.
-        if (isTracked && exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
+        //
+        // Both the launch-time decision AND the current one, because they can
+        // disagree: this fires up to POST_LAUNCH_BLOCK_MS after the launch, so
+        // a toggle inside that window leaves `isTracked` stale (Codex on #834).
+        // The stored warning would be pruned by the reconcile on the next
+        // publish, but the toast is already on the user's screen and there is
+        // no retracting it. Re-read rather than replace: the message is only
+        // ever true if the app was tracked when it started as well.
+        //
+        // Residual, accepted: mid profile-switch the store still names the
+        // OUTGOING profile, so switching from an untracked profile to a tracked
+        // one can swallow a legitimate warning for a few milliseconds. A missed
+        // warning costs the user nothing permanent; a wrong one is a toast they
+        // cannot dismiss the cause of.
+        const stillTracked = isTracked && isProcessTrackingEnabled(getActiveProfileForGame(gameKey))
+
+        if (stillTracked && exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
           const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add it under "Secondary executables to watch" in the profile editor. Right-click the icon to dismiss this warning.`
 
           processNameMismatchWarnings.set(normalizePathForComparison(appPath), {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -3,7 +3,12 @@ import fs from 'fs'
 import path from 'path'
 
 import { writeAppErrorLog } from '../errorLog'
-import { getActiveProfileForGame, isProcessTrackingEnabled } from '../profiles'
+import {
+  getActiveProfileForGame,
+  getStoredProfiles,
+  isProcessTrackingEnabled,
+  resolveNamedProfile
+} from '../profiles'
 import { getStoredStringRecord, store } from '../store'
 import {
   getErrorCode,
@@ -207,6 +212,18 @@ export async function launchProfileApps(
     const launchDelayMs = getLaunchDelayMs()
     const gamePaths = getStoredStringRecord('gamePaths')
     const gamePath = gamePaths?.[gameKey]
+    // Resolved from the profile these entries came FROM, which during a profile
+    // switch is not the one the store calls active: the renderer launches the
+    // incoming profile's apps and saves the new activeProfileId afterwards
+    // (GameRow). Reading the store here would apply the OUTGOING profile's
+    // tracking setting, so switching to a fire-and-forget profile would still
+    // record its apps, and switching away from one would leave the incoming
+    // tracked profile with no running strip at all.
+    const trackingEnabled = isProcessTrackingEnabled(
+      options?.profileId
+        ? resolveNamedProfile(getStoredProfiles()[gameKey], options.profileId)
+        : getActiveProfileForGame(gameKey)
+    )
     const { processNames } = await readRunningProcessNames()
     const normalizedEntries = profileApps.map((input) => normalizeLaunchInput(input, gameKey))
     // Entries filtered out below never reach spawn — tracked here (not just
@@ -310,7 +327,8 @@ export async function launchProfileApps(
         gameKey,
         appsToLaunch[index],
         gamePath,
-        launchController.signal
+        launchController.signal,
+        trackingEnabled
       )
       // Nothing was started, so don't count it (and don't arm the post-launch
       // cooldown for an attempt that never happened).
@@ -859,7 +877,8 @@ export async function spawnDetachedApp(
   gameKey: string,
   entry: ProfileLaunchEntry,
   gamePath?: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  trackingEnabled?: boolean
 ): Promise<AppLaunchResult> {
   const { path: appPath, key: appKey } = entry
   // Console-subsystem exes must NOT get DETACHED_PROCESS: without a console
@@ -873,9 +892,13 @@ export async function spawnDetachedApp(
   // in flight. None of those windows needs its own check: spawnUnlessAborted
   // re-reads the signal in the same synchronous block as spawn() (#715).
   const consoleApp = await isConsoleExecutable(appPath)
-  // Read once per app rather than at each use below, so one launch cannot be
-  // half-tracked if the user flips the toggle while its handlers are pending.
-  const trackingEnabled = isProcessTrackingEnabled(getActiveProfileForGame(gameKey))
+  // Resolved once per app rather than at each use below, so one launch cannot
+  // end up half-tracked if the user flips the toggle while its handlers are
+  // still pending.
+  //
+  // The caller passes it whenever the profile being launched is not the
+  // persisted active one; the fallback covers direct use of this function.
+  const isTracked = trackingEnabled ?? isProcessTrackingEnabled(getActiveProfileForGame(gameKey))
 
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
@@ -924,7 +947,7 @@ export async function spawnDetachedApp(
       //
       // Not managing them afterwards is the feature, not a gap: the user asked
       // SimLauncher to be a launcher and nothing else.
-      if (trackingEnabled) {
+      if (isTracked) {
         runningProcesses.set(runningKey, {
           process: child,
           path: appPath,
@@ -992,7 +1015,7 @@ export async function spawnDetachedApp(
         // nothing to say to a profile that asked not to be tracked (#591). It
         // would also be the one thing still lighting that game's card, which is
         // exactly what fire-and-forget promises not to do.
-        if (trackingEnabled && exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
+        if (isTracked && exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
           const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add it under "Secondary executables to watch" in the profile editor. Right-click the icon to dismiss this warning.`
 
           processNameMismatchWarnings.set(normalizePathForComparison(appPath), {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { writeAppErrorLog } from '../errorLog'
+import { getActiveProfileForGame, isProcessTrackingEnabled } from '../profiles'
 import { getStoredStringRecord, store } from '../store'
 import {
   getErrorCode,
@@ -872,6 +873,9 @@ export async function spawnDetachedApp(
   // in flight. None of those windows needs its own check: spawnUnlessAborted
   // re-reads the signal in the same synchronous block as spawn() (#715).
   const consoleApp = await isConsoleExecutable(appPath)
+  // Read once per app rather than at each use below, so one launch cannot be
+  // half-tracked if the user flips the toggle while its handlers are pending.
+  const trackingEnabled = isProcessTrackingEnabled(getActiveProfileForGame(gameKey))
 
   return new Promise<AppLaunchResult>((resolve) => {
     let settled = false
@@ -906,13 +910,29 @@ export async function spawnDetachedApp(
         return
       }
       const runningKey = normalizePathForComparison(appPath)
-      runningProcesses.set(runningKey, {
-        process: child,
-        path: appPath,
-        name: path.basename(appPath),
-        gameKey,
-        isGame: !!gamePath && pathsEqual(appPath, gamePath)
-      })
+      // Fire-and-forget when this game's profile has tracking off (#591): the
+      // app is never recorded, so it cannot be surfaced, counted, killed or
+      // auto-closed later. Not recorded rather than filtered on the way out,
+      // deliberately. A display filter was tried and reverted for two reasons
+      // a filter cannot avoid: `launchedExeNames` is a global basename dedup
+      // set built from the UNFILTERED list, so an untracked profile launching
+      // a shared exe (SimHub is the normal case for multi-sim users) would
+      // suppress a tracked profile's own copy of it and surface the companion
+      // nowhere; and profile switch derives `isRunning` from the same list,
+      // so hiding the apps silently skipped its stop/start pipeline while
+      // reporting success.
+      //
+      // Not managing them afterwards is the feature, not a gap: the user asked
+      // SimLauncher to be a launcher and nothing else.
+      if (trackingEnabled) {
+        runningProcesses.set(runningKey, {
+          process: child,
+          path: appPath,
+          name: path.basename(appPath),
+          gameKey,
+          isGame: !!gamePath && pathsEqual(appPath, gamePath)
+        })
+      }
 
       child.once('spawn', () => {
         child.unref()
@@ -968,7 +988,11 @@ export async function spawnDetachedApp(
         const exitedDuringPostLaunchWindow = Date.now() - launchStartedAt <= POST_LAUNCH_BLOCK_MS
         const wasClosedBySimLauncher = consumeProcessNameMismatchWarningSuppression(appPath)
 
-        if (exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
+        // The whole warning is about tracking having been lost, so it has
+        // nothing to say to a profile that asked not to be tracked (#591). It
+        // would also be the one thing still lighting that game's card, which is
+        // exactly what fire-and-forget promises not to do.
+        if (trackingEnabled && exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
           const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add it under "Secondary executables to watch" in the profile editor. Right-click the icon to dismiss this warning.`
 
           processNameMismatchWarnings.set(normalizePathForComparison(appPath), {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -680,7 +680,8 @@ function launchElevated(
   appPath: string,
   args: string[] = [],
   gameKey?: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  tracked = true
 ) {
   return new Promise<AppLaunchResult>((resolve) => {
     const elevatedWarning = `${path.basename(appPath)} requested administrator permission. SimLauncher will detect when it's running but cannot close it from here.`
@@ -771,17 +772,32 @@ function launchElevated(
       // still-live host so a later Close Apps can still reach it (#779 Codex
       // P1), otherwise approving the prompt afterwards would start the app the
       // user just asked to close.
-      registerPendingElevatedHandoff(handoffId, {
-        gameKey,
-        cancel: () => {
-          cancelledByKill = true
-          noteHandoffCancelled()
-          // Same reason as onAbort (#809), and the same guard: mid-sequence
-          // both this and the abort fire for this one handoff.
-          noteStrandedPromptOnce()
-          child?.kill()
-        }
-      })
+      //
+      // Not for a fire-and-forget profile though (#591). This registry has
+      // exactly one consumer, `cancelPendingElevatedHandoffs`, called from both
+      // kill entry points BEFORE they filter profile targets, so registering
+      // here would let a global Close Apps kill the host of an app the user
+      // opted out of us managing: the late approval would then start nothing
+      // and they would be told a consent prompt was stranded. Not registering
+      // is what leaves the prompt answerable.
+      //
+      // Only the post-grace-window registry is skipped. The abort signal above
+      // still cancels this handoff while the sequence is in flight, because
+      // cancelling a launch in progress is a different thing from managing the
+      // apps it already started.
+      if (tracked) {
+        registerPendingElevatedHandoff(handoffId, {
+          gameKey,
+          cancel: () => {
+            cancelledByKill = true
+            noteHandoffCancelled()
+            // Same reason as onAbort (#809), and the same guard: mid-sequence
+            // both this and the abort fire for this one handoff.
+            noteStrandedPromptOnce()
+            child?.kill()
+          }
+        })
+      }
       resolve({
         status: 'elevated',
         appPath,
@@ -990,7 +1006,7 @@ export async function spawnDetachedApp(
           // in which case launchElevated starts nothing and reports the attempt
           // as cancelled — its own start is guarded (#715). Nothing is running
           // here either way: this spawn failed.
-          resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey, signal))
+          resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey, signal, isTracked))
           return
         }
 
@@ -1050,7 +1066,7 @@ export async function spawnDetachedApp(
 
       // Same handoff-vs-failure distinction as the 'error' handler above.
       if (isElevatedLaunchError(err)) {
-        launchElevated(appPath, getAppArgs(appKey), gameKey, signal).then(resolveOnce)
+        launchElevated(appPath, getAppArgs(appKey), gameKey, signal, isTracked).then(resolveOnce)
         return
       }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -705,7 +705,14 @@ function launchElevated(
   tracked = true
 ) {
   return new Promise<AppLaunchResult>((resolve) => {
-    const elevatedWarning = `${path.basename(appPath)} requested administrator permission. SimLauncher will detect when it's running but cannot close it from here.`
+    // Two sentences because the second one is a promise, and it is only true
+    // when we are tracking (CodeRabbit on #834). Telling a fire-and-forget
+    // profile that SimLauncher "will detect when it's running" is exactly the
+    // lie #591 exists to stop: it will not, deliberately, because the user
+    // asked it not to.
+    const elevatedWarning = tracked
+      ? `${path.basename(appPath)} requested administrator permission. SimLauncher will detect when it's running but cannot close it from here.`
+      : `${path.basename(appPath)} requested administrator permission. Process tracking is off for this profile, so SimLauncher will not detect or close it.`
 
     // A kill (Close Apps) can land while the UAC handoff is still pending —
     // the consent prompt sits on screen until the user answers it, so this

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -926,6 +926,17 @@ function launchElevated(
   })
 }
 
+/**
+ * Starts one profile entry and reports how it settled.
+ *
+ * @param trackingEnabled Whether SimLauncher manages what it starts. `false`
+ * means fire-and-forget (#591): the process is never recorded, so it cannot
+ * afterwards be surfaced in the running strip, counted, closed by Close Apps,
+ * or auto-closed with the game. Omit it to resolve the setting from the active
+ * profile in the store; pass it explicitly whenever the caller knows which
+ * profile these entries came from, because mid profile-switch the store still
+ * names the OUTGOING one (see `LaunchProfileAppsOptions.profileId`).
+ */
 export async function spawnDetachedApp(
   sender: WebContents,
   gameKey: string,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -162,6 +162,16 @@ export function buildLaunchSummaryMessage(
   return 'All profile applications launched.'
 }
 
+// Mirrors the per-app wording built in `launchElevated`. Kept in step with it
+// deliberately: the plural branch REPLACES those warnings rather than joining
+// them, so an unconditional plural string puts the promise back the moment a
+// second app needs elevation (Codex on #834).
+function buildPluralElevatedWarning(count: number, tracked: boolean): string {
+  return tracked
+    ? `${count} apps requested administrator permission. SimLauncher will detect when they're running but cannot close them from here.`
+    : `${count} apps requested administrator permission. Process tracking is off for this profile, so SimLauncher will not detect or close them.`
+}
+
 export async function launchProfileApps(
   sender: WebContents,
   gameKey: string,
@@ -466,7 +476,7 @@ export async function launchProfileApps(
       standingElevated.length === 1
         ? standingElevated[0].warning
         : standingElevated.length > 1
-          ? `${standingElevated.length} apps requested administrator permission. SimLauncher will detect when they're running but cannot close them from here.`
+          ? buildPluralElevatedWarning(standingElevated.length, trackingEnabled)
           : undefined
 
     return {

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -256,6 +256,35 @@ export function pruneStoppedRunningProcesses(processNames: Set<string>): void {
   })
 }
 
+/**
+ * Drop every surfaced record belonging to a game whose active profile has
+ * process tracking off (#591), without touching the processes themselves.
+ *
+ * Takes the keys rather than reading the store so this module stays free of
+ * profile knowledge, matching `pruneStoppedRunningProcesses` above.
+ */
+export function pruneUntrackedGames(untrackedGameKeys: Set<string>): void {
+  if (untrackedGameKeys.size === 0) {
+    return
+  }
+
+  runningProcesses.forEach((entry, key) => {
+    if (untrackedGameKeys.has(entry.gameKey)) {
+      runningProcesses.delete(key)
+    }
+  })
+  unclosedProcesses.forEach((entry, key) => {
+    if (untrackedGameKeys.has(entry.gameKey)) {
+      unclosedProcesses.delete(key)
+    }
+  })
+  processNameMismatchWarnings.forEach((entry, key) => {
+    if (untrackedGameKeys.has(entry.gameKey)) {
+      processNameMismatchWarnings.delete(key)
+    }
+  })
+}
+
 export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()): void {
   processNameMismatchWarnings.forEach((entry, key) => {
     if (entry.expiresAt !== undefined && entry.expiresAt <= now) {

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -283,6 +283,22 @@ export function pruneUntrackedGames(untrackedGameKeys: Set<string>): void {
       processNameMismatchWarnings.delete(key)
     }
   })
+  // The fourth map, and the one that is easy to miss because it holds a
+  // callback rather than a record (Codex on #834). `launchElevated` already
+  // refuses to register a handoff for a profile that was untracked AT LAUNCH,
+  // but a launch that started while tracked and timed out into this registry
+  // predates the toggle, so only this pass can reach it. Left behind, a later
+  // Close Apps would still kill its PowerShell host and strand the consent
+  // prompt of a profile that is now fire-and-forget.
+  //
+  // Deleted WITHOUT calling `cancel`. That callback is what kills the host, and
+  // killing it is precisely what this is preventing: forgetting the handoff has
+  // to leave the prompt answerable.
+  pendingElevatedHandoffs.forEach((entry, handoffId) => {
+    if (entry.gameKey !== undefined && untrackedGameKeys.has(entry.gameKey)) {
+      pendingElevatedHandoffs.delete(handoffId)
+    }
+  })
 }
 
 export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()): void {

--- a/src/main/processes/types.ts
+++ b/src/main/processes/types.ts
@@ -117,6 +117,15 @@ export interface KillResult {
  */
 export interface LaunchProfileAppsOptions {
   controller?: AbortController
+  /**
+   * Which profile these entries came from, when it is NOT the persisted active
+   * one. Only `switch-profile-apps` needs it: the renderer launches the incoming
+   * profile's apps and saves the new `activeProfileId` afterwards, so anything
+   * reading the store mid-switch sees the OUTGOING profile. Today that decides
+   * whether the launched apps are tracked at all (#591), which is the difference
+   * between a fire-and-forget profile and a managed one.
+   */
+  profileId?: string
 }
 
 /**

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -228,6 +228,28 @@ export function getActiveStoredProfile(
   return profileEntry
 }
 
+export function getActiveProfileForGame(gameKey: string): StoredProfile | undefined {
+  const profileEntry = getStoredProfiles()[gameKey]
+  return profileEntry ? getActiveStoredProfile(profileEntry) : undefined
+}
+
+/**
+ * Whether SimLauncher should follow this game's processes at all (#591).
+ *
+ * `!== false` rather than `=== true`, matching every profile boolean except
+ * `closeAppsOnGameExit`: tracking is on unless the user turned it off, so an
+ * absent or malformed value means on. Nobody has the key set, so inverting this
+ * would silently make every existing profile untracked.
+ *
+ * One spelling on purpose. The rule is read from three places now (launch
+ * recording, tasklist discovery, auto-close arming), and it decides whether a
+ * process is recorded at all rather than merely displayed, so two of them
+ * drifting apart would leave a game surfaced by one and invisible to the others.
+ */
+export function isProcessTrackingEnabled(profile: StoredProfile | undefined): boolean {
+  return profile?.trackingEnabled !== false
+}
+
 export function getProfileTrackablePaths(
   gameKey: string,
   profile: StoredProfile | undefined,

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -96,7 +96,13 @@ async function loadAutoCloseModule(opts?: {
     getStoredProfiles: vi.fn(() => opts?.profiles ?? {}),
     // Tests pass a flat profile per game key; profile-set resolution is
     // profiles.ts' concern and has its own suite.
-    getActiveStoredProfile: vi.fn((entry: unknown) => entry)
+    getActiveStoredProfile: vi.fn((entry: unknown) => entry),
+    getActiveProfileForGame: vi.fn((gameKey: string) => (opts?.profiles ?? {})[gameKey] as unknown),
+    // The real predicate, not a stub: these tests drive `trackingEnabled`
+    // through their fixtures, so stubbing it would decide the answer here
+    // instead of exercising it.
+    isProcessTrackingEnabled: (profile: { trackingEnabled?: boolean } | undefined) =>
+      profile?.trackingEnabled !== false
   }
   vi.doMock('../profiles', () => profilesMock)
   vi.doMock('/src/main/profiles.ts', () => profilesMock)

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -727,6 +727,33 @@ test('turning the toggle off inside the window cancels the pending close (#204)'
 // A game that was never seen running cannot have exited. Without this the first
 // scan of a session (or the first after the observer is re-registered) looks
 // exactly like an exit.
+// The same re-check, driven by the OTHER switch. The test above pins it for
+// `closeAppsOnGameExit`; this one pins it for `trackingEnabled`, which reaches
+// the same guard by a different field and is the switch #591 is about. Without
+// it, `pendingAutoCloses` would be the one registry in this subsystem that
+// survives the tracking toggle and then KILLS apps, rather than merely
+// surfacing them.
+test('turning tracking off inside the window cancels the pending close (#591)', async () => {
+  const profiles: Record<string, Record<string, unknown>> = { ac: { ...ARMED } }
+  const { observeProcessScan, AUTO_CLOSE_GRACE_MS, MIN_SESSION_MS } = await loadAutoCloseModule({
+    profiles,
+    gamePaths: AC_GAME_PATHS
+  })
+  readRunningProcessNamesMock.mockResolvedValue(GONE)
+
+  // Armed while tracked, so the timer really is pending before the toggle.
+  observeProcessScan(RUNNING)
+  await advance(MIN_SESSION_MS)
+  observeProcessScan(GONE)
+  await advance(AUTO_CLOSE_GRACE_MS / 2)
+
+  profiles.ac.trackingEnabled = false
+  observeProcessScan(GONE)
+  await advance(AUTO_CLOSE_GRACE_MS * 2)
+
+  expect(killLaunchedAppsMock).not.toHaveBeenCalled()
+})
+
 test('a game absent from the very first scan is not treated as an exit (#204)', async () => {
   const { observeProcessScan, AUTO_CLOSE_GRACE_MS } = await loadAutoCloseModule({
     profiles: AC_PROFILES,

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -50,7 +50,15 @@ async function loadConfigModule() {
     }
   }))
   vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
-  vi.doMock('../../src/main/profiles', () => ({ isStoredProfileSet: vi.fn() }))
+  // The real discriminator rather than a stub: the profile handlers below bail
+  // early when it says no, so a stub would make their tests pass vacuously.
+  vi.doMock('../../src/main/profiles', () => ({
+    isStoredProfileSet: (value: unknown) =>
+      !!value &&
+      typeof value === 'object' &&
+      Array.isArray((value as { profiles?: unknown }).profiles)
+  }))
+  vi.doMock('../../src/main/processes', () => ({ publishRunningApps: vi.fn(async () => {}) }))
   vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
   vi.doMock('../../src/main/window', () => ({
     applyRuntimeConfigSettings: vi.fn(),
@@ -195,4 +203,54 @@ test('save-settings survives a throwing login-item write, and says so (#676)', a
     expect.objectContaining({ message: 'registry write refused' })
   )
   consoleError.mockRestore()
+})
+
+/**
+ * #591: a tracking toggle is a `profiles` write, and nothing else in the main
+ * process notices one until the next tasklist scan, which is up to 12s away on
+ * the SLOW cadence. Every path that writes `profiles` therefore republishes.
+ *
+ * Asserted rather than assumed: the call is fire-and-forget, so dropping it
+ * changes nothing observable in the handler's return value.
+ */
+async function invokeProfileHandler(channel: string, ...args: unknown[]): Promise<void> {
+  const { __ipcHandlers } = await import('electron')
+  await (__ipcHandlers as Record<string, MockIpcHandler>)[channel]({}, ...args)
+}
+
+test('save-profile republishes the running apps (#591)', async () => {
+  await loadConfigModule()
+  const { publishRunningApps } = await import('../../src/main/processes')
+
+  await invokeProfileHandler('save-profile', 'ac', {
+    activeProfileId: 'default',
+    profiles: [{ id: 'default', name: 'Default', trackingEnabled: false }]
+  })
+
+  expect(publishRunningApps).toHaveBeenCalledWith('config')
+})
+
+// The bulk write, which the Settings screen uses and which can change tracking
+// for several games at once. Separate test: wiring only the single-profile
+// handler passes the one above and fails this.
+test('save-profiles republishes the running apps too (#591)', async () => {
+  await loadConfigModule()
+  const { publishRunningApps } = await import('../../src/main/processes')
+
+  await invokeProfileHandler('save-profiles', {
+    ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+  })
+
+  expect(publishRunningApps).toHaveBeenCalledWith('config')
+})
+
+// A save that the sanitizer rejects writes nothing, so it must not claim the
+// running list changed either.
+test('a rejected profile save does not republish (#591)', async () => {
+  await loadConfigModule()
+  const { publishRunningApps } = await import('../../src/main/processes')
+
+  await invokeProfileHandler('save-profile', '', { activeProfileId: 'default', profiles: [] })
+
+  expect(publishRunningApps).not.toHaveBeenCalled()
 })

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -431,7 +431,10 @@ test('switch-profile-apps never kills or relaunches the game executable', async 
   const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
   expect(controller.signal.aborted).toBe(false)
   expect(killProfileApps).toHaveBeenCalledWith('iracing', [utilA.path], { except: controller })
-  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [utilB], { controller })
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [utilB], {
+    controller,
+    profileId: 'p-to'
+  })
   expect(unregisterActiveLaunch).toHaveBeenCalledWith('iracing', controller)
 })
 
@@ -576,4 +579,32 @@ test('get-profile-switch-diff counts stops/starts without the game executable', 
   await expect(
     handlers['get-profile-switch-diff'](event, 'iracing', 'p-from', 'p-to')
   ).resolves.toEqual({ toStopCount: 1, toStartCount: 1 })
+})
+
+// #591: the renderer launches the incoming profile's apps and only saves the
+// new activeProfileId afterwards, so anything resolving "the active profile"
+// from the store mid-switch gets the OUTGOING one. Whether the launched apps
+// are tracked at all now depends on that, so the handler has to name the
+// profile it is actually launching.
+test('switch-profile-apps tells the launch which profile it is launching (#591)', async () => {
+  const handlers = await loadLaunchHandlers()
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe']),
+    succeeded: true
+  })
+  launchProfileApps.mockResolvedValue({ success: true, launchedCount: 1, skippedCount: 0 })
+
+  await handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+
+  expect(launchProfileApps).toHaveBeenCalledWith(
+    sender,
+    'iracing',
+    [utilB],
+    expect.objectContaining({ profileId: 'p-to' })
+  )
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -6377,3 +6377,44 @@ test('a toggle saved during a launch is applied when the sequence ends (#591)', 
   expect(runningProcesses.size).toBe(0)
   await expect(getRunningApps()).resolves.toEqual([])
 })
+
+// The elevation warning is a PROMISE about what SimLauncher will do next, and
+// it was made unconditionally (CodeRabbit on #834). Telling a fire-and-forget
+// profile that we "will detect when it's running" is the same lie #591 exists
+// to stop: we will not, deliberately.
+test('the elevated warning does not promise detection to an untracked profile (#591)', async () => {
+  markExistingPath('C:/Tools/Admin Tool.exe')
+  const { launchProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+    profiles: {
+      ac: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+      }
+    }
+  })
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+
+  const result = await launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])
+
+  expect(result.warning).toContain('Process tracking is off for this profile')
+  expect(result.warning).not.toContain('will detect when')
+})
+
+// The same launch with tracking on keeps the original promise, which is true
+// there: the tasklist scan really does surface an elevated app it cannot close.
+test('a tracked profile still gets the detection promise (#591)', async () => {
+  markExistingPath('C:/Tools/Admin Tool.exe')
+  const { launchProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+    profiles: {
+      ac: { activeProfileId: 'loud', profiles: [{ id: 'loud', name: 'Loud' }] }
+    }
+  })
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+
+  const result = await launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])
+
+  expect(result.warning).toContain('will detect when')
+  expect(result.warning).not.toContain('Process tracking is off')
+})

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -5951,3 +5951,110 @@ test('a switch away from an untracked profile still records the incoming one (#5
 
   expect(runningProcesses.size).toBe(1)
 })
+
+// #591 desired behavior 2, verbatim: "Tray 'Close Apps' must not offer that
+// profile." Not recording the launch is not enough on its own, because
+// `getProfileCompanionTargets` rebuilds targets from the STORED profile rather
+// than from what was launched — so the global Close Apps found and killed the
+// companion anyway, whether SimLauncher started it or the user did. Found by
+// Codex on PR #834, not by the tests above, all of which assert on
+// `runningProcesses` and are blind to the target map.
+test('close apps does not kill a tracking-off profile companion (#591)', async () => {
+  processNames.add('garage61 telemetry agent.exe')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', garage61: true, trackingEnabled: false }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls).toHaveLength(0)
+})
+
+// The same rule from the other side, and the half the user actually sees: the
+// action must not be OFFERED. Both read `getProfileCompanionTargets`, so one
+// guard covers them, but a future refactor could easily give them separate
+// paths again.
+test('close apps is not offered for a tracking-off profile (#591)', async () => {
+  processNames.add('garage61 telemetry agent.exe')
+
+  const { hasClosableLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', garage61: true, trackingEnabled: false }]
+      }
+    }
+  })
+
+  await expect(hasClosableLaunchedApps('ac')).resolves.toBe(false)
+})
+
+// The same profile with tracking left ON, so the two tests above cannot pass by
+// the target map being empty for some unrelated reason.
+test('close apps still targets the same companion when tracking is on (#591)', async () => {
+  processNames.add('garage61 telemetry agent.exe')
+
+  const { killLaunchedApps, hasClosableLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'loud',
+        profiles: [{ id: 'loud', name: 'Loud', garage61: true }]
+      }
+    }
+  })
+
+  await expect(hasClosableLaunchedApps('ac')).resolves.toBe(true)
+  await killLaunchedApps()
+
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls.map((call) => call.args)).toContainEqual([
+    '/IM',
+    'garage61 telemetry agent.exe',
+    '/T',
+    '/F'
+  ])
+})
+
+// Turning tracking OFF has to act on what is already recorded, not only on the
+// next launch. `runningProcesses` is written at launch time and nothing removes
+// an entry until its exe exits, so the strip, the dot and Close Apps used to
+// keep offering the apps for the rest of the session — the saved setting simply
+// did not apply to the state it was saved to change.
+//
+// `simhub.exe` is added to `processNames` for every read that matters, so the
+// entry does NOT disappear via `pruneStoppedRunningProcesses`: it has to be this
+// rule removing it, not the exe appearing to have exited. It is added AFTER the
+// launch because an app already in the tasklist is skipped as already running.
+test('turning tracking off forgets apps already recorded under it (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+    id: 'default',
+    name: 'Default'
+  }
+  const { launchProfileApps, getRunningApps, runningProcesses } = await loadProcessModulesWithStore(
+    {
+      profiles: { ac: { activeProfileId: 'default', profiles: [profile] } },
+      gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+    }
+  )
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  expect(runningProcesses.size).toBe(1)
+  processNames.add('simhub.exe')
+  await expect(getRunningApps()).resolves.not.toEqual([])
+
+  // What saving the profile with the toggle off does to the store.
+  profile.trackingEnabled = false
+
+  await expect(getRunningApps()).resolves.toEqual([])
+  // Forgotten, not killed: nothing was asked to close.
+  expect(runningProcesses.size).toBe(0)
+  expect(execFileCalls.filter((call) => call.command === 'taskkill')).toHaveLength(0)
+})

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -102,6 +102,10 @@ const wmiLookupCounts = new Map<string, number>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnErrors = new Map<string, NodeJS.ErrnoException>()
+// Runs at the moment `spawn()` is called for a given path, so a test can change
+// the world MID-sequence (turning a profile's tracking off while the launch
+// loop is still running, say) rather than only before or after it.
+const spawnHooks = new Map<string, () => void>()
 // Makes `spawn()` THROW synchronously rather than emit an 'error' event.
 // `spawnDetachedApp` handles the two separately: the event lands in
 // `child.once('error')`, the throw in the surrounding try/catch, and each has
@@ -415,6 +419,7 @@ async function loadProcessModules() {
     }),
     spawn: vi.fn((appPath: string, args: string[] = [], options: Record<string, unknown> = {}) => {
       spawnCalls.push({ appPath, args, options })
+      spawnHooks.get(appPath)?.()
       if (spawnThrows.has(appPath)) {
         throw spawnThrows.get(appPath)!
       }
@@ -706,6 +711,7 @@ beforeEach(async () => {
   spawnCalls.length = 0
   spawnErrors.clear()
   spawnThrows.clear()
+  spawnHooks.clear()
   elevatedLaunchHangs = false
   heldElevatedCallback = null
   heldElevatedCallbacks.length = 0
@@ -6333,4 +6339,41 @@ test('a shared companion is still a target when a tracked profile configures it 
     '/T',
     '/F'
   ])
+})
+
+// The deferred half of the reconcile (Codex on #834). Saving the toggle DURING
+// a launch is skipped on purpose, because the store's active profile is
+// unreliable mid-sequence. Nothing else publishes when a sequence ENDS, though:
+// every per-app publish runs before the unregister, and the poll stops outright
+// once the last subscriber goes. So the sequence has to reconcile on its way
+// out or the stale records can outlive the toggle indefinitely.
+test('a toggle saved during a launch is applied when the sequence ends (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('C:/Tools/CrewChief.exe')
+  const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+    id: 'default',
+    name: 'Default'
+  }
+  const { launchProfileApps, runningProcesses, getRunningApps } = await loadProcessModulesWithStore(
+    {
+      profiles: { ac: { activeProfileId: 'default', profiles: [profile] } },
+      gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+    }
+  )
+
+  // Flipped WHILE the sequence is in flight: the first app's publish reconciles
+  // and must skip this game, because a launch is active.
+  spawnHooks.set('C:/Tools/SimHub.exe', () => {
+    profile.trackingEnabled = false
+  })
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe', 'C:/Tools/CrewChief.exe'])
+
+  // Both really started: turning tracking off is not cancelling the launch.
+  expect(spawnCalls.map((call) => call.appPath)).toEqual(
+    expect.arrayContaining(['C:/Tools/SimHub.exe', 'C:/Tools/CrewChief.exe'])
+  )
+  // And by the time the sequence returns, the toggle has been applied.
+  expect(runningProcesses.size).toBe(0)
+  await expect(getRunningApps()).resolves.toEqual([])
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -6295,3 +6295,42 @@ test('turning tracking off forgets a handoff registered while it was on (#591)',
     vi.useRealTimers()
   }
 })
+
+// The BOUNDARY of the Close Apps guard above, pinned so the residual is a
+// recorded decision rather than something a later reader discovers.
+//
+// `addOwner` never overwrites, so a tracked profile contributes a shared
+// companion on its own and the target survives the untracked profile being
+// skipped. The process is therefore still killed, exactly as it was before this
+// PR, because back then the untracked profile contributed the same target
+// itself. The guard only ever changed the case where NO tracked profile
+// configures the app.
+//
+// #839 holds the decision on whether that should change. If it does, this test
+// is the one to update, deliberately.
+test('a shared companion is still a target when a tracked profile configures it too (#591)', async () => {
+  processNames.add('garage61 telemetry agent.exe')
+
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', garage61: true, trackingEnabled: false }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    }
+  })
+
+  await killLaunchedApps()
+
+  const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')
+  expect(killCalls.map((call) => call.args)).toContainEqual([
+    '/IM',
+    'garage61 telemetry agent.exe',
+    '/T',
+    '/F'
+  ])
+})

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -6471,3 +6471,101 @@ test('a tracked profile still gets the plural detection promise (#591)', async (
   expect(result.warning).toContain('will detect when')
   expect(result.warning).not.toContain('Process tracking is off')
 })
+
+// The fast-exit warning fires up to POST_LAUNCH_BLOCK_MS after the launch, so
+// the launch-time tracking decision can be stale by the time it speaks (Codex on
+// #834). The stored warning would be pruned by the reconcile on the next
+// publish, but the toast is already on screen and cannot be retracted.
+test('a toggle inside the post-launch window silences the fast-exit warning (#591)', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 4321,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  markExistingPath('C:/Tools/Perplexity.exe')
+  const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+    id: 'default',
+    name: 'Default'
+  }
+  const { launchProfileApps, processNameMismatchWarnings } = await loadProcessModulesWithStore({
+    profiles: { ac: { activeProfileId: 'default', profiles: [profile] } },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+  })
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/Perplexity.exe'])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  // Tracking goes off while the app is still inside the window, i.e. after the
+  // sequence has ended and its own reconcile has already run.
+  profile.trackingEnabled = false
+
+  processNames.delete('perplexity.exe')
+  processNames.add('perplexity-helper.exe')
+  childHandlers.get('exit')?.()
+
+  expect(processNameMismatchWarnings.size).toBe(0)
+  expect(
+    sender.send.mock.calls.filter(([channel]) => channel === 'process-name-mismatch-warning')
+  ).toHaveLength(0)
+})
+
+// `isGame` was read back off the running record, and the reconcile can delete
+// that record while the app is still alive. The exe being the game does not
+// depend on us having recorded it, so it must not be looked up in something
+// prunable (Codex on #834). Contrived path to reach the state, but it is the
+// only one that reaches it with tracking back on.
+test('the game exe keeps its toast suppressed after its record is pruned (#591)', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 5678,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  markExistingPath('C:/Games/AssettoCorsa.exe')
+  const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+    id: 'default',
+    name: 'Default'
+  }
+  const { launchProfileApps, publishRunningApps, runningProcesses, processNameMismatchWarnings } =
+    await loadProcessModulesWithStore({
+      profiles: { ac: { activeProfileId: 'default', profiles: [profile] } },
+      gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+    })
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Games/AssettoCorsa.exe'])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+  expect(runningProcesses.size).toBe(1)
+
+  // Off, then the reconcile forgets the record, then the user changes their mind.
+  profile.trackingEnabled = false
+  await publishRunningApps('config')
+  expect(runningProcesses.size).toBe(0)
+  profile.trackingEnabled = true
+
+  processNames.delete('assettocorsa.exe')
+  processNames.add('acs.exe')
+  childHandlers.get('exit')?.()
+
+  // Tracking is on again, so the card warning is correct to appear.
+  expect(processNameMismatchWarnings.size).toBe(1)
+  // A launcher stub exiting fast is the normal pattern for the game exe, so the
+  // toast stays suppressed. Nothing in the record survives to say so.
+  expect(
+    sender.send.mock.calls.filter(([channel]) => channel === 'process-name-mismatch-warning')
+  ).toHaveLength(0)
+})

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -551,6 +551,14 @@ async function loadProcessModules() {
     // profile fixtures, so stubbing it would answer the question for them.
     isProcessTrackingEnabled: (profile: { trackingEnabled?: boolean } | undefined) =>
       profile?.trackingEnabled !== false,
+    // Resolves a NAMED profile, which is what a profile switch launches: the
+    // store still calls the outgoing one active at that moment.
+    resolveNamedProfile: vi.fn((entry: unknown, profileId: string) => {
+      const set = entry as { profiles?: { id: string }[] } | undefined
+      return Array.isArray(set?.profiles)
+        ? set.profiles.find((profile) => profile.id === profileId) || set.profiles[0]
+        : entry
+    }),
     getStoredProfiles: vi.fn(() => {
       const value = storeData.profiles
 
@@ -5890,4 +5898,56 @@ test('a tracking-off profile gets no process-name-mismatch warning (#591)', asyn
   childHandlers.get('exit')?.()
 
   expect(processNameMismatchWarnings.size).toBe(0)
+})
+
+// A profile switch launches the incoming profile's apps BEFORE the renderer
+// saves the new activeProfileId, so the store still calls the outgoing profile
+// active while these apps start. Resolving tracking from the store there would
+// apply the wrong profile's setting in both directions: switching to a
+// fire-and-forget profile would still record its apps, and switching away from
+// one would leave the incoming tracked profile with no running strip at all.
+test('a switch to an untracked profile records nothing, before the switch is saved (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps, runningProcesses } = await loadProcessModulesWithStore({
+    // The store still says 'default' (tracked) is active, exactly as it would
+    // be mid-switch.
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [
+          { id: 'default', name: 'Default' },
+          { id: 'quiet', name: 'Quiet', trackingEnabled: false }
+        ]
+      }
+    },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+  })
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'], { profileId: 'quiet' })
+
+  expect(spawnCalls.map((call) => call.appPath)).toContain('C:/Tools/SimHub.exe')
+  expect(runningProcesses.size).toBe(0)
+})
+
+// The same switch in the other direction, which is the worse failure: reading
+// the store would take the outgoing untracked profile's setting and leave the
+// incoming tracked profile with nothing in its strip.
+test('a switch away from an untracked profile still records the incoming one (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps, runningProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'quiet',
+        profiles: [
+          { id: 'quiet', name: 'Quiet', trackingEnabled: false },
+          { id: 'default', name: 'Default' }
+        ]
+      }
+    },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+  })
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'], { profileId: 'default' })
+
+  expect(runningProcesses.size).toBe(1)
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -102,6 +102,13 @@ const wmiLookupCounts = new Map<string, number>()
 const execFileCalls: { command: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnCalls: { appPath: string; args: string[]; options: Record<string, unknown> }[] = []
 const spawnErrors = new Map<string, NodeJS.ErrnoException>()
+// Makes `spawn()` THROW synchronously rather than emit an 'error' event.
+// `spawnDetachedApp` handles the two separately: the event lands in
+// `child.once('error')`, the throw in the surrounding try/catch, and each has
+// its own `isElevatedLaunchError` branch calling `launchElevated`. Only the
+// event path had a fixture, so the whole catch branch was uncovered - dropping
+// an argument from its call left all 166 tests green (#591).
+const spawnThrows = new Map<string, NodeJS.ErrnoException>()
 // #675: when true, the elevated (-EncodedCommand) PowerShell call never invokes
 // its callback, modelling a UAC consent prompt the user never answers.
 let elevatedLaunchHangs = false
@@ -408,6 +415,9 @@ async function loadProcessModules() {
     }),
     spawn: vi.fn((appPath: string, args: string[] = [], options: Record<string, unknown> = {}) => {
       spawnCalls.push({ appPath, args, options })
+      if (spawnThrows.has(appPath)) {
+        throw spawnThrows.get(appPath)!
+      }
       const handlers = new Map<string, (...args: unknown[]) => void>()
       const child = {
         pid: 1234,
@@ -695,6 +705,7 @@ beforeEach(async () => {
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
+  spawnThrows.clear()
   elevatedLaunchHangs = false
   heldElevatedCallback = null
   heldElevatedCallbacks.length = 0
@@ -6057,4 +6068,178 @@ test('turning tracking off forgets apps already recorded under it (#591)', async
   // Forgotten, not killed: nothing was asked to close.
   expect(runningProcesses.size).toBe(0)
   expect(execFileCalls.filter((call) => call.command === 'taskkill')).toHaveLength(0)
+})
+
+// The same defect as the two Close Apps findings above, one layer down, and the
+// tests above are blind to it for the same reason: they assert on
+// `runningProcesses`, and the pending-handoff registry is neither that map nor
+// the companion-target map.
+//
+// `cancelPendingElevatedHandoffs` runs in BOTH kill entry points' prologues,
+// before any profile filtering, so a global Close Apps would kill the
+// PowerShell host of an app the user opted out of us managing. The late
+// approval would then start nothing, and they would be told a consent prompt
+// was stranded by a profile SimLauncher promised not to touch.
+test('a tracking-off profile does not register its elevated handoff for Close Apps (#591)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' },
+      profiles: {
+        ac: {
+          activeProfileId: 'quiet',
+          profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+        }
+      }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // The global (tray) form, with no gameKey, which is the one that reaches
+    // every profile regardless of which game the user was looking at.
+    const killPromise = killLaunchedApps()
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    // The host stays alive, so answering the prompt still starts the app.
+    expect(elevatedHostKills).toHaveLength(0)
+    // Absent rather than 0: `withStrandedConsentPrompts` only attaches the
+    // field when the count is above zero, so this IS the "nothing stranded"
+    // shape, and the paired test below shows the same fixture producing 1.
+    expect(result.strandedConsentPrompts).toBeUndefined()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The same fixture with tracking left ON, so the test above cannot pass because
+// the handoff never reached the grace window in the first place.
+test('a tracked profile still registers its elevated handoff for Close Apps (#591)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' },
+      profiles: {
+        ac: {
+          activeProfileId: 'loud',
+          profiles: [{ id: 'loud', name: 'Loud' }]
+        }
+      }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    const killPromise = killLaunchedApps()
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The same rule on the OTHER elevation branch. `spawnDetachedApp` reaches
+// `launchElevated` from two places: the 'error' event (covered above) and the
+// try/catch around a synchronous throw from spawn(). Both had to be given the
+// tracking decision, and only the first had a fixture, so dropping the argument
+// from this one left the whole suite green.
+test('the same holds when spawn throws elevation synchronously (#591)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnThrows.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' },
+      profiles: {
+        ac: {
+          activeProfileId: 'quiet',
+          profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+        }
+      }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    const killPromise = killLaunchedApps()
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    expect(elevatedHostKills).toHaveLength(0)
+    expect(result.strandedConsentPrompts).toBeUndefined()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// And the positive control for that branch, which also pins that the throw
+// fixture reaches the elevation path at all rather than failing the launch.
+test('a tracked profile registers it on the synchronous-throw branch too (#591)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnThrows.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killLaunchedApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' },
+      profiles: {
+        ac: { activeProfileId: 'loud', profiles: [{ id: 'loud', name: 'Loud' }] }
+      }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    const killPromise = killLaunchedApps()
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -534,6 +534,23 @@ async function loadProcessModules() {
     getActiveStoredProfile: vi.fn((p: { activeProfileId: string; profiles: { id: string }[] }) =>
       p.profiles.find((i) => i.id === p.activeProfileId)
     ),
+    // Resolves through the same storeData the rest of this harness writes, so a
+    // test can turn tracking off for one game by editing its profile fixture
+    // (#591). Flat profiles and profile sets both appear in this file.
+    getActiveProfileForGame: vi.fn((gameKey: string) => {
+      const profiles = storeData.profiles
+      if (!profiles || typeof profiles !== 'object' || Array.isArray(profiles)) return undefined
+      const entry = (profiles as Record<string, unknown>)[gameKey]
+      if (!entry || typeof entry !== 'object') return undefined
+      const set = entry as { activeProfileId?: string; profiles?: { id: string }[] }
+      return Array.isArray(set.profiles)
+        ? set.profiles.find((profile) => profile.id === set.activeProfileId) || set.profiles[0]
+        : entry
+    }),
+    // The real predicate, not a stub: these tests decide tracking through their
+    // profile fixtures, so stubbing it would answer the question for them.
+    isProcessTrackingEnabled: (profile: { trackingEnabled?: boolean } | undefined) =>
+      profile?.trackingEnabled !== false,
     getStoredProfiles: vi.fn(() => {
       const value = storeData.profiles
 
@@ -5723,4 +5740,154 @@ test('finalizeKillAttempts treats a notFound elevated-suspect attempt as still r
     reason: 'access_denied'
   })
   expect(unclosedProcesses.size).toBe(1)
+})
+
+// --- Fire-and-forget when tracking is off (#591) ---
+//
+// The rule is applied at the SOURCE: an untracked profile's launched apps are
+// never recorded in `runningProcesses`. An earlier attempt filtered them on the
+// way out of getRunningApps instead and was reverted, because two things
+// downstream read the unfiltered list and a display filter cannot reach either.
+// The second test below is that reverted approach's worst case.
+
+test('a tracking-off profile launches its apps and records nothing (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps, getRunningApps, runningProcesses } = await loadProcessModulesWithStore(
+    {
+      profiles: {
+        ac: {
+          activeProfileId: 'default',
+          profiles: [{ id: 'default', name: 'Default', trackingEnabled: false }]
+        }
+      },
+      gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+    }
+  )
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  // It really launched: opting out of tracking is not opting out of launching.
+  expect(spawnCalls.map((call) => call.appPath)).toContain('C:/Tools/SimHub.exe')
+  // ...and left nothing behind to surface, count, kill or auto-close.
+  expect(runningProcesses.size).toBe(0)
+  await expect(getRunningApps()).resolves.toEqual([])
+})
+
+// The same fixture WITHOUT the flag, because that is what every existing
+// profile looks like: nobody has `trackingEnabled` set.
+//
+// What this pins is that the launch path is WIRED to the rule and records when
+// it says yes: with the tracking-off test above, a guard hardcoded either way
+// fails one of the two. It cannot pin the rule ITSELF, because this suite mocks
+// `../profiles` and the mock carries its own copy of the predicate, so the real
+// one could be inverted with every test here still green. The default is pinned
+// against the real function in profiles.test.ts, which is where it belongs.
+test('a profile with no tracking flag is still tracked (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  const { launchProfileApps, runningProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default' }]
+      }
+    },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+  })
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+
+  expect(runningProcesses.size).toBe(1)
+})
+
+// M2 from the reverted output-filter spike, and the reason the fix lives at the
+// source. `launchedExeNames` is a GLOBAL basename dedup set built from the
+// unfiltered list, so an untracked profile launching a shared exe used to
+// suppress a tracked profile's own copy of it, and the final filter then
+// removed the untracked copy: the companion surfaced nowhere. Shared companion
+// exes are the normal case for anyone running more than one sim.
+test('an untracked profile launching a shared exe does not hide it from a tracked one (#591)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  // Both game exes exist AND both games are running below, so AC is adoptable
+  // on every axis except the one under test. Without that the "nothing for AC"
+  // assertion would hold for the wrong reason.
+  markExistingPath('C:/Games/AssettoCorsa.exe')
+  markExistingPath('C:/Games/iRacingUI.exe')
+  const { launchProfileApps, getRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackingEnabled: false }]
+      },
+      iracing: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: ['C:/Tools/SimHub.exe'] }]
+      }
+    },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe', iracing: 'C:/Games/iRacingUI.exe' },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  // Both games are already running, so both profiles are adoptable and their
+  // tracked paths would be surfaced from the tasklist.
+  processNames.add('iracingui.exe')
+  processNames.add('assettocorsa.exe')
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+
+  // SimHub is now up because AC's profile started it. The tasklist snapshot is
+  // cached for 500ms and the launch already primed it, so invalidate rather
+  // than waiting the window out.
+  processNames.add('simhub.exe')
+  ;(await import('../../src/main/processes/tasklist')).invalidateProcessNameCache()
+
+  const runningApps = await getRunningApps()
+
+  expect(runningApps).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ path: 'C:/Tools/SimHub.exe', gameKey: 'iracing', tracked: true })
+    ])
+  )
+  // And it is not attributed to the profile that opted out.
+  expect(runningApps.filter((app) => app.gameKey === 'ac')).toEqual([])
+})
+
+// The mismatch warning exists to say "tracking was lost". It has nothing to
+// tell a profile that asked not to be tracked, and it would be the one thing
+// still lighting that game's card.
+test('a tracking-off profile gets no process-name-mismatch warning (#591)', async () => {
+  const childHandlers = new Map<string, (...args: unknown[]) => void>()
+  const child = {
+    pid: 1234,
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      childHandlers.set(event, handler)
+      return child
+    }),
+    unref: vi.fn(),
+    kill: vi.fn()
+  }
+
+  markExistingPath('C:/Games/AssettoCorsa.exe')
+  const { launchProfileApps, processNameMismatchWarnings } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackingEnabled: false }]
+      }
+    },
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' }
+  })
+  vi.mocked(await import('child_process')).spawn.mockReturnValueOnce(child as never)
+
+  const launchPromise = launchProfileApps(sender, 'ac', ['C:/Games/AssettoCorsa.exe'])
+  childHandlers.get('spawn')?.()
+  await launchPromise
+
+  // A fast exit inside the post-launch window: exactly what writes the warning
+  // for a tracked profile.
+  childHandlers.get('exit')?.()
+
+  expect(processNameMismatchWarnings.size).toBe(0)
 })

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -6418,3 +6418,56 @@ test('a tracked profile still gets the detection promise (#591)', async () => {
   expect(result.warning).toContain('will detect when')
   expect(result.warning).not.toContain('Process tracking is off')
 })
+
+// Two elevated apps do not produce two warnings: the plural branch REPLACES the
+// per-app ones with a count, so fixing the singular copy alone left the promise
+// standing behind a second app (Codex on #834).
+test('the plural elevated warning does not promise detection either (#591)', async () => {
+  markExistingPath('C:/Tools/Admin Tool.exe')
+  markExistingPath('C:/Tools/Admin Tool 2.exe')
+  const { launchProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { admin: 'C:/Tools/Admin Tool.exe', admin2: 'C:/Tools/Admin Tool 2.exe' },
+    profiles: {
+      ac: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+      }
+    }
+  })
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+  spawnErrors.set('C:/Tools/Admin Tool 2.exe', makeAccessDeniedError())
+
+  const result = await launchProfileApps(sender, 'ac', [
+    'C:/Tools/Admin Tool.exe',
+    'C:/Tools/Admin Tool 2.exe'
+  ])
+
+  expect(result.elevatedCount).toBe(2)
+  expect(result.warning).toContain('2 apps requested administrator permission')
+  expect(result.warning).toContain('Process tracking is off for this profile')
+  expect(result.warning).not.toContain('will detect when')
+})
+
+// Same pairing as the singular case: with tracking on the plural promise is
+// true, so the fix must not have flattened both branches into the safe wording.
+test('a tracked profile still gets the plural detection promise (#591)', async () => {
+  markExistingPath('C:/Tools/Admin Tool.exe')
+  markExistingPath('C:/Tools/Admin Tool 2.exe')
+  const { launchProfileApps } = await loadProcessModulesWithStore({
+    appPaths: { admin: 'C:/Tools/Admin Tool.exe', admin2: 'C:/Tools/Admin Tool 2.exe' },
+    profiles: {
+      ac: { activeProfileId: 'loud', profiles: [{ id: 'loud', name: 'Loud' }] }
+    }
+  })
+  spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+  spawnErrors.set('C:/Tools/Admin Tool 2.exe', makeAccessDeniedError())
+
+  const result = await launchProfileApps(sender, 'ac', [
+    'C:/Tools/Admin Tool.exe',
+    'C:/Tools/Admin Tool 2.exe'
+  ])
+
+  expect(result.elevatedCount).toBe(2)
+  expect(result.warning).toContain('will detect when')
+  expect(result.warning).not.toContain('Process tracking is off')
+})

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -6243,3 +6243,55 @@ test('a tracked profile registers it on the synchronous-throw branch too (#591)'
     vi.useRealTimers()
   }
 })
+
+// The toggle has to reach a handoff that was registered BEFORE it was flipped.
+// `launchElevated` refuses to register one for a profile that is untracked at
+// launch, but a launch that started while tracked and timed out into the
+// registry predates the toggle entirely, so only the reconcile pass can reach
+// it (Codex on #834). Left behind, a later Close Apps still kills its host and
+// strands the prompt of a profile that is now fire-and-forget.
+test('turning tracking off forgets a handoff registered while it was on (#591)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+      id: 'default',
+      name: 'Default'
+    }
+    const { launchProfileApps, killLaunchedApps, getRunningApps } =
+      await loadProcessModulesWithStore({
+        appPaths: { admin: 'C:/Tools/Admin Tool.exe' },
+        gamePaths: { ac: 'C:/Games/Race.exe' },
+        profiles: { ac: { activeProfileId: 'default', profiles: [profile] } }
+      })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    // Launched while TRACKED, so the handoff really is registered.
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Games/Race.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // What saving the profile with the toggle off does to the store, followed
+    // by the publish that reconciles against it.
+    profile.trackingEnabled = false
+    await getRunningApps()
+
+    const killPromise = killLaunchedApps()
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    // Forgotten, not cancelled: the host is alive, so the prompt is still
+    // answerable, and nothing is reported as stranded.
+    expect(elevatedHostKills).toHaveLength(0)
+    expect(result.strandedConsentPrompts).toBeUndefined()
+  } finally {
+    vi.useRealTimers()
+  }
+})

--- a/tests/main/profiles.test.ts
+++ b/tests/main/profiles.test.ts
@@ -206,3 +206,34 @@ test('getProfileTrackablePaths tolerates a missing profile and missing path reco
 
   expect(getProfileTrackablePaths('iracing', undefined, undefined, undefined)).toEqual([])
 })
+
+// #591: tracking is ON unless the user turned it off, matching every profile
+// boolean except closeAppsOnGameExit. Pinned explicitly because the difference
+// between `!== false` and `=== true` is invisible in behavioural tests that all
+// set the key: nobody has it set, so an inverted predicate would silently make
+// every existing profile untracked, and the launch path would stop recording
+// anything for anyone.
+test('isProcessTrackingEnabled treats an absent flag as tracking ON (#591)', async () => {
+  const { isProcessTrackingEnabled } = await import('../../src/main/profiles')
+
+  expect(isProcessTrackingEnabled({})).toBe(true)
+  expect(isProcessTrackingEnabled(undefined)).toBe(true)
+  expect(isProcessTrackingEnabled({ trackingEnabled: true })).toBe(true)
+  expect(isProcessTrackingEnabled({ trackingEnabled: false })).toBe(false)
+})
+
+test('getActiveProfileForGame resolves the active member of a profile set (#591)', async () => {
+  const { getActiveProfileForGame } = await import('../../src/main/profiles')
+  storeData.profiles = {
+    ac: {
+      activeProfileId: 'race',
+      profiles: [
+        { id: 'default', name: 'Default', trackingEnabled: false },
+        { id: 'race', name: 'Race', trackingEnabled: true }
+      ]
+    }
+  }
+
+  expect(getActiveProfileForGame('ac')).toMatchObject({ id: 'race', trackingEnabled: true })
+  expect(getActiveProfileForGame('unknown')).toBeUndefined()
+})

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -39,7 +39,19 @@ async function loadRunningModule(opts?: {
 
   const profilesMock = {
     getStoredProfiles: vi.fn(() => opts?.profiles ?? {}),
-    getActiveStoredProfile: vi.fn(() => undefined),
+    // Resolves the fixture rather than returning undefined (CodeRabbit on
+    // #834). It used to answer `undefined` unconditionally, which fed
+    // `undefined` into the predicate below and therefore always said "tracked":
+    // a `trackingEnabled: false` fixture could not reach the pruning or
+    // tracked-app paths at all, and the comment under it claimed otherwise.
+    // Nothing was silently passing yet, because no test had tried, but the next
+    // one to write that fixture would have got a green test for no reason.
+    getActiveStoredProfile: vi.fn((entry: unknown) => {
+      const set = entry as { activeProfileId?: string; profiles?: { id: string }[] } | undefined
+      return Array.isArray(set?.profiles)
+        ? set.profiles.find((profile) => profile.id === set.activeProfileId) || set.profiles[0]
+        : entry
+    }),
     getProfileTrackablePaths: vi.fn(() => opts?.trackablePaths ?? []),
     // The real predicate rather than a stub, so a tracking-off fixture is
     // decided by the rule under test and not by the mock.
@@ -350,4 +362,117 @@ test('an externally-adopted app keeps the poll fast even with empty maps (#672)'
   const reads = readRunningProcessNamesMock.mock.calls.length
   await vi.advanceTimersByTimeAsync(FAST_SCAN_MS)
   expect(readRunningProcessNamesMock.mock.calls.length).toBeGreaterThan(reads)
+})
+
+// Proves the loader's profile resolution actually reaches the rule, rather than
+// leaving the fixture inert (CodeRabbit on #834). Before the mock was fixed
+// both of these passed identically, because every profile read as tracked.
+//
+// Paired deliberately: the tracking-off half alone would pass on a harness that
+// surfaces nothing for any reason, so the tracking-on half is what proves the
+// fixture is otherwise live.
+test('tracking off prunes the seeded state and surfaces nothing (#591)', async () => {
+  const { runningModule, stateModule } = await loadRunningModule({
+    profiles: {
+      iracing: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+      }
+    }
+  })
+  seedState(stateModule)
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['simhub.exe', 'crewchief.exe']),
+    succeeded: true
+  })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(stateModule.runningProcesses.size).toBe(0)
+  expect(stateModule.unclosedProcesses.size).toBe(0)
+  expect(apps).toEqual([])
+})
+
+test('the same fixture with tracking on keeps both entries (#591)', async () => {
+  const { runningModule, stateModule } = await loadRunningModule({
+    profiles: {
+      iracing: {
+        activeProfileId: 'loud',
+        profiles: [{ id: 'loud', name: 'Loud' }]
+      }
+    }
+  })
+  seedState(stateModule)
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['simhub.exe', 'crewchief.exe']),
+    succeeded: true
+  })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(stateModule.runningProcesses.size).toBe(1)
+  expect(apps.map((app) => app.path).sort()).toEqual([
+    'C:/Tools/CrewChief.exe',
+    'C:/Tools/SimHub.exe'
+  ])
+})
+
+// The reconcile has to happen at CALL time, not inside the publish's promise
+// chain (CodeRabbit on #834). `save-profile` writes the store and then calls
+// this synchronously, so anything reading `runningProcesses` before the publish
+// settles - `killLaunchedApps` on a tray click - would otherwise still find the
+// entries the user just opted out of, for one tasklist read.
+//
+// Deliberately NOT awaited before the assertion. Awaiting would pass either
+// way and prove nothing.
+test('a config publish reconciles before it returns, not after (#591)', async () => {
+  const { runningModule, stateModule } = await loadRunningModule({
+    profiles: {
+      iracing: {
+        activeProfileId: 'quiet',
+        profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+      }
+    }
+  })
+  seedState(stateModule)
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['simhub.exe', 'crewchief.exe']),
+    succeeded: true
+  })
+  expect(stateModule.runningProcesses.size).toBe(1)
+
+  const pending = runningModule.publishRunningApps('config')
+
+  expect(stateModule.runningProcesses.size).toBe(0)
+  await pending
+})
+
+// Running the reconcile synchronously moved it onto the CALLER's stack, so a
+// throw in it would now fail `save-profile` itself, where the same throw inside
+// the promise chain was contained by the caller's `.catch`. Reconciling a view
+// of running apps must never take down a settings write.
+//
+// Asserting the log rather than only the absence of a throw: swallowing IS the
+// point of the catch, so the log line is the only evidence it happened, and a
+// silent swallow is the failure mode worth catching.
+test('a throwing reconcile does not fail the caller (#591)', async () => {
+  const opts = {} as { profiles?: Record<string, unknown> }
+  Object.defineProperty(opts, 'profiles', {
+    get() {
+      throw new Error('store unavailable')
+    }
+  })
+  const { runningModule } = await loadRunningModule(opts)
+  readRunningProcessNamesMock.mockResolvedValue({ processNames: new Set(), succeeded: true })
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  try {
+    expect(() => runningModule.publishRunningApps('config')).not.toThrow()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to reconcile untracked games before publishing:',
+      expect.any(Error)
+    )
+  } finally {
+    consoleError.mockRestore()
+  }
 })

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -40,7 +40,11 @@ async function loadRunningModule(opts?: {
   const profilesMock = {
     getStoredProfiles: vi.fn(() => opts?.profiles ?? {}),
     getActiveStoredProfile: vi.fn(() => undefined),
-    getProfileTrackablePaths: vi.fn(() => opts?.trackablePaths ?? [])
+    getProfileTrackablePaths: vi.fn(() => opts?.trackablePaths ?? []),
+    // The real predicate rather than a stub, so a tracking-off fixture is
+    // decided by the rule under test and not by the mock.
+    isProcessTrackingEnabled: (profile: { trackingEnabled?: boolean } | undefined) =>
+      profile?.trackingEnabled !== false
   }
   vi.doMock('../profiles', () => profilesMock)
   vi.doMock('/src/main/profiles.ts', () => profilesMock)


### PR DESCRIPTION
## Summary

- `trackingEnabled = false` was honoured in exactly **one** place, the tasklist discovery path, so externally-running apps were not adopted. Apps SimLauncher launched itself took a different route and were recorded regardless: the strip still showed the companions, the dot still lit, and tray Close Apps still offered them. That is the opposite of what the setting promises.
- Fixed at the **source**: an untracked profile's launched apps are never written to `runningProcesses`, so nothing downstream can surface, count, kill or auto-close them. Its fast-exit mismatch warning is skipped too, since a warning about *losing tracking* has nothing to say to a profile that asked not to be tracked, and it would be the one thing still lighting that game's card.
- Not managing those apps afterwards is the feature, not a gap. The user asked for a launcher and nothing else.

### Why not a display filter, in one paragraph

That was tried and reverted, and neither of its two failures is reachable from the output layer:

- **`launchedExeNames` is a global basename dedup set built from the unfiltered list.** An untracked profile launching a shared exe (SimHub is the normal case for anyone running more than one sim) suppressed a **tracked** profile's own copy of it, and the final filter then removed the untracked copy, so the companion surfaced nowhere and the tracked game's `canKill` read false.
- **Profile switch derives `isRunning` from the same list.** Hiding the apps made the entire stop/start pipeline a no-op behind `if (isRunning)`, while still showing a "Switched" success toast.

Both are impossible by construction now. The shared-exe case has its own regression test, built so the negative half is not vacuous: both games are running and both game exes exist, so AC is adoptable on every axis except the one under test.

### One spelling of the rule

`isProcessTrackingEnabled` in `profiles.ts`, used by all three readers (launch recording, tasklist discovery, auto-close arming). It now decides whether a process is **recorded** rather than merely displayed, so two copies drifting apart would leave a game surfaced by one path and invisible to the others. `getActiveProfileForGame` moves out of `autoClose.ts` for the same reason.

### `save-profile` now republishes

With the `'config'` reason, so a tracking toggle takes effect on save rather than up to 12s later on the next scan. That change reason has been declared and unused since it was introduced; this is its first producer.

### Mutation-verified, and one injection found a hole in my own tests

| Injection | Result |
|---|---|
| the record guard removed (pre-PR behaviour) | 2 tests fail |
| the mismatch-warning guard removed | 1 test fails |
| the predicate inverted to `=== true` | **initially passed all 472 tests** |

That third one matters: nobody has `trackingEnabled` set, so inverting the default would silently make **every existing profile untracked** and the launch path would stop recording anything for anyone. Nothing caught it, because every behavioural test set the flag explicitly. Now pinned against the real function in `profiles.test.ts`.

Worth stating plainly, since a reader will reasonably assume otherwise: the behavioural test for the absent-flag default **cannot** catch that inversion either. This suite mocks `../profiles`, and the mock carries its own copy of the predicate. What it does pin is that the launch path is wired to the rule and records when it says yes; with the tracking-off test, a guard hardcoded either way fails one of the two. The comment above it says so rather than overclaiming.

### Deferred, with an issue rather than prose

The issue's fourth bullet was "(Perf) stop the 2s monitor entirely when nothing is tracked". Most of it came for free: the cadence is FAST/SLOW now, and empty `runningProcesses` / `unclosedProcesses` maps already drop an untracked setup to SLOW. What remains is the gap between 12s and stopped, which needs a "no profile is tracked" signal computed off the very timer it is avoiding, plus a provably correct restart path, or tracking silently dies until restart. That is [#833](https://github.com/Stashpeak/SimLauncher/issues/833) in 1.3.0, starting with a measurement.


### Codex round: two halves of the issue were still missing

The recording guard alone did not deliver two of the four desired behaviours, and my tests could not see it: they all assert on `runningProcesses`, which is precisely the thing the missing paths do not consult.

| Codex | Verdict | Fix |
|---|---|---|
| P1 Close Apps still kills untracked companions | **Real, and it is desired behaviour 2 verbatim** | `getProfileCompanionTargets` skips untracked profiles. `kill.ts` had no reference to the predicate at all: it rebuilds targets from the stored profile, so the recording guard could never reach it. `hasClosableLaunchedApps` reads the same map, so one guard also stops the action being offered. |
| P2 turning tracking off leaves existing state surfaced | **Real** | `pruneUntrackedGames` in `getRunningApps`, next to the two prunes already there, so every publish and every poll heals it. Taken one level up from the suggested save-handler reconcile so no call site can forget. Forget, never kill. |
| P1 profile switch does nothing while tracking is off | **Held**, tracked as [#836](https://github.com/Stashpeak/SimLauncher/issues/836) | Mechanism confirmed, framing disputed: SimLauncher cannot reconcile what it is not watching, and the user asked it to stop watching. What is missing is the signal, not the behaviour, and that is a sentence in a toast. One scope correction: the new `profileId` is unreachable in one direction only, not both. |

Both fixes mutation-verified: removing the `kill.ts` guard fails exactly the two Close Apps tests, and making the prune a no-op fails exactly the reconcile test.


### Second Codex round: the same shape a third time

One P2, real, and it names the pattern better than the first round did. The tracking guard sits where apps are **recorded**; any registry populated somewhere else never sees it.

An untracked profile launching an app that needs elevation, with the UAC prompt outliving the grace window, registered its still-live PowerShell host in the pending-handoff registry. That registry's only consumer is `cancelPendingElevatedHandoffs`, called from the prologue of **both** kill entry points ahead of any profile filtering. A global Close Apps therefore killed the host of an app the user opted out of us managing: the late approval started nothing, and they were told a consent prompt had been stranded by a profile SimLauncher promised not to touch.

Not registering is the whole fix, scoped to the post-grace-window registry only. The abort signal still cancels the handoff while the sequence is in flight, because cancelling a launch in progress is a different thing from managing the apps it already started.

### It also closed a hole in this suite

`spawnDetachedApp` reaches `launchElevated` from two places: the `'error'` event and the try/catch around a synchronous throw from `spawn()`. The catch branch had **no fixture at all**, so dropping the argument from that call site left all 166 tests green.

`spawnThrows` now makes `spawn()` throw synchronously. That branch has a negative and a positive test, and each of the two call sites is pinned by exactly one test, verified by mutating them one at a time.

| Injection | Result |
|---|---|
| the `tracked` guard removed | 1 test fails |
| argument dropped at the `'error'` call site | 1 test fails |
| argument dropped at the catch call site | **initially passed all 166 tests** |


### Third Codex round: two P2s, one fixed, one held

| Codex | Verdict | Outcome |
|---|---|---|
| a pending UAC handoff registered BEFORE the toggle survives the reconcile | **Real, and a gap in this PR's own rule** | Fixed. The reconcile pass exists because the toggle must act on already-recorded state, and it cleared three maps while missing the fourth. Deleted without calling `cancel`, since that callback kills the host and killing it is what this prevents. |
| pruning ownership means re-enabling tracking cannot recover a companions-only session | **Real, but it is [#673](https://github.com/Stashpeak/SimLauncher/issues/673)** | Held. Same root cause as the restart case that issue is about: adoption is keyed on the game exe and there is no other route back to ownership. Recorded there as a second route in. |

The held one is not a close call in the trade it implies. Not pruning leaves the strip, the dot and Close Apps offering apps the saved setting says to hide, for the rest of the session, for **every** user who turns tracking off. The gap it leaves needs tracking off AND back on in one session AND companions still running AND the game not running, and it recovers on the next launch.

The handoff fix is mutation-pinned in both directions, because the rule has two halves that fail for opposite reasons: removing the block fails the test, and calling `entry.cancel()` inside it fails the same test.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (700 passed, was 679)
- [ ] Manual: turn *Track running indicator* off for one profile, launch it. The apps start, and **nothing** appears in that game's running strip, no green dot, no Close Apps. Turn it back on and save: the strip must repopulate on save, not seconds later.
- [ ] Manual, the Close Apps half: with a tracking-off profile whose companions are running, the tray **Close Apps** must not offer that game, and a global Close Apps must leave its companions alive.
- [ ] Manual, the reconcile half: launch a profile with tracking ON, then turn tracking off and Save. The strip, the dot and Close Apps must clear immediately, and the apps must keep running.
- [ ] Manual, the elevated half: with tracking OFF, launch a profile containing an app that needs administrator permission, leave the UAC prompt unanswered for more than 10s, then hit tray Close Apps. The prompt must stay answerable, and approving it must still start the app.
- [ ] Manual, the shared-exe case: with a tracking-off profile that launches SimHub and a second, tracking-on profile that watches SimHub, launch the first and then start the second game. SimHub must still show under the tracked game.

Closes #591


<!-- auto-closes -->
Closes #591
<!-- auto-closes -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-profile process-tracking controls, enabled by default unless explicitly disabled.
  * Untracked games are excluded from process management, mismatch warnings, automatic closing, and elevated launch handoffs.
  * Profile switching now launches apps using the destination profile’s settings.
* **Bug Fixes**
  * Running-app state now refreshes after profile configuration changes and app launches finish.
  * Disabling tracking cleans up existing tracking records and warnings without interrupting active processes.
  * Shared companion apps remain managed when configured by tracked profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->