### PR TITLE
fix(processes): cancel a leaving profile's pending UAC handoff (#782)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -28,6 +28,7 @@ import {
 } from '../store'
 import { isRecord } from '../utils'
 import {
+  abortActiveLaunches,
   cancelPendingElevatedHandoffs,
   drainStrandedConsentPrompts,
   publishRunningApps
@@ -579,10 +580,32 @@ export function registerConfigHandlers(): void {
     // for an app the incoming profile also enables.
     let strandedConsentPrompts = 0
     if (leavingEntries.length > 0) {
-      // Matched by SLOT, not by path. Two slots can point at one exe (#357), so
-      // a path match here would cancel the retained slot's prompt alongside the
-      // leaving one, which is the same over-cancel this fix exists to remove
-      // (CodeRabbit on #782).
+      // A pending handoff is reachable through TWO different mechanisms
+      // depending on its age, and this switch has to use both.
+      //
+      // Before the grace window expires the handoff is not in the registry at
+      // all: `spawn.ts` only registers it when the timer fires, so until then
+      // the abort signal is the only handle on it. That is the whole first ten
+      // seconds of an unanswered prompt, and it is reachable because the row
+      // only blocks switching when `isRunning && isLaunchBlocked` and an app
+      // parked on a UAC prompt has started nothing, so `isRunning` is false
+      // (Codex P1 on #842).
+      //
+      // `killProfileApps` already aborts on the way in, which is why the switch
+      // was covered whenever it stopped something. This save is exactly the path
+      // that skips the kill: a handoff contributes nothing to the tasklist diff
+      // the renderer gates that IPC on. Without this line the save was doing
+      // half of what the kill does, and the surviving half of #782 was simply
+      // the faster user.
+      //
+      // Whole-game rather than per-entry, matching `killProfileApps`: the
+      // sequence in flight belongs to the profile being left, and the user has
+      // left it.
+      abortActiveLaunches(gameKey)
+      // And the post-grace half, from the registry. Matched by SLOT, not by
+      // path. Two slots can point at one exe (#357), so a path match here would
+      // cancel the retained slot's prompt alongside the leaving one, which is
+      // the same over-cancel this fix exists to remove (CodeRabbit on #782).
       const leavingIds = new Set(leavingEntries.map(getProfileLaunchEntryId))
       cancelPendingElevatedHandoffs(gameKey, (handoff) =>
         leavingIds.has(

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -23,7 +23,11 @@ import {
   store
 } from '../store'
 import { isRecord } from '../utils'
-import { cancelPendingElevatedHandoffs, publishRunningApps } from '../processes'
+import {
+  cancelPendingElevatedHandoffs,
+  drainStrandedConsentPrompts,
+  publishRunningApps
+} from '../processes'
 import { applyTrayVisibility } from '../tray'
 import { applyRuntimeConfigSettings, getMainWindow, sendToRenderer } from '../window'
 
@@ -525,8 +529,17 @@ export function registerConfigHandlers(): void {
     // anything. Scoped to the leaving paths, so a plain profile edit (same
     // `activeProfileId`) cancels nothing, and a switch never touches a prompt
     // for an app the incoming profile also enables.
+    let strandedConsentPrompts = 0
     if (leavingPaths.length > 0) {
       cancelPendingElevatedHandoffs(gameKey, leavingPaths)
+      // Killing the host does NOT remove the consent prompt, so every cancel
+      // above leaves a dialog on screen that now does nothing (#809). The count
+      // is a single module-level scalar drained by whoever reports it, so this
+      // has to drain it here for two separate reasons: the user is never told
+      // otherwise, AND the stale count would be picked up by the next kill,
+      // including one for a completely different game, which would attribute
+      // the warning to an operation that stranded nothing (Codex P2 on #782).
+      strandedConsentPrompts = drainStrandedConsentPrompts()
     }
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })
     // Republish so a tracking toggle takes effect on save rather than on the
@@ -537,6 +550,10 @@ export function registerConfigHandlers(): void {
     publishRunningApps('config').catch((err) => {
       console.error('Failed to publish running apps after a profile change:', err)
     })
+    // Same shape as the kill results (`withStrandedConsentPrompts`): the field
+    // only appears when there is something to report, so the renderer's existing
+    // formatter can be pointed straight at it.
+    return strandedConsentPrompts > 0 ? { strandedConsentPrompts } : undefined
   })
 
   ipcMain.handle('save-profiles', (_event, profiles: unknown) => {

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 import { getHighestReferencedCustomSlot } from '../../shared/domain/slots'
 import { migrateProfilesToNamedSets } from '../migrator'
-import { getProfileSwitchLeavingEntries, isStoredProfileSet } from '../profiles'
+import { getProfileSwitchLeavingKeys, isStoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
@@ -562,7 +562,7 @@ export function registerConfigHandlers(): void {
     if (!sanitizedProfileSet) return
     // Computed BEFORE the write, because the outgoing side only exists on disk
     // until the next line replaces it.
-    const leavingEntries = getProfileSwitchLeavingEntries(gameKey, sanitizedProfileSet)
+    const leavingKeys = getProfileSwitchLeavingKeys(gameKey, sanitizedProfileSet)
     const storedProfiles = store.get('profiles')
     const profiles = isRecord(storedProfiles) ? storedProfiles : {}
     profiles[gameKey] = sanitizedProfileSet
@@ -582,7 +582,7 @@ export function registerConfigHandlers(): void {
     // `activeProfileId`) cancels nothing, and a switch never touches a prompt
     // for an app the incoming profile also enables.
     let strandedConsentPrompts = 0
-    if (leavingEntries.length > 0) {
+    if (leavingKeys.length > 0) {
       // A pending handoff is reachable through TWO different mechanisms
       // depending on its age, and this switch has to use both.
       //
@@ -615,10 +615,10 @@ export function registerConfigHandlers(): void {
       // `appPaths`, so changing that slot's exe in Settings while its prompt is
       // unanswered makes the two disagree and the handoff outlives the switch
       // (Codex P2 on #842). The slot key is the only part that does not move.
-      const leavingKeys = new Set(leavingEntries.map((entry) => entry.key))
+      const leaving = new Set(leavingKeys)
       cancelPendingElevatedHandoffs(
         gameKey,
-        (handoff) => handoff.appKey !== undefined && leavingKeys.has(handoff.appKey)
+        (handoff) => handoff.appKey !== undefined && leaving.has(handoff.appKey)
       )
       // Killing the host does NOT remove the consent prompt, so every cancel
       // above leaves a dialog on screen that now does nothing (#809). The count

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -271,6 +271,13 @@ function applySanitizedConfig(supportedConfig: Record<string, unknown>) {
     // Deliberately AFTER the writes and the migrate: anything above throwing
     // restores the old config, and cancelling a prompt that is still valid for
     // the restored config would be the worse mistake.
+    //
+    // Both mechanisms, for the same reason the switch needs both: a handoff
+    // younger than the grace window is not in the registry yet, so the abort
+    // signal is the only thing that reaches it. Unscoped here, unlike the
+    // switch's per-game abort, because an import replaces every game's config at
+    // once (CodeRabbit on #842).
+    abortActiveLaunches()
     cancelPendingElevatedHandoffs()
     reportStrandedConsentPrompts(drainStrandedConsentPrompts())
     notifyStoreConfigChanged({ reason: 'import-config', keys: ['*'] })

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -4,7 +4,11 @@ import fs from 'fs'
 
 import { getHighestReferencedCustomSlot } from '../../shared/domain/slots'
 import { migrateProfilesToNamedSets } from '../migrator'
-import { getProfileSwitchLeavingPaths, isStoredProfileSet } from '../profiles'
+import {
+  getProfileLaunchEntryId,
+  getProfileSwitchLeavingEntries,
+  isStoredProfileSet
+} from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
@@ -510,7 +514,7 @@ export function registerConfigHandlers(): void {
     if (!sanitizedProfileSet) return
     // Computed BEFORE the write, because the outgoing side only exists on disk
     // until the next line replaces it.
-    const leavingPaths = getProfileSwitchLeavingPaths(gameKey, sanitizedProfileSet)
+    const leavingEntries = getProfileSwitchLeavingEntries(gameKey, sanitizedProfileSet)
     const storedProfiles = store.get('profiles')
     const profiles = isRecord(storedProfiles) ? storedProfiles : {}
     profiles[gameKey] = sanitizedProfileSet
@@ -530,8 +534,17 @@ export function registerConfigHandlers(): void {
     // `activeProfileId`) cancels nothing, and a switch never touches a prompt
     // for an app the incoming profile also enables.
     let strandedConsentPrompts = 0
-    if (leavingPaths.length > 0) {
-      cancelPendingElevatedHandoffs(gameKey, leavingPaths)
+    if (leavingEntries.length > 0) {
+      // Matched by SLOT, not by path. Two slots can point at one exe (#357), so
+      // a path match here would cancel the retained slot's prompt alongside the
+      // leaving one, which is the same over-cancel this fix exists to remove
+      // (CodeRabbit on #782).
+      const leavingIds = new Set(leavingEntries.map(getProfileLaunchEntryId))
+      cancelPendingElevatedHandoffs(gameKey, (handoff) =>
+        leavingIds.has(
+          getProfileLaunchEntryId({ key: handoff.appKey ?? '', path: handoff.appPath })
+        )
+      )
       // Killing the host does NOT remove the consent prompt, so every cancel
       // above leaves a dialog on screen that now does nothing (#809). The count
       // is a single module-level scalar drained by whoever reports it, so this

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -38,6 +38,7 @@ import { applyRuntimeConfigSettings, getMainWindow, sendToRenderer } from '../wi
 // Channel name is a contract shared with preload/index.ts. Renaming either
 // side without updating the other silently breaks store-change notifications.
 const STORE_CONFIG_CHANGED_CHANNEL = 'store-config-changed'
+const STRANDED_CONSENT_PROMPTS_CHANNEL = 'stranded-consent-prompts'
 // 24 bytes → 32-character base64url token, which is unguessable for a
 // single-session nonce and fits comfortably in an IPC argument.
 const IMPORT_PREVIEW_TOKEN_BYTES = 24
@@ -554,6 +555,23 @@ export function registerConfigHandlers(): void {
       // the warning to an operation that stranded nothing (Codex P2 on #782).
       strandedConsentPrompts = drainStrandedConsentPrompts()
     }
+    // PUSHED, not returned, and this is the one place in the codebase where that
+    // distinction is load-bearing. The kill results hand their count back to the
+    // caller because the caller ASKED to close things and is therefore certain
+    // to read the answer. Nobody asks `save-profile` to cancel anything: it is a
+    // side effect of the active profile changing, so returning the count means
+    // every switching caller has to know a contract it has no reason to suspect.
+    // Four of them exist (the row dropdown, the editor's save, its delete, its
+    // discard-pending restore) and an earlier version of this handler returned
+    // the count to all four while only the dropdown read it. Because the drain
+    // is destructive, the three that ignored it did not merely stay quiet, they
+    // consumed the count and destroyed it, leaving the user with a dead consent
+    // dialog and no explanation anywhere (Codex P2 on #782). A push cannot be
+    // dropped by forgetting to read it, and the sentence is written to stand on
+    // its own, so it needs no host toast to be understood.
+    if (strandedConsentPrompts > 0) {
+      sendToRenderer(STRANDED_CONSENT_PROMPTS_CHANNEL, strandedConsentPrompts)
+    }
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })
     // Republish so a tracking toggle takes effect on save rather than on the
     // next poll (#591). Saving a profile changes which processes are surfaced
@@ -563,10 +581,6 @@ export function registerConfigHandlers(): void {
     publishRunningApps('config').catch((err) => {
       console.error('Failed to publish running apps after a profile change:', err)
     })
-    // Same shape as the kill results (`withStrandedConsentPrompts`): the field
-    // only appears when there is something to report, so the renderer's existing
-    // formatter can be pointed straight at it.
-    return strandedConsentPrompts > 0 ? { strandedConsentPrompts } : undefined
   })
 
   ipcMain.handle('save-profiles', (_event, profiles: unknown) => {

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -86,6 +86,31 @@ function notifyStoreConfigChanged(payload: StoreConfigChangePayload) {
   sendToRenderer(STORE_CONFIG_CHANGED_CHANNEL, payload)
 }
 
+/**
+ * Tells the user about consent prompts left on screen by elevated handoffs a
+ * config change cancelled (#809).
+ *
+ * PUSHED, not returned, and this is the one place in the codebase where that
+ * distinction is load-bearing. The kill results hand their count back to the
+ * caller because the caller ASKED to close things and is therefore certain to
+ * read the answer. Nobody asks a config write to cancel anything: it is a side
+ * effect of the active profile changing, so returning the count means every
+ * caller has to know a contract it has no reason to suspect. Four exist for
+ * `save-profile` alone (the row dropdown, the editor's save, its delete, its
+ * discard-pending restore) and an earlier version returned the count to all four
+ * while only the dropdown read it. Because the drain is destructive, the three
+ * that ignored it did not merely stay quiet, they consumed the count and
+ * destroyed it, leaving the user with a dead consent dialog and no explanation
+ * anywhere (Codex P2 on #782). A push cannot be dropped by forgetting to read
+ * it, and the sentence is written to stand on its own, so it needs no host toast
+ * to be understood.
+ */
+function reportStrandedConsentPrompts(count: number): void {
+  if (count > 0) {
+    sendToRenderer(STRANDED_CONSENT_PROMPTS_CHANNEL, count)
+  }
+}
+
 function clearPendingImport() {
   pendingImport = null
 }
@@ -229,6 +254,24 @@ function applySanitizedConfig(supportedConfig: Record<string, unknown>) {
     migrateProfilesToNamedSets()
     applyRuntimeConfigSettings()
     applyTrayVisibility(store.get('showTrayIcon') !== false)
+    // An import is the user replacing their configuration wholesale, so any
+    // pending elevated handoff is now waiting on a profile that may not exist
+    // any more. Approving its prompt afterwards would start a companion from
+    // the config they just replaced (Codex P2 on #842).
+    //
+    // Cancels ALL of them rather than diffing, and that is a different rule from
+    // `save-profile` on purpose. There the outgoing and incoming profiles are
+    // two known sets, so a leaving diff is well defined; here every game's
+    // profiles changed at once and there is no "the profile being left". Same
+    // reasoning that keeps `killLaunchedApps` game-wide for "close everything".
+    // The cost of over-cancelling is a prompt the user must re-trigger; the cost
+    // of under-cancelling is an app from a config that no longer exists.
+    //
+    // Deliberately AFTER the writes and the migrate: anything above throwing
+    // restores the old config, and cancelling a prompt that is still valid for
+    // the restored config would be the worse mistake.
+    cancelPendingElevatedHandoffs()
+    reportStrandedConsentPrompts(drainStrandedConsentPrompts())
     notifyStoreConfigChanged({ reason: 'import-config', keys: ['*'] })
     // An import replaces every profile, so it can turn tracking on or off for
     // any of them (#591). Both branches publish, because a rollback restores a
@@ -555,23 +598,7 @@ export function registerConfigHandlers(): void {
       // the warning to an operation that stranded nothing (Codex P2 on #782).
       strandedConsentPrompts = drainStrandedConsentPrompts()
     }
-    // PUSHED, not returned, and this is the one place in the codebase where that
-    // distinction is load-bearing. The kill results hand their count back to the
-    // caller because the caller ASKED to close things and is therefore certain
-    // to read the answer. Nobody asks `save-profile` to cancel anything: it is a
-    // side effect of the active profile changing, so returning the count means
-    // every switching caller has to know a contract it has no reason to suspect.
-    // Four of them exist (the row dropdown, the editor's save, its delete, its
-    // discard-pending restore) and an earlier version of this handler returned
-    // the count to all four while only the dropdown read it. Because the drain
-    // is destructive, the three that ignored it did not merely stay quiet, they
-    // consumed the count and destroyed it, leaving the user with a dead consent
-    // dialog and no explanation anywhere (Codex P2 on #782). A push cannot be
-    // dropped by forgetting to read it, and the sentence is written to stand on
-    // its own, so it needs no host toast to be understood.
-    if (strandedConsentPrompts > 0) {
-      sendToRenderer(STRANDED_CONSENT_PROMPTS_CHANNEL, strandedConsentPrompts)
-    }
+    reportStrandedConsentPrompts(strandedConsentPrompts)
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })
     // Republish so a tracking toggle takes effect on save rather than on the
     // next poll (#591). Saving a profile changes which processes are surfaced

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 import { getHighestReferencedCustomSlot } from '../../shared/domain/slots'
 import { migrateProfilesToNamedSets } from '../migrator'
-import { isStoredProfileSet } from '../profiles'
+import { getProfileSwitchLeavingPaths, isStoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
@@ -23,7 +23,7 @@ import {
   store
 } from '../store'
 import { isRecord } from '../utils'
-import { publishRunningApps } from '../processes'
+import { cancelPendingElevatedHandoffs, publishRunningApps } from '../processes'
 import { applyTrayVisibility } from '../tray'
 import { applyRuntimeConfigSettings, getMainWindow, sendToRenderer } from '../window'
 
@@ -504,10 +504,30 @@ export function registerConfigHandlers(): void {
     if (typeof gameKey !== 'string' || !gameKey) return
     const sanitizedProfileSet = getSanitizedProfileSet(gameKey, profileSet)
     if (!sanitizedProfileSet) return
+    // Computed BEFORE the write, because the outgoing side only exists on disk
+    // until the next line replaces it.
+    const leavingPaths = getProfileSwitchLeavingPaths(gameKey, sanitizedProfileSet)
     const storedProfiles = store.get('profiles')
     const profiles = isRecord(storedProfiles) ? storedProfiles : {}
     profiles[gameKey] = sanitizedProfileSet
     store.set('profiles', profiles)
+    // A pending UAC handoff has never started, so it is in no tasklist snapshot,
+    // so `switch-profile-apps` can never see it: it decides what to stop from
+    // exactly such a snapshot and only calls the kill path when that set is
+    // non-empty. Worse, the renderer often does not reach that handler at all,
+    // because it gates the whole IPC on a diff the handoff contributes zero to
+    // (GameRow) and falls through to this save instead. Approving the old prompt
+    // afterwards then starts a companion belonging to a profile the user has
+    // already left (#782).
+    //
+    // Here rather than in the switch handler because THIS is the call the
+    // renderer cannot skip: every switch saves, whether or not it stops
+    // anything. Scoped to the leaving paths, so a plain profile edit (same
+    // `activeProfileId`) cancels nothing, and a switch never touches a prompt
+    // for an app the incoming profile also enables.
+    if (leavingPaths.length > 0) {
+      cancelPendingElevatedHandoffs(gameKey, leavingPaths)
+    }
     notifyStoreConfigChanged({ reason: 'save-profile', keys: ['profiles'] })
     // Republish so a tracking toggle takes effect on save rather than on the
     // next poll (#591). Saving a profile changes which processes are surfaced

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -4,11 +4,7 @@ import fs from 'fs'
 
 import { getHighestReferencedCustomSlot } from '../../shared/domain/slots'
 import { migrateProfilesToNamedSets } from '../migrator'
-import {
-  getProfileLaunchEntryId,
-  getProfileSwitchLeavingEntries,
-  isStoredProfileSet
-} from '../profiles'
+import { getProfileSwitchLeavingEntries, isStoredProfileSet } from '../profiles'
 import {
   CONFIG_FILE_NAME,
   KNOWN_GAME_KEYS,
@@ -609,15 +605,20 @@ export function registerConfigHandlers(): void {
       // sequence in flight belongs to the profile being left, and the user has
       // left it.
       abortActiveLaunches(gameKey)
-      // And the post-grace half, from the registry. Matched by SLOT, not by
-      // path. Two slots can point at one exe (#357), so a path match here would
-      // cancel the retained slot's prompt alongside the leaving one, which is
-      // the same over-cancel this fix exists to remove (CodeRabbit on #782).
-      const leavingIds = new Set(leavingEntries.map(getProfileLaunchEntryId))
-      cancelPendingElevatedHandoffs(gameKey, (handoff) =>
-        leavingIds.has(
-          getProfileLaunchEntryId({ key: handoff.appKey ?? '', path: handoff.appPath })
-        )
+      // And the post-grace half, from the registry. Matched by SLOT KEY.
+      //
+      // Two slots can point at one exe (#357), so a path match would cancel the
+      // retained slot's prompt alongside the leaving one, which is the
+      // over-cancel this fix exists to remove (CodeRabbit on #782). Including
+      // the path as well then breaks it the other way: the registry stores the
+      // path as launched, while `leavingEntries` is rebuilt from the CURRENT
+      // `appPaths`, so changing that slot's exe in Settings while its prompt is
+      // unanswered makes the two disagree and the handoff outlives the switch
+      // (Codex P2 on #842). The slot key is the only part that does not move.
+      const leavingKeys = new Set(leavingEntries.map((entry) => entry.key))
+      cancelPendingElevatedHandoffs(
+        gameKey,
+        (handoff) => handoff.appKey !== undefined && leavingKeys.has(handoff.appKey)
       )
       // Killing the host does NOT remove the consent prompt, so every cancel
       // above leaves a dialog on screen that now does nothing (#809). The count

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -1,9 +1,12 @@
 import { ipcMain } from 'electron'
 
-import { buildActiveProfileLaunchEntries, buildNamedProfileLaunchEntries } from '../profiles'
+import {
+  buildActiveProfileLaunchEntries,
+  buildNamedProfileLaunchEntries,
+  getProfileLaunchEntryId
+} from '../profiles'
 import {
   type KillResult,
-  type ProfileLaunchEntry,
   getRunningApps,
   hasOtherActiveLaunchControllers,
   isAnyLaunchActive,
@@ -18,19 +21,7 @@ import {
   unsubscribeRunningApps
 } from '../processes'
 import { KNOWN_GAME_KEYS, getStoredStringRecord } from '../store'
-import { getExeName, normalizePathForComparison, pathsEqual } from '../utils'
-
-/**
- * Identifier used to diff profile-switch targets. Two entries match only when
- * they share BOTH the utility/game key AND the executable path. Comparing on
- * path alone would treat e.g. `customapp1` and `customapp2` pointing at the
- * same exe as equal, which is wrong after the #357 key-based arg refactor:
- * the slots may carry different `appArgs`, so a slot move must still trigger
- * a stop + relaunch with the new args.
- */
-export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
-  return `${entry.key} ${normalizePathForComparison(entry.path)}`
-}
+import { getExeName, pathsEqual } from '../utils'
 
 /**
  * Returns an error payload when `gameKey` is not a recognised game identifier,

--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -263,11 +263,12 @@ export function registerLaunchHandlers(): void {
           // cancel the switch's OWN registration above — the switch would
           // then always report itself as cancelled, even with no Close Apps
           // click involved.
-          killResult = await killProfileApps(
-            gameKey,
-            entriesToStop.map((entry) => entry.path),
-            { except: launchController }
-          )
+          // Whole entries, not `.map((entry) => entry.path)`. Flattening here is
+          // what let the kill's handoff cancellation match by path and take out
+          // a retained slot's consent prompt (Codex P2 on #842).
+          killResult = await killProfileApps(gameKey, entriesToStop, {
+            except: launchController
+          })
         }
 
         const { processNames: processNamesAfterStop } = await readRunningProcessNames()

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -9,6 +9,7 @@ export {
 export {
   cancelPendingElevatedHandoffs,
   dismissAppIcon,
+  drainStrandedConsentPrompts,
   hasOtherActiveLaunchControllers,
   registerActiveLaunch,
   unregisterActiveLaunch

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -7,6 +7,7 @@ export {
   unsubscribeRunningApps
 } from './processes/running'
 export {
+  cancelPendingElevatedHandoffs,
   dismissAppIcon,
   hasOtherActiveLaunchControllers,
   registerActiveLaunch,

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -7,6 +7,7 @@ export {
   unsubscribeRunningApps
 } from './processes/running'
 export {
+  abortActiveLaunches,
   cancelPendingElevatedHandoffs,
   dismissAppIcon,
   drainStrandedConsentPrompts,

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -112,6 +112,21 @@ function getStoredAppPathTargets() {
   )
 }
 
+/**
+ * Whether the game a pending elevated handoff belongs to is currently managed
+ * (#591). Answered from the store on every call, never cached on the handoff:
+ * the prompt can outlive any number of tracking toggles in both directions.
+ *
+ * A handoff with no `gameKey` counts as tracked. It cannot be attributed to a
+ * profile that opted out, and the safe default for Close Apps is to close.
+ */
+function isHandoffProfileTracked(handoffGameKey?: string): boolean {
+  if (handoffGameKey === undefined) {
+    return true
+  }
+  return isProcessTrackingEnabled(getActiveStoredProfile(getStoredProfiles()[handoffGameKey]))
+}
+
 function hasProcessNameMismatchWarning(gameKey?: string) {
   return Array.from(processNameMismatchWarnings.values()).some(
     (warning) => gameKey === undefined || warning.gameKey === gameKey
@@ -666,7 +681,15 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // those are profile-departure events, and fire-and-forget protects a running
   // app from being closed, not a departed profile from being finished with
   // (Codex P2 on #842).
-  cancelPendingElevatedHandoffs(gameKey, (handoff) => handoff.tracked)
+  //
+  // Read LIVE from the active profile, not from anything stored on the handoff.
+  // A prompt can sit unanswered across any number of toggles in both directions,
+  // and a recorded flag only gets refreshed by whatever pass thinks to refresh
+  // it -- the version that stored it was updated by the untracked reconcile,
+  // which only ever sees the untracked set, so turning tracking back ON never
+  // restored it and Close Apps ignored the handoff forever. The current profile
+  // is the answer to "does the user manage this?" by definition.
+  cancelPendingElevatedHandoffs(gameKey, (handoff) => isHandoffProfileTracked(handoff.gameKey))
   const strandedPromptCount = drainStrandedConsentPrompts()
 
   const { processNames } = await readRunningProcessNames()

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -834,7 +834,14 @@ export async function killProfileApps(
   // profile switch stopping one app was cancelling every pending handoff for
   // the game, including one for an app both profiles enable and that the switch
   // was never going to touch (#782).
-  cancelPendingElevatedHandoffs(gameKey, validAppPathsToKill)
+  //
+  // By path and not by slot, because paths are all this function is given. That
+  // is a real limit, not an oversight: two slots on one exe are one target here,
+  // and stopping the exe stops it for both.
+  const pathsBeingKilled = new Set(validAppPathsToKill.map(normalizePathForComparison))
+  cancelPendingElevatedHandoffs(gameKey, (handoff) =>
+    pathsBeingKilled.has(normalizePathForComparison(handoff.appPath))
+  )
   const strandedPromptCount = drainStrandedConsentPrompts()
 
   const { processNames } = await readRunningProcessNames()

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -828,7 +828,13 @@ export async function killProfileApps(
   // Same reason as killLaunchedApps: a timed-out handoff is not reachable
   // through the abort signal once its sequence ended (#779 Codex P1). And the
   // same consequence: each one killed leaves its consent prompt behind (#809).
-  cancelPendingElevatedHandoffs(gameKey)
+  //
+  // Scoped to the paths this call is actually stopping, unlike killLaunchedApps
+  // which really does mean the whole game. This one is a SUBSET operation: a
+  // profile switch stopping one app was cancelling every pending handoff for
+  // the game, including one for an app both profiles enable and that the switch
+  // was never going to touch (#782).
+  cancelPendingElevatedHandoffs(gameKey, validAppPathsToKill)
   const strandedPromptCount = drainStrandedConsentPrompts()
 
   const { processNames } = await readRunningProcessNames()

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -3,7 +3,6 @@ import path from 'path'
 
 import {
   getActiveStoredProfile,
-  getProfileLaunchEntryId,
   getProfileTrackablePaths,
   getStoredProfiles,
   isProcessTrackingEnabled,
@@ -658,7 +657,16 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
   // (#675), so aborting is not enough: kill the still-live PowerShell host too,
   // or approving the prompt afterwards starts an app the user just closed
   // (Codex P1 on #779).
-  cancelPendingElevatedHandoffs(gameKey)
+  //
+  // Tracked handoffs only. This is the "close everything I manage" action, and a
+  // fire-and-forget profile (#591) has opted its apps out of being managed, so
+  // killing the host would strand a prompt the user was still entitled to
+  // answer. The exclusion is HERE rather than at registration because the other
+  // consumers, the profile switch and the config import, want the opposite:
+  // those are profile-departure events, and fire-and-forget protects a running
+  // app from being closed, not a departed profile from being finished with
+  // (Codex P2 on #842).
+  cancelPendingElevatedHandoffs(gameKey, (handoff) => handoff.tracked)
   const strandedPromptCount = drainStrandedConsentPrompts()
 
   const { processNames } = await readRunningProcessNames()
@@ -854,22 +862,26 @@ export async function killProfileApps(
   // including one for an app both profiles enable and that the switch was never
   // going to touch (#782).
   //
-  // Matched by SLOT, not by path, and only entries that survived validation are
-  // eligible: a path this call refused to kill has no business cancelling
-  // anything. Two slots can share an exe with different args (#357), so if the
-  // switch stops the running instance of the leaving slot while the retained
-  // slot has an unanswered prompt, a path match kills the prompt for the app
-  // that is staying (Codex P2 on #842).
+  // Matched by SLOT KEY, and only entries that survived validation are eligible:
+  // a path this call refused to kill has no business cancelling anything.
+  //
+  // The key alone, not key plus path. Two slots can share an exe with different
+  // args (#357), so a path match kills the retained slot's prompt alongside the
+  // leaving one, and the key is what tells them apart. Adding the path on top
+  // then breaks it the other way: the registry's path is a launch-time snapshot
+  // while these entries carry the CURRENT `appPaths`, so editing that slot's exe
+  // in Settings while a prompt is unanswered makes the two disagree and the
+  // handoff survives the switch away from it (Codex P2 on #842). The key does
+  // not move.
   const validPaths = new Set(validAppPathsToKill.map(normalizePathForComparison))
-  const idsBeingKilled = new Set(
+  const keysBeingKilled = new Set(
     entriesToKill
       .filter((entry) => validPaths.has(normalizePathForComparison(entry.path)))
-      .map(getProfileLaunchEntryId)
+      .map((entry) => entry.key)
   )
-  cancelPendingElevatedHandoffs(gameKey, (handoff) =>
-    idsBeingKilled.has(
-      getProfileLaunchEntryId({ key: handoff.appKey ?? '', path: handoff.appPath })
-    )
+  cancelPendingElevatedHandoffs(
+    gameKey,
+    (handoff) => handoff.appKey !== undefined && keysBeingKilled.has(handoff.appKey)
   )
   const strandedPromptCount = drainStrandedConsentPrompts()
 

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -3,6 +3,7 @@ import path from 'path'
 
 import {
   getActiveStoredProfile,
+  getProfileLaunchEntryId,
   getProfileTrackablePaths,
   getStoredProfiles,
   isProcessTrackingEnabled,
@@ -28,7 +29,8 @@ import type {
   KillFailure,
   KillFailureReason,
   KillProfileAppsOptions,
-  KillResult
+  KillResult,
+  ProfileLaunchEntry
 } from './types'
 import {
   GRACEFUL_CLOSE_WINDOW_MS,
@@ -779,11 +781,28 @@ export async function hasClosableLaunchedApps(gameKey?: string): Promise<boolean
   return false
 }
 
+/**
+ * Stops the apps a profile switch is leaving behind.
+ *
+ * Takes ENTRIES rather than paths, and that is load-bearing rather than
+ * cosmetic. The kill itself only ever needs paths: two slots pointing at one exe
+ * (#357) are a single target to a process killer, and stopping the exe stops it
+ * for both. But this call also cancels pending elevated handoffs, and a pending
+ * handoff has never started, so it is not a process at all -- it is a registry
+ * entry that knows exactly which slot it belongs to. Narrowing that by path
+ * cancels the retained slot's consent prompt alongside the leaving one, which is
+ * the same over-cancel #782 exists to remove (Codex P2 on #842).
+ *
+ * The caller is the only party that knows which SLOTS are stopping, so the
+ * signature takes what it has instead of letting it flatten the identity away
+ * and leaving this function to guess.
+ */
 export async function killProfileApps(
   gameKey: string,
-  appPathsToKill: string[],
+  entriesToKill: ProfileLaunchEntry[],
   options?: KillProfileAppsOptions
 ): Promise<KillResult> {
+  const appPathsToKill = entriesToKill.map((entry) => entry.path)
   const gamePaths = getStoredStringRecord('gamePaths')
   const gamePath = gamePaths?.[gameKey]
   const storedAppPathTargets = getStoredAppPathTargets()
@@ -829,18 +848,28 @@ export async function killProfileApps(
   // through the abort signal once its sequence ended (#779 Codex P1). And the
   // same consequence: each one killed leaves its consent prompt behind (#809).
   //
-  // Scoped to the paths this call is actually stopping, unlike killLaunchedApps
-  // which really does mean the whole game. This one is a SUBSET operation: a
-  // profile switch stopping one app was cancelling every pending handoff for
-  // the game, including one for an app both profiles enable and that the switch
-  // was never going to touch (#782).
+  // Scoped to what this call is actually stopping, unlike killLaunchedApps which
+  // really does mean the whole game. This one is a SUBSET operation: a profile
+  // switch stopping one app was cancelling every pending handoff for the game,
+  // including one for an app both profiles enable and that the switch was never
+  // going to touch (#782).
   //
-  // By path and not by slot, because paths are all this function is given. That
-  // is a real limit, not an oversight: two slots on one exe are one target here,
-  // and stopping the exe stops it for both.
-  const pathsBeingKilled = new Set(validAppPathsToKill.map(normalizePathForComparison))
+  // Matched by SLOT, not by path, and only entries that survived validation are
+  // eligible: a path this call refused to kill has no business cancelling
+  // anything. Two slots can share an exe with different args (#357), so if the
+  // switch stops the running instance of the leaving slot while the retained
+  // slot has an unanswered prompt, a path match kills the prompt for the app
+  // that is staying (Codex P2 on #842).
+  const validPaths = new Set(validAppPathsToKill.map(normalizePathForComparison))
+  const idsBeingKilled = new Set(
+    entriesToKill
+      .filter((entry) => validPaths.has(normalizePathForComparison(entry.path)))
+      .map(getProfileLaunchEntryId)
+  )
   cancelPendingElevatedHandoffs(gameKey, (handoff) =>
-    pathsBeingKilled.has(normalizePathForComparison(handoff.appPath))
+    idsBeingKilled.has(
+      getProfileLaunchEntryId({ key: handoff.appKey ?? '', path: handoff.appPath })
+    )
   )
   const strandedPromptCount = drainStrandedConsentPrompts()
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -826,6 +826,11 @@ function launchElevated(
       if (tracked) {
         registerPendingElevatedHandoff(handoffId, {
           gameKey,
+          // Recorded so cancellation can target the app rather than the whole
+          // game (#782). A pending handoff has never started, so it has no
+          // image name in any tasklist snapshot: this path is the only handle
+          // anything downstream gets on which app it belongs to.
+          appPath,
           cancel: () => {
             cancelledByKill = true
             noteHandoffCancelled()

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -712,7 +712,8 @@ function launchElevated(
   args: string[] = [],
   gameKey?: string,
   signal?: AbortSignal,
-  tracked = true
+  tracked = true,
+  appKey?: string
 ) {
   return new Promise<AppLaunchResult>((resolve) => {
     // Two sentences because the second one is a promise, and it is only true
@@ -828,8 +829,12 @@ function launchElevated(
           gameKey,
           // Recorded so cancellation can target the app rather than the whole
           // game (#782). A pending handoff has never started, so it has no
-          // image name in any tasklist snapshot: this path is the only handle
-          // anything downstream gets on which app it belongs to.
+          // image name in any tasklist snapshot: these two are the only handle
+          // anything downstream gets on which app it belongs to. The slot key
+          // is needed as well as the path because two slots can point at one
+          // exe with different args (#357), and cancelling the wrong one costs
+          // the user a prompt they were about to approve.
+          appKey,
           appPath,
           cancel: () => {
             cancelledByKill = true
@@ -1060,7 +1065,9 @@ export async function spawnDetachedApp(
           // in which case launchElevated starts nothing and reports the attempt
           // as cancelled — its own start is guarded (#715). Nothing is running
           // here either way: this spawn failed.
-          resolveOnce(await launchElevated(appPath, getAppArgs(appKey), gameKey, signal, isTracked))
+          resolveOnce(
+            await launchElevated(appPath, getAppArgs(appKey), gameKey, signal, isTracked, appKey)
+          )
           return
         }
 
@@ -1142,7 +1149,9 @@ export async function spawnDetachedApp(
 
       // Same handoff-vs-failure distinction as the 'error' handler above.
       if (isElevatedLaunchError(err)) {
-        launchElevated(appPath, getAppArgs(appKey), gameKey, signal, isTracked).then(resolveOnce)
+        launchElevated(appPath, getAppArgs(appKey), gameKey, signal, isTracked, appKey).then(
+          resolveOnce
+        )
         return
       }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -819,7 +819,9 @@ function launchElevated(
       // consumers, the profile switch and the config import, and those want the
       // opposite: leaving a profile should cancel its pending prompt whether or
       // not its apps were going to be tracked (Codex P2 on #842). The exclusion
-      // now lives in `killLaunchedApps`, the only consumer that needs it.
+      // now lives in `killLaunchedApps`, the only consumer that needs it, and it
+      // reads the CURRENT profile rather than anything recorded here: tracking
+      // can be toggled either way while a prompt sits unanswered.
       registerPendingElevatedHandoff(handoffId, {
         gameKey,
         // A pending handoff has never started, so it has no image name in any
@@ -829,7 +831,6 @@ function launchElevated(
         // snapshot the caller's current `appPaths` may no longer agree with.
         appKey,
         appPath,
-        tracked,
         cancel: () => {
           cancelledByKill = true
           noteHandoffCancelled()

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -812,40 +812,33 @@ function launchElevated(
       // P1), otherwise approving the prompt afterwards would start the app the
       // user just asked to close.
       //
-      // Not for a fire-and-forget profile though (#591). This registry has
-      // exactly one consumer, `cancelPendingElevatedHandoffs`, called from both
-      // kill entry points BEFORE they filter profile targets, so registering
-      // here would let a global Close Apps kill the host of an app the user
-      // opted out of us managing: the late approval would then start nothing
-      // and they would be told a consent prompt was stranded. Not registering
-      // is what leaves the prompt answerable.
-      //
-      // Only the post-grace-window registry is skipped. The abort signal above
-      // still cancels this handoff while the sequence is in flight, because
-      // cancelling a launch in progress is a different thing from managing the
-      // apps it already started.
-      if (tracked) {
-        registerPendingElevatedHandoff(handoffId, {
-          gameKey,
-          // Recorded so cancellation can target the app rather than the whole
-          // game (#782). A pending handoff has never started, so it has no
-          // image name in any tasklist snapshot: these two are the only handle
-          // anything downstream gets on which app it belongs to. The slot key
-          // is needed as well as the path because two slots can point at one
-          // exe with different args (#357), and cancelling the wrong one costs
-          // the user a prompt they were about to approve.
-          appKey,
-          appPath,
-          cancel: () => {
-            cancelledByKill = true
-            noteHandoffCancelled()
-            // Same reason as onAbort (#809), and the same guard: mid-sequence
-            // both this and the abort fire for this one handoff.
-            noteStrandedPromptOnce()
-            child?.kill()
-          }
-        })
-      }
+      // A fire-and-forget profile (#591) is registered too, and used NOT to be.
+      // The old reasoning was that this registry had exactly one consumer, the
+      // kill paths, so registering here would let a global Close Apps kill the
+      // host of an app the user opted out of us managing. #782 gave it two more
+      // consumers, the profile switch and the config import, and those want the
+      // opposite: leaving a profile should cancel its pending prompt whether or
+      // not its apps were going to be tracked (Codex P2 on #842). The exclusion
+      // now lives in `killLaunchedApps`, the only consumer that needs it.
+      registerPendingElevatedHandoff(handoffId, {
+        gameKey,
+        // A pending handoff has never started, so it has no image name in any
+        // tasklist snapshot: this is the only handle anything downstream gets on
+        // which app it belongs to (#782). The SLOT key, because two slots can
+        // share an exe (#357) and because the path recorded here is a launch-time
+        // snapshot the caller's current `appPaths` may no longer agree with.
+        appKey,
+        appPath,
+        tracked,
+        cancel: () => {
+          cancelledByKill = true
+          noteHandoffCancelled()
+          // Same reason as onAbort (#809), and the same guard: mid-sequence
+          // both this and the abort fire for this one handoff.
+          noteStrandedPromptOnce()
+          child?.kill()
+        }
+      })
       resolve({
         status: 'elevated',
         appPath,

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -81,12 +81,37 @@ export function registerActiveLaunch(gameKey: string): AbortController {
 export interface PendingElevatedHandoff {
   gameKey?: string
   /**
-   * The profile SLOT this handoff belongs to. Two slots can point at one exe
-   * with different `appArgs` (#357), so the path alone does not identify it and
-   * a caller matching on path would cancel both (CodeRabbit on #782).
+   * The profile SLOT this handoff belongs to, and the ONLY stable way to decide
+   * whether it is leaving.
+   *
+   * Two slots can point at one exe with different `appArgs` (#357), so the path
+   * alone does not identify it and a caller matching on path cancels both
+   * (CodeRabbit on #782). The path is not a usable tie-breaker either: it is a
+   * launch-time snapshot, while a caller's entries are rebuilt from the CURRENT
+   * `appPaths`, so editing that slot's exe in Settings while a prompt is
+   * unanswered makes the two disagree and a `key + path` match miss the handoff
+   * entirely (Codex P2 on #842). The key does not move.
    */
   appKey?: string
   appPath: string
+  /**
+   * Whether the launching profile has process tracking on (#591).
+   *
+   * Recorded rather than used as a registration filter. Registration used to be
+   * skipped outright for a fire-and-forget profile, on the reasoning that this
+   * registry had exactly one consumer -- the kill paths -- and letting a global
+   * Close Apps kill the host of an app the user opted out of managing would
+   * break the #591 promise. That premise stopped being true when #782 added
+   * profile-switch and config-import consumers, which want the opposite: leaving
+   * a profile should cancel its pending prompt whether or not the apps were
+   * going to be tracked, because approving it starts an app for a profile that
+   * no longer exists (Codex P2 on #842).
+   *
+   * So the exclusion moved to the one consumer that needs it. Fire-and-forget
+   * protects a running app from being CLOSED; it was never a promise to keep
+   * launching apps for profiles the user has left.
+   */
+  tracked: boolean
   cancel: () => void
 }
 
@@ -325,19 +350,26 @@ export function pruneUntrackedGames(untrackedGameKeys: Set<string>): void {
     }
   })
   // The fourth map, and the one that is easy to miss because it holds a
-  // callback rather than a record (Codex on #834). `launchElevated` already
-  // refuses to register a handoff for a profile that was untracked AT LAUNCH,
-  // but a launch that started while tracked and timed out into this registry
-  // predates the toggle, so only this pass can reach it. Left behind, a later
-  // Close Apps would still kill its PowerShell host and strand the consent
-  // prompt of a profile that is now fire-and-forget.
+  // callback rather than a record (Codex on #834). A launch that started while
+  // tracked and timed out into this registry predates the toggle, so only this
+  // pass can reach it. Untouched, a later Close Apps would kill its PowerShell
+  // host and strand the consent prompt of a profile that is now
+  // fire-and-forget.
   //
-  // Deleted WITHOUT calling `cancel`. That callback is what kills the host, and
-  // killing it is precisely what this is preventing: forgetting the handoff has
-  // to leave the prompt answerable.
-  pendingElevatedHandoffs.forEach((entry, handoffId) => {
+  // MARKED, not deleted, and never cancelled. Deleting it used to be right when
+  // the kill paths were this registry's only consumers, but #782 added the
+  // profile switch and the config import, and forgetting the handoff would put
+  // it back out of THEIR reach too: switching away from the profile could then
+  // no longer cancel a prompt whose approval starts an app for a profile that no
+  // longer exists (Codex P2 on #842). Marking keeps it reachable by the
+  // consumers that should have it and hidden from the one that should not.
+  //
+  // `cancel` is deliberately not called either way. That callback is what kills
+  // the host, and killing it is precisely what this is preventing: turning
+  // tracking off has to leave the prompt answerable.
+  pendingElevatedHandoffs.forEach((entry) => {
     if (entry.gameKey !== undefined && untrackedGameKeys.has(entry.gameKey)) {
-      pendingElevatedHandoffs.delete(handoffId)
+      entry.tracked = false
     }
   })
 }

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -78,14 +78,23 @@ export function registerActiveLaunch(gameKey: string): AbortController {
  * Lives here, next to activeLaunchControllers, for the same reason: kill.ts must
  * reach it without importing spawn.ts.
  */
-const pendingElevatedHandoffs = new Map<
-  number,
-  { gameKey?: string; appPath: string; cancel: () => void }
->()
+export interface PendingElevatedHandoff {
+  gameKey?: string
+  /**
+   * The profile SLOT this handoff belongs to. Two slots can point at one exe
+   * with different `appArgs` (#357), so the path alone does not identify it and
+   * a caller matching on path would cancel both (CodeRabbit on #782).
+   */
+  appKey?: string
+  appPath: string
+  cancel: () => void
+}
+
+const pendingElevatedHandoffs = new Map<number, PendingElevatedHandoff>()
 
 export function registerPendingElevatedHandoff(
   handoffId: number,
-  entry: { gameKey?: string; appPath: string; cancel: () => void }
+  entry: PendingElevatedHandoff
 ): void {
   pendingElevatedHandoffs.set(handoffId, entry)
 }
@@ -99,23 +108,28 @@ export function unregisterPendingElevatedHandoff(handoffId: number): void {
  * `gameKey` is undefined (the global "close everything" kill). Each entry
  * removes itself as its callback settles, so this is safe to call on every kill.
  *
- * `appPaths` narrows it further to specific apps. Without it the scope is the
- * whole game, which is right for "close everything I started here" but wrong for
- * anything that stops a SUBSET: a profile switch that happens to stop one app
- * would otherwise also kill the host of an app both profiles enable and that the
- * switch never intended to touch, costing the user a permission prompt they were
- * about to approve (#782). Callers that know which paths they are acting on
- * should pass them.
+ * `matches` narrows it further. Without it the scope is the whole game, which is
+ * right for "close everything I started here" but wrong for anything that stops
+ * a SUBSET: a profile switch that happens to stop one app would otherwise also
+ * kill the host of an app both profiles enable and that the switch never
+ * intended to touch, costing the user a permission prompt they were about to
+ * approve (#782).
+ *
+ * A predicate rather than a path list, because the two narrowing callers do not
+ * hold the same identity. `killProfileApps` is given paths and nothing else, so
+ * a path is all it can match on. A profile switch knows the SLOT, and has to use
+ * it: with two slots on one exe, matching by path there cancels the retained
+ * slot's prompt along with the leaving one (CodeRabbit on #782).
  */
-export function cancelPendingElevatedHandoffs(gameKey?: string, appPaths?: string[]): void {
-  const targetPaths =
-    appPaths && new Set(appPaths.map((appPath) => normalizePathForComparison(appPath)))
-
+export function cancelPendingElevatedHandoffs(
+  gameKey?: string,
+  matches?: (entry: PendingElevatedHandoff) => boolean
+): void {
   pendingElevatedHandoffs.forEach((entry, handoffId) => {
     if (gameKey !== undefined && entry.gameKey !== gameKey) {
       return
     }
-    if (targetPaths && !targetPaths.has(normalizePathForComparison(entry.appPath))) {
+    if (matches && !matches(entry)) {
       return
     }
     pendingElevatedHandoffs.delete(handoffId)

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -122,11 +122,18 @@ export function unregisterPendingElevatedHandoff(handoffId: number): void {
  * intended to touch, costing the user a permission prompt they were about to
  * approve (#782).
  *
- * A predicate rather than a path list, because the two narrowing callers do not
- * hold the same identity. `killProfileApps` is given paths and nothing else, so
- * a path is all it can match on. A profile switch knows the SLOT, and has to use
- * it: with two slots on one exe, matching by path there cancels the retained
- * slot's prompt along with the leaving one (CodeRabbit on #782).
+ * A predicate rather than a path list, for two reasons that pull the same way.
+ *
+ * Identity here is the SLOT, never the path. Two slots can share one exe (#357),
+ * so a path list cancels the retained slot's prompt along with the leaving one
+ * (CodeRabbit on #782), and the path recorded on an entry is a launch-time
+ * snapshot that the caller's current `appPaths` may no longer agree with (Codex
+ * on #842). Both narrowing callers, `killProfileApps` and the profile switch,
+ * therefore match on `appKey`.
+ *
+ * And a predicate does not have to narrow by identity at all: `killLaunchedApps`
+ * uses one to keep the whole-game scope while excluding handoffs whose profile
+ * currently has tracking off (#591).
  */
 export function cancelPendingElevatedHandoffs(
   gameKey?: string,

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -78,11 +78,14 @@ export function registerActiveLaunch(gameKey: string): AbortController {
  * Lives here, next to activeLaunchControllers, for the same reason: kill.ts must
  * reach it without importing spawn.ts.
  */
-const pendingElevatedHandoffs = new Map<number, { gameKey?: string; cancel: () => void }>()
+const pendingElevatedHandoffs = new Map<
+  number,
+  { gameKey?: string; appPath: string; cancel: () => void }
+>()
 
 export function registerPendingElevatedHandoff(
   handoffId: number,
-  entry: { gameKey?: string; cancel: () => void }
+  entry: { gameKey?: string; appPath: string; cancel: () => void }
 ): void {
   pendingElevatedHandoffs.set(handoffId, entry)
 }
@@ -95,14 +98,38 @@ export function unregisterPendingElevatedHandoff(handoffId: number): void {
  * Cancel every still-pending elevated handoff for `gameKey`, or all of them when
  * `gameKey` is undefined (the global "close everything" kill). Each entry
  * removes itself as its callback settles, so this is safe to call on every kill.
+ *
+ * `appPaths` narrows it further to specific apps. Without it the scope is the
+ * whole game, which is right for "close everything I started here" but wrong for
+ * anything that stops a SUBSET: a profile switch that happens to stop one app
+ * would otherwise also kill the host of an app both profiles enable and that the
+ * switch never intended to touch, costing the user a permission prompt they were
+ * about to approve (#782). Callers that know which paths they are acting on
+ * should pass them.
  */
-export function cancelPendingElevatedHandoffs(gameKey?: string): void {
+export function cancelPendingElevatedHandoffs(gameKey?: string, appPaths?: string[]): void {
+  const targetPaths =
+    appPaths && new Set(appPaths.map((appPath) => normalizePathForComparison(appPath)))
+
   pendingElevatedHandoffs.forEach((entry, handoffId) => {
     if (gameKey !== undefined && entry.gameKey !== gameKey) {
       return
     }
+    if (targetPaths && !targetPaths.has(normalizePathForComparison(entry.appPath))) {
+      return
+    }
     pendingElevatedHandoffs.delete(handoffId)
-    entry.cancel()
+    // `cancel` is a callback owned by spawn.ts and it runs synchronously inside
+    // this loop, so a throw would abandon every entry after it AND propagate
+    // into whichever caller is running. That matters now that one of them is
+    // `save-profile` (#782): the same shape took down four config tests when the
+    // untracked reconcile went synchronous on #834. Deleted before the call, so
+    // a throwing entry cannot be retried forever either.
+    try {
+      entry.cancel()
+    } catch (err) {
+      console.error('Failed to cancel a pending elevated handoff:', err)
+    }
   })
 }
 

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -94,24 +94,6 @@ export interface PendingElevatedHandoff {
    */
   appKey?: string
   appPath: string
-  /**
-   * Whether the launching profile has process tracking on (#591).
-   *
-   * Recorded rather than used as a registration filter. Registration used to be
-   * skipped outright for a fire-and-forget profile, on the reasoning that this
-   * registry had exactly one consumer -- the kill paths -- and letting a global
-   * Close Apps kill the host of an app the user opted out of managing would
-   * break the #591 promise. That premise stopped being true when #782 added
-   * profile-switch and config-import consumers, which want the opposite: leaving
-   * a profile should cancel its pending prompt whether or not the apps were
-   * going to be tracked, because approving it starts an app for a profile that
-   * no longer exists (Codex P2 on #842).
-   *
-   * So the exclusion moved to the one consumer that needs it. Fire-and-forget
-   * protects a running app from being CLOSED; it was never a promise to keep
-   * launching apps for profiles the user has left.
-   */
-  tracked: boolean
   cancel: () => void
 }
 
@@ -349,29 +331,22 @@ export function pruneUntrackedGames(untrackedGameKeys: Set<string>): void {
       processNameMismatchWarnings.delete(key)
     }
   })
-  // The fourth map, and the one that is easy to miss because it holds a
-  // callback rather than a record (Codex on #834). A launch that started while
-  // tracked and timed out into this registry predates the toggle, so only this
-  // pass can reach it. Untouched, a later Close Apps would kill its PowerShell
-  // host and strand the consent prompt of a profile that is now
-  // fire-and-forget.
+  // `pendingElevatedHandoffs` is deliberately NOT touched here, and it used to
+  // be (Codex on #834). A handoff belonging to a now-untracked game has to be
+  // hidden from Close Apps, and this pass was how that happened: the entry was
+  // deleted outright.
   //
-  // MARKED, not deleted, and never cancelled. Deleting it used to be right when
-  // the kill paths were this registry's only consumers, but #782 added the
-  // profile switch and the config import, and forgetting the handoff would put
-  // it back out of THEIR reach too: switching away from the profile could then
-  // no longer cancel a prompt whose approval starts an app for a profile that no
-  // longer exists (Codex P2 on #842). Marking keeps it reachable by the
-  // consumers that should have it and hidden from the one that should not.
+  // Both attempts to express it as stored state were wrong. Deleting put the
+  // handoff out of reach of the profile-switch and config-import consumers #782
+  // added, which need it precisely because the user is leaving that profile.
+  // Marking `tracked = false` instead fixed that and introduced a one-way door:
+  // this pass only ever receives the UNTRACKED set, so turning tracking back on
+  // while the prompt is still pending never restored the flag and Close Apps
+  // ignored the handoff forever (Codex P2 on #842).
   //
-  // `cancel` is deliberately not called either way. That callback is what kills
-  // the host, and killing it is precisely what this is preventing: turning
-  // tracking off has to leave the prompt answerable.
-  pendingElevatedHandoffs.forEach((entry) => {
-    if (entry.gameKey !== undefined && untrackedGameKeys.has(entry.gameKey)) {
-      entry.tracked = false
-    }
-  })
+  // So tracking is not stored on the handoff at all. `killLaunchedApps` reads it
+  // live from the active profile at cancellation time, which is always current
+  // by construction and has no direction to get wrong.
 }
 
 export function pruneExpiredProcessNameMismatchWarnings(now = Date.now()): void {

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -13,7 +13,7 @@ import type {
 } from '../shared/domain/profile'
 import type { ProfileLaunchEntry } from './processes/types'
 import { getStoredStringRecord, store } from './store'
-import { isRecord, isValidExePath, normalizePathForComparison } from './utils'
+import { isRecord, isValidExePath, normalizePathForComparison, pathsEqual } from './utils'
 
 // Profile domain types are process-agnostic (#692); the canonical defs live in
 // the shared domain layer. Re-exported here under the main process's historical
@@ -151,6 +151,46 @@ function buildProfileLaunchEntries(gameKey: string, profile: StoredNamedProfile)
 export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchEntry[] {
   const profiles = getStoredProfiles()
   return buildProfileLaunchEntries(gameKey, resolveActiveProfile(profiles[gameKey]))
+}
+
+/**
+ * The app paths a profile switch leaves behind: enabled in the OUTGOING profile
+ * and not in the incoming one, with the game excluded the same way the switch
+ * diff excludes it.
+ *
+ * Takes the incoming set as an argument rather than reading it back, because the
+ * one caller runs BEFORE the store is written and the outgoing side has to come
+ * from what is still on disk.
+ *
+ * Returns nothing unless `activeProfileId` actually changed. Editing the profile
+ * you are already on is not a switch, however much its contents moved, and
+ * treating it as one would let a profile edit cancel a permission prompt (#782).
+ */
+export function getProfileSwitchLeavingPaths(
+  gameKey: string,
+  nextEntry: StoredProfileEntry | undefined
+): string[] {
+  const storedEntry = getStoredProfiles()[gameKey]
+  const fromProfileId = isStoredProfileSet(storedEntry) ? storedEntry.activeProfileId : undefined
+  const toProfileId = isStoredProfileSet(nextEntry) ? nextEntry.activeProfileId : undefined
+
+  if (!fromProfileId || !toProfileId || fromProfileId === toProfileId) {
+    return []
+  }
+
+  const gamePath = getStoredStringRecord('gamePaths')[gameKey]
+  const utilityPaths = (entry: StoredProfileEntry | undefined, profileId: string): string[] =>
+    buildProfileLaunchEntries(gameKey, resolveNamedProfile(entry, profileId))
+      .filter((launchEntry) => !gamePath || !pathsEqual(launchEntry.path, gamePath))
+      .map((launchEntry) => launchEntry.path)
+
+  const incoming = new Set(
+    utilityPaths(nextEntry, toProfileId).map((appPath) => normalizePathForComparison(appPath))
+  )
+
+  return utilityPaths(storedEntry, fromProfileId).filter(
+    (appPath) => !incoming.has(normalizePathForComparison(appPath))
+  )
 }
 
 export function buildNamedProfileLaunchEntries(

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -168,9 +168,13 @@ export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
 }
 
 /**
- * The app paths a profile switch leaves behind: enabled in the OUTGOING profile
- * and not in the incoming one, with the game excluded the same way the switch
- * diff excludes it.
+ * The launch entries a profile switch leaves behind: enabled in the OUTGOING
+ * profile and not in the incoming one, with the game excluded the same way the
+ * switch diff excludes it.
+ *
+ * Entries and not paths, because the caller has to cancel by SLOT. Two slots can
+ * share an exe, so handing on only the path lets a switch that drops one of them
+ * cancel the retained one's consent prompt too (CodeRabbit on #782).
  *
  * Takes the incoming set as an argument rather than reading it back, because the
  * one caller runs BEFORE the store is written and the outgoing side has to come
@@ -180,10 +184,10 @@ export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
  * you are already on is not a switch, however much its contents moved, and
  * treating it as one would let a profile edit cancel a permission prompt (#782).
  */
-export function getProfileSwitchLeavingPaths(
+export function getProfileSwitchLeavingEntries(
   gameKey: string,
   nextEntry: StoredProfileEntry | undefined
-): string[] {
+): ProfileLaunchEntry[] {
   const storedEntry = getStoredProfiles()[gameKey]
   const fromProfileId = isStoredProfileSet(storedEntry) ? storedEntry.activeProfileId : undefined
   const toProfileId = isStoredProfileSet(nextEntry) ? nextEntry.activeProfileId : undefined
@@ -208,9 +212,9 @@ export function getProfileSwitchLeavingPaths(
   // exe with the OUTGOING slot's arguments (Codex P1 on #782).
   const incoming = new Set(utilityEntries(nextEntry, toProfileId).map(getProfileLaunchEntryId))
 
-  return utilityEntries(storedEntry, fromProfileId)
-    .filter((launchEntry) => !incoming.has(getProfileLaunchEntryId(launchEntry)))
-    .map((launchEntry) => launchEntry.path)
+  return utilityEntries(storedEntry, fromProfileId).filter(
+    (launchEntry) => !incoming.has(getProfileLaunchEntryId(launchEntry))
+  )
 }
 
 export function buildNamedProfileLaunchEntries(

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -13,7 +13,7 @@ import type {
 } from '../shared/domain/profile'
 import type { ProfileLaunchEntry } from './processes/types'
 import { getStoredStringRecord, store } from './store'
-import { isRecord, isValidExePath, normalizePathForComparison, pathsEqual } from './utils'
+import { isRecord, isValidExePath, normalizePathForComparison } from './utils'
 
 // Profile domain types are process-agnostic (#692); the canonical defs live in
 // the shared domain layer. Re-exported here under the main process's historical
@@ -95,11 +95,29 @@ export function resolveNamedProfile(
   return { ...((entry as StoredProfile | undefined) || {}), id: 'default', name: 'Default' }
 }
 
-export function getEnabledUtilityEntries(
-  profile: StoredProfile,
-  appPaths: Record<string, string>,
-  customSlots: unknown
-): ProfileLaunchEntry[] {
+/**
+ * The utility SLOTS a profile has switched on, whether or not they currently
+ * have an executable configured.
+ *
+ * Split out from `getEnabledUtilityEntries` because "which slots does this
+ * profile own?" and "what can this profile launch?" are different questions and
+ * only the second one needs a path. Cancelling a pending UAC handoff asks the
+ * first: the handoff was created when the slot DID have a path, so deciding
+ * ownership from the current `appPaths` means clearing that path in Settings
+ * makes the slot vanish from the outgoing profile, the switch finds nothing
+ * leaving, and approving the old prompt still launches the executable recorded
+ * at launch time (Codex P2 on #842).
+ *
+ * Preserves the launch ordering of both profile shapes, including the legacy
+ * flat-boolean one, because it is the single place that decides membership.
+ *
+ * SLOT keys, hence the name: unlike `getEnabledUtilityKeys` below, every key is
+ * validated against the configured slot list, so the legacy branch cannot leak
+ * non-utility booleans like `launchAutomatically`. That looser version is
+ * tolerable for its own caller and would not be here, where a stray key becomes
+ * a slot the switch claims to be leaving.
+ */
+export function getEnabledUtilitySlotKeys(profile: StoredProfile, customSlots: unknown): string[] {
   const count =
     typeof customSlots === 'number' && Number.isFinite(customSlots)
       ? Math.max(1, Math.floor(customSlots))
@@ -108,23 +126,30 @@ export function getEnabledUtilityEntries(
     ...BUILT_IN_UTILITY_KEYS,
     ...Array.from({ length: count }, (_, i) => `customapp${i + 1}`)
   ]
-  const entries: ProfileLaunchEntry[] = []
 
   if (Array.isArray(profile.utilities)) {
-    profile.utilities
+    return profile.utilities
       .filter(
         (u): u is StoredProfileUtility =>
           isRecord(u) && typeof u.id === 'string' && typeof u.enabled === 'boolean'
       )
-      .filter((u) => u.enabled && utilityKeys.includes(u.id) && appPaths[u.id])
-      .forEach((u) => entries.push({ key: u.id, path: appPaths[u.id] }))
-  } else {
-    utilityKeys.forEach((key) => {
-      if (profile[key] === true && appPaths[key]) entries.push({ key, path: appPaths[key] })
-    })
+      .filter((u) => u.enabled && utilityKeys.includes(u.id))
+      .map((u) => u.id)
   }
 
-  return entries
+  return utilityKeys.filter((key) => profile[key] === true)
+}
+
+export function getEnabledUtilityEntries(
+  profile: StoredProfile,
+  appPaths: Record<string, string>,
+  customSlots: unknown
+): ProfileLaunchEntry[] {
+  // The path filter lives here and nowhere else: a slot with no configured
+  // executable is still owned by the profile, it just has nothing to launch.
+  return getEnabledUtilitySlotKeys(profile, customSlots)
+    .filter((key) => appPaths[key])
+    .map((key) => ({ key, path: appPaths[key] }))
 }
 
 function buildProfileLaunchEntries(gameKey: string, profile: StoredNamedProfile) {
@@ -168,13 +193,24 @@ export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
 }
 
 /**
- * The launch entries a profile switch leaves behind: enabled in the OUTGOING
- * profile and not in the incoming one, with the game excluded the same way the
- * switch diff excludes it.
+ * The utility SLOTS a profile switch leaves behind: switched on in the OUTGOING
+ * profile and not in the incoming one.
  *
- * Entries and not paths, because the caller has to cancel by SLOT. Two slots can
- * share an exe, so handing on only the path lets a switch that drops one of them
- * cancel the retained one's consent prompt too (CodeRabbit on #782).
+ * Keys, not entries, and computed from slot membership rather than from built
+ * launch entries. Three separate findings pushed it here and they only agree on
+ * the key:
+ *
+ *   - the path alone cancels both of two slots sharing an exe (#357), because it
+ *     cannot tell them apart (CodeRabbit on #782)
+ *   - `key + path` misses a slot whose executable was edited in Settings after
+ *     the handoff was recorded, since the registry holds the path AS LAUNCHED
+ *     while this side is rebuilt from the current `appPaths` (Codex on #842)
+ *   - and building entries at all drops a slot whose path was CLEARED, because
+ *     an entry needs something to launch, so the switch would find nothing
+ *     leaving and cancel nothing (Codex on #842)
+ *
+ * The game is excluded by construction: it is not a utility slot, and a switch
+ * never stops the game.
  *
  * Takes the incoming set as an argument rather than reading it back, because the
  * one caller runs BEFORE the store is written and the outgoing side has to come
@@ -184,10 +220,10 @@ export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
  * you are already on is not a switch, however much its contents moved, and
  * treating it as one would let a profile edit cancel a permission prompt (#782).
  */
-export function getProfileSwitchLeavingEntries(
+export function getProfileSwitchLeavingKeys(
   gameKey: string,
   nextEntry: StoredProfileEntry | undefined
-): ProfileLaunchEntry[] {
+): string[] {
   const storedEntry = getStoredProfiles()[gameKey]
   const fromProfileId = isStoredProfileSet(storedEntry) ? storedEntry.activeProfileId : undefined
   const toProfileId = isStoredProfileSet(nextEntry) ? nextEntry.activeProfileId : undefined
@@ -196,25 +232,13 @@ export function getProfileSwitchLeavingEntries(
     return []
   }
 
-  const gamePath = getStoredStringRecord('gamePaths')[gameKey]
-  const utilityEntries = (
-    entry: StoredProfileEntry | undefined,
-    profileId: string
-  ): ProfileLaunchEntry[] =>
-    buildProfileLaunchEntries(gameKey, resolveNamedProfile(entry, profileId)).filter(
-      (launchEntry) => !gamePath || !pathsEqual(launchEntry.path, gamePath)
-    )
+  const customSlots = store.get('customSlots')
+  const utilityKeys = (entry: StoredProfileEntry | undefined, profileId: string): string[] =>
+    getEnabledUtilitySlotKeys(resolveNamedProfile(entry, profileId), customSlots)
 
-  // Compared by SLOT identity, not by path, and by the same function the switch
-  // flow uses. Two slots can point at one exe with different `appArgs` (#357),
-  // so a path-only comparison calls `customapp1` retained when only
-  // `customapp2` came in: the old prompt survives and approving it launches the
-  // exe with the OUTGOING slot's arguments (Codex P1 on #782).
-  const incoming = new Set(utilityEntries(nextEntry, toProfileId).map(getProfileLaunchEntryId))
+  const incoming = new Set(utilityKeys(nextEntry, toProfileId))
 
-  return utilityEntries(storedEntry, fromProfileId).filter(
-    (launchEntry) => !incoming.has(getProfileLaunchEntryId(launchEntry))
-  )
+  return utilityKeys(storedEntry, fromProfileId).filter((key) => !incoming.has(key))
 }
 
 export function buildNamedProfileLaunchEntries(

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -154,6 +154,20 @@ export function buildActiveProfileLaunchEntries(gameKey: string): ProfileLaunchE
 }
 
 /**
+ * Identity of a launch entry: the SLOT plus the path, never the path alone.
+ * After the #357 key-based arg refactor `customapp1` and `customapp2` can point
+ * at the same exe while carrying different `appArgs`, so two entries sharing a
+ * path are still two different things to launch.
+ *
+ * Lives here rather than in `ipc/launch.ts` because more than one caller has to
+ * agree on it, and agreeing by having copied the same expression is how they
+ * stop agreeing (Codex P1 on #782).
+ */
+export function getProfileLaunchEntryId(entry: ProfileLaunchEntry): string {
+  return `${entry.key} ${normalizePathForComparison(entry.path)}`
+}
+
+/**
  * The app paths a profile switch leaves behind: enabled in the OUTGOING profile
  * and not in the incoming one, with the game excluded the same way the switch
  * diff excludes it.
@@ -179,18 +193,24 @@ export function getProfileSwitchLeavingPaths(
   }
 
   const gamePath = getStoredStringRecord('gamePaths')[gameKey]
-  const utilityPaths = (entry: StoredProfileEntry | undefined, profileId: string): string[] =>
-    buildProfileLaunchEntries(gameKey, resolveNamedProfile(entry, profileId))
-      .filter((launchEntry) => !gamePath || !pathsEqual(launchEntry.path, gamePath))
-      .map((launchEntry) => launchEntry.path)
+  const utilityEntries = (
+    entry: StoredProfileEntry | undefined,
+    profileId: string
+  ): ProfileLaunchEntry[] =>
+    buildProfileLaunchEntries(gameKey, resolveNamedProfile(entry, profileId)).filter(
+      (launchEntry) => !gamePath || !pathsEqual(launchEntry.path, gamePath)
+    )
 
-  const incoming = new Set(
-    utilityPaths(nextEntry, toProfileId).map((appPath) => normalizePathForComparison(appPath))
-  )
+  // Compared by SLOT identity, not by path, and by the same function the switch
+  // flow uses. Two slots can point at one exe with different `appArgs` (#357),
+  // so a path-only comparison calls `customapp1` retained when only
+  // `customapp2` came in: the old prompt survives and approving it launches the
+  // exe with the OUTGOING slot's arguments (Codex P1 on #782).
+  const incoming = new Set(utilityEntries(nextEntry, toProfileId).map(getProfileLaunchEntryId))
 
-  return utilityPaths(storedEntry, fromProfileId).filter(
-    (appPath) => !incoming.has(normalizePathForComparison(appPath))
-  )
+  return utilityEntries(storedEntry, fromProfileId)
+    .filter((launchEntry) => !incoming.has(getProfileLaunchEntryId(launchEntry)))
+    .map((launchEntry) => launchEntry.path)
 }
 
 export function buildNamedProfileLaunchEntries(

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -251,10 +251,24 @@ export interface ElectronAPI {
     toProfileId: string
   ) => Promise<LaunchResult>
   browsePath: (inputId: string) => Promise<BrowsePathResult>
+  // The three main-to-renderer push subscriptions. Each registers `cb` for the
+  // lifetime of the returned `Unsubscribe` and is consumed by NotifyProvider,
+  // which turns the payload into a toast. Documented as a group because what is
+  // worth knowing is shared: main pushes these because nobody asked for them, so
+  // there is no invoke whose result a caller could read instead.
+  /** A launch failed. Payload is validated in the renderer, hence `unknown`. */
   onAppLaunchError: (cb: (data: unknown) => void) => Unsubscribe
+  /** A launched app is running under a name SimLauncher cannot match (#402). */
   onProcessNameMismatchWarning: (
     cb: (data: ProcessNameMismatchWarningPayload) => void
   ) => Unsubscribe
+  /**
+   * How many Windows consent prompts a config change left on screen (#809). The
+   * count only; the wording is composed at the surface that shows it, since the
+   * tray reports the same number through a native dialog. Only ever pushed above
+   * zero, and pushed rather than returned so that no caller of `saveProfile` can
+   * drop it by not reading it (#782).
+   */
   onStrandedConsentPrompts: (cb: (count: number) => void) => Unsubscribe
   minimize: () => Promise<void>
   maximize: () => Promise<void>

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -255,6 +255,7 @@ export interface ElectronAPI {
   onProcessNameMismatchWarning: (
     cb: (data: ProcessNameMismatchWarningPayload) => void
   ) => Unsubscribe
+  onStrandedConsentPrompts: (cb: (count: number) => void) => Unsubscribe
   minimize: () => Promise<void>
   maximize: () => Promise<void>
   close: () => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,6 +42,14 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.on('process-name-mismatch-warning', handler)
     return () => ipcRenderer.removeListener('process-name-mismatch-warning', handler)
   },
+  // A profile switch that cancels a pending elevated launch leaves its Windows
+  // consent prompt on screen (#809). Pushed rather than returned from
+  // `saveProfile` so no switching caller can silently drop it (#782).
+  onStrandedConsentPrompts: (cb: (count: number) => void) => {
+    const handler = (_: unknown, count: number) => cb(count)
+    ipcRenderer.on('stranded-consent-prompts', handler)
+    return () => ipcRenderer.removeListener('stranded-consent-prompts', handler)
+  },
 
   // window controls
   minimize: () => ipcRenderer.invoke('window-minimize'),

--- a/src/renderer/src/components/Notify.tsx
+++ b/src/renderer/src/components/Notify.tsx
@@ -11,7 +11,12 @@ import {
 import { createPortal } from 'react-dom'
 import { getPathDisplayName } from '../../../shared/path'
 import { isRecord } from '../lib/config'
-import { onAppLaunchError, onProcessNameMismatchWarning } from '../lib/electron'
+import {
+  onAppLaunchError,
+  onProcessNameMismatchWarning,
+  onStrandedConsentPrompts
+} from '../lib/electron'
+import { formatStrandedConsentPrompts } from '../../../shared/strandedConsentPrompts'
 import { CheckIcon, WarningTriangleIcon, ErrorIcon } from './icons'
 
 type ToastType = 'success' | 'warn' | 'error'
@@ -264,6 +269,21 @@ export function NotifyProvider({ children }: { children: ReactNode }): ReactNode
   useEffect(() => {
     return onProcessNameMismatchWarning((data: unknown) => {
       notify(formatProcessNameMismatchToast(data), 'warn', 5000)
+    })
+  }, [notify])
+
+  // Here rather than at the profile-switching callers because cancelling a
+  // pending elevated launch is a side effect of switching, not the thing the
+  // user asked for, and the four callers that can trigger it have no reason to
+  // suspect they owe the user a message (#782). Main pushes the count; this is
+  // the surface that composes the wording, like the tray's native dialog does
+  // for the same count on the Close Apps path.
+  useEffect(() => {
+    return onStrandedConsentPrompts((count: number) => {
+      const message = formatStrandedConsentPrompts(count)
+      if (message) {
+        notify(message, 'warn', 5000)
+      }
     })
   }, [notify])
 

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -337,13 +337,10 @@ export function GameRow({
       // The save is what cancels a pending UAC handoff the outgoing profile
       // leaves behind, and it is reached on every switch, including the ones
       // that skip `switchProfileApps` entirely because the diff is empty
-      // (#782). That is precisely the case with no other chance to speak, so
-      // the note has to be folded in here rather than only above.
-      const saveResult = await saveProfileSet(updatedProfileSet)
-      const saveStrandedNote = formatStrandedConsentPrompts(saveResult.strandedConsentPrompts)
-      if (saveStrandedNote) {
-        switchWarning = [switchWarning, saveStrandedNote].filter(Boolean).join(' ')
-      }
+      // (#782). Nothing is read back from it: main pushes that note to the toast
+      // layer itself, because three other callers change the active profile the
+      // same way and none of them would think to look for it here.
+      await saveProfileSet(updatedProfileSet)
       // Switching to another profile keeps the pending "+" profile on purpose,
       // so it's no longer a discard-on-close candidate (#453).
       pendingNewProfileRef.current = null

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -334,7 +334,16 @@ export function GameRow({
         await onRunningStateRefresh()
       }
 
-      await saveProfileSet(updatedProfileSet)
+      // The save is what cancels a pending UAC handoff the outgoing profile
+      // leaves behind, and it is reached on every switch, including the ones
+      // that skip `switchProfileApps` entirely because the diff is empty
+      // (#782). That is precisely the case with no other chance to speak, so
+      // the note has to be folded in here rather than only above.
+      const saveResult = await saveProfileSet(updatedProfileSet)
+      const saveStrandedNote = formatStrandedConsentPrompts(saveResult.strandedConsentPrompts)
+      if (saveStrandedNote) {
+        switchWarning = [switchWarning, saveStrandedNote].filter(Boolean).join(' ')
+      }
       // Switching to another profile keeps the pending "+" profile on purpose,
       // so it's no longer a discard-on-close candidate (#453).
       pendingNewProfileRef.current = null

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -35,7 +35,17 @@ export interface UseGameProfileResult {
   profileState: ProfileState
   loadProfileSet: () => Promise<GameProfileSet>
   getProfileRuntimeConfig: () => Promise<GameProfileSet>
-  saveProfileSet: (nextProfileSet: GameProfileSet) => Promise<void>
+  saveProfileSet: (nextProfileSet: GameProfileSet) => Promise<SaveProfileSetResult>
+}
+
+/**
+ * A profile switch can cancel a pending UAC handoff belonging to the outgoing
+ * profile (#782). Killing its host does not remove the consent prompt, so the
+ * caller has to tell the user the dialog on screen is now dead, exactly as the
+ * kill results do. Absent when there is nothing to report.
+ */
+export interface SaveProfileSetResult {
+  strandedConsentPrompts?: number
 }
 
 export function useGameProfile(
@@ -104,9 +114,11 @@ export function useGameProfile(
   )
 
   const saveProfileSet = useCallback(
-    async (nextProfileSet: GameProfileSet) => {
-      await saveProfile(gameKey, nextProfileSet)
+    async (nextProfileSet: GameProfileSet): Promise<SaveProfileSetResult> => {
+      const result = (await saveProfile(gameKey, nextProfileSet)) as
+        SaveProfileSetResult | undefined
       applyProfileSet(nextProfileSet)
+      return result ?? {}
     },
     [applyProfileSet, gameKey]
   )

--- a/src/renderer/src/hooks/useGameProfile.ts
+++ b/src/renderer/src/hooks/useGameProfile.ts
@@ -35,17 +35,7 @@ export interface UseGameProfileResult {
   profileState: ProfileState
   loadProfileSet: () => Promise<GameProfileSet>
   getProfileRuntimeConfig: () => Promise<GameProfileSet>
-  saveProfileSet: (nextProfileSet: GameProfileSet) => Promise<SaveProfileSetResult>
-}
-
-/**
- * A profile switch can cancel a pending UAC handoff belonging to the outgoing
- * profile (#782). Killing its host does not remove the consent prompt, so the
- * caller has to tell the user the dialog on screen is now dead, exactly as the
- * kill results do. Absent when there is nothing to report.
- */
-export interface SaveProfileSetResult {
-  strandedConsentPrompts?: number
+  saveProfileSet: (nextProfileSet: GameProfileSet) => Promise<void>
 }
 
 export function useGameProfile(
@@ -113,12 +103,13 @@ export function useGameProfile(
     [readProfileSet]
   )
 
+  // Returns nothing on purpose. A switch that strands a consent prompt reports
+  // it by a push from main straight to the toast layer, so no caller of this
+  // has to know that cancelling a UAC handoff is even possible (#782).
   const saveProfileSet = useCallback(
-    async (nextProfileSet: GameProfileSet): Promise<SaveProfileSetResult> => {
-      const result = (await saveProfile(gameKey, nextProfileSet)) as
-        SaveProfileSetResult | undefined
+    async (nextProfileSet: GameProfileSet): Promise<void> => {
+      await saveProfile(gameKey, nextProfileSet)
       applyProfileSet(nextProfileSet)
-      return result ?? {}
     },
     [applyProfileSet, gameKey]
   )

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -5,6 +5,7 @@ export const switchProfileApps = window.electronAPI.switchProfileApps
 export const browsePath = window.electronAPI.browsePath
 export const onAppLaunchError = window.electronAPI.onAppLaunchError
 export const onProcessNameMismatchWarning = window.electronAPI.onProcessNameMismatchWarning
+export const onStrandedConsentPrompts = window.electronAPI.onStrandedConsentPrompts
 export const minimize = () => window.electronAPI.minimize()
 export const maximize = () => window.electronAPI.maximize()
 export const close = () => window.electronAPI.close()

--- a/tests/main/configImport.test.ts
+++ b/tests/main/configImport.test.ts
@@ -108,7 +108,7 @@ async function loadConfigHandlers(initialStore: Record<string, unknown>) {
   const profilesMock = {
     isStoredProfileSet: vi.fn(() => false),
     getProfileLaunchEntryId: vi.fn(),
-    getProfileSwitchLeavingEntries: vi.fn(() => [])
+    getProfileSwitchLeavingKeys: vi.fn(() => [])
   }
   vi.doMock('../profiles', () => profilesMock)
   vi.doMock('/src/main/profiles.ts', () => profilesMock)

--- a/tests/main/configImport.test.ts
+++ b/tests/main/configImport.test.ts
@@ -4,6 +4,7 @@ type MockIpcHandler = (...args: unknown[]) => Promise<unknown>
 
 const migrateProfilesToNamedSets = vi.fn()
 const cancelPendingElevatedHandoffs = vi.fn()
+const abortActiveLaunches = vi.fn()
 // Defaults to 1 so the report path is exercised. The real counter is a
 // module-level scalar the cancel callback increments; what matters here is that
 // the import DRAINS it and pushes the count (#842).
@@ -116,6 +117,7 @@ async function loadConfigHandlers(initialStore: Record<string, unknown>) {
 
   const processesMock = {
     publishRunningApps: vi.fn(async () => {}),
+    abortActiveLaunches,
     cancelPendingElevatedHandoffs,
     drainStrandedConsentPrompts
   }
@@ -206,6 +208,13 @@ test('applying an import cancels every pending elevated handoff (#842)', async (
 
   await expect(previewThenApply(handlers)).resolves.toMatchObject({ success: true })
 
+  // Both mechanisms. A handoff younger than the grace window is not in the
+  // registry yet, so the abort signal is the only thing that reaches it and
+  // cancelling the registry alone left the whole pre-grace window uncovered
+  // (CodeRabbit on #842). Unscoped, unlike the switch's per-game abort, because
+  // an import replaces every game's config at once.
+  expect(abortActiveLaunches).toHaveBeenCalledTimes(1)
+  expect(abortActiveLaunches.mock.calls[0]).toEqual([])
   expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
   // No game key and no predicate: unlike a profile switch there is no "profile
   // being left" to diff against, so this is deliberately unscoped.
@@ -229,6 +238,7 @@ test('a rolled-back import cancels nothing (#842)', async () => {
   await expect(previewThenApply(handlers)).resolves.toMatchObject({ success: false })
 
   expect(mockStore.data).toEqual(initial)
+  expect(abortActiveLaunches).not.toHaveBeenCalled()
   expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
   expect(drainStrandedConsentPrompts).not.toHaveBeenCalled()
   expect(pushedStrandedCounts()).toEqual([])

--- a/tests/main/configImport.test.ts
+++ b/tests/main/configImport.test.ts
@@ -3,6 +3,19 @@ import { beforeEach, expect, test, vi } from 'vitest'
 type MockIpcHandler = (...args: unknown[]) => Promise<unknown>
 
 const migrateProfilesToNamedSets = vi.fn()
+const cancelPendingElevatedHandoffs = vi.fn()
+// Defaults to 1 so the report path is exercised. The real counter is a
+// module-level scalar the cancel callback increments; what matters here is that
+// the import DRAINS it and pushes the count (#842).
+const drainStrandedConsentPrompts = vi.fn(() => 1)
+const sendToRenderer = vi.fn()
+
+/** The stranded-prompt counts the import pushed to the renderer. */
+function pushedStrandedCounts(): number[] {
+  return sendToRenderer.mock.calls
+    .filter(([channel]) => channel === 'stranded-consent-prompts')
+    .map(([, count]) => count as number)
+}
 const importedConfig = {
   customSlots: 2,
   appPaths: { simhub: 'C:/Tools/NewSimHub.exe' }
@@ -57,7 +70,7 @@ async function loadConfigHandlers(initialStore: Record<string, unknown>) {
   const windowMock = {
     getMainWindow: vi.fn(() => null),
     applyRuntimeConfigSettings: vi.fn(),
-    sendToRenderer: vi.fn()
+    sendToRenderer
   }
   vi.doMock('../window', () => windowMock)
   vi.doMock('/src/main/window.ts', () => windowMock)
@@ -91,11 +104,25 @@ async function loadConfigHandlers(initialStore: Record<string, unknown>) {
   vi.doMock('../../src/main/store', () => storeMock)
   vi.doMock('../../src/main/store.ts', () => storeMock)
 
-  const profilesMock = { isStoredProfileSet: vi.fn(() => false) }
+  const profilesMock = {
+    isStoredProfileSet: vi.fn(() => false),
+    getProfileLaunchEntryId: vi.fn(),
+    getProfileSwitchLeavingEntries: vi.fn(() => [])
+  }
   vi.doMock('../profiles', () => profilesMock)
   vi.doMock('/src/main/profiles.ts', () => profilesMock)
   vi.doMock('../../src/main/profiles', () => profilesMock)
   vi.doMock('../../src/main/profiles.ts', () => profilesMock)
+
+  const processesMock = {
+    publishRunningApps: vi.fn(async () => {}),
+    cancelPendingElevatedHandoffs,
+    drainStrandedConsentPrompts
+  }
+  vi.doMock('../processes', () => processesMock)
+  vi.doMock('/src/main/processes.ts', () => processesMock)
+  vi.doMock('../../src/main/processes', () => processesMock)
+  vi.doMock('../../src/main/processes.ts', () => processesMock)
 
   const configModule = await import('../../src/main/ipc/config')
   configModule.registerConfigHandlers()
@@ -168,6 +195,43 @@ test('applying an import rolls the store back when the apply throws', async () =
   expect(result.success).toBe(false)
   expect(result.error).toContain('corrupted profile set')
   expect(mockStore.data).toEqual(initial)
+})
+
+// An import replaces the whole store, so a pending elevated handoff is left
+// waiting on a profile that may no longer exist. Nothing else covers it:
+// `save-profile` never runs on this path, and a pending handoff has never
+// started, so no tasklist-diff-driven code can see it either (Codex P2 on #842).
+test('applying an import cancels every pending elevated handoff (#842)', async () => {
+  const { handlers } = await loadConfigHandlers({ customSlots: 5 })
+
+  await expect(previewThenApply(handlers)).resolves.toMatchObject({ success: true })
+
+  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
+  // No game key and no predicate: unlike a profile switch there is no "profile
+  // being left" to diff against, so this is deliberately unscoped.
+  expect(cancelPendingElevatedHandoffs.mock.calls[0]).toEqual([])
+  // Killing the host does not remove the consent dialog, so the count has to
+  // reach the renderer or the user is never told the prompt is dead (#809).
+  expect(pushedStrandedCounts()).toEqual([1])
+})
+
+// The rollback half. Cancelling before the apply is known to have succeeded
+// would kill a prompt that is still valid for the config the rollback restores,
+// which is a worse outcome than the bug above: the user loses a live prompt for
+// a config they never stopped using.
+test('a rolled-back import cancels nothing (#842)', async () => {
+  const initial = { customSlots: 5, gamePaths: { iracing: 'C:/Games/Old.exe' } }
+  const { handlers, mockStore } = await loadConfigHandlers(initial)
+  migrateProfilesToNamedSets.mockImplementationOnce(() => {
+    throw new Error('corrupted profile set')
+  })
+
+  await expect(previewThenApply(handlers)).resolves.toMatchObject({ success: false })
+
+  expect(mockStore.data).toEqual(initial)
+  expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+  expect(drainStrandedConsentPrompts).not.toHaveBeenCalled()
+  expect(pushedStrandedCounts()).toEqual([])
 })
 
 test('apply-import-config only accepts the token issued by the matching preview', async () => {

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -28,7 +28,9 @@ async function loadConfigModule() {
   vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
   vi.doMock('../../src/main/profiles', () => ({
     isStoredProfileSet: vi.fn(),
-    getProfileSwitchLeavingPaths: vi.fn(() => [])
+    getProfileSwitchLeavingEntries: vi.fn(() => []),
+    getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
+      `${entry.key} ${entry.path.toLowerCase()}`
   }))
   const storeModuleMock = {
     CONFIG_FILE_NAME: 'simlauncher-config.json',

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -26,7 +26,10 @@ async function loadConfigModule() {
   const { clearIpcHandlers } = await import('electron')
   ;(clearIpcHandlers as () => void)()
   vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
-  vi.doMock('../../src/main/profiles', () => ({ isStoredProfileSet: vi.fn() }))
+  vi.doMock('../../src/main/profiles', () => ({
+    isStoredProfileSet: vi.fn(),
+    getProfileSwitchLeavingPaths: vi.fn(() => [])
+  }))
   const storeModuleMock = {
     CONFIG_FILE_NAME: 'simlauncher-config.json',
     KNOWN_GAME_KEYS: new Set(['ac', 'acc']),

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -28,7 +28,7 @@ async function loadConfigModule() {
   vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
   vi.doMock('../../src/main/profiles', () => ({
     isStoredProfileSet: vi.fn(),
-    getProfileSwitchLeavingEntries: vi.fn(() => []),
+    getProfileSwitchLeavingKeys: vi.fn(() => []),
     getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
       `${entry.key} ${entry.path.toLowerCase()}`
   }))

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -80,6 +80,20 @@ async function saveProfile(gameKey: string, profileSet: unknown): Promise<unknow
 
 const utility = (id: string) => ({ id, enabled: true })
 
+/**
+ * The predicate `save-profile` handed to `cancelPendingElevatedHandoffs`, applied
+ * to a synthetic registry entry. Asserting on the predicate rather than on an
+ * argument list is what lets these tests tell two slots apart when they share an
+ * executable, which is the whole reason cancellation matches by slot
+ * (CodeRabbit on #782).
+ */
+function cancelsHandoffFor(appKey: string, appPath: string): boolean {
+  const matches = cancelPendingElevatedHandoffs.mock.calls[0]?.[1] as
+    ((entry: { appKey?: string; appPath: string }) => boolean) | undefined
+  expect(matches).toBeDefined()
+  return matches!({ appKey, appPath })
+}
+
 function profileSet(activeProfileId: string, profiles: Record<string, string[]>) {
   return {
     activeProfileId,
@@ -121,7 +135,9 @@ test('a switch cancels a handoff for an app only the outgoing profile enabled (#
   )
 
   expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
-  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledWith('ac', ['C:/Tools/Admin Tool.exe'])
+  expect(cancelPendingElevatedHandoffs.mock.calls[0][0]).toBe('ac')
+  expect(cancelsHandoffFor('customapp1', 'C:/Tools/Admin Tool.exe')).toBe(true)
+  expect(cancelsHandoffFor('simhub', 'C:/Tools/SimHub.exe')).toBe(false)
   // Killing the host leaves the consent dialog on screen, so the count has to
   // come back out to the renderer or the user is never told it is dead (#809).
   expect(result).toEqual({ strandedConsentPrompts: 1 })
@@ -197,7 +213,12 @@ test('a slot move to the same exe still counts as leaving (#782)', async () => {
 
   await saveProfile('ac', sets('loud'))
 
-  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledWith('ac', ['C:/Tools/Shared Utility.exe'])
+  // The leaving slot is cancelled...
+  expect(cancelsHandoffFor('customapp1', 'C:/Tools/Shared Utility.exe')).toBe(true)
+  // ...and the slot the incoming profile keeps is NOT, even though it is the
+  // same binary. Matching on path alone cancels both, which loses a prompt the
+  // user was about to approve for an app that is staying.
+  expect(cancelsHandoffFor('customapp2', 'C:/Tools/Shared Utility.exe')).toBe(false)
 })
 
 // Editing the profile you are already on is not a switch, whatever moved inside

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -308,20 +308,23 @@ test('editing the active profile cancels nothing, even when it drops an app (#78
   expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
 })
 
-// The game is excluded the same way the switch diff excludes it: a switch never
-// stops the game, so it must never cancel the game's own handoff either. Getting
-// this wrong means a companion-only operation silently cancels a game launch the
-// user is still being prompted for, and the game is not in the incoming
-// profile's start list to recover it.
+// A switch never stops the game, so it must never cancel the game's own handoff
+// either: that would silently kill a game launch the user is still being
+// prompted for, and the game is not in the incoming profile's start list to
+// recover it.
+//
+// The previous version of this test gave the outgoing profile no utilities at
+// all and asserted nothing was cancelled. That passed for the wrong reason and
+// would have kept passing with any game exclusion removed, because leaving keys
+// come from utility SLOTS and an empty profile has none (CodeRabbit on #842). So
+// the outgoing profile now has a real leaving utility, and the assertion is that
+// the predicate accepts that utility while rejecting the game.
 test('a switch never cancels the handoff for the game itself (#782)', async () => {
-  // The incoming profile must NOT launch the game, or the game appears on both
-  // sides of the diff and subtracts itself. That made this test pass with the
-  // exclusion deleted, i.e. prove nothing.
   const sets = (activeProfileId: string) => ({
     activeProfileId,
     profiles: [
-      { id: 'quiet', name: 'quiet', utilities: [] },
-      { id: 'loud', name: 'loud', launchAutomatically: false, utilities: [utility('simhub')] }
+      { id: 'quiet', name: 'quiet', utilities: [utility('customapp1')] },
+      { id: 'loud', name: 'loud', utilities: [utility('simhub')] }
     ]
   })
 
@@ -333,9 +336,37 @@ test('a switch never cancels the handoff for the game itself (#782)', async () =
 
   await saveProfile('ac', sets('loud'))
 
-  // The outgoing profile launches the game and nothing else, so once the game is
-  // excluded there is nothing leaving at all.
-  expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+  // There IS something leaving, so this is a real switch and the predicate ran.
+  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
+  expect(cancelsHandoffFor('customapp1', 'C:/Tools/Admin Tool.exe')).toBe(true)
+  // Both profiles launch the game, and the game is not a utility slot either
+  // way, so its own handoff must survive.
+  expect(cancelsHandoffFor('ac', 'C:/Games/AssettoCorsa.exe')).toBe(false)
+})
+
+// The `appKey === undefined` branch of the predicate. Requested by CodeRabbit on
+// #842 and worth keeping, but labelled honestly: this pins a DEFENSIVE guard, not
+// a behavioural difference. No current input distinguishes it, because leaving
+// keys are validated slot keys and never include the empty string, so the
+// obvious `appKey ?? ''` rewrite passes this test too (verified by mutation).
+//
+// It earns its place as a tripwire rather than as coverage. The guard is what
+// stops "unknown slot" from ever collapsing into "some key" if the key source is
+// later loosened, which is exactly what `getEnabledUtilityKeys` (the older,
+// unvalidated sibling in profiles.ts) would do.
+test('a handoff with no recorded slot is never cancelled (#842)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
+
+  const matches = cancelPendingElevatedHandoffs.mock.calls[0]?.[1] as
+    ((entry: { appKey?: string; appPath: string }) => boolean) | undefined
+  expect(matches).toBeDefined()
+  // Same path as the leaving slot, so only the missing key can be what rejects it.
+  expect(matches!({ appPath: 'C:/Tools/Admin Tool.exe' })).toBe(false)
 })
 
 // Ownership is decided by SLOT MEMBERSHIP, not by what the profile can launch

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -18,6 +18,10 @@ import { expect, test, vi, beforeEach } from 'vitest'
 type MockIpcHandler = (...args: unknown[]) => unknown
 
 const cancelPendingElevatedHandoffs = vi.fn()
+// Defaults to 1 so the handler's report path is exercised. The real counter is a
+// module-level scalar incremented by the cancel callback; what matters here is
+// that the handler DRAINS it and hands the count back (#782 Codex P2).
+const drainStrandedConsentPrompts = vi.fn(() => 1)
 
 interface StoredState {
   profiles?: Record<string, unknown>
@@ -55,7 +59,8 @@ async function loadConfigModule(initial: StoredState) {
   vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
   vi.doMock('../../src/main/processes', () => ({
     publishRunningApps: vi.fn(async () => {}),
-    cancelPendingElevatedHandoffs
+    cancelPendingElevatedHandoffs,
+    drainStrandedConsentPrompts
   }))
   vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
   vi.doMock('../../src/main/window', () => ({
@@ -68,9 +73,9 @@ async function loadConfigModule(initial: StoredState) {
   mod.registerConfigHandlers()
 }
 
-async function saveProfile(gameKey: string, profileSet: unknown): Promise<void> {
+async function saveProfile(gameKey: string, profileSet: unknown): Promise<unknown> {
   const { __ipcHandlers } = await import('electron')
-  await (__ipcHandlers as Record<string, MockIpcHandler>)['save-profile']({}, gameKey, profileSet)
+  return (__ipcHandlers as Record<string, MockIpcHandler>)['save-profile']({}, gameKey, profileSet)
 }
 
 const utility = (id: string) => ({ id, enabled: true })
@@ -98,6 +103,7 @@ const APP_PATHS = {
 beforeEach(() => {
   vi.resetModules()
   cancelPendingElevatedHandoffs.mockClear()
+  drainStrandedConsentPrompts.mockClear()
 })
 
 // The acceptance criterion from the issue, on the path the renderer actually
@@ -109,10 +115,48 @@ test('a switch cancels a handoff for an app only the outgoing profile enabled (#
     profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
   })
 
-  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
+  const result = await saveProfile(
+    'ac',
+    profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] })
+  )
 
   expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
   expect(cancelPendingElevatedHandoffs).toHaveBeenCalledWith('ac', ['C:/Tools/Admin Tool.exe'])
+  // Killing the host leaves the consent dialog on screen, so the count has to
+  // come back out to the renderer or the user is never told it is dead (#809).
+  expect(result).toEqual({ strandedConsentPrompts: 1 })
+})
+
+// The half that bites a different game entirely. The counter is one module-level
+// scalar drained by whoever reports it, so a save that cancels something and
+// does NOT drain leaves the count sitting there for the next kill to pick up and
+// attribute to an operation that stranded nothing (Codex P2 on #782).
+test('a switch that cancels drains the stranded count rather than leaving it (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
+
+  expect(drainStrandedConsentPrompts).toHaveBeenCalledTimes(1)
+})
+
+// And the mirror: a save that cancels nothing must not drain either, or it would
+// swallow a count belonging to an operation still waiting to report it.
+test('a save that cancels nothing does not touch the stranded count (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1', 'simhub'], loud: ['simhub'] }) }
+  })
+
+  const result = await saveProfile(
+    'ac',
+    profileSet('quiet', { quiet: ['simhub'], loud: ['simhub'] })
+  )
+
+  expect(drainStrandedConsentPrompts).not.toHaveBeenCalled()
+  expect(result).toBeUndefined()
 })
 
 // The over-cancel half. An app both profiles enable is not leaving, so its
@@ -129,6 +173,31 @@ test('a switch leaves a handoff alone when the incoming profile enables it too (
   )
 
   expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+})
+
+// Two slots, one exe, different `appArgs` (#357). Comparing paths alone calls
+// the outgoing slot retained because the incoming profile happens to run the
+// same binary, so the old prompt survives and approving it launches that exe
+// with the OUTGOING slot's arguments (Codex P1 on #782). Identity is the slot
+// plus the path, and it has to be the same function the switch diff uses.
+test('a slot move to the same exe still counts as leaving (#782)', async () => {
+  const twoSlots = {
+    customapp1: 'C:/Tools/Shared Utility.exe',
+    customapp2: 'C:/Tools/Shared Utility.exe'
+  }
+  const sets = (activeProfileId: string) => ({
+    activeProfileId,
+    profiles: [
+      { id: 'quiet', name: 'quiet', utilities: [utility('customapp1')] },
+      { id: 'loud', name: 'loud', utilities: [utility('customapp2')] }
+    ]
+  })
+
+  await loadConfigModule({ appPaths: twoSlots, customSlots: 2, profiles: { ac: sets('quiet') } })
+
+  await saveProfile('ac', sets('loud'))
+
+  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledWith('ac', ['C:/Tools/Shared Utility.exe'])
 })
 
 // Editing the profile you are already on is not a switch, whatever moved inside

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -286,6 +286,12 @@ test('a slot move to the same exe still counts as leaving (#782)', async () => {
   // same binary. Matching on path alone cancels both, which loses a prompt the
   // user was about to approve for an app that is staying.
   expect(cancelsHandoffFor('customapp2', 'C:/Tools/Shared Utility.exe')).toBe(false)
+
+  // The key is doing that work on its own. The registry stores the path AS
+  // LAUNCHED while `leavingEntries` is rebuilt from the current `appPaths`, so
+  // requiring the path to match as well makes a slot whose exe was edited in
+  // Settings mid-prompt escape cancellation entirely (Codex P2 on #842).
+  expect(cancelsHandoffFor('customapp1', 'C:/Tools/Some Older Binary.exe')).toBe(true)
 })
 
 // Editing the profile you are already on is not a switch, whatever moved inside

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -1,0 +1,189 @@
+import { expect, test, vi, beforeEach } from 'vitest'
+
+/**
+ * #782: a profile switch has to cancel a pending elevated (UAC) handoff left
+ * behind by the outgoing profile.
+ *
+ * The reason this lives on `save-profile` and not on `switch-profile-apps` is
+ * that the renderer frequently never calls the latter. It gates the whole IPC on
+ * a diff built from a tasklist snapshot, and a pending handoff has never
+ * started, so it contributes zero to both halves of that diff and the renderer
+ * falls through to this save instead.
+ *
+ * The REAL `../../src/main/profiles` is used deliberately. The leaving-path
+ * calculation is the entire fix, so a mocked version would prove nothing beyond
+ * "the handler calls a function".
+ */
+
+type MockIpcHandler = (...args: unknown[]) => unknown
+
+const cancelPendingElevatedHandoffs = vi.fn()
+
+interface StoredState {
+  profiles?: Record<string, unknown>
+  appPaths?: Record<string, string>
+  gamePaths?: Record<string, string>
+  customSlots?: number
+}
+
+let storedState: StoredState = {}
+
+async function loadConfigModule(initial: StoredState) {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+  storedState = { customSlots: 1, ...initial }
+
+  vi.doMock('electron-store', () => ({
+    default: class MockStore {
+      get store() {
+        return storedState as Record<string, unknown>
+      }
+
+      get(key: string) {
+        return (storedState as Record<string, unknown>)[key]
+      }
+
+      set(key: string, value: unknown) {
+        ;(storedState as Record<string, unknown>)[key] = value
+      }
+
+      clear() {
+        storedState = {}
+      }
+    }
+  }))
+  vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
+  vi.doMock('../../src/main/processes', () => ({
+    publishRunningApps: vi.fn(async () => {}),
+    cancelPendingElevatedHandoffs
+  }))
+  vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
+  vi.doMock('../../src/main/window', () => ({
+    applyRuntimeConfigSettings: vi.fn(),
+    getMainWindow: vi.fn(),
+    sendToRenderer: vi.fn()
+  }))
+
+  const mod = await import('../../src/main/ipc/config')
+  mod.registerConfigHandlers()
+}
+
+async function saveProfile(gameKey: string, profileSet: unknown): Promise<void> {
+  const { __ipcHandlers } = await import('electron')
+  await (__ipcHandlers as Record<string, MockIpcHandler>)['save-profile']({}, gameKey, profileSet)
+}
+
+const utility = (id: string) => ({ id, enabled: true })
+
+function profileSet(activeProfileId: string, profiles: Record<string, string[]>) {
+  return {
+    activeProfileId,
+    profiles: Object.entries(profiles).map(([id, utilityIds]) => ({
+      id,
+      name: id,
+      utilities: utilityIds.map(utility)
+    }))
+  }
+}
+
+// Real slot keys. `getEnabledUtilityEntries` drops anything that is not a
+// built-in utility or a configured custom slot, so an invented key would make
+// every profile below resolve to zero entries and every assertion here vacuous.
+const APP_PATHS = {
+  customapp1: 'C:/Tools/Admin Tool.exe',
+  simhub: 'C:/Tools/SimHub.exe',
+  crewchief: 'C:/Tools/Other.exe'
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  cancelPendingElevatedHandoffs.mockClear()
+})
+
+// The acceptance criterion from the issue, on the path the renderer actually
+// takes. Profile "quiet" holds the app with the unanswered prompt and profile
+// "loud" does not, so the switch leaves it behind.
+test('a switch cancels a handoff for an app only the outgoing profile enabled (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
+
+  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
+  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledWith('ac', ['C:/Tools/Admin Tool.exe'])
+})
+
+// The over-cancel half. An app both profiles enable is not leaving, so its
+// prompt is still worth answering and must survive the switch.
+test('a switch leaves a handoff alone when the incoming profile enables it too (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['customapp1', 'simhub'] }) }
+  })
+
+  await saveProfile(
+    'ac',
+    profileSet('loud', { quiet: ['customapp1'], loud: ['customapp1', 'simhub'] })
+  )
+
+  expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+})
+
+// Editing the profile you are already on is not a switch, whatever moved inside
+// it. Without the `activeProfileId` guard, disabling an app in the profile editor
+// would kill a consent prompt the user is mid-way through answering.
+test('editing the active profile cancels nothing, even when it drops an app (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1', 'simhub'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('quiet', { quiet: ['simhub'], loud: ['simhub'] }))
+
+  expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+})
+
+// The game is excluded the same way the switch diff excludes it: a switch never
+// stops the game, so it must never cancel the game's own handoff either. Getting
+// this wrong means a companion-only operation silently cancels a game launch the
+// user is still being prompted for, and the game is not in the incoming
+// profile's start list to recover it.
+test('a switch never cancels the handoff for the game itself (#782)', async () => {
+  // The incoming profile must NOT launch the game, or the game appears on both
+  // sides of the diff and subtracts itself. That made this test pass with the
+  // exclusion deleted, i.e. prove nothing.
+  const sets = (activeProfileId: string) => ({
+    activeProfileId,
+    profiles: [
+      { id: 'quiet', name: 'quiet', utilities: [] },
+      { id: 'loud', name: 'loud', launchAutomatically: false, utilities: [utility('simhub')] }
+    ]
+  })
+
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    gamePaths: { ac: 'C:/Games/AssettoCorsa.exe' },
+    profiles: { ac: sets('quiet') }
+  })
+
+  await saveProfile('ac', sets('loud'))
+
+  // The outgoing profile launches the game and nothing else, so once the game is
+  // excluded there is nothing leaving at all.
+  expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+})
+
+// A save for a game that has never been switched (flat legacy profile, no
+// `activeProfileId` on either side) must not throw or cancel.
+test('a legacy flat profile save cancels nothing (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: { simhub: true } }
+  })
+
+  await saveProfile('ac', profileSet('loud', { loud: ['simhub'] }))
+
+  expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
+})

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -20,8 +20,9 @@ type MockIpcHandler = (...args: unknown[]) => unknown
 const cancelPendingElevatedHandoffs = vi.fn()
 // Defaults to 1 so the handler's report path is exercised. The real counter is a
 // module-level scalar incremented by the cancel callback; what matters here is
-// that the handler DRAINS it and hands the count back (#782 Codex P2).
+// that the handler DRAINS it and reports the count (#782 Codex P2).
 const drainStrandedConsentPrompts = vi.fn(() => 1)
+const sendToRenderer = vi.fn()
 
 interface StoredState {
   profiles?: Record<string, unknown>
@@ -66,7 +67,7 @@ async function loadConfigModule(initial: StoredState) {
   vi.doMock('../../src/main/window', () => ({
     applyRuntimeConfigSettings: vi.fn(),
     getMainWindow: vi.fn(),
-    sendToRenderer: vi.fn()
+    sendToRenderer
   }))
 
   const mod = await import('../../src/main/ipc/config')
@@ -114,10 +115,23 @@ const APP_PATHS = {
   crewchief: 'C:/Tools/Other.exe'
 }
 
+/**
+ * The stranded-prompt counts this save pushed to the renderer. Asserting on the
+ * push rather than on the handler's return value is the point: three of the four
+ * callers that change the active profile never read a return value, and because
+ * the drain is destructive that silently destroyed the count (Codex P2 on #782).
+ */
+function pushedStrandedCounts(): number[] {
+  return sendToRenderer.mock.calls
+    .filter(([channel]) => channel === 'stranded-consent-prompts')
+    .map(([, count]) => count as number)
+}
+
 beforeEach(() => {
   vi.resetModules()
   cancelPendingElevatedHandoffs.mockClear()
   drainStrandedConsentPrompts.mockClear()
+  sendToRenderer.mockClear()
 })
 
 // The acceptance criterion from the issue, on the path the renderer actually
@@ -129,18 +143,15 @@ test('a switch cancels a handoff for an app only the outgoing profile enabled (#
     profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
   })
 
-  const result = await saveProfile(
-    'ac',
-    profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] })
-  )
+  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
 
   expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
   expect(cancelPendingElevatedHandoffs.mock.calls[0][0]).toBe('ac')
   expect(cancelsHandoffFor('customapp1', 'C:/Tools/Admin Tool.exe')).toBe(true)
   expect(cancelsHandoffFor('simhub', 'C:/Tools/SimHub.exe')).toBe(false)
   // Killing the host leaves the consent dialog on screen, so the count has to
-  // come back out to the renderer or the user is never told it is dead (#809).
-  expect(result).toEqual({ strandedConsentPrompts: 1 })
+  // reach the renderer or the user is never told it is dead (#809).
+  expect(pushedStrandedCounts()).toEqual([1])
 })
 
 // The half that bites a different game entirely. The counter is one module-level
@@ -166,13 +177,30 @@ test('a save that cancels nothing does not touch the stranded count (#782)', asy
     profiles: { ac: profileSet('quiet', { quiet: ['customapp1', 'simhub'], loud: ['simhub'] }) }
   })
 
-  const result = await saveProfile(
-    'ac',
-    profileSet('quiet', { quiet: ['simhub'], loud: ['simhub'] })
-  )
+  await saveProfile('ac', profileSet('quiet', { quiet: ['simhub'], loud: ['simhub'] }))
 
   expect(drainStrandedConsentPrompts).not.toHaveBeenCalled()
-  expect(result).toBeUndefined()
+  expect(pushedStrandedCounts()).toEqual([])
+})
+
+// The caller Codex found on top of the row dropdown: deleting the ACTIVE profile
+// moves `activeProfileId` to whatever survives, which is a switch by every
+// definition this handler uses, and its leaving set is the whole deleted
+// profile. `confirmDeleteProfile` reports "Profile deleted" and nothing else, so
+// while the count was a return value it was drained and thrown away and the user
+// kept a dead consent dialog with no explanation anywhere (Codex P2 on #782).
+// Written as a shrinking profiles array rather than a reordering one so it also
+// fails if leaving-set computation is ever gated on the profile count holding.
+test('deleting the active profile cancels its handoff and reports it (#782)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('loud', { loud: ['simhub'] }))
+
+  expect(cancelsHandoffFor('customapp1', 'C:/Tools/Admin Tool.exe')).toBe(true)
+  expect(pushedStrandedCounts()).toEqual([1])
 })
 
 // The over-cancel half. An app both profiles enable is not leaving, so its

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -338,6 +338,30 @@ test('a switch never cancels the handoff for the game itself (#782)', async () =
   expect(cancelPendingElevatedHandoffs).not.toHaveBeenCalled()
 })
 
+// Ownership is decided by SLOT MEMBERSHIP, not by what the profile can launch
+// right now. A handoff is created while the slot has an exe; clearing that exe
+// in Settings before switching used to make the slot vanish from the outgoing
+// profile entirely, because leaving entries were built from launchable entries
+// and an entry needs something to launch. The switch then found nothing leaving,
+// skipped the whole block (abort included), and approving the old prompt still
+// started the executable recorded at launch time (Codex P2 on #842).
+test('a slot whose path was cleared is still leaving (#842)', async () => {
+  await loadConfigModule({
+    // customapp1 has NO configured path, and is the slot with the pending prompt.
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
+
+  expect(cancelPendingElevatedHandoffs).toHaveBeenCalledTimes(1)
+  // The registry still holds the path the handoff was launched with.
+  expect(cancelsHandoffFor('customapp1', 'C:/Tools/Admin Tool.exe')).toBe(true)
+  // And the abort half runs too, which is what the empty-leaving-set bug also
+  // silently skipped.
+  expect(abortActiveLaunches).toHaveBeenCalledWith('ac')
+})
+
 // A save for a game that has never been switched (flat legacy profile, no
 // `activeProfileId` on either side) must not throw or cancel.
 test('a legacy flat profile save cancels nothing (#782)', async () => {

--- a/tests/main/configProfileSwitchHandoff.test.ts
+++ b/tests/main/configProfileSwitchHandoff.test.ts
@@ -18,6 +18,7 @@ import { expect, test, vi, beforeEach } from 'vitest'
 type MockIpcHandler = (...args: unknown[]) => unknown
 
 const cancelPendingElevatedHandoffs = vi.fn()
+const abortActiveLaunches = vi.fn()
 // Defaults to 1 so the handler's report path is exercised. The real counter is a
 // module-level scalar incremented by the cancel callback; what matters here is
 // that the handler DRAINS it and reports the count (#782 Codex P2).
@@ -60,6 +61,7 @@ async function loadConfigModule(initial: StoredState) {
   vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
   vi.doMock('../../src/main/processes', () => ({
     publishRunningApps: vi.fn(async () => {}),
+    abortActiveLaunches,
     cancelPendingElevatedHandoffs,
     drainStrandedConsentPrompts
   }))
@@ -130,8 +132,45 @@ function pushedStrandedCounts(): number[] {
 beforeEach(() => {
   vi.resetModules()
   cancelPendingElevatedHandoffs.mockClear()
+  abortActiveLaunches.mockClear()
   drainStrandedConsentPrompts.mockClear()
   sendToRenderer.mockClear()
+})
+
+// The pre-grace half of the same bug. For the first ELEVATED_HANDOFF_MAX_WAIT_MS
+// of an unanswered prompt the handoff is not in the registry at all -- spawn.ts
+// registers it when the grace timer fires -- so the predicate-based cancellation
+// above cannot reach it and the abort signal is the only handle. `killProfileApps`
+// aborts on the way in, but this save is precisely the path that skips the kill,
+// so without this the outgoing launch stayed live and approving the old prompt
+// still started its app (Codex P1 on #842).
+test('a switch aborts the outgoing launch, not just the registered handoffs (#842)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('loud', { quiet: ['customapp1'], loud: ['simhub'] }))
+
+  expect(abortActiveLaunches).toHaveBeenCalledTimes(1)
+  // Whole-game, matching `killProfileApps`: the sequence in flight belongs to
+  // the profile being left. Scoping it to this game is what keeps a switch on
+  // one game from aborting another game's launch.
+  expect(abortActiveLaunches).toHaveBeenCalledWith('ac')
+})
+
+// The guard that makes the abort safe to add. `save-profile` is also the
+// editor's Save, and aborting a live launch because the user edited the profile
+// they are already on would break a launch they never asked to stop.
+test('editing the active profile does not abort a launch in flight (#842)', async () => {
+  await loadConfigModule({
+    appPaths: APP_PATHS,
+    profiles: { ac: profileSet('quiet', { quiet: ['customapp1', 'simhub'], loud: ['simhub'] }) }
+  })
+
+  await saveProfile('ac', profileSet('quiet', { quiet: ['simhub'], loud: ['simhub'] }))
+
+  expect(abortActiveLaunches).not.toHaveBeenCalled()
 })
 
 // The acceptance criterion from the issue, on the path the renderer actually

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -64,9 +64,16 @@ async function loadConfigModule() {
     getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
       `${entry.key} ${entry.path.toLowerCase()}`
   }))
+  // All four exports `ipc/config.ts` imports, not just the two these tests
+  // happen to reach. `getProfileSwitchLeavingKeys` is stubbed to `[]` here, so
+  // the cancellation block never runs and the gap is currently invisible; the
+  // day it does run, a missing export is a TypeError rather than a readable
+  // assertion failure (CodeRabbit on #842).
   vi.doMock('../../src/main/processes', () => ({
     publishRunningApps: vi.fn(async () => {}),
-    cancelPendingElevatedHandoffs: vi.fn()
+    abortActiveLaunches: vi.fn(),
+    cancelPendingElevatedHandoffs: vi.fn(),
+    drainStrandedConsentPrompts: vi.fn(() => 0)
   }))
   vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
   vi.doMock('../../src/main/window', () => ({

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -60,7 +60,9 @@ async function loadConfigModule() {
     // Stubbed to "nothing is leaving": these tests are about the store write and
     // the republish, not about #782's cancellation. The real behaviour is pinned
     // in configProfileSwitchHandoff.test.ts against the real module.
-    getProfileSwitchLeavingPaths: vi.fn(() => [])
+    getProfileSwitchLeavingEntries: vi.fn(() => []),
+    getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
+      `${entry.key} ${entry.path.toLowerCase()}`
   }))
   vi.doMock('../../src/main/processes', () => ({
     publishRunningApps: vi.fn(async () => {}),

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -60,7 +60,7 @@ async function loadConfigModule() {
     // Stubbed to "nothing is leaving": these tests are about the store write and
     // the republish, not about #782's cancellation. The real behaviour is pinned
     // in configProfileSwitchHandoff.test.ts against the real module.
-    getProfileSwitchLeavingEntries: vi.fn(() => []),
+    getProfileSwitchLeavingKeys: vi.fn(() => []),
     getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
       `${entry.key} ${entry.path.toLowerCase()}`
   }))

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -56,9 +56,16 @@ async function loadConfigModule() {
     isStoredProfileSet: (value: unknown) =>
       !!value &&
       typeof value === 'object' &&
-      Array.isArray((value as { profiles?: unknown }).profiles)
+      Array.isArray((value as { profiles?: unknown }).profiles),
+    // Stubbed to "nothing is leaving": these tests are about the store write and
+    // the republish, not about #782's cancellation. The real behaviour is pinned
+    // in configProfileSwitchHandoff.test.ts against the real module.
+    getProfileSwitchLeavingPaths: vi.fn(() => [])
   }))
-  vi.doMock('../../src/main/processes', () => ({ publishRunningApps: vi.fn(async () => {}) }))
+  vi.doMock('../../src/main/processes', () => ({
+    publishRunningApps: vi.fn(async () => {}),
+    cancelPendingElevatedHandoffs: vi.fn()
+  }))
   vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
   vi.doMock('../../src/main/window', () => ({
     applyRuntimeConfigSettings: vi.fn(),

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -437,7 +437,7 @@ test('switch-profile-apps never kills or relaunches the game executable', async 
   expect(registerActiveLaunch).toHaveBeenCalledWith('iracing')
   const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
   expect(controller.signal.aborted).toBe(false)
-  expect(killProfileApps).toHaveBeenCalledWith('iracing', [utilA.path], { except: controller })
+  expect(killProfileApps).toHaveBeenCalledWith('iracing', [utilA], { except: controller })
   expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [utilB], {
     controller,
     profileId: 'p-to'

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -67,7 +67,14 @@ async function loadLaunchHandlers() {
   vi.doMock('../../src/main/processes', () => processesMock)
   vi.doMock('../../src/main/processes.ts', () => processesMock)
 
-  const profilesMock = { buildActiveProfileLaunchEntries, buildNamedProfileLaunchEntries }
+  // Copy of the real identity function, because this suite mocks the module that
+  // owns it. The rule is pinned against the real one in profiles.test.ts.
+  const profilesMock = {
+    buildActiveProfileLaunchEntries,
+    buildNamedProfileLaunchEntries,
+    getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
+      `${entry.key} ${entry.path.toLowerCase().replace(/\\/g, '/')}`
+  }
   vi.doMock('../profiles', () => profilesMock)
   vi.doMock('/src/main/profiles.ts', () => profilesMock)
   vi.doMock('../../src/main/profiles', () => profilesMock)

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -61,7 +61,13 @@ vi.mock('../../src/main/store', () => ({
   })
 }))
 
+// `getProfileLaunchEntryId` is re-implemented here because this suite mocks the
+// module that owns it. That makes it a COPY: these tests prove `ipc/launch.ts`
+// is wired to an identity function, not that the identity rule is right. The
+// rule itself is pinned against the real module in profiles.test.ts.
 vi.mock('../../src/main/profiles', () => ({
+  getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
+    `${entry.key} ${entry.path.toLowerCase().replace(/\\/g, '/')}`,
   buildActiveProfileLaunchEntries: (gameKey: string) =>
     mocks.buildActiveProfileLaunchEntries(gameKey),
   buildNamedProfileLaunchEntries: (gameKey: string, profileId: string) =>
@@ -218,28 +224,6 @@ test('validateProfileIds accepts string profile ids', async () => {
   const { validateProfileIds } = await import('../../src/main/ipc/launch')
 
   expect(validateProfileIds('base', 'race')).toBeUndefined()
-})
-
-test('getProfileLaunchEntryId distinguishes utility slots that share an executable path', async () => {
-  // Two custom-app slots configured with the same .exe but different keys
-  // (e.g. one carries `--mode debug` args, the other `--mode silent`). The
-  // diff helper that powers `switch-profile-apps` must consider these as
-  // different entries so a slot swap triggers a stop + relaunch with the
-  // new args (regression for #397, follow-up to #357).
-  const { getProfileLaunchEntryId } = await import('../../src/main/ipc/launch')
-
-  const slot1 = { key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }
-  const slot2 = { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
-
-  expect(getProfileLaunchEntryId(slot1)).not.toBe(getProfileLaunchEntryId(slot2))
-})
-
-test('getProfileLaunchEntryId is case-insensitive for the executable path', async () => {
-  const { getProfileLaunchEntryId } = await import('../../src/main/ipc/launch')
-
-  expect(getProfileLaunchEntryId({ key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' })).toBe(
-    getProfileLaunchEntryId({ key: 'customapp1', path: 'c:/Tools/shared utility.exe' })
-  )
 })
 
 test('switch-profile-apps stops and relaunches when a slot moves to a new key but keeps the same exe', async () => {

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -34,7 +34,11 @@ const mocks = vi.hoisted(() => ({
     ) => Promise<unknown>
   >(async () => ({ success: true, launchedCount: 0, skippedCount: 0 })),
   killProfileApps: vi.fn<
-    (gameKey: string, paths: string[], options?: { except?: AbortController }) => Promise<unknown>
+    (
+      gameKey: string,
+      entries: ProfileLaunchEntry[],
+      options?: { except?: AbortController }
+    ) => Promise<unknown>
   >(async () => ({
     success: true,
     closedCount: 0,
@@ -95,7 +99,7 @@ vi.mock('../../src/main/processes', async () => {
     ) => mocks.launchProfileApps(sender, gameKey, entries, options),
     killProfileApps: (
       gameKey: string,
-      entries: { key: string; path: string }[],
+      entries: ProfileLaunchEntry[],
       options?: { except?: AbortController }
     ) => mocks.killProfileApps(gameKey, entries, options),
     killLaunchedApps: vi.fn(),

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -93,8 +93,11 @@ vi.mock('../../src/main/processes', async () => {
       entries: ProfileLaunchInput[],
       options?: { controller?: AbortController }
     ) => mocks.launchProfileApps(sender, gameKey, entries, options),
-    killProfileApps: (gameKey: string, paths: string[], options?: { except?: AbortController }) =>
-      mocks.killProfileApps(gameKey, paths, options),
+    killProfileApps: (
+      gameKey: string,
+      entries: { key: string; path: string }[],
+      options?: { except?: AbortController }
+    ) => mocks.killProfileApps(gameKey, entries, options),
     killLaunchedApps: vi.fn(),
     getRunningApps: vi.fn(),
     isRunningExePath: (processNames: Set<string>, appPath: string) =>
@@ -254,9 +257,13 @@ test('switch-profile-apps stops and relaunches when a slot moves to a new key bu
   const sender = { isDestroyed: () => false, send: vi.fn() } as unknown as WebContents
   await handler({ sender } as never, 'ac', 'from', 'to')
 
+  // The whole ENTRY, not the bare path. This test is the same-exe slot move, so
+  // it is exactly the case where flattening to a path loses the only thing that
+  // tells the leaving slot from the retained one, and the kill's handoff
+  // cancellation then takes out both (Codex P2 on #842).
   expect(mocks.killProfileApps).toHaveBeenCalledWith(
     'ac',
-    ['C:/Tools/Shared Utility.exe'],
+    [{ key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }],
     expect.objectContaining({ except: expect.any(AbortController) })
   )
   expect(mocks.launchProfileApps).toHaveBeenCalledWith(

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -573,8 +573,15 @@ async function loadProcessModules() {
     // against the real module in profiles.test.ts.
     getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
       `${entry.key} ${entry.path.toLowerCase().replace(/\\/g, '/')}`,
-    getActiveStoredProfile: vi.fn((p: { activeProfileId: string; profiles: { id: string }[] }) =>
-      p.profiles.find((i) => i.id === p.activeProfileId)
+    // The undefined branch mirrors the real function, which returns undefined
+    // for a game with no stored profile. The mock used to omit it and threw
+    // instead, which stayed invisible until a caller looked up a handoff's game
+    // key rather than iterating stored profiles (#842). A mock that is stricter
+    // than the module it stands in for turns "no profile configured" into a
+    // crash that production would never have.
+    getActiveStoredProfile: vi.fn(
+      (p: { activeProfileId: string; profiles: { id: string }[] } | undefined) =>
+        p?.profiles.find((i) => i.id === p.activeProfileId)
     ),
     // Resolves through the same storeData the rest of this harness writes, so a
     // test can turn tracking off for one game by editing its profile fixture
@@ -6444,12 +6451,61 @@ test('turning tracking off puts a handoff registered while it was on out of Clos
   }
 })
 
-// The other half of that reconcile, and the reason it MARKS the handoff rather
-// than deleting it. Deleting was right while the kill paths were this registry's
-// only consumers; #782 added the profile switch, which wants the opposite. A
-// forgotten handoff is out of the switch's reach too, so leaving the profile
-// could no longer cancel a prompt whose approval starts an app for a profile the
-// user is no longer on (Codex P2 on #842).
+// Tracking is read LIVE at cancellation, so it works in both directions. Two
+// earlier attempts to keep it as stored state on the handoff failed the other
+// way round: deleting the entry hid it from the profile-switch consumer, and
+// marking `tracked = false` was a one-way door, because the untracked reconcile
+// only ever receives the untracked set and so never restored the flag when the
+// user turned tracking back on (Codex P2 on #842). Close Apps then ignored the
+// handoff for the rest of its life even though the profile was managed again.
+test('turning tracking back on brings a handoff into Close Apps reach again (#842)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+      id: 'default',
+      name: 'Default'
+    }
+    const { launchProfileApps, killLaunchedApps, getRunningApps } =
+      await loadProcessModulesWithStore({
+        appPaths: { customapp1: 'C:/Tools/Admin Tool.exe' },
+        gamePaths: { ac: 'C:/Games/Race.exe' },
+        profiles: { ac: { activeProfileId: 'default', profiles: [profile] } }
+      })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // Off, reconciled, then back on and reconciled again, all while the consent
+    // prompt is still unanswered.
+    profile.trackingEnabled = false
+    await getRunningApps()
+    profile.trackingEnabled = true
+    await getRunningApps()
+
+    const killPromise = killLaunchedApps()
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await killPromise
+
+    // Managed again, so Close Apps closes it and says the prompt is dead.
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The switch consumer is unaffected by any of that: it cancels a handoff for a
+// profile the user is leaving whether or not that profile is managed (Codex P2
+// on #842).
 test('a handoff hidden from Close Apps is still cancellable by a profile switch (#842)', async () => {
   vi.useFakeTimers()
   try {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -632,6 +632,7 @@ async function loadProcessModules() {
     unregisterActiveLaunch: stateModule.unregisterActiveLaunch,
     abortActiveLaunches: stateModule.abortActiveLaunches,
     processNameMismatchWarnings: stateModule.processNameMismatchWarnings,
+    cancelPendingElevatedHandoffs: stateModule.cancelPendingElevatedHandoffs,
     suppressedProcessNameMismatchWarnings: stateModule.suppressedProcessNameMismatchWarnings,
     runningProcesses: stateModule.runningProcesses,
     unclosedProcesses: stateModule.unclosedProcesses,
@@ -2550,6 +2551,36 @@ test('a profile switch that cancels a pending handoff explains the stranded prom
 
     expect(elevatedHostKills).toHaveLength(1)
     expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// Pins that the registration itself records the slot. Everything else about slot
+// scoping is asserted against synthetic registry entries, so dropping `appKey`
+// at the one place it is written left all of it green (CodeRabbit on #782).
+test('a pending handoff records which slot it belongs to (#782)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, cancelPendingElevatedHandoffs } = await loadProcessModulesWithStore({
+      appPaths: { customapp1: 'C:/Tools/Admin Tool.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // A predicate that only the right slot satisfies. If the key were not
+    // recorded this matches nothing and no host is killed.
+    cancelPendingElevatedHandoffs('ac', (handoff) => handoff.appKey === 'customapp1')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(1)
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -2542,14 +2542,49 @@ test('a profile switch that cancels a pending handoff explains the stranded prom
     await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
     await launchPromise
 
-    // The switch stops the outgoing profile's apps, not the elevated one whose
-    // prompt is still up. The handoff is cancelled by gameKey either way, so
-    // the count must survive a kill that targets something else entirely.
-    const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+    // The elevated app is among the paths this kill is stopping, which is what
+    // brings its handoff into scope (#782). It is not running, and that is the
+    // point: a pending handoff never is.
+    const result = await killProfileApps('ac', ['C:/Tools/Admin Tool.exe', 'C:/Tools/App2.exe'])
     await vi.advanceTimersByTimeAsync(0)
 
     expect(elevatedHostKills).toHaveLength(1)
     expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The other half of #782, and the half nothing had ever asserted. The scope used
+// to be the whole game, so ANY switch that stopped ANYTHING took every pending
+// handoff with it, including one for an app the incoming profile also enables.
+// The user loses a permission prompt they were about to approve, and it is
+// counted against them as a stranded prompt on top.
+test('a kill does not cancel a handoff for an app it is not stopping (#782)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // Same game, and deliberately NOT the elevated app's path.
+    const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(0)
+    // Nothing was stranded, because nothing was killed. Reporting a prompt here
+    // would tell the user to dismiss a dialog that is still doing its job.
+    expect(result.strandedConsentPrompts).toBeUndefined()
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -6228,7 +6228,7 @@ test('turning tracking off forgets apps already recorded under it (#591)', async
 // PowerShell host of an app the user opted out of us managing. The late
 // approval would then start nothing, and they would be told a consent prompt
 // was stranded by a profile SimLauncher promised not to touch.
-test('a tracking-off profile does not register its elevated handoff for Close Apps (#591)', async () => {
+test('a tracking-off profile keeps its elevated handoff answerable through Close Apps (#591)', async () => {
   vi.useFakeTimers()
   try {
     markExistingPath('C:/Tools/Admin Tool.exe')
@@ -6274,7 +6274,7 @@ test('a tracking-off profile does not register its elevated handoff for Close Ap
 
 // The same fixture with tracking left ON, so the test above cannot pass because
 // the handoff never reached the grace window in the first place.
-test('a tracked profile still registers its elevated handoff for Close Apps (#591)', async () => {
+test('a tracked profile has its elevated handoff cancelled by Close Apps (#591)', async () => {
   vi.useFakeTimers()
   try {
     markExistingPath('C:/Tools/Admin Tool.exe')
@@ -6357,7 +6357,7 @@ test('the same holds when spawn throws elevation synchronously (#591)', async ()
 
 // And the positive control for that branch, which also pins that the throw
 // fixture reaches the elevation path at all rather than failing the launch.
-test('a tracked profile registers it on the synchronous-throw branch too (#591)', async () => {
+test('a tracked profile is cancelled on the synchronous-throw branch too (#591)', async () => {
   vi.useFakeTimers()
   try {
     markExistingPath('C:/Tools/Admin Tool.exe')
@@ -6398,7 +6398,7 @@ test('a tracked profile registers it on the synchronous-throw branch too (#591)'
 // registry predates the toggle entirely, so only the reconcile pass can reach
 // it (Codex on #834). Left behind, a later Close Apps still kills its host and
 // strands the prompt of a profile that is now fire-and-forget.
-test('turning tracking off forgets a handoff registered while it was on (#591)', async () => {
+test('turning tracking off puts a handoff registered while it was on out of Close Apps reach (#591)', async () => {
   vi.useFakeTimers()
   try {
     markExistingPath('C:/Tools/Admin Tool.exe')
@@ -6435,10 +6435,142 @@ test('turning tracking off forgets a handoff registered while it was on (#591)',
     await vi.advanceTimersByTimeAsync(0)
     const result = await killPromise
 
-    // Forgotten, not cancelled: the host is alive, so the prompt is still
+    // Out of reach, not cancelled: the host is alive, so the prompt is still
     // answerable, and nothing is reported as stranded.
     expect(elevatedHostKills).toHaveLength(0)
     expect(result.strandedConsentPrompts).toBeUndefined()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The other half of that reconcile, and the reason it MARKS the handoff rather
+// than deleting it. Deleting was right while the kill paths were this registry's
+// only consumers; #782 added the profile switch, which wants the opposite. A
+// forgotten handoff is out of the switch's reach too, so leaving the profile
+// could no longer cancel a prompt whose approval starts an app for a profile the
+// user is no longer on (Codex P2 on #842).
+test('a handoff hidden from Close Apps is still cancellable by a profile switch (#842)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const profile: { id: string; name: string; trackingEnabled?: boolean } = {
+      id: 'default',
+      name: 'Default'
+    }
+    const { launchProfileApps, killProfileApps, getRunningApps } =
+      await loadProcessModulesWithStore({
+        appPaths: { customapp1: 'C:/Tools/Admin Tool.exe' },
+        gamePaths: { ac: 'C:/Games/Race.exe' },
+        profiles: { ac: { activeProfileId: 'default', profiles: [profile] } }
+      })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // Tracking goes off, and the publish reconciles against it. Under the old
+    // delete-based reconcile the handoff would be gone from here on.
+    profile.trackingEnabled = false
+    await getRunningApps()
+
+    const result = await killProfileApps('ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// A profile that was fire-and-forget from the START, which used never to be
+// registered at all. Leaving the profile has to cancel it for the same reason:
+// approving the prompt afterwards starts an app for a profile the user left.
+// Fire-and-forget is a promise not to CLOSE running apps, not a promise to keep
+// launching them for profiles that are gone (Codex P2 on #842).
+test('a switch cancels a fire-and-forget profile pending handoff (#842)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Games/Race.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { customapp1: 'C:/Tools/Admin Tool.exe' },
+      gamePaths: { ac: 'C:/Games/Race.exe' },
+      profiles: {
+        ac: {
+          activeProfileId: 'quiet',
+          profiles: [{ id: 'quiet', name: 'Quiet', trackingEnabled: false }]
+        }
+      }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    const result = await killProfileApps('ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// Fix 2: the registry records the path AS LAUNCHED, while a caller's entries are
+// rebuilt from the CURRENT `appPaths`. Editing that slot's exe in Settings while
+// its prompt is unanswered makes the two disagree, and a `key + path` match then
+// misses the handoff entirely, so approving it starts the FORMER executable for
+// a profile the user has left (Codex P2 on #842). The slot key does not move.
+test('a slot whose exe changed after launch is still cancelled by its key (#842)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/Replacement.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const appPaths: Record<string, string> = { customapp1: 'C:/Tools/Admin Tool.exe' }
+    const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({ appPaths })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', [
+      { key: 'customapp1', path: 'C:/Tools/Admin Tool.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // What editing the slot's path in Settings does to the store. The registry
+    // still holds 'Admin Tool.exe'; every entry built from here on says
+    // 'Replacement.exe'.
+    appPaths.customapp1 = 'C:/Tools/Replacement.exe'
+
+    const result = await killProfileApps('ac', [
+      { key: 'customapp1', path: 'C:/Tools/Replacement.exe' }
+    ])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(result.strandedConsentPrompts).toBe(1)
   } finally {
     vi.useRealTimers()
   }

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -185,6 +185,27 @@ function makeAccessDeniedError() {
   return error
 }
 
+/**
+ * Turns the paths a test wants stopped into the `{key, path}` entries
+ * `killProfileApps` now takes (#842).
+ *
+ * The key is looked up in the SAME `appPaths` fixture the harness serves to the
+ * code under test, rather than invented per call site. That matters: the kill's
+ * handoff cancellation matches by slot, so a made-up key would make every
+ * slot-scoping assertion pass without proving anything. A path with no
+ * configured slot (an unknown exe, the game itself) keeps the empty key, which
+ * is what production would carry for something that is not a utility slot.
+ */
+function killEntries(...appPaths: string[]): { key: string; path: string }[] {
+  const configured = Object.entries(storeData.appPaths ?? {})
+  return appPaths.map((appPath) => {
+    const match = configured.find(
+      ([, configuredPath]) => configuredPath.toLowerCase() === appPath.toLowerCase()
+    )
+    return { key: match?.[0] ?? '', path: appPath }
+  })
+}
+
 async function loadProcessModules() {
   vi.resetModules()
 
@@ -546,6 +567,12 @@ async function loadProcessModules() {
   vi.doMock('../../src/main/store.js', () => storeModuleMock)
 
   const profilesMock = {
+    // Re-implemented because this suite mocks the module that owns it, which
+    // makes it a COPY: the tests below prove `kill.ts` is wired to an identity
+    // function, not that the identity rule is right. The rule itself is pinned
+    // against the real module in profiles.test.ts.
+    getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
+      `${entry.key} ${entry.path.toLowerCase().replace(/\\/g, '/')}`,
     getActiveStoredProfile: vi.fn((p: { activeProfileId: string; profiles: { id: string }[] }) =>
       p.profiles.find((i) => i.id === p.activeProfileId)
     ),
@@ -2515,7 +2542,7 @@ test('a profile switch never runs the graceful phase, toggle or not (#659)', asy
     appPaths: { customapp2: 'C:/Tools/App2.exe' }
   })
 
-  const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+  const result = await killProfileApps('ac', killEntries('C:/Tools/App2.exe'))
 
   expect(gracefulRequests()).toHaveLength(0)
   expect(result.closedCount).toBe(1)
@@ -2546,11 +2573,58 @@ test('a profile switch that cancels a pending handoff explains the stranded prom
     // The elevated app is among the paths this kill is stopping, which is what
     // brings its handoff into scope (#782). It is not running, and that is the
     // point: a pending handoff never is.
-    const result = await killProfileApps('ac', ['C:/Tools/Admin Tool.exe', 'C:/Tools/App2.exe'])
+    const result = await killProfileApps(
+      'ac',
+      killEntries('C:/Tools/Admin Tool.exe', 'C:/Tools/App2.exe')
+    )
     await vi.advanceTimersByTimeAsync(0)
 
     expect(elevatedHostKills).toHaveLength(1)
     expect(result.strandedConsentPrompts).toBe(1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+// The kill-side mirror of the over-cancel #782 removes from the save side. Two
+// slots on one exe (#357): the switch stops the LEAVING slot, whose instance is
+// running, while the RETAINED slot has an unanswered prompt. Matching the
+// handoff registry by path cannot tell them apart, so it kills the prompt for
+// the app that is staying, and approving it then starts nothing (Codex P2 on
+// #842). Both directions are asserted here because a predicate that cancels
+// nothing at all would satisfy the first half on its own.
+test('a kill stops a shared exe without cancelling the retained slot prompt (#842)', async () => {
+  vi.useFakeTimers()
+  try {
+    const shared = 'C:/Tools/Shared Utility.exe'
+    markExistingPath(shared)
+    spawnErrors.set(shared, makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, killProfileApps } = await loadProcessModulesWithStore({
+      appPaths: { customapp1: shared, customapp2: shared }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    // The prompt belongs to customapp1, the slot the incoming profile keeps.
+    const launchPromise = launchProfileApps(sender, 'ac', [{ key: 'customapp1', path: shared }])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // Stopping customapp2, the slot that is leaving. Same executable.
+    const leaving = await killProfileApps('ac', [{ key: 'customapp2', path: shared }])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(0)
+    expect(leaving.strandedConsentPrompts).toBeUndefined()
+
+    // ...and the prompt is still cancellable by the slot that actually owns it,
+    // so the predicate discriminates rather than simply never matching.
+    const retained = await killProfileApps('ac', [{ key: 'customapp1', path: shared }])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(elevatedHostKills).toHaveLength(1)
+    expect(retained.strandedConsentPrompts).toBe(1)
   } finally {
     vi.useRealTimers()
   }
@@ -2609,7 +2683,7 @@ test('a kill does not cancel a handoff for an app it is not stopping (#782)', as
     await launchPromise
 
     // Same game, and deliberately NOT the elevated app's path.
-    const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+    const result = await killProfileApps('ac', killEntries('C:/Tools/App2.exe'))
     await vi.advanceTimersByTimeAsync(0)
 
     expect(elevatedHostKills).toHaveLength(0)
@@ -2630,7 +2704,7 @@ test('an ordinary profile switch with no pending handoff says nothing about a pr
     appPaths: { customapp2: 'C:/Tools/App2.exe' }
   })
 
-  const result = await killProfileApps('ac', ['C:/Tools/App2.exe'])
+  const result = await killProfileApps('ac', killEntries('C:/Tools/App2.exe'))
 
   expect(result.strandedConsentPrompts).toBeUndefined()
 })
@@ -2918,7 +2992,7 @@ test('killProfileApps rejects paths that are not configured app paths', async ()
   markExistingPath('C:/Tools/Unknown.exe')
   storeData.appPaths = { simhub: 'C:/Tools/SimHub.exe' }
 
-  await expect(killProfileApps('ac', ['C:/Tools/Unknown.exe'])).resolves.toEqual({
+  await expect(killProfileApps('ac', killEntries('C:/Tools/Unknown.exe'))).resolves.toEqual({
     success: false,
     error: 'Kill request includes an app path that is not configured.',
     closedCount: 0,
@@ -2935,7 +3009,7 @@ test('killProfileApps targets configured untracked Windows apps by resolved PID 
     appPaths: { simhub: 'C:/Tools/SimHub.exe' }
   })
 
-  await expect(killProfileApps('ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+  await expect(killProfileApps('ac', killEntries('C:/Tools/SimHub.exe'))).resolves.toMatchObject({
     success: true,
     closedCount: 1,
     failedCount: 0
@@ -2973,7 +3047,7 @@ test('PID lookup injects the name via env and matches it in PowerShell, not WQL 
     appPaths: { simhub: quotedPath }
   })
 
-  await killProfileApps('ac', [quotedPath])
+  await killProfileApps('ac', killEntries(quotedPath))
 
   const psCall = execFileCalls.find(
     (call) =>
@@ -3011,7 +3085,7 @@ test('killProfileApps only kills the PID matching the requested executable path 
     appPaths: { simhub: 'C:/Tools/SimHub.exe', other: 'D:/Other/SimHub.exe' }
   })
 
-  await expect(killProfileApps('ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+  await expect(killProfileApps('ac', killEntries('C:/Tools/SimHub.exe'))).resolves.toMatchObject({
     success: true,
     closedCount: 1,
     failedCount: 0
@@ -3044,7 +3118,7 @@ test('killProfileApps excludes processes with null executable paths when resolvi
     appPaths: { simhub: 'C:/Tools/SimHub.exe' }
   })
 
-  await expect(killProfileApps('ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+  await expect(killProfileApps('ac', killEntries('C:/Tools/SimHub.exe'))).resolves.toMatchObject({
     success: true,
     closedCount: 1,
     failedCount: 0
@@ -3092,7 +3166,7 @@ test('killProfileApps publishes promptly when untracked app remains elevated aft
   await subscribeRunningApps(asWebContents(webContents))
   webContents.send.mockClear()
 
-  await expect(killProfileApps('ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+  await expect(killProfileApps('ac', killEntries('C:/Tools/SimHub.exe'))).resolves.toMatchObject({
     success: false,
     closedCount: 0,
     failedCount: 1,
@@ -3988,7 +4062,9 @@ test('killProfileApps skips game executable paths without issuing kill commands'
   })
   processNames.add('assettocorsa.exe')
 
-  await expect(killProfileApps('ac', ['C:/Games/AssettoCorsa.exe'])).resolves.toMatchObject({
+  await expect(
+    killProfileApps('ac', killEntries('C:/Games/AssettoCorsa.exe'))
+  ).resolves.toMatchObject({
     success: true,
     closedCount: 0,
     failedCount: 0
@@ -4025,7 +4101,7 @@ test('killProfileApps clears previous unclosed and running state after successfu
     elevated: true
   })
 
-  await expect(killProfileApps('ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+  await expect(killProfileApps('ac', killEntries('C:/Tools/SimHub.exe'))).resolves.toMatchObject({
     success: true,
     closedCount: 1,
     failedCount: 0
@@ -4067,7 +4143,7 @@ test('killProfileApps suppresses wrapper warnings for SimLauncher-initiated prof
   childHandlers.get('spawn')?.()
   await launchPromise
 
-  const killPromise = killProfileApps('ac', ['C:/Tools/Cheat Engine.exe'])
+  const killPromise = killProfileApps('ac', killEntries('C:/Tools/Cheat Engine.exe'))
   processNames.delete('cheat engine.exe')
   childHandlers.get('exit')?.()
 
@@ -4336,7 +4412,7 @@ test('killProfileApps mid-sequence also cancels the launch loop before remaining
   const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/App1.exe', 'C:/Tools/App2.exe'])
   await flushMicrotasks()
 
-  await killProfileApps('ac', ['C:/Tools/App1.exe'])
+  await killProfileApps('ac', killEntries('C:/Tools/App1.exe'))
   const launchResult = await launchPromise
 
   expect(spawnCalls.map((call) => call.appPath)).toEqual(['C:/Tools/App1.exe'])
@@ -4433,7 +4509,7 @@ test('killProfileApps aborts the launch before waiting on its tasklist scan (#67
   let releaseTasklistRead: () => void = () => {}
   tasklistReadBlocker = new Promise((resolve) => (releaseTasklistRead = resolve))
 
-  const killPromise = killProfileApps('ac', ['C:/Tools/App1.exe'])
+  const killPromise = killProfileApps('ac', killEntries('C:/Tools/App1.exe'))
   // The abort fired in killProfileApps' synchronous prefix, so the launch
   // resolves cancelled even though the kill is still stuck in its scan.
   await expect(launchPromise).resolves.toMatchObject({ cancelled: true, launchedCount: 1 })

--- a/tests/main/profiles.test.ts
+++ b/tests/main/profiles.test.ts
@@ -29,6 +29,7 @@ import {
   buildActiveProfileLaunchEntries,
   buildNamedProfileLaunchEntries,
   getActiveStoredProfile,
+  getProfileLaunchEntryId,
   getProfileTrackablePaths,
   resolveActiveProfile,
   type StoredProfileEntry
@@ -236,4 +237,25 @@ test('getActiveProfileForGame resolves the active member of a profile set (#591)
 
   expect(getActiveProfileForGame('ac')).toMatchObject({ id: 'race', trackingEnabled: true })
   expect(getActiveProfileForGame('unknown')).toBeUndefined()
+})
+
+// Moved here from launch.test.ts when the helper moved out of ipc/launch.ts
+// (#782). That suite mocks this module, so its copy was answering: these have to
+// run against the real implementation to mean anything.
+test('getProfileLaunchEntryId distinguishes utility slots that share an executable path', () => {
+  // Two custom-app slots configured with the same .exe but different keys (e.g.
+  // one carries `--mode debug`, the other `--mode silent`). Everything that
+  // diffs two profiles has to treat these as different entries, or a slot swap
+  // neither stops nor relaunches, and a leaving slot's pending UAC handoff is
+  // read as retained (regression for #397, follow-up to #357, reused by #782).
+  const slot1 = { key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' }
+  const slot2 = { key: 'customapp2', path: 'C:/Tools/Shared Utility.exe' }
+
+  expect(getProfileLaunchEntryId(slot1)).not.toBe(getProfileLaunchEntryId(slot2))
+})
+
+test('getProfileLaunchEntryId is case-insensitive for the executable path', () => {
+  expect(getProfileLaunchEntryId({ key: 'customapp1', path: 'C:/Tools/Shared Utility.exe' })).toBe(
+    getProfileLaunchEntryId({ key: 'customapp1', path: 'c:/Tools/shared utility.exe' })
+  )
 })

--- a/tests/renderer/announcer.test.tsx
+++ b/tests/renderer/announcer.test.tsx
@@ -25,12 +25,13 @@ beforeAll(() => {
   Element.prototype.animate = vi.fn(() => ({ cancel: vi.fn() })) as never
 })
 
-// Notify subscribes to two main-process push channels at mount. Stub the
+// Notify subscribes to three main-process push channels at mount. Stub the
 // electron bridge so the module doesn't touch window.electronAPI (undefined in
 // jsdom); each subscriber just returns its no-op unsubscribe.
 vi.mock('../../src/renderer/src/lib/electron', () => ({
   onAppLaunchError: () => () => {},
-  onProcessNameMismatchWarning: () => () => {}
+  onProcessNameMismatchWarning: () => () => {},
+  onStrandedConsentPrompts: () => () => {}
 }))
 
 import { NotifyProvider, useNotify } from '../../src/renderer/src/components/Notify'

--- a/tests/renderer/gameListShellFetchSkip.test.tsx
+++ b/tests/renderer/gameListShellFetchSkip.test.tsx
@@ -25,7 +25,8 @@ vi.mock('../../src/renderer/src/lib/electron', () => ({
   getFileIcon: (...args: unknown[]) => getFileIconMock(...args),
   // Consumed by NotifyProvider; inert subscriptions are enough here.
   onAppLaunchError: () => () => {},
-  onProcessNameMismatchWarning: () => () => {}
+  onProcessNameMismatchWarning: () => () => {},
+  onStrandedConsentPrompts: () => () => {}
 }))
 
 // GameList only consumes { runningApps, runningStatus, refreshRunningState }.

--- a/tests/renderer/gameRowBlockedActions.test.tsx
+++ b/tests/renderer/gameRowBlockedActions.test.tsx
@@ -65,7 +65,10 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(activeProfileSet),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(activeProfileSet),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Resolves to an object, not undefined: the real hook always returns a
+    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
+    // (#782). A mock resolving to undefined would make every switch throw.
+    saveProfileSet: vi.fn().mockResolvedValue({})
   })
 }))
 

--- a/tests/renderer/gameRowBlockedActions.test.tsx
+++ b/tests/renderer/gameRowBlockedActions.test.tsx
@@ -65,10 +65,12 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(activeProfileSet),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(activeProfileSet),
-    // Resolves to an object, not undefined: the real hook always returns a
-    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
-    // (#782). A mock resolving to undefined would make every switch throw.
-    saveProfileSet: vi.fn().mockResolvedValue({})
+    // `Promise<void>`, matching the hook. It briefly returned a stranded-prompt
+    // count for GameRow to read, until that count moved to a push from main so
+    // that no caller could drop it by not reading it (#782). Resolving to
+    // anything else here would let a future GameRow start depending on a value
+    // the real hook does not produce.
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
   })
 }))
 

--- a/tests/renderer/gameRowLaunchAnnounce.test.tsx
+++ b/tests/renderer/gameRowLaunchAnnounce.test.tsx
@@ -70,7 +70,10 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Resolves to an object, not undefined: the real hook always returns a
+    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
+    // (#782). A mock resolving to undefined would make every switch throw.
+    saveProfileSet: vi.fn().mockResolvedValue({})
   })
 }))
 

--- a/tests/renderer/gameRowLaunchAnnounce.test.tsx
+++ b/tests/renderer/gameRowLaunchAnnounce.test.tsx
@@ -70,10 +70,12 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    // Resolves to an object, not undefined: the real hook always returns a
-    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
-    // (#782). A mock resolving to undefined would make every switch throw.
-    saveProfileSet: vi.fn().mockResolvedValue({})
+    // `Promise<void>`, matching the hook. It briefly returned a stranded-prompt
+    // count for GameRow to read, until that count moved to a push from main so
+    // that no caller could drop it by not reading it (#782). Resolving to
+    // anything else here would let a future GameRow start depending on a value
+    // the real hook does not produce.
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
   })
 }))
 

--- a/tests/renderer/gameRowLaunchCancelled.test.tsx
+++ b/tests/renderer/gameRowLaunchCancelled.test.tsx
@@ -60,7 +60,10 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Resolves to an object, not undefined: the real hook always returns a
+    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
+    // (#782). A mock resolving to undefined would make every switch throw.
+    saveProfileSet: vi.fn().mockResolvedValue({})
   })
 }))
 

--- a/tests/renderer/gameRowLaunchCancelled.test.tsx
+++ b/tests/renderer/gameRowLaunchCancelled.test.tsx
@@ -60,10 +60,12 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    // Resolves to an object, not undefined: the real hook always returns a
-    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
-    // (#782). A mock resolving to undefined would make every switch throw.
-    saveProfileSet: vi.fn().mockResolvedValue({})
+    // `Promise<void>`, matching the hook. It briefly returned a stranded-prompt
+    // count for GameRow to read, until that count moved to a push from main so
+    // that no caller could drop it by not reading it (#782). Resolving to
+    // anything else here would let a future GameRow start depending on a value
+    // the real hook does not produce.
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
   })
 }))
 

--- a/tests/renderer/gameRowLaunchLabel.test.tsx
+++ b/tests/renderer/gameRowLaunchLabel.test.tsx
@@ -58,10 +58,12 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(activeProfileSet),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(activeProfileSet),
-    // Resolves to an object, not undefined: the real hook always returns a
-    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
-    // (#782). A mock resolving to undefined would make every switch throw.
-    saveProfileSet: vi.fn().mockResolvedValue({})
+    // `Promise<void>`, matching the hook. It briefly returned a stranded-prompt
+    // count for GameRow to read, until that count moved to a push from main so
+    // that no caller could drop it by not reading it (#782). Resolving to
+    // anything else here would let a future GameRow start depending on a value
+    // the real hook does not produce.
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
   })
 }))
 

--- a/tests/renderer/gameRowLaunchLabel.test.tsx
+++ b/tests/renderer/gameRowLaunchLabel.test.tsx
@@ -58,7 +58,10 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(activeProfileSet),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(activeProfileSet),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Resolves to an object, not undefined: the real hook always returns a
+    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
+    // (#782). A mock resolving to undefined would make every switch throw.
+    saveProfileSet: vi.fn().mockResolvedValue({})
   })
 }))
 

--- a/tests/renderer/gameRowLaunchSkipped.test.tsx
+++ b/tests/renderer/gameRowLaunchSkipped.test.tsx
@@ -58,10 +58,12 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    // Resolves to an object, not undefined: the real hook always returns a
-    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
-    // (#782). A mock resolving to undefined would make every switch throw.
-    saveProfileSet: vi.fn().mockResolvedValue({})
+    // `Promise<void>`, matching the hook. It briefly returned a stranded-prompt
+    // count for GameRow to read, until that count moved to a push from main so
+    // that no caller could drop it by not reading it (#782). Resolving to
+    // anything else here would let a future GameRow start depending on a value
+    // the real hook does not produce.
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
   })
 }))
 

--- a/tests/renderer/gameRowLaunchSkipped.test.tsx
+++ b/tests/renderer/gameRowLaunchSkipped.test.tsx
@@ -58,7 +58,10 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Resolves to an object, not undefined: the real hook always returns a
+    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
+    // (#782). A mock resolving to undefined would make every switch throw.
+    saveProfileSet: vi.fn().mockResolvedValue({})
   })
 }))
 

--- a/tests/renderer/gameRowStatusDismiss.test.tsx
+++ b/tests/renderer/gameRowStatusDismiss.test.tsx
@@ -61,10 +61,12 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    // Resolves to an object, not undefined: the real hook always returns a
-    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
-    // (#782). A mock resolving to undefined would make every switch throw.
-    saveProfileSet: vi.fn().mockResolvedValue({})
+    // `Promise<void>`, matching the hook. It briefly returned a stranded-prompt
+    // count for GameRow to read, until that count moved to a push from main so
+    // that no caller could drop it by not reading it (#782). Resolving to
+    // anything else here would let a future GameRow start depending on a value
+    // the real hook does not produce.
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
   })
 }))
 

--- a/tests/renderer/gameRowStatusDismiss.test.tsx
+++ b/tests/renderer/gameRowStatusDismiss.test.tsx
@@ -61,7 +61,10 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Resolves to an object, not undefined: the real hook always returns a
+    // SaveProfileSetResult and GameRow reads the stranded-prompt count off it
+    // (#782). A mock resolving to undefined would make every switch throw.
+    saveProfileSet: vi.fn().mockResolvedValue({})
   })
 }))
 

--- a/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
+++ b/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
@@ -22,6 +22,7 @@ const notifyMock = vi.fn()
 const killLaunchedAppsMock = vi.fn()
 const switchProfileAppsMock = vi.fn()
 const getProfileSwitchDiffMock = vi.fn()
+const saveProfileSetMock = vi.fn()
 
 vi.mock('../../src/renderer/src/lib/electron', () => ({
   launchProfile: vi.fn(),
@@ -72,7 +73,11 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+    // Hoisted so a test can control what the save reports back. The real hook
+    // always resolves to a SaveProfileSetResult and GameRow reads the
+    // stranded-prompt count off it (#782), so resolving to undefined here would
+    // make every switch throw.
+    saveProfileSet: saveProfileSetMock
   })
 }))
 
@@ -180,6 +185,28 @@ async function switchToProfile(name: string): Promise<void> {
   })
 }
 
+/**
+ * The same first step without the confirmation, for the switch that has nothing
+ * to stop or start. GameRow only stages a confirm dialog when the diff is
+ * non-empty, so waiting for one here would fail on the very path being tested.
+ */
+async function switchToProfileWithoutConfirm(name: string): Promise<void> {
+  const option = Array.from(container.querySelectorAll('button[role="menuitemradio"]')).find(
+    (button) => button.textContent?.includes(name)
+  ) as HTMLButtonElement | undefined
+  expect(option).toBeDefined()
+  await act(async () => {
+    option!.click()
+  })
+
+  // Pins the precondition rather than assuming it: if a dialog DID appear, the
+  // test below would be asserting on a switch that never ran.
+  const confirm = Array.from(document.body.querySelectorAll('button')).find(
+    (button) => button.textContent?.trim() === 'Switch Profile'
+  )
+  expect(confirm).toBeUndefined()
+}
+
 /** Everything the toast said, across however many notify() calls. */
 function allToastText(): string {
   return notifyMock.mock.calls.map((call) => String(call[0])).join(' | ')
@@ -191,6 +218,8 @@ beforeEach(() => {
   killLaunchedAppsMock.mockReset()
   switchProfileAppsMock.mockReset()
   getProfileSwitchDiffMock.mockReset()
+  saveProfileSetMock.mockReset()
+  saveProfileSetMock.mockResolvedValue({})
   // Non-zero counts are what make the switch prompt for confirmation rather
   // than silently doing nothing.
   getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 1, toStartCount: 1 })
@@ -365,6 +394,44 @@ describe('profile switch stranded consent prompt toast (#809)', () => {
     expect(allToastText()).not.toContain('Switched to Race')
     // Warned switches are shown as a warning, not as a success.
     expect(notifyMock.mock.calls.some((call) => call[1] === 'warn')).toBe(true)
+  })
+
+  // The case with no other chance to speak, and the reason #782 puts the cancel
+  // on the save rather than on `switch-profile-apps`. A pending handoff adds
+  // nothing to the switch diff, so the renderer skips that IPC entirely and the
+  // save is the only thing that runs. Without the note folded in here, the user
+  // gets a plain "Switched to Race" while a dead consent dialog sits on screen.
+  test('a switch that never reaches switchProfileApps still explains the prompt', async () => {
+    getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 0, toStartCount: 0 })
+    saveProfileSetMock.mockResolvedValue({ strandedConsentPrompts: 1 })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+    await switchToProfileWithoutConfirm('Race')
+
+    expect(switchProfileAppsMock).not.toHaveBeenCalled()
+    expect(allToastText()).toContain(SINGULAR)
+    expect(notifyMock.mock.calls.some((call) => call[1] === 'warn')).toBe(true)
+  })
+
+  // Both halves can report on one switch: the kill strands prompts for what it
+  // stopped, the save strands one for a leaving app that was never running. The
+  // notes must accumulate rather than one replacing the other.
+  test('a switch reports prompts stranded by the kill AND by the save', async () => {
+    switchProfileAppsMock.mockResolvedValue({
+      success: true,
+      launchedCount: 1,
+      skippedCount: 0,
+      strandedConsentPrompts: 2
+    })
+    saveProfileSetMock.mockResolvedValue({ strandedConsentPrompts: 1 })
+
+    profileMenuOpen = true
+    await renderRunningRow()
+    await switchToProfile('Race')
+
+    expect(allToastText()).toContain(PLURAL)
+    expect(allToastText()).toContain(SINGULAR)
   })
 
   test('an ordinary switch says nothing about a prompt', async () => {

--- a/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
+++ b/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
@@ -193,7 +193,9 @@ beforeEach(() => {
   switchProfileAppsMock.mockReset()
   getProfileSwitchDiffMock.mockReset()
   saveProfileSetMock.mockReset()
-  saveProfileSetMock.mockResolvedValue({})
+  // `Promise<void>`, matching the hook. The stranded-prompt count is pushed from
+  // main now, not returned from here (#782).
+  saveProfileSetMock.mockResolvedValue(undefined)
   // Non-zero counts are what make the switch prompt for confirmation rather
   // than silently doing nothing.
   getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 1, toStartCount: 1 })

--- a/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
+++ b/tests/renderer/gameRowStrandedConsentPrompt.test.tsx
@@ -73,10 +73,6 @@ vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
     getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
-    // Hoisted so a test can control what the save reports back. The real hook
-    // always resolves to a SaveProfileSetResult and GameRow reads the
-    // stranded-prompt count off it (#782), so resolving to undefined here would
-    // make every switch throw.
     saveProfileSet: saveProfileSetMock
   })
 }))
@@ -183,28 +179,6 @@ async function switchToProfile(name: string): Promise<void> {
   await act(async () => {
     confirm!.click()
   })
-}
-
-/**
- * The same first step without the confirmation, for the switch that has nothing
- * to stop or start. GameRow only stages a confirm dialog when the diff is
- * non-empty, so waiting for one here would fail on the very path being tested.
- */
-async function switchToProfileWithoutConfirm(name: string): Promise<void> {
-  const option = Array.from(container.querySelectorAll('button[role="menuitemradio"]')).find(
-    (button) => button.textContent?.includes(name)
-  ) as HTMLButtonElement | undefined
-  expect(option).toBeDefined()
-  await act(async () => {
-    option!.click()
-  })
-
-  // Pins the precondition rather than assuming it: if a dialog DID appear, the
-  // test below would be asserting on a switch that never ran.
-  const confirm = Array.from(document.body.querySelectorAll('button')).find(
-    (button) => button.textContent?.trim() === 'Switch Profile'
-  )
-  expect(confirm).toBeUndefined()
 }
 
 /** Everything the toast said, across however many notify() calls. */
@@ -396,43 +370,13 @@ describe('profile switch stranded consent prompt toast (#809)', () => {
     expect(notifyMock.mock.calls.some((call) => call[1] === 'warn')).toBe(true)
   })
 
-  // The case with no other chance to speak, and the reason #782 puts the cancel
-  // on the save rather than on `switch-profile-apps`. A pending handoff adds
-  // nothing to the switch diff, so the renderer skips that IPC entirely and the
-  // save is the only thing that runs. Without the note folded in here, the user
-  // gets a plain "Switched to Race" while a dead consent dialog sits on screen.
-  test('a switch that never reaches switchProfileApps still explains the prompt', async () => {
-    getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 0, toStartCount: 0 })
-    saveProfileSetMock.mockResolvedValue({ strandedConsentPrompts: 1 })
-
-    profileMenuOpen = true
-    await renderRunningRow()
-    await switchToProfileWithoutConfirm('Race')
-
-    expect(switchProfileAppsMock).not.toHaveBeenCalled()
-    expect(allToastText()).toContain(SINGULAR)
-    expect(notifyMock.mock.calls.some((call) => call[1] === 'warn')).toBe(true)
-  })
-
-  // Both halves can report on one switch: the kill strands prompts for what it
-  // stopped, the save strands one for a leaving app that was never running. The
-  // notes must accumulate rather than one replacing the other.
-  test('a switch reports prompts stranded by the kill AND by the save', async () => {
-    switchProfileAppsMock.mockResolvedValue({
-      success: true,
-      launchedCount: 1,
-      skippedCount: 0,
-      strandedConsentPrompts: 2
-    })
-    saveProfileSetMock.mockResolvedValue({ strandedConsentPrompts: 1 })
-
-    profileMenuOpen = true
-    await renderRunningRow()
-    await switchToProfile('Race')
-
-    expect(allToastText()).toContain(PLURAL)
-    expect(allToastText()).toContain(SINGULAR)
-  })
+  // A switch that skips `switchProfileApps` entirely (empty diff) can still
+  // strand a prompt, because the save is what cancels the outgoing profile's
+  // pending handoff. That case is NOT tested here any more: the count no longer
+  // comes back through `saveProfileSet` for this row to fold in, it is pushed
+  // from main to the toast layer so the editor's delete and discard paths get it
+  // too (Codex P2 on #782). See notifyStrandedConsentPrompts.test.tsx. What this
+  // file still owns is everything the KILL reports, below.
 
   test('an ordinary switch says nothing about a prompt', async () => {
     switchProfileAppsMock.mockResolvedValue({

--- a/tests/renderer/notifyStrandedConsentPrompts.test.tsx
+++ b/tests/renderer/notifyStrandedConsentPrompts.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * #782: the stranded-consent-prompt note is delivered by a PUSH from main to the
+ * toast layer, not by a value returned from `save-profile`.
+ *
+ * Why it moved here from GameRow. Cancelling a pending elevated launch is a side
+ * effect of the active profile changing, and four callers change it: the row's
+ * profile dropdown, the editor's save, its delete, and its discard-pending
+ * restore. Only the dropdown ever read the returned count, and because the
+ * counter is a module-level scalar that the read DRAINS, the other three did not
+ * merely stay silent -- they consumed the count and destroyed it, leaving the
+ * user with a consent dialog that does nothing and no explanation anywhere
+ * (Codex P2 on #782, found on the delete path).
+ *
+ * So the contract worth pinning is no longer "GameRow folds the note into its
+ * switch toast". It is "a pushed count becomes a visible warning toast, whoever
+ * caused it". That is what this file tests, and it is why the two save-path
+ * tests that used to live in gameRowStrandedConsentPrompt.test.tsx are gone: the
+ * behaviour they described is now impossible to express at a single caller.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { formatStrandedConsentPrompts } from '../../src/shared/strandedConsentPrompts'
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  // The toast progress bar is WAAPI-driven; jsdom doesn't implement
+  // Element.animate, so stub it to a no-op animation when a real toast renders.
+  Element.prototype.animate = vi.fn(() => ({ cancel: vi.fn() })) as never
+})
+
+// Captured so a test can fire the channel the way main does. The unsubscribe is
+// real rather than a no-op so the unmount assertion below means something.
+let pushStrandedConsentPrompts: ((count: number) => void) | null = null
+let subscriberCount = 0
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  onAppLaunchError: () => () => {},
+  onProcessNameMismatchWarning: () => () => {},
+  onStrandedConsentPrompts: (cb: (count: number) => void) => {
+    pushStrandedConsentPrompts = cb
+    subscriberCount += 1
+    return () => {
+      pushStrandedConsentPrompts = null
+      subscriberCount -= 1
+    }
+  }
+}))
+
+import { NotifyProvider } from '../../src/renderer/src/components/Notify'
+
+const SINGULAR = formatStrandedConsentPrompts(1)!
+const PLURAL = formatStrandedConsentPrompts(2)!
+
+async function renderProvider(): Promise<{ unmount: () => void }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root: Root | null = null
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<NotifyProvider>{null}</NotifyProvider>)
+  })
+  return {
+    unmount: () => {
+      act(() => root?.unmount())
+      container.remove()
+    }
+  }
+}
+
+async function push(count: number): Promise<void> {
+  if (!pushStrandedConsentPrompts) throw new Error('nothing subscribed to the push channel')
+  await act(async () => {
+    pushStrandedConsentPrompts!(count)
+  })
+}
+
+// Toasts are portaled to document.body, not into the provider's container.
+function allToastText(): string {
+  return document.body.textContent ?? ''
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  pushStrandedConsentPrompts = null
+  subscriberCount = 0
+})
+
+describe('stranded consent prompt push (#782)', () => {
+  test('a pushed count becomes a warning toast', async () => {
+    const { unmount } = await renderProvider()
+
+    await push(1)
+
+    expect(allToastText()).toContain(SINGULAR)
+    unmount()
+  })
+
+  // The wording is composed at the surface that shows it, so the plural form has
+  // to be reached through the push and not only through the formatter's own unit
+  // test -- an implementation that hardcoded the singular sentence would pass the
+  // test above and still tell the user one prompt when three are on screen.
+  test('the plural wording is used when more than one prompt was stranded', async () => {
+    const { unmount } = await renderProvider()
+
+    await push(3)
+
+    expect(allToastText()).toContain(PLURAL)
+    expect(allToastText()).not.toContain(SINGULAR)
+    unmount()
+  })
+
+  // Main only pushes above zero, but the formatter returning undefined must not
+  // reach `notify`: an empty toast is worse than no toast, and 'undefined' has
+  // rendered into a toast here before (#809).
+  test('a zero count renders nothing at all', async () => {
+    const { unmount } = await renderProvider()
+
+    await push(0)
+
+    expect(allToastText()).not.toContain('permission prompt')
+    expect(allToastText()).not.toContain('undefined')
+    unmount()
+  })
+
+  test('the subscription is torn down on unmount', async () => {
+    const { unmount } = await renderProvider()
+    expect(subscriberCount).toBe(1)
+
+    unmount()
+
+    expect(subscriberCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

A pending elevated handoff has **never started**, so it appears in no tasklist snapshot. `switch-profile-apps` decides what to stop from exactly such a snapshot and only calls the kill path when that set is non-empty, so it can never select the handoff. Worse, the renderer usually does not reach that handler at all: `GameRow` gates the IPC on a diff the handoff contributes zero to, and falls through to `save-profile` instead. Approving the old prompt then starts a companion belonging to a profile the user has already left.

The **second half, which the issue did not name**: cancellation was scoped to the game, not to what was being stopped. So the cancel only ever fired as collateral of an unrelated stop, and when it did it took every handoff for that game, including one for an app the incoming profile also enables. Both halves are one cause: the scope was the game and the trigger was a diff the handoff cannot appear in.

Nine review rounds turned that into two rules the code now states outright.

**A handoff is reachable through exactly one of two mechanisms, decided by whether its grace timer has fired.** Before it, there is no registry entry and the sequence abort signal is the only handle. After it, the registry is. They are not alternatives, so every path that cancels one cancels both. Fixing only the registry half is what left the whole pre-grace window open, twice.

**Ownership is the SLOT KEY, never the path.** The path alone cannot tell two slots sharing an exe apart (#357); `key + path` misses a slot whose exe was edited after launch, because the registry holds the path as launched; and building launch entries at all misses a slot whose exe was cleared, because an entry needs something to launch. Only the key survives all three.

**What changed**

| Where | Change |
|---|---|
| `processes/state.ts` | Entries carry `appKey` + `appPath`; `cancelPendingElevatedHandoffs(gameKey?, matches?)` takes a predicate. `entry.cancel()` wrapped per entry. Tracking is deliberately NOT stored here. |
| `processes/spawn.ts` | Registers the slot key, and registers fire-and-forget profiles too (the exclusion moved to the one consumer that needs it). |
| `processes/kill.ts` | `killProfileApps` takes entries, not paths, and matches by slot key. `killLaunchedApps` keeps game scope and excludes handoffs whose profile currently has tracking off, read live. |
| `profiles.ts` | `getProfileSwitchLeavingKeys` returns leaving slot keys, computed from membership via the new `getEnabledUtilitySlotKeys` rather than from launchable entries. |
| `ipc/config.ts` | `save-profile` aborts the outgoing launch AND cancels the leaving slots' handoffs, computed before the store write. Config import does the same, unscoped. The stranded-prompt count is PUSHED to the toast layer, not returned. |
| `preload` + `Notify.tsx` | New `stranded-consent-prompts` push channel. |

**Why the count is pushed and not returned:** four callers change the active profile through `save-profile` and only one read the return value. The drain is destructive, so the other three did not merely stay quiet, they consumed the count and destroyed it. A push cannot be dropped by forgetting to read it.

**Why `save-profile` and not the switch handler:** it is the call the renderer cannot skip. Every switch saves, whether or not it stops anything.

## Explicitly not done

The sibling handlers (`launch-profile`, `relaunch-missing-profile`) do **not** cancel. My analysis on #782 floated it on the grounds that every registry entry at their entry provably belongs to an ended sequence, which is true but is not a reason to cancel: to launch a different profile the user must switch first, which saves, which this fix already covers. Cancelling there would kill a prompt for an app they are re-launching on purpose.

`save-profiles` (the bulk write) is not covered: filed as #841, whose body was corrected during this PR after Codex showed that config import does not reach it at all.

The switch abort has **game granularity**, so it can take down a pending prompt for the game itself or for a utility the incoming profile keeps. Filed as #843. It is an over-cancel in the family this PR spent three rounds removing, and it is held only because it is the one instance not fixable in the registry predicate: a pre-grace handoff has no registry entry, and the abort signal is per game by construction. The alternative is worse, since without the abort every pre-grace switch leaves the outgoing prompt live.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 warnings)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test` (746 passed, 84 files)
- [x] Mutation-verified throughout. Each of these kills at least one test: removing the push, hardcoding the singular wording, deleting the import cancel, moving it before the writes, reverting kill-path matching to paths, restoring the fire-and-forget registration skip, deleting instead of marking on the untracked reconcile, restoring the stored `tracked` flag, re-adding the path to either matcher, re-adding the path filter to leaving keys, and leaking the game key into leaving keys.
- [ ] Manual: covered by the #591 and #830 delta sections in the 1.2.0 smoke doc.

Closes #782
