### PR TITLE
fix(ui): stop the blocked action buttons naming an action they cannot run (#830)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -300,14 +300,28 @@ textarea {
   outline-offset: 2px;
 }
 
+/* `aria-disabled` carries the same look as `disabled` (#830). A control that
+   must explain WHY it is unavailable cannot use the `disabled` attribute: that
+   removes it from the tab order and stops mouse events being dispatched, so its
+   tooltip becomes unreachable by exactly the users who need it. Such controls
+   drop their click handler and mark themselves with aria-disabled instead, and
+   this pairing is what keeps them looking identical to a truly disabled one. */
 .accent-action:disabled,
+.accent-action[aria-disabled='true'],
 .accent-surface-action:disabled,
+.accent-surface-action[aria-disabled='true'],
 .accent-subtle-hover:disabled,
+.accent-subtle-hover[aria-disabled='true'],
 .neutral-action:disabled,
+.neutral-action[aria-disabled='true'],
 .danger-action:disabled,
+.danger-action[aria-disabled='true'],
 .icon-action:disabled,
+.icon-action[aria-disabled='true'],
 .dropdown-item:disabled,
-.selected-surface:disabled {
+.dropdown-item[aria-disabled='true'],
+.selected-surface:disabled,
+.selected-surface[aria-disabled='true'] {
   cursor: not-allowed;
   filter: none;
   opacity: 0.55;

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -46,20 +46,41 @@ export function GameRowActions({
   // WHY a colon separator: no em dashes in public-facing copy, and profile
   // names often contain hyphens, so a dash-style separator would get lost.
   const launchTarget = `${gameName}: ${activeProfileName} profile`
-  const primaryTitle =
-    isLaunching && !canKill ? 'Launching' : canKill ? 'Close Apps' : `Launch ${launchTarget}`
+  // While a launch is in flight, or in its post-launch cooldown, these buttons
+  // do nothing — so their tooltip and accessible name have to say why instead of
+  // naming an action that cannot run (#830). `isLaunchBlocked` is global (any
+  // game launching blocks every row), so the reason depends on whose launch it
+  // is; `isLaunching` is this row's. Deliberately not two sentences: the tooltip
+  // is 350ms of hover, and "please wait" is the part that says it is temporary.
+  const blockedReason = isLaunching ? 'Launching, please wait' : 'Another launch is in progress'
+  const isPrimaryBlocked = isLaunchBlocked && !canKill
+  const primaryTitle = canKill
+    ? 'Close Apps'
+    : isPrimaryBlocked
+      ? blockedReason
+      : `Launch ${launchTarget}`
 
   return (
     <div className="flex items-center gap-3 no-drag">
       <div className="flex h-9 w-9 items-center justify-center">
         {canRelaunch && (
-          <Tooltip label="Relaunch missing apps">
+          <Tooltip label={isLaunchBlocked ? blockedReason : 'Relaunch missing apps'}>
             <button
               type="button"
-              onClick={onRelaunchMissing}
-              disabled={isLaunchBlocked}
+              // aria-disabled rather than `disabled`, for both buttons here
+              // (#830). A `disabled` button is removed from the tab order AND
+              // is dispatched no mouse events, so the very tooltip that
+              // explains the block is the one thing a blocked user cannot
+              // reach, by hover or by keyboard. Dropping the handler is what
+              // makes the click inert; the attribute is what announces it.
+              onClick={isLaunchBlocked ? undefined : onRelaunchMissing}
+              aria-disabled={isLaunchBlocked || undefined}
               className="icon-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
-              aria-label={`Relaunch missing apps for ${gameName}`}
+              aria-label={
+                isLaunchBlocked
+                  ? `Relaunch missing apps for ${gameName}. ${blockedReason}`
+                  : `Relaunch missing apps for ${gameName}`
+              }
             >
               <RefreshIcon
                 width={18}
@@ -80,15 +101,17 @@ export function GameRowActions({
         <Tooltip label={primaryTitle}>
           <button
             type="button"
-            onClick={primaryAction}
-            disabled={isLaunchBlocked && !canKill}
+            onClick={isPrimaryBlocked ? undefined : primaryAction}
+            aria-disabled={isPrimaryBlocked || undefined}
             className={`launcher-play-btn group/btn flex h-9 w-[54px] shrink-0 cursor-pointer items-center justify-center rounded-r-full transition-all ${primaryButtonClass}`}
             aria-label={
-              isLaunching && !canKill
-                ? `Launching ${gameName}`
-                : canKill
-                  ? `Close companion apps for ${gameName}`
-                  : `Launch ${launchTarget}`
+              canKill
+                ? `Close companion apps for ${gameName}`
+                : isLaunching
+                  ? `Launching ${gameName}`
+                  : isPrimaryBlocked
+                    ? `Launch ${launchTarget}. ${blockedReason}`
+                    : `Launch ${launchTarget}`
             }
             aria-busy={isLaunching && !canKill ? true : undefined}
           >

--- a/tests/renderer/gameRowBlockedActions.test.tsx
+++ b/tests/renderer/gameRowBlockedActions.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Regression test for #830 (ux: the blocked Relaunch missing apps button still
+ * advertises itself on hover).
+ *
+ * While a launch is in flight, or in its 10s post-launch cooldown, the relaunch
+ * and primary buttons do nothing. They used to keep naming their action anyway:
+ * "Relaunch missing apps" / "Launch <game>: <profile> profile", with no hint
+ * that it was unavailable or that it was temporary.
+ *
+ * `isLaunchBlocked` is GLOBAL (`launchingGameKey !== null` in GameList), so it
+ * is true for every row while any one game launches. The reason therefore has
+ * two forms and both are pinned below, because the copy is the whole fix.
+ *
+ * Also pinned: the buttons carry `aria-disabled` and NOT `disabled`. That is
+ * not a style preference. A `disabled` button leaves the tab order and is
+ * dispatched no mouse events, so the tooltip explaining the block would be
+ * unreachable by hover AND by keyboard, which is precisely backwards.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const launchProfileMock = vi.fn().mockResolvedValue({ success: true, launchedCount: 1 })
+const relaunchMissingProfileMock = vi.fn().mockResolvedValue({ success: true, launchedCount: 1 })
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: (...args: unknown[]) => relaunchMissingProfileMock(...args),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const activeProfileSet = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: activeProfileSet,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(activeProfileSet),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(activeProfileSet),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { GameRowActions } from '../../src/renderer/src/components/game-list/GameRowActions'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+
+const PROFILE_MENU_PROPS = {
+  profileSet: activeProfileSet,
+  activeProfile: activeProfileSet.profiles[0],
+  profileMenuOpen: false,
+  openProfileMenu: vi.fn(),
+  closeProfileMenu: vi.fn(),
+  profileMenuRef: { current: null },
+  menuRef: { current: null },
+  triggerRef: { current: null },
+  handleProfileMenuTriggerKeyDown: vi.fn(),
+  handleProfileMenuKeyDown: vi.fn(),
+  newProfileFormOpen: false,
+  newProfileName: '',
+  setNewProfileName: vi.fn(),
+  newProfileInputRef: { current: null },
+  gameName: GAME.name,
+  onProfileSelect: vi.fn(),
+  onNewProfileSubmit: vi.fn()
+} as unknown as React.ComponentProps<typeof GameRowActions>['profileMenuProps']
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+// `canRelaunch` is `isRunning && relaunchControlsEnabled`, so the relaunch
+// button only exists with the game running. That is also the only state in
+// which the bug is reachable.
+async function renderRow(state: { isLaunching: boolean; isLaunchBlocked: boolean }): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={true}
+          isGameRunning={true}
+          runningAppIcons={[]}
+          isDimmed={false}
+          isLaunching={state.isLaunching}
+          isLaunchBlocked={state.isLaunchBlocked}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+async function renderActions(state: {
+  isLaunchBlocked: boolean
+  onPrimary: () => void
+  onRelaunchMissing: () => void
+}): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <GameRowActions
+        isActive={false}
+        isLaunching={false}
+        isLaunchBlocked={state.isLaunchBlocked}
+        canKill={false}
+        canRelaunch={true}
+        onPrimary={state.onPrimary}
+        onKill={vi.fn()}
+        onRelaunchMissing={state.onRelaunchMissing}
+        onToggleEditor={vi.fn()}
+        gameName={GAME.name}
+        activeProfileName="Default"
+        editorId="editor-ac"
+        profileMenuProps={PROFILE_MENU_PROPS}
+      />
+    )
+  })
+}
+
+function relaunchButton(): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(
+    'button[aria-label^="Relaunch missing apps"]'
+  )
+  if (!button) throw new Error('relaunch button not rendered')
+  return button
+}
+
+function primaryButton(): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>('button.launcher-play-btn')
+  if (!button) throw new Error('primary button not rendered')
+  return button
+}
+
+beforeEach(() => {
+  launchProfileMock.mockClear()
+  relaunchMissingProfileMock.mockClear()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+})
+
+describe('blocked action buttons (#830)', () => {
+  test('this game launching: both buttons say so instead of naming their action', async () => {
+    await renderRow({ isLaunching: true, isLaunchBlocked: true })
+
+    expect(relaunchButton().getAttribute('aria-label')).toBe(
+      'Relaunch missing apps for Assetto Corsa. Launching, please wait'
+    )
+    expect(primaryButton().getAttribute('aria-label')).toBe('Launching Assetto Corsa')
+  })
+
+  // The case the report came from is more likely this one: the block outlives
+  // the sequence by the 10s cooldown, and it applies to every OTHER row too,
+  // where "Launching" would be a lie about which game is busy.
+  test('another game launching: the reason names the other launch', async () => {
+    await renderRow({ isLaunching: false, isLaunchBlocked: true })
+
+    expect(relaunchButton().getAttribute('aria-label')).toBe(
+      'Relaunch missing apps for Assetto Corsa. Another launch is in progress'
+    )
+    expect(primaryButton().getAttribute('aria-label')).toBe(
+      'Launch Assetto Corsa: Default profile. Another launch is in progress'
+    )
+  })
+
+  test('not blocked: both buttons name their action, with no disabled state', async () => {
+    await renderRow({ isLaunching: false, isLaunchBlocked: false })
+
+    expect(relaunchButton().getAttribute('aria-label')).toBe(
+      'Relaunch missing apps for Assetto Corsa'
+    )
+    expect(primaryButton().getAttribute('aria-label')).toBe('Launch Assetto Corsa: Default profile')
+    expect(relaunchButton().getAttribute('aria-disabled')).toBeNull()
+    expect(primaryButton().getAttribute('aria-disabled')).toBeNull()
+  })
+
+  test('blocked buttons stay in the tab order and announce as disabled', async () => {
+    await renderRow({ isLaunching: false, isLaunchBlocked: true })
+
+    for (const button of [relaunchButton(), primaryButton()]) {
+      expect(button.getAttribute('aria-disabled')).toBe('true')
+      // The whole point: `disabled` would take the button out of the tab order
+      // and stop it receiving the hover/focus that opens its own explanation.
+      expect(button.hasAttribute('disabled')).toBe(false)
+      expect(button.disabled).toBe(false)
+    }
+  })
+
+  // Rendered directly rather than through GameRow, and that is the whole point
+  // of the test. GameRow's own handlers already return early on isLaunchBlocked
+  // (`GameRow.tsx:391` and `:494`), so a GameRow-level click assertion passes
+  // whether or not these buttons guard anything: it was green with the guard
+  // deleted. Dropping `disabled` moved this from the DOM's responsibility to the
+  // component's, so it has to be pinned where the component answers for it.
+  test('a blocked button does not invoke its own handler', async () => {
+    const onPrimary = vi.fn()
+    const onRelaunchMissing = vi.fn()
+    await renderActions({ isLaunchBlocked: true, onPrimary, onRelaunchMissing })
+
+    await act(async () => {
+      relaunchButton().click()
+      primaryButton().click()
+    })
+
+    expect(onRelaunchMissing).not.toHaveBeenCalled()
+    expect(onPrimary).not.toHaveBeenCalled()
+  })
+
+  // The negative half: the same click on the same buttons, unblocked.
+  test('an unblocked button still invokes its handler', async () => {
+    const onPrimary = vi.fn()
+    const onRelaunchMissing = vi.fn()
+    await renderActions({ isLaunchBlocked: false, onPrimary, onRelaunchMissing })
+
+    await act(async () => {
+      relaunchButton().click()
+      primaryButton().click()
+    })
+
+    expect(onRelaunchMissing).toHaveBeenCalledTimes(1)
+    expect(onPrimary).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Source-level, because jsdom applies no stylesheet: dropping `disabled` for
+// `aria-disabled` silently loses the dim unless App.css matches both, and every
+// assertion above would still pass. This is the only thing that notices.
+describe('the aria-disabled dim (#830)', () => {
+  test('App.css dims aria-disabled controls exactly as it dims disabled ones', () => {
+    const css = fs.readFileSync(path.join(__dirname, '../../src/renderer/src/App.css'), 'utf8')
+    const rule = css
+      .split('}')
+      .find((block) => block.includes('.icon-action:disabled') && block.includes('opacity: 0.55'))
+    expect(rule).toBeTruthy()
+
+    // Every class that gets the disabled look must get it for aria-disabled too,
+    // or a control switched to aria-disabled loses its dim in one theme-wide
+    // rule that nothing else covers.
+    const disabledClasses = Array.from(rule!.matchAll(/\.([\w-]+):disabled/g)).map(
+      (match) => match[1]
+    )
+    expect(disabledClasses.length).toBeGreaterThan(0)
+    for (const className of disabledClasses) {
+      expect(rule).toContain(`.${className}[aria-disabled='true']`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- While a launch is in flight, or in its 10s post-launch cooldown, the relaunch and primary buttons kept naming their action. They now carry the **reason** instead, in both the tooltip and the accessible name.
- `isLaunchBlocked` is **global** (`launchingGameKey !== null`), so the reason has two forms: this row's own launch says `Launching, please wait`, any other game's says `Another launch is in progress`. A single string would have been a lie on every other row.
- The **primary** button was worse than the one reported. Its copy only switched while `isLaunching` held, so for the whole cooldown it read `Launch <game>: <profile> profile` on a button that would not launch. Fixing only the relaunch button would have left the two inconsistent.

### Why `aria-disabled` and not `disabled`

This is the part worth reviewing, because it changes how the buttons behave rather than just what they say.

A `disabled` button is removed from the tab order **and** is dispatched no mouse events. So the tooltip that explains the block is unreachable by hover and by keyboard, by exactly the users who need it: the fix would have been invisible in the state it exists for. Both buttons now drop their click handler and mark themselves `aria-disabled` instead. The handler is what makes the click inert; the attribute is what announces it.

`App.css` pairs `[aria-disabled='true']` with `:disabled` in the shared dim rule, so the look is identical and nothing else in the app changes. That pairing is pinned by a source-level test, because jsdom applies no stylesheet and every other assertion here would pass while the dim silently vanished.

### One acceptance box deliberately not ticked

> The unavailable state is legible at a glance on the 36px icon button

`opacity: 0.55` is unchanged. The issue itself said to judge that in the app rather than decide it in a diff, and that judgment is David's. Flagged for the smoke run rather than guessed at here.

### Found while fixing this, filed rather than folded in

[#837](https://github.com/Stashpeak/SimLauncher/issues/837): disabled controls still take their full hover **background**. The shared `:disabled` rule never declares `background` or `color`, and every `:hover` rule sits later at equal specificity, so hovering a disabled control still lights it up at 0.55 opacity. That is the other half of the original report, it affects every disabled control in the app, and reordering does not fix it. App-wide visual change, so it wants an eyeball in a running build.

### Mutation-verified, and one mutation found a vacuous test of mine

| Injection | Result |
|---|---|
| relaunch `aria-label` back to the plain action | 2 tests fail |
| `aria-disabled` back to `disabled` | 1 test fails |
| `[aria-disabled='true']` removed from App.css | 1 test fails |
| the button's own click guard removed | **initially passed all 6 tests** |

That last one matters. `GameRow`'s handlers already return early on `isLaunchBlocked` (`GameRow.tsx:391` and `:494`), so a GameRow-level "clicking does nothing" assertion passes whether or not the button guards anything. Dropping `disabled` moved that responsibility from the DOM to the component, so the test now renders `GameRowActions` directly, where the component answers for itself. It fails under that mutation now, and there is a matching positive test that an unblocked click still fires.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (686 passed, was 679)
- [ ] Manual: launch a game, and during the ~10s cooldown hover the relaunch button on **that** row. The tooltip must read `Launching, please wait`, not `Relaunch missing apps`.
- [ ] Manual: during the same cooldown, hover the Launch button on a **different** row. It must read `Another launch is in progress`.
- [ ] Manual, keyboard: Tab to either blocked button. It must still take focus, the tooltip must open on focus, and a screen reader must announce it as unavailable.
- [ ] Manual, judgment: is `opacity: 0.55` enough to read as unavailable on the 36px icon button, or should it go lower?

Closes #830


<!-- auto-closes -->
Closes #830
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved game launch and relaunch controls while another launch is in progress.
  - Blocked actions now clearly communicate their status through updated labels and tooltips.
  - Prevented accidental activation of temporarily unavailable launch actions.
  - Preserved the ability to view helpful action messaging even when controls are blocked.

- **Accessibility**
  - Added consistent disabled-state behavior and visual dimming for accessibility-disabled controls.
  - Improved accessible labels for launch actions, including launches affecting other game rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->