### PR TITLE
a11y: add focus-visible rings to inputs (#762)

### DIFF
--- a/src/renderer/src/components/ColorPickerPopover.tsx
+++ b/src/renderer/src/components/ColorPickerPopover.tsx
@@ -140,7 +140,7 @@ export function ColorPickerPopover({
                 onChange('#AD46FF')
               }
             }}
-            className="w-full rounded-lg bg-black/20 px-2 py-1.5 text-xs font-medium text-(--text-primary) outline-none transition-colors focus:bg-black/30"
+            className="w-full rounded-lg bg-black/20 px-2 py-1.5 text-xs font-medium text-(--text-primary) outline-none transition-colors focus:bg-black/30 focus-visible:ring-2 focus-visible:ring-(--accent)"
             spellCheck={false}
           />
         </div>

--- a/src/renderer/src/components/profile-editor/ProcessTrackingSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProcessTrackingSection.tsx
@@ -67,7 +67,7 @@ export function ProcessTrackingSection({
                   readOnly
                   aria-label={`Secondary executable ${index + 1}`}
                   placeholder="No secondary executable selected"
-                  className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle)"
+                  className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus-visible:ring-2 focus-visible:ring-(--accent)"
                 />
                 <button
                   type="button"

--- a/src/renderer/src/components/profile-editor/ProfileNameSection.tsx
+++ b/src/renderer/src/components/profile-editor/ProfileNameSection.tsx
@@ -28,7 +28,7 @@ export function ProfileNameSection({
           type="text"
           value={profileName}
           onChange={(event) => onProfileNameChange(event.target.value)}
-          className="glass-recessed min-w-0 flex-1 rounded-lg px-3 py-2 text-sm text-(--text-primary) outline-none transition-colors placeholder:text-(--text-subtle) focus:ring-2 focus:ring-(--accent)"
+          className="glass-recessed min-w-0 flex-1 rounded-lg px-3 py-2 text-sm text-(--text-primary) outline-none transition-colors placeholder:text-(--text-subtle) focus-visible:ring-2 focus-visible:ring-(--accent)"
         />
         {onCreateProfile !== undefined && (
           <Tooltip label="New profile">

--- a/src/renderer/src/components/settings/AppsSection.tsx
+++ b/src/renderer/src/components/settings/AppsSection.tsx
@@ -159,7 +159,7 @@ export function AppsSection(): ReactNode {
               onChange={(e) => onAppPathChange(utility.key, e.target.value)}
               placeholder="No executable path set"
               aria-label={`${appNames[utility.key] || utility.name} executable path`}
-              className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+              className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus-visible:ring-2 focus-visible:ring-(--accent) focus:text-(--text-primary)"
             />
 
             {utility.isCustom && (
@@ -207,7 +207,7 @@ export function AppsSection(): ReactNode {
               value={appArgs[utility.key] || ''}
               onChange={(e) => onAppArgsChange(utility.key, e.target.value)}
               placeholder="Optional command line arguments"
-              className="glass-recessed rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+              className="glass-recessed rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus-visible:ring-2 focus-visible:ring-(--accent) focus:text-(--text-primary)"
               aria-label={`${appNames[utility.key] || utility.name} command line arguments`}
             />
           )}

--- a/src/renderer/src/components/settings/BehaviorSection.tsx
+++ b/src/renderer/src/components/settings/BehaviorSection.tsx
@@ -156,7 +156,7 @@ export function BehaviorSection(): ReactNode {
                   onLaunchDelayMsChange(normalizeLaunchDelayMs(val * 1000))
                 }
               }}
-              className="w-full bg-transparent pl-1 text-right text-[11px] font-semibold text-(--text-primary) outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              className="w-full bg-transparent pl-1 text-right text-[11px] font-semibold text-(--text-primary) outline-none focus-visible:ring-2 focus-visible:ring-(--accent) [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
               placeholder="0.0"
             />
             <div className="mx-1 h-4 w-px bg-(--glass-border) opacity-35" />

--- a/src/renderer/src/components/settings/GamesSection.tsx
+++ b/src/renderer/src/components/settings/GamesSection.tsx
@@ -48,7 +48,7 @@ export function GamesSection(): ReactNode {
               onChange={(e) => onGamePathChange(game.key, e.target.value)}
               placeholder="No game path set"
               aria-label={`${game.name} executable path`}
-              className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus:text-(--text-primary)"
+              className="glass-recessed min-w-0 flex-1 truncate rounded-lg px-3 py-2 font-mono text-xs text-(--text-secondary) outline-none placeholder:text-(--text-subtle) focus-visible:ring-2 focus-visible:ring-(--accent) focus:text-(--text-primary)"
             />
 
             <button


### PR DESCRIPTION
💡 **What:** Replaced `outline-none` with `focus-visible:ring-2 focus-visible:ring-(--accent)` on input elements in `AppsSection`, `GamesSection`, `BehaviorSection`, `ProcessTrackingSection`, and `ColorPickerPopover`. Also updated `ProfileNameSection` to use `focus-visible:` instead of `focus:` for consistency across the application.

🎯 **Why:** To improve accessibility by providing clear visual indicators when input fields receive keyboard focus, satisfying WCAG 2.4.7. This addresses item 1 of the a11y polish batch.

♿ **Accessibility:** Keyboard users now have a clear, consistent focus ring on all text and number inputs. Mouse users will not see the ring on click, as `focus-visible` is used, preserving the intended visual design for pointer interactions.

## Smoke check

- [ ] **Needs no manual check.** <!-- smoke:none --> Reason:
- [x] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like: with the mouse untouched, `Tab` through Settings > Apps, Settings > Games, Settings > Behavior, the profile name field, the process-tracking fields, and open the accent colour picker. Every text and number input that receives focus shows a ring in the current accent colour, and the ring follows focus rather than lingering on the previous field. Then click the same inputs with the mouse: **no ring appears on click**, which is the half `focus-visible` exists for and the half a `focus:` regression would break silently. Check it under a non-default accent, since the ring is bound to `--accent` rather than a fixed colour.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test`
- [ ] Manual: the focus-ring pass described above

Refs #762

---
*PR created automatically by Jules for task [8029670106890970151](https://jules.google.com/task/8029670106890970151) started by @Shieldxx*
