### PR TITLE
fix(processes): stop a same-named stranger from speaking for a configured app (#674)

### DIFF
--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -10,12 +10,12 @@ import {
   getRunningApps,
   hasOtherActiveLaunchControllers,
   isAnyLaunchActive,
-  isRunningExePath,
   killLaunchedApps,
   killProfileApps,
   launchProfileApps,
   readRunningProcessNames,
   registerActiveLaunch,
+  resolveRunningConfiguredPaths,
   subscribeRunningApps,
   unregisterActiveLaunch,
   unsubscribeRunningApps
@@ -119,9 +119,16 @@ export function registerLaunchHandlers(): void {
     const launchController = registerActiveLaunch(gameKey)
     try {
       const { processNames } = await readRunningProcessNames()
-      const missingEntries = allEntries.filter(
-        (entry) => !isRunningExePath(processNames, entry.path)
+      // Verified against the path, not the image name (#674). "Missing" is the
+      // whole point of this handler, and a name-only reading of it made an app
+      // that had crashed look present because something unrelated on the system
+      // happened to share its exe name -- the exact situation the user reaches
+      // for this action in.
+      const runningPaths = await resolveRunningConfiguredPaths(
+        processNames,
+        allEntries.map((entry) => entry.path)
       )
+      const missingEntries = allEntries.filter((entry) => !runningPaths.has(entry.path))
 
       if (missingEntries.length === 0) {
         return {
@@ -174,25 +181,31 @@ export function registerLaunchHandlers(): void {
       const toEntries = utilityEntries(toProfileId)
       const toEntryIds = new Set(toEntries.map(getProfileLaunchEntryId))
       const fromEntryIds = new Set(fromEntries.map(getProfileLaunchEntryId))
-      // Slots that leave the profile and whose image is currently running
-      // need to be stopped. Match on `{key, path}` so a slot whose key
-      // changes (different args) still counts as a stop even when the
-      // exe path is unchanged.
+      // Both counts below are shown to the user in a confirmation dialog, so a
+      // name-only reading of "running" put numbers in front of them that no
+      // configured app backed: "stop 2 app(s)" for slots nothing was running,
+      // and "start 0" for slots that were not running at all (#674). One
+      // enumeration answers for both sides of the diff.
+      const runningPaths = await resolveRunningConfiguredPaths(
+        processNames,
+        [...fromEntries, ...toEntries].map((entry) => entry.path)
+      )
+      // Slots that leave the profile and are currently running need to be
+      // stopped. Match on `{key, path}` so a slot whose key changes (different
+      // args) still counts as a stop even when the exe path is unchanged.
       const stopping = fromEntries.filter(
-        (entry) =>
-          !toEntryIds.has(getProfileLaunchEntryId(entry)) &&
-          processNames.has(getExeName(entry.path))
+        (entry) => !toEntryIds.has(getProfileLaunchEntryId(entry)) && runningPaths.has(entry.path)
       )
       const stoppedExeNames = new Set(stopping.map((entry) => getExeName(entry.path)))
       const toStopCount = stopping.length
-      // A slot that newly enters the profile needs a start when either its
-      // image isn't running, or its image is about to be stopped above
-      // (same exe, different key — the incoming slot still needs its own
-      // args, so the running process must be replaced).
+      // A slot that newly enters the profile needs a start when either it isn't
+      // running, or its image is about to be stopped above (same exe, different
+      // key — the incoming slot still needs its own args, so the running process
+      // must be replaced).
       const toStartCount = toEntries.filter(
         (entry) =>
           !fromEntryIds.has(getProfileLaunchEntryId(entry)) &&
-          (stoppedExeNames.has(getExeName(entry.path)) || !processNames.has(getExeName(entry.path)))
+          (stoppedExeNames.has(getExeName(entry.path)) || !runningPaths.has(entry.path))
       ).length
 
       return { toStopCount, toStartCount }
@@ -250,10 +263,17 @@ export function registerLaunchHandlers(): void {
       try {
         const { processNames: processNamesBeforeSwitch } = await readRunningProcessNames()
 
+        // Path-verified, and it has to be, or this action and the dialog that
+        // announced it disagree: `get-profile-switch-diff` counts the same slots
+        // the same way (#674).
+        const runningPathsBeforeSwitch = await resolveRunningConfiguredPaths(
+          processNamesBeforeSwitch,
+          fromEntries.map((entry) => entry.path)
+        )
         const entriesToStop = fromEntries.filter(
           (entry) =>
             !toEntryIds.has(getProfileLaunchEntryId(entry)) &&
-            processNamesBeforeSwitch.has(getExeName(entry.path))
+            runningPathsBeforeSwitch.has(entry.path)
         )
         let killResult: KillResult | undefined
 
@@ -272,16 +292,21 @@ export function registerLaunchHandlers(): void {
         }
 
         const { processNames: processNamesAfterStop } = await readRunningProcessNames()
+        // Re-verified rather than reusing the pre-switch answer: the kill phase
+        // is exactly what this is measuring the effect of.
+        const runningPathsAfterStop = await resolveRunningConfiguredPaths(
+          processNamesAfterStop,
+          toEntries.map((entry) => entry.path)
+        )
         // If we just stopped a slot pointing at the same exe (different key
         // and args), the incoming slot still needs to start with its own
         // args — treat that exe as "needs to launch" regardless of post-kill
-        // tasklist state. Without this, a same-exe key swap would skip the
-        // relaunch and leave the old args active.
+        // state. Without this, a same-exe key swap would skip the relaunch and
+        // leave the old args active.
         const stoppedExeNames = new Set(entriesToStop.map((entry) => getExeName(entry.path)))
         const entriesToStart = toEntries.filter(
           (entry) =>
-            stoppedExeNames.has(getExeName(entry.path)) ||
-            !processNamesAfterStop.has(getExeName(entry.path))
+            stoppedExeNames.has(getExeName(entry.path)) || !runningPathsAfterStop.has(entry.path)
         )
 
         if (entriesToStart.length === 0) {

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -15,8 +15,9 @@ export {
   registerActiveLaunch,
   unregisterActiveLaunch
 } from './processes/state'
-export { launchProfileApps, isAnyLaunchActive, isRunningExePath } from './processes/spawn'
+export { launchProfileApps, isAnyLaunchActive } from './processes/spawn'
 export { readRunningProcessNames, invalidateProcessNameCache } from './processes/tasklist'
+export { resolveRunningConfiguredPaths } from './processes/win32KillUtils'
 export type { RunningAppsChangedPayload, RunningAppsChangeReason } from './processes/running'
 export type {
   KillFailure,

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -33,13 +33,16 @@ import type {
 } from './types'
 import {
   GRACEFUL_CLOSE_WINDOW_MS,
+  type ConfiguredPathState,
   findProcessIdsByExecutablePath,
   hasChildExited,
   isFullExePath,
   isPathScopedExe,
   killProcessByImageName,
   killProcessTree,
-  requestGracefulClose
+  requestGracefulClose,
+  resolveConfiguredPathStates,
+  resolveRunningConfiguredPaths
 } from './win32KillUtils'
 
 // Hardcoded list of companion process names for utilities that spawn background
@@ -177,14 +180,19 @@ export async function finalizeKillAttempts(
   //     PIDs are found and taskkill then reports them already gone
   //
   // Deliberately narrow. With no such sibling the ambiguity is real and stays
-  // unresolved; discriminating name from path in general is #674.
+  // unresolved.
   //
-  // KNOWN RESIDUAL, recorded on #674: a sibling that located its target and
-  // closed it successfully still counts, even though an image surviving in the
-  // tasklist afterwards can only be something else, possibly a genuinely
-  // elevated-invisible process at this very path. Telling those apart needs each
-  // sibling's POST-kill state, which is what #674 builds. The trade is
-  // deliberate: the false positive suppressed here is far likelier than the
+  // #674 has since built the direct answer (`postKillPathStates` below), which
+  // needs no sibling at all. This stays as the fallback rather than being
+  // replaced, because the enumeration can fail, and a failed enumeration is
+  // reported as `unknown` -- indistinguishable here from an enumeration that ran
+  // and could not decide. Dropping this would hand those cases back to #818.
+  //
+  // KNOWN RESIDUAL, unchanged and now confined to this fallback: a sibling that
+  // located its target and closed it successfully still counts, even though an
+  // image surviving in the tasklist afterwards can only be something else,
+  // possibly a genuinely elevated-invisible process at this very path. The trade
+  // is deliberate: the false positive suppressed here is far likelier than the
   // false negative left behind.
   // Image names a bare-name `/IM` attempt actually closed. That kill is not
   // path-scoped, so it takes down whatever was running under the name, including
@@ -199,6 +207,37 @@ export async function finalizeKillAttempts(
       .filter((attempt) => !isPathScopedExe(attempt.appPath) && attempt.success)
       .map((attempt) => attempt.processName)
   )
+
+  // What the sibling heuristic above approximates, asked directly (#674).
+  //
+  // The whole ambiguity is that `processNamesAfterKill` knows names and not
+  // paths, so an image surviving the kill cannot say whether it survived at OUR
+  // path. A name-scoped enumeration can: it returns each surviving instance with
+  // its path and session, and a path with no instance of its own is empty no
+  // matter how many strangers share its name. On the field repro that is the
+  // difference between "SimHub could not be closed, it may be running as
+  // administrator" and the truth, which was 20 unrelated `cmd.exe` processes.
+  //
+  // Gated on `tasklistReadSucceeded`, and that gate is load-bearing rather than
+  // defensive: a failed read yields an EMPTY name set, which this function would
+  // otherwise read as "no path can be running" and answer every attempt
+  // `not-running` for free — turning a read failure into confident absence, the
+  // exact inversion #399 exists to prevent.
+  //
+  // The cost follows the same rule as the launch filter. A path whose image is
+  // absent from the post-kill tasklist is answered without enumerating, so the
+  // ordinary close (everything asked for actually died) pays nothing, and a
+  // batch that leaves survivors pays one spawn for all of them.
+  const fullPathAttemptPaths: string[] = []
+  attempts.forEach((attempt) => {
+    const appPath = attempt.appPath
+    if (isFullExePath(appPath)) {
+      fullPathAttemptPaths.push(appPath)
+    }
+  })
+  const postKillPathStates = tasklistReadSucceeded
+    ? await resolveConfiguredPathStates(processNamesAfterKill, fullPathAttemptPaths)
+    : new Map<string, ConfiguredPathState>()
 
   const confirmedPathsByImage = new Map<string, Set<string>>()
   attempts.forEach((attempt) => {
@@ -278,12 +317,33 @@ export async function finalizeKillAttempts(
         // or hides a leftover. `closedNothing` only decides whether to count the
         // attempt, and an attempt that found nothing closed nothing no matter
         // what else was running.
+        //
+        // The enumeration answers the same question outright and without needing
+        // a sibling, so it is tried first: `not-running` means no instance of
+        // this image is at this path, whoever else is holding the name (#674).
+        // The sibling heuristic below stays reachable when it cannot decide,
+        // which covers both an undecidable instance (#390's shape: an unreadable
+        // path in an interactive session) and an enumeration that failed
+        // outright. Its known residual comes along with it, documented above.
+        //
+        // ONLY `not-running` counts. `unknown` and a missing entry both mean the
+        // enumeration could not decide, and neither may weaken a verdict.
+        //
+        // `!imageGoneFromTasklist` is not redundant with it, and dropping it
+        // inverts a whole class of result. An image absent from the post-kill
+        // tasklist is `not-running` for free, but that is the SUCCESS case: this
+        // attempt closed the last instance. Only a path found empty while its
+        // image SURVIVES is the #674 shape, where the survivor is somebody
+        // else's process and the attempt was aimed at nothing.
+        const pathVerifiedEmpty =
+          !imageGoneFromTasklist && postKillPathStates.get(appPath) === 'not-running'
         const ownPath = normalizePathForComparison(appPath)
         const confirmedPaths = confirmedPathsByImage.get(attempt.processName)
         isEmptySameNameTarget =
           verifiablyEmpty &&
-          !!confirmedPaths &&
-          Array.from(confirmedPaths).some((confirmedPath) => confirmedPath !== ownPath)
+          (pathVerifiedEmpty ||
+            (!!confirmedPaths &&
+              Array.from(confirmedPaths).some((confirmedPath) => confirmedPath !== ownPath)))
 
         // Either kind of sibling is enough to say this attempt closed nothing.
         // Without one, a lone empty attempt keeps its long-standing treatment
@@ -309,6 +369,14 @@ export async function finalizeKillAttempts(
             isElevatedInconclusive ||
             (attempt.accessDenied === true &&
               !attempt.notFound &&
+              // The same name-only reasoning one branch down (#674). Here
+              // taskkill was refused on PIDs found AT this path, so the image
+              // surviving is normally the refused process itself -- but if the
+              // enumeration can see the whole name and none of it is at this
+              // path, the refusal outlived the process and the survivor is
+              // somebody else. An elevated holdout cannot be dismissed this way:
+              // its path is unreadable, which resolves to `unknown`.
+              !pathVerifiedEmpty &&
               (processNamesAfterKill.has(attempt.processName) || !tasklistReadSucceeded)))
       } else {
         stillRunning = processNamesAfterKill.has(attempt.processName)
@@ -785,11 +853,25 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
  * getRunningApps(): that list gates companions on the owning game being launched
  * or adopted, while killLaunchedApps closes configured companions regardless, so
  * the surfaced list would under-report closable targets.
+ *
+ * One deliberate asymmetry with killLaunchedApps, and it is not drift: this
+ * verifies a candidate against its PATH (#674) where the scheduling there stays
+ * name-gated. The two answer different questions. Scheduling a kill for a path
+ * nothing is running at costs a lookup and nothing else, because the kill is
+ * path-scoped and finalizeKillAttempts now judges the empty result correctly.
+ * Telling the user there is something to close when there is not is the defect
+ * this function would otherwise ship to #673, so it pays for the enumeration and
+ * the scheduling does not.
+ *
+ * On-demand only. This is one PowerShell spawn in the collision case, which is
+ * fine for a click and is not fine on the running-apps poll — do not call it
+ * from a timer.
  */
 export async function hasClosableLaunchedApps(gameKey?: string): Promise<boolean> {
   const { processNames } = await readRunningProcessNames()
   const gameExePaths = getConfiguredGameExePaths()
 
+  const candidatePaths: string[] = []
   for (const appProcess of runningProcesses.values()) {
     if (gameKey && appProcess.gameKey !== gameKey) {
       continue
@@ -797,19 +879,32 @@ export async function hasClosableLaunchedApps(gameKey?: string): Promise<boolean
     if (appProcess.isGame || gameExePaths.has(normalizePathForComparison(appProcess.path))) {
       continue
     }
-    if (processNames.has(getExeName(appProcess.path))) {
-      return true
-    }
+    candidatePaths.push(appProcess.path)
   }
 
   const companionTargets = getProfileCompanionTargets(gameKey)
   for (const target of companionTargets.values()) {
-    if (processNames.has(target.processName)) {
-      return true
+    // A curated name-scoped target has no path to verify against, so it keeps
+    // the name-only answer. That is not a gap being tolerated: `/IM` is how such
+    // a target would be closed too, so name membership is exactly the condition
+    // under which closing it would do something.
+    if (target.scope === 'name') {
+      if (processNames.has(target.processName)) {
+        return true
+      }
+      continue
     }
+    candidatePaths.push(target.appPath)
   }
 
-  return false
+  if (candidatePaths.length === 0) {
+    return false
+  }
+
+  // One enumeration for both branches, and none at all unless some candidate's
+  // image is actually in the tasklist.
+  const runningPaths = await resolveRunningConfiguredPaths(processNames, candidatePaths)
+  return candidatePaths.some((candidatePath) => runningPaths.has(candidatePath))
 }
 
 /**

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -367,16 +367,17 @@ export async function finalizeKillAttempts(
           !imageGoneFromTasklist &&
           (processIds.length > 0 ||
             isElevatedInconclusive ||
+            // Deliberately NOT path-verified, unlike the two branches above
+            // (#674, review bot on #845 asked why it has no test). Every
+            // producer of `accessDenied` sets it only alongside `success: false`,
+            // and `hasFailedToClose` below independently fails any attempt that
+            // is unsuccessful, not-notFound and whose image survives -- exactly
+            // this branch's own conditions. So a discriminator here could not
+            // change a single outcome; it would be a line that reads as
+            // load-bearing while doing nothing. If that coupling is ever broken,
+            // this is the branch to revisit.
             (attempt.accessDenied === true &&
               !attempt.notFound &&
-              // The same name-only reasoning one branch down (#674). Here
-              // taskkill was refused on PIDs found AT this path, so the image
-              // surviving is normally the refused process itself -- but if the
-              // enumeration can see the whole name and none of it is at this
-              // path, the refusal outlived the process and the survivor is
-              // somebody else. An elevated holdout cannot be dismissed this way:
-              // its path is unreadable, which resolves to `unknown`.
-              !pathVerifiedEmpty &&
               (processNamesAfterKill.has(attempt.processName) || !tasklistReadSucceeded)))
       } else {
         stillRunning = processNamesAfterKill.has(attempt.processName)

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -34,6 +34,7 @@ import {
 } from './state'
 import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
+import { isConfiguredPathRunning, resolveConfiguredPathStates } from './win32KillUtils'
 import type {
   AppLaunchResult,
   LateElevatedOutcome,
@@ -288,7 +289,28 @@ export async function launchProfileApps(
       return { success: false, error: 'No valid executable paths configured.', skipped }
     }
 
-    const appsToLaunch = validApps.filter((entry) => !isRunningExePath(processNames, entry.path))
+    // Verified against the PATH, not just the image name. `processNames` comes
+    // from `tasklist`, which reports names with no path, so a same-named process
+    // from anywhere on the system used to make this filter drop a configured app
+    // that was not running at all: it never started, was counted as "already
+    // running", and later got blamed on elevation when it could not be closed
+    // (#674). The collider need not be related to anything the user configured;
+    // on a real machine it was ambient `cmd.exe` instances.
+    //
+    // Costs nothing when nothing collides. `resolveConfiguredPathStates` answers
+    // every path whose name is absent from `processNames` for free, so a launch
+    // with no name collisions never reaches the enumeration.
+    //
+    // `unknown` still skips, which keeps #390: a process running at higher
+    // integrity than SimLauncher hides its path, and starting a second copy of
+    // an app that IS running is worse than the skip this is fixing.
+    const pathStates = await resolveConfiguredPathStates(
+      processNames,
+      validApps.map((entry) => entry.path)
+    )
+    const appsToLaunch = validApps.filter(
+      (entry) => !isConfiguredPathRunning(pathStates.get(entry.path))
+    )
     const skippedCount = validApps.length - appsToLaunch.length
 
     if (appsToLaunch.length === 0) {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -13,7 +13,6 @@ import { getStoredStringRecord, store } from '../store'
 import {
   getErrorCode,
   getErrorMessage,
-  getExeName,
   isValidExePath,
   normalizePathForComparison,
   pathsEqual,
@@ -34,7 +33,7 @@ import {
 } from './state'
 import { isConsoleExecutable } from './subsystem'
 import { invalidateProcessNameCache, readRunningProcessNames } from './tasklist'
-import { isConfiguredPathRunning, resolveConfiguredPathStates } from './win32KillUtils'
+import { resolveRunningConfiguredPaths } from './win32KillUtils'
 import type {
   AppLaunchResult,
   LateElevatedOutcome,
@@ -297,20 +296,18 @@ export async function launchProfileApps(
     // (#674). The collider need not be related to anything the user configured;
     // on a real machine it was ambient `cmd.exe` instances.
     //
-    // Costs nothing when nothing collides. `resolveConfiguredPathStates` answers
-    // every path whose name is absent from `processNames` for free, so a launch
-    // with no name collisions never reaches the enumeration.
+    // Costs nothing when nothing collides. `resolveRunningConfiguredPaths`
+    // answers every path whose name is absent from `processNames` for free, so a
+    // launch with no name collisions never reaches the enumeration.
     //
     // `unknown` still skips, which keeps #390: a process running at higher
     // integrity than SimLauncher hides its path, and starting a second copy of
     // an app that IS running is worse than the skip this is fixing.
-    const pathStates = await resolveConfiguredPathStates(
+    const runningPaths = await resolveRunningConfiguredPaths(
       processNames,
       validApps.map((entry) => entry.path)
     )
-    const appsToLaunch = validApps.filter(
-      (entry) => !isConfiguredPathRunning(pathStates.get(entry.path))
-    )
+    const appsToLaunch = validApps.filter((entry) => !runningPaths.has(entry.path))
     const skippedCount = validApps.length - appsToLaunch.length
 
     if (appsToLaunch.length === 0) {
@@ -549,10 +546,6 @@ export function getLaunchDelayMs(): number {
   }
 
   return Math.min(Math.max(Math.round(value), 0), 30000)
-}
-
-export function isRunningExePath(processNames: Set<string>, appPath: string): boolean {
-  return processNames.has(getExeName(appPath))
 }
 
 /**

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -16,7 +16,7 @@ import { execFile, type ChildProcess } from 'child_process'
 import path from 'path'
 
 import { writeAppErrorLog } from '../errorLog'
-import { getErrorMessage, getExeName, isValidExePath } from '../utils'
+import { getErrorMessage, getExeName, isValidExePath, normalizePathForComparison } from '../utils'
 
 import type { KillAttemptResult } from './types'
 
@@ -426,4 +426,187 @@ export async function killProcessByImageName(
     // failure is ambiguous, so it does not count as evidence.
     targetConfirmed: result.success || result.accessDenied === true
   }
+}
+
+/**
+ * One running instance of an image name, as seen by a name-scoped WMI
+ * enumeration.
+ *
+ * `executablePath` is null when WMI would not disclose it. That is not an
+ * error: a non-elevated SimLauncher cannot read the path of a process running
+ * at higher integrity, and on a real machine that is roughly 38% of all
+ * processes. Callers must treat null as "unknown", never as "different".
+ */
+export interface NamedProcessInstance {
+  /** Lowercased image name, matching how `tasklist` results are keyed. */
+  name: string
+  processId: number
+  executablePath: string | null
+  /**
+   * Windows session. 0 is the non-interactive services session, which cannot
+   * host a companion the user launched, so it is the one case where an
+   * unreadable path is still decidable (#674).
+   */
+  sessionId: number
+}
+
+/**
+ * Enumerate every running process whose image name is one of `processNames`.
+ *
+ * The discriminator `tasklist` cannot provide. `tasklist` returns image names
+ * with no path, so every "is my configured app already running?" answer built
+ * on it is name-only, and a same-named process from an unrelated path passes
+ * for the configured one (#674).
+ *
+ * ONE spawn regardless of how many names are asked about. Every caller batches
+ * its whole question into a single call, because the cost here is dominated by
+ * starting PowerShell, not by the enumeration.
+ *
+ * Names are injected as JSON through the environment rather than interpolated
+ * into the script, for the same reason `findProcessIdsByExecutablePath`
+ * documents: WQL string-literal escaping is ambiguous and version-dependent,
+ * and an exe name containing a quote would otherwise break the lookup or worse
+ * (#531). Comparison happens in the host language, which handles any character.
+ */
+export function findProcessesByName(processNames: string[]): Promise<{
+  instances: NamedProcessInstance[]
+  succeeded: boolean
+}> {
+  return new Promise((resolve) => {
+    const wanted = Array.from(new Set(processNames.map((name) => name.toLowerCase()))).filter(
+      (name) => name.length > 0
+    )
+
+    if (wanted.length === 0) {
+      // Not a failure: nothing was asked. `succeeded: true` matters, because
+      // callers treat a failed read as "no observation" and fall back to the
+      // conservative branch.
+      resolve({ instances: [], succeeded: true })
+      return
+    }
+
+    const script = [
+      '$names = $env:SIMLAUNCHER_TARGET_PROCESS_NAMES | ConvertFrom-Json',
+      // Force an array: a single-element JSON array deserializes to a scalar,
+      // and `-contains` against a scalar silently matches nothing.
+      '$wanted = @($names) | ForEach-Object { $_.ToLowerInvariant() }',
+      'Get-CimInstance Win32_Process |',
+      '  Where-Object { $wanted -contains $_.Name.ToLowerInvariant() } |',
+      '  Select-Object @{N="name";E={$_.Name.ToLowerInvariant()}},',
+      '    @{N="processId";E={[int]$_.ProcessId}},',
+      '    @{N="executablePath";E={$_.ExecutablePath}},',
+      '    @{N="sessionId";E={[int]$_.SessionId}} |',
+      // -AsArray so a single match is still a JSON array, matching the parse
+      // below. Without it PowerShell emits a bare object and the parse drops it.
+      '  ConvertTo-Json -Compress -AsArray'
+    ].join('\n')
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
+      {
+        windowsHide: true,
+        timeout: WMI_LOOKUP_TIMEOUT_MS,
+        env: {
+          ...process.env,
+          SIMLAUNCHER_TARGET_PROCESS_NAMES: JSON.stringify(wanted)
+        }
+      },
+      (error, stdout) => {
+        if (error) {
+          console.error('Failed to enumerate processes by name:', getErrorMessage(error))
+          resolve({ instances: [], succeeded: false })
+          return
+        }
+
+        try {
+          const parsed: unknown = JSON.parse(stdout.trim() || '[]')
+          if (!Array.isArray(parsed)) {
+            resolve({ instances: [], succeeded: false })
+            return
+          }
+          const instances = parsed.flatMap((entry): NamedProcessInstance[] => {
+            if (typeof entry !== 'object' || entry === null) return []
+            const record = entry as Record<string, unknown>
+            if (typeof record.name !== 'string' || typeof record.processId !== 'number') return []
+            return [
+              {
+                name: record.name.toLowerCase(),
+                processId: record.processId,
+                executablePath:
+                  typeof record.executablePath === 'string' && record.executablePath.length > 0
+                    ? record.executablePath
+                    : null,
+                sessionId: typeof record.sessionId === 'number' ? record.sessionId : 0
+              }
+            ]
+          })
+          resolve({ instances, succeeded: true })
+        } catch (err) {
+          console.error('Failed to parse the process enumeration:', getErrorMessage(err))
+          resolve({ instances: [], succeeded: false })
+        }
+      }
+    )
+  })
+}
+
+/**
+ * What a name-scoped enumeration can say about ONE configured path.
+ *
+ * `unknown` is not a failure and must not be collapsed into either answer. It
+ * means the evidence is genuinely ambiguous, and every caller answers it the
+ * way it answered before #674, which is what keeps #390 (a genuinely elevated
+ * process invisible to a non-elevated SimLauncher) reporting as elevated.
+ */
+export type ConfiguredPathState = 'running' | 'not-running' | 'unknown'
+
+/**
+ * Decide whether the exe at `configuredPath` is among `instances`.
+ *
+ * The single decision rule behind every "is this app already running?" answer
+ * in the app (#674). It lives here, next to the enumeration that feeds it,
+ * because five call sites depend on agreeing, and agreeing by having copied the
+ * same expression is how they stop agreeing.
+ *
+ * Order matters and each step earns its place:
+ *
+ *   1. A path match wins outright, INCLUDING in session 0. Session is only ever
+ *      used to dismiss an instance, never to deny one that positively matches:
+ *      a service-hosted copy of the configured exe is still the configured exe.
+ *   2. An instance is dismissible when it has a readable path that differs, or
+ *      when it is in session 0. Session 0 is the non-interactive services
+ *      session, so it cannot be the companion the user launched, and that is
+ *      what makes an UNREADABLE path decidable there. On a real machine that
+ *      resolves 170 of the 187 processes whose path WMI will not disclose.
+ *   3. Anything left is an instance with an unreadable path in an interactive
+ *      session. That is exactly the shape of #390, so the answer is `unknown`
+ *      and the caller keeps its pre-#674 behaviour.
+ */
+export function resolveConfiguredPathState(
+  instances: NamedProcessInstance[],
+  configuredPath: string
+): ConfiguredPathState {
+  const targetName = getExeName(configuredPath)
+  const relevant = instances.filter((instance) => instance.name === targetName)
+
+  if (relevant.length === 0) {
+    return 'not-running'
+  }
+
+  const target = normalizePathForComparison(configuredPath)
+  if (
+    relevant.some(
+      (instance) =>
+        instance.executablePath && normalizePathForComparison(instance.executablePath) === target
+    )
+  ) {
+    return 'running'
+  }
+
+  const undecidable = relevant.filter(
+    (instance) => !instance.executablePath && instance.sessionId !== 0
+  )
+
+  return undecidable.length === 0 ? 'not-running' : 'unknown'
 }

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -485,20 +485,34 @@ export function findProcessesByName(processNames: string[]): Promise<{
       return
     }
 
+    // ⚠️ Windows PowerShell 5.1 ONLY. `powershell.exe` is always 5.1 on Windows;
+    // `pwsh` is a separate binary this never invokes. Anything added after 5.1
+    // is unavailable here and fails at RUNTIME with a parameter-binding error,
+    // which this function reports as `succeeded: false` — so every candidate
+    // resolves `unknown` and the whole discriminator silently degrades to the
+    // name-only behaviour it exists to replace. `-AsArray` (PowerShell 6+) did
+    // exactly that and no mocked test could see it (CodeRabbit on #845).
+    // `tests/main/processEnumeration.win.test.ts` runs this against the real
+    // host so the next such parameter fails loudly instead.
     const script = [
       '$names = $env:SIMLAUNCHER_TARGET_PROCESS_NAMES | ConvertFrom-Json',
       // Force an array: a single-element JSON array deserializes to a scalar,
       // and `-contains` against a scalar silently matches nothing.
       '$wanted = @($names) | ForEach-Object { $_.ToLowerInvariant() }',
-      'Get-CimInstance Win32_Process |',
+      // `@(...)` around the whole pipeline, then `-InputObject`, is the 5.1 way
+      // to guarantee a JSON array. Piping into ConvertTo-Json unrolls a
+      // single-element collection back to a scalar; `-InputObject` takes the
+      // array as one value. Verified on 5.1 for zero, one and many matches.
+      '$found = @(Get-CimInstance Win32_Process |',
       '  Where-Object { $wanted -contains $_.Name.ToLowerInvariant() } |',
       '  Select-Object @{N="name";E={$_.Name.ToLowerInvariant()}},',
       '    @{N="processId";E={[int]$_.ProcessId}},',
       '    @{N="executablePath";E={$_.ExecutablePath}},',
-      '    @{N="sessionId";E={[int]$_.SessionId}} |',
-      // -AsArray so a single match is still a JSON array, matching the parse
-      // below. Without it PowerShell emits a bare object and the parse drops it.
-      '  ConvertTo-Json -Compress -AsArray'
+      '    @{N="sessionId";E={[int]$_.SessionId}})',
+      // Explicit depth: 5.1 defaults to 2 and truncates deeper structures
+      // SILENTLY. These records are flat, so 3 is slack rather than a fix, but
+      // the silence is what makes leaving it implicit a bad trade.
+      'ConvertTo-Json -Compress -Depth 3 -InputObject $found'
     ].join('\n')
 
     execFile(
@@ -512,20 +526,43 @@ export function findProcessesByName(processNames: string[]): Promise<{
           SIMLAUNCHER_TARGET_PROCESS_NAMES: JSON.stringify(wanted)
         }
       },
-      (error, stdout) => {
+      (error, stdout, stderr) => {
         if (error) {
-          console.error('Failed to enumerate processes by name:', getErrorMessage(error))
+          // Written to the on-disk log, not just the console, and that is the
+          // point rather than symmetry with the sibling lookup. A failure here
+          // is INVISIBLE in the product: every candidate resolves `unknown`,
+          // which folds to the conservative answer, so the app behaves exactly
+          // as it did before #674 and reports nothing wrong. The log entry is
+          // the only way anyone finds out the discriminator stopped working.
+          //
+          // `killed` is how execFile reports that IT terminated the child, which
+          // with a plain timeout option means the deadline elapsed.
+          const detail = error.killed
+            ? `Process enumeration timed out after ${WMI_LOOKUP_TIMEOUT_MS / 1000} seconds.`
+            : stderr.trim() || getErrorMessage(error)
+          console.error('Failed to enumerate processes by name:', detail)
+          writeAppErrorLog('kill', `Failed to enumerate processes by name: ${detail}`)
           resolve({ instances: [], succeeded: false })
           return
         }
 
         try {
           const parsed: unknown = JSON.parse(stdout.trim() || '[]')
-          if (!Array.isArray(parsed)) {
+          // A bare object is accepted as a one-element result. The script above
+          // guarantees an array, so this is not reachable through it — the point
+          // is that the parse must not depend on that guarantee holding. When it
+          // stopped holding, the failure was not a parse error but a silent
+          // total no-op, which is the worst shape a failure here can take.
+          const records = Array.isArray(parsed)
+            ? parsed
+            : typeof parsed === 'object' && parsed !== null
+              ? [parsed]
+              : null
+          if (!records) {
             resolve({ instances: [], succeeded: false })
             return
           }
-          const instances = parsed.flatMap((entry): NamedProcessInstance[] => {
+          const instances = records.flatMap((entry): NamedProcessInstance[] => {
             if (typeof entry !== 'object' || entry === null) return []
             const record = entry as Record<string, unknown>
             if (typeof record.name !== 'string' || typeof record.processId !== 'number') return []

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -610,3 +610,68 @@ export function resolveConfiguredPathState(
 
   return undecidable.length === 0 ? 'not-running' : 'unknown'
 }
+
+/**
+ * Decide, for a batch of configured paths, which of them are actually running.
+ *
+ * The shared entry point for every "is my configured app already running?"
+ * question in the app (#674). Callers pass the `tasklist` name set they already
+ * hold plus the paths they care about, and get one verdict per path.
+ *
+ * **It only pays when there is something to pay for.** A path whose image name
+ * is absent from `processNames` cannot be running, so it is answered for free
+ * and never reaches the enumeration. A launch with no collisions at all — the
+ * overwhelmingly common case — therefore costs ZERO extra spawns, and the cost
+ * of the rest is proportional to collisions, not to how often this is called.
+ *
+ * When the enumeration fails, its candidates come back `unknown` rather than
+ * either answer. That is the same no-observation discipline the running-apps
+ * poll documents for pruning (#399): a failed read is not evidence of absence,
+ * and inventing one here would silently un-skip apps mid-launch.
+ */
+export async function resolveConfiguredPathStates(
+  processNames: Set<string>,
+  configuredPaths: string[]
+): Promise<Map<string, ConfiguredPathState>> {
+  const states = new Map<string, ConfiguredPathState>()
+  const candidates: string[] = []
+
+  configuredPaths.forEach((configuredPath) => {
+    if (processNames.has(getExeName(configuredPath))) {
+      candidates.push(configuredPath)
+    } else {
+      states.set(configuredPath, 'not-running')
+    }
+  })
+
+  if (candidates.length === 0) {
+    return states
+  }
+
+  const { instances, succeeded } = await findProcessesByName(
+    candidates.map((configuredPath) => getExeName(configuredPath))
+  )
+
+  candidates.forEach((configuredPath) => {
+    states.set(
+      configuredPath,
+      succeeded ? resolveConfiguredPathState(instances, configuredPath) : 'unknown'
+    )
+  })
+
+  return states
+}
+
+/**
+ * Whether a configured path should be treated as running, folding `unknown`
+ * into "yes".
+ *
+ * The conservative reading, and the one every caller wants when it is deciding
+ * whether to SKIP something: an app that might be running must not be started
+ * twice, and #390's elevated-invisible process must keep being treated as
+ * present. Callers that need to distinguish ambiguity from certainty read the
+ * state directly instead.
+ */
+export function isConfiguredPathRunning(state: ConfiguredPathState | undefined): boolean {
+  return state !== 'not-running'
+}

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -537,7 +537,13 @@ export function findProcessesByName(processNames: string[]): Promise<{
                   typeof record.executablePath === 'string' && record.executablePath.length > 0
                     ? record.executablePath
                     : null,
-                sessionId: typeof record.sessionId === 'number' ? record.sessionId : 0
+                // -1, not 0. Session 0 is the one value that DISMISSES an
+                // instance with an unreadable path, so defaulting a malformed
+                // record to it would silently license a double launch. A
+                // sentinel that is not a real session leaves such a record
+                // undecidable, which is the direction a missing field should
+                // fail in.
+                sessionId: typeof record.sessionId === 'number' ? record.sessionId : -1
               }
             ]
           })
@@ -674,4 +680,28 @@ export async function resolveConfiguredPathStates(
  */
 export function isConfiguredPathRunning(state: ConfiguredPathState | undefined): boolean {
   return state !== 'not-running'
+}
+
+/**
+ * Which of `configuredPaths` count as running, folding `unknown` into "yes".
+ *
+ * The form every caller outside this module wants, and the reason it exists
+ * here rather than as an expression repeated at each of them: "is this configured
+ * app running?" is asked at five places that decide launches, kills, and the
+ * counts a confirmation dialog shows the user, and those answers have to agree.
+ * Before #674 they agreed because they all called the same name-only helper.
+ * They must keep agreeing now that the answer is harder to compute.
+ *
+ * Keyed by the path STRING as supplied, not a normalized form, so a caller can
+ * look its own entries back up without restating the normalization rule.
+ */
+export async function resolveRunningConfiguredPaths(
+  processNames: Set<string>,
+  configuredPaths: string[]
+): Promise<Set<string>> {
+  const states = await resolveConfiguredPathStates(processNames, configuredPaths)
+
+  return new Set(
+    configuredPaths.filter((configuredPath) => isConfiguredPathRunning(states.get(configuredPath)))
+  )
 }

--- a/src/main/processes/win32KillUtils.ts
+++ b/src/main/processes/win32KillUtils.ts
@@ -24,6 +24,24 @@ import type { KillAttemptResult } from './types'
 // bounded so a wedged WMI service cannot hang a kill request forever.
 const WMI_LOOKUP_TIMEOUT_MS = 3000
 
+/**
+ * Separate, larger budget for the name-scoped enumeration (#674), which is a
+ * different shape of query from the path-scoped lookup above: that one filters
+ * in WQL and returns a handful of PIDs, this one enumerates every process on the
+ * machine and filters in PowerShell.
+ *
+ * MEASURED, not guessed. On a warm developer machine the whole call is 300 to
+ * 400ms, but on a cold CI runner (windows-latest) the FIRST call took over 3s
+ * and blew the shared budget, while the two after it took 2523ms and 629ms. The
+ * cost is dominated by starting `powershell.exe`, not by the enumeration.
+ *
+ * Getting this wrong is not a slow path, it is a silently disabled feature: a
+ * timeout resolves `succeeded: false`, every candidate becomes `unknown`, and
+ * `unknown` folds to the pre-#674 answer. The first call after a boot is exactly
+ * when PowerShell is coldest and when a user is most likely to hit Launch.
+ */
+const PROCESS_ENUMERATION_TIMEOUT_MS = 10000
+
 function isAccessDeniedMessage(message: string) {
   return /(access is denied|permission denied|administrator|elevat)/i.test(message)
 }
@@ -503,7 +521,10 @@ export function findProcessesByName(processNames: string[]): Promise<{
       // to guarantee a JSON array. Piping into ConvertTo-Json unrolls a
       // single-element collection back to a scalar; `-InputObject` takes the
       // array as one value. Verified on 5.1 for zero, one and many matches.
-      '$found = @(Get-CimInstance Win32_Process |',
+      // `-Property` narrows what CIM marshals back. Worth ~15% on a fast
+      // machine and more where it matters, since the four fields below are all
+      // this needs and the default pulls every property of every process.
+      '$found = @(Get-CimInstance Win32_Process -Property Name,ProcessId,ExecutablePath,SessionId |',
       '  Where-Object { $wanted -contains $_.Name.ToLowerInvariant() } |',
       '  Select-Object @{N="name";E={$_.Name.ToLowerInvariant()}},',
       '    @{N="processId";E={[int]$_.ProcessId}},',
@@ -520,7 +541,7 @@ export function findProcessesByName(processNames: string[]): Promise<{
       ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
       {
         windowsHide: true,
-        timeout: WMI_LOOKUP_TIMEOUT_MS,
+        timeout: PROCESS_ENUMERATION_TIMEOUT_MS,
         env: {
           ...process.env,
           SIMLAUNCHER_TARGET_PROCESS_NAMES: JSON.stringify(wanted)
@@ -538,7 +559,7 @@ export function findProcessesByName(processNames: string[]): Promise<{
           // `killed` is how execFile reports that IT terminated the child, which
           // with a plain timeout option means the deadline elapsed.
           const detail = error.killed
-            ? `Process enumeration timed out after ${WMI_LOOKUP_TIMEOUT_MS / 1000} seconds.`
+            ? `Process enumeration timed out after ${PROCESS_ENUMERATION_TIMEOUT_MS / 1000} seconds.`
             : stderr.trim() || getErrorMessage(error)
           console.error('Failed to enumerate processes by name:', detail)
           writeAppErrorLog('kill', `Failed to enumerate processes by name: ${detail}`)

--- a/tests/main/configuredPathState.test.ts
+++ b/tests/main/configuredPathState.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  resolveConfiguredPathState,
+  type NamedProcessInstance
+} from '../../src/main/processes/win32KillUtils'
+
+/**
+ * #674: `tasklist` returns image NAMES with no path, so every "is my configured
+ * app already running?" answer built on it treats a same-named process from an
+ * unrelated path as the configured one. `resolveConfiguredPathState` is the one
+ * rule that separates them, shared by every call site that used to ask the
+ * name-only question.
+ *
+ * The rule has to hold two things at once that pull in opposite directions:
+ *
+ *   - a collision must resolve to `not-running`, or the configured app is
+ *     silently never launched and is then blamed on elevation when it cannot be
+ *     closed
+ *   - a genuinely elevated process invisible to a non-elevated SimLauncher
+ *     (#390) must stay `unknown`, because inverting it there reopens #390
+ *
+ * Those two produce a byte-identical signal from a path-scoped query, which is
+ * the whole reason the fix had to widen the query rather than flip a predicate.
+ * Everything below is about which side of that line a given shape falls on.
+ */
+
+const CONFIGURED = 'C:/Tools/Overlay.exe'
+
+function instance(overrides: Partial<NamedProcessInstance> = {}): NamedProcessInstance {
+  return {
+    name: 'overlay.exe',
+    processId: 1000,
+    executablePath: 'C:/Tools/Overlay.exe',
+    sessionId: 1,
+    ...overrides
+  }
+}
+
+describe('resolveConfiguredPathState (#674)', () => {
+  test('nothing under that name is not running', () => {
+    expect(resolveConfiguredPathState([], CONFIGURED)).toBe('not-running')
+  })
+
+  // Only instances of the asked-about name may be considered. A caller batches
+  // several names into one enumeration, so the list it hands back routinely
+  // contains images this path has nothing to do with.
+  test('instances of a different name are ignored', () => {
+    const other = instance({ name: 'simhub.exe', executablePath: 'C:/Tools/SimHub.exe' })
+    expect(resolveConfiguredPathState([other], CONFIGURED)).toBe('not-running')
+  })
+
+  test('a process at the configured path is running', () => {
+    expect(resolveConfiguredPathState([instance()], CONFIGURED)).toBe('running')
+  })
+
+  // Path comparison must survive the forms Windows hands back: different
+  // separators, different case, trailing-dot-free normalization.
+  test('the path match is normalized, not a string compare', () => {
+    const backslashes = instance({ executablePath: 'c:\\tools\\OVERLAY.exe' })
+    expect(resolveConfiguredPathState([backslashes], CONFIGURED)).toBe('running')
+  })
+
+  // THE BUG. A readable path that differs is positive evidence that this
+  // instance is somebody else's, so the configured app is not running.
+  test('a same-named process at another path is not running (#674)', () => {
+    const collider = instance({ executablePath: 'C:/UserApps/Overlay.exe' })
+    expect(resolveConfiguredPathState([collider], CONFIGURED)).toBe('not-running')
+  })
+
+  test('several colliders are still not running', () => {
+    const colliders = [
+      instance({ processId: 1, executablePath: 'C:/UserApps/Overlay.exe' }),
+      instance({ processId: 2, executablePath: 'D:/Other/Overlay.exe' })
+    ]
+    expect(resolveConfiguredPathState(colliders, CONFIGURED)).toBe('not-running')
+  })
+
+  // #390 MUST NOT REGRESS. An unreadable path in an interactive session is the
+  // signature of a process running at higher integrity than SimLauncher, which
+  // is exactly the elevated-invisible case. Answering anything but `unknown`
+  // here inverts #390 instead of discriminating.
+  test('an unreadable path in an interactive session is unknown (#390)', () => {
+    const invisible = instance({ executablePath: null })
+    expect(resolveConfiguredPathState([invisible], CONFIGURED)).toBe('unknown')
+  })
+
+  // The free half of the discriminator. Session 0 is the non-interactive
+  // services session and cannot host a companion the user launched, so an
+  // unreadable path is still decidable there. This is what takes the
+  // undecidable population from 187 processes to 17 on a real machine, at the
+  // cost of one integer already present in the tasklist output.
+  test('an unreadable path in session 0 is not running (#674)', () => {
+    const service = instance({ executablePath: null, sessionId: 0 })
+    expect(resolveConfiguredPathState([service], CONFIGURED)).toBe('not-running')
+  })
+
+  test('a readable session 0 path at another location is not running either', () => {
+    const service = instance({ executablePath: 'C:/Windows/System32/Overlay.exe', sessionId: 0 })
+    expect(resolveConfiguredPathState([service], CONFIGURED)).toBe('not-running')
+  })
+
+  // Session is only ever allowed to DISMISS an instance, never to deny one that
+  // positively matches. A service-hosted copy of the configured exe is still
+  // the configured exe, and calling it absent would invent the mirror bug.
+  test('a session 0 process AT the configured path still counts as running', () => {
+    const service = instance({ sessionId: 0 })
+    expect(resolveConfiguredPathState([service], CONFIGURED)).toBe('running')
+  })
+
+  // Mixed evidence resolves to the strongest signal available. One undecidable
+  // instance does not get to hide a positive match.
+  test('a path match wins over an undecidable sibling', () => {
+    const mixed = [
+      instance({ processId: 1, executablePath: null }),
+      instance({ processId: 2, executablePath: 'C:/Tools/Overlay.exe' })
+    ]
+    expect(resolveConfiguredPathState(mixed, CONFIGURED)).toBe('running')
+  })
+
+  // ...but a collider does NOT get to dismiss an undecidable sibling. The
+  // undecidable one could be the configured app running elevated, so the honest
+  // answer stays `unknown` and the caller keeps its conservative branch.
+  test('a collider alongside an undecidable sibling is still unknown', () => {
+    const mixed = [
+      instance({ processId: 1, executablePath: 'C:/UserApps/Overlay.exe' }),
+      instance({ processId: 2, executablePath: null })
+    ]
+    expect(resolveConfiguredPathState(mixed, CONFIGURED)).toBe('unknown')
+  })
+
+  // The realistic ambient shape from the repro: many colliders, all in the user
+  // session with readable paths, none of them the configured app.
+  test('the measured collision shape resolves cleanly (#674)', () => {
+    const ambient = Array.from({ length: 20 }, (_value, index) =>
+      instance({
+        name: 'cmd.exe',
+        processId: 2000 + index,
+        executablePath: 'C:/WINDOWS/system32/cmd.exe'
+      })
+    )
+    expect(resolveConfiguredPathState(ambient, 'D:/ReproA/cmd.exe')).toBe('not-running')
+  })
+})

--- a/tests/main/configuredPathState.test.ts
+++ b/tests/main/configuredPathState.test.ts
@@ -181,6 +181,28 @@ describe('findProcessesByName parsing (#674)', () => {
     expect(resolveConfiguredPathState(instances, CONFIGURED)).toBe('unknown')
   })
 
+  test('a bare object is read as a one-element result, not a parse failure', async () => {
+    // The script forces an array, so this shape should not reach here. It is
+    // accepted anyway because the parse must not DEPEND on that: when the array
+    // guarantee broke, the symptom was not a parse error but every candidate
+    // resolving `unknown`, i.e. the whole discriminator silently off.
+    respondWith(
+      null,
+      JSON.stringify({
+        name: 'overlay.exe',
+        processId: 1000,
+        executablePath: 'C:/Tools/Overlay.exe',
+        sessionId: 1
+      })
+    )
+
+    const { instances, succeeded } = await findProcessesByName(['overlay.exe'])
+
+    expect(succeeded).toBe(true)
+    expect(instances).toHaveLength(1)
+    expect(resolveConfiguredPathState(instances, CONFIGURED)).toBe('running')
+  })
+
   test('a failed enumeration is a failure, never an empty result', async () => {
     // `succeeded: false` is what makes every candidate resolve `unknown`
     // upstream. Reporting an empty instance list as a success would read as

--- a/tests/main/configuredPathState.test.ts
+++ b/tests/main/configuredPathState.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import {
+  findProcessesByName,
   resolveConfiguredPathState,
   type NamedProcessInstance
 } from '../../src/main/processes/win32KillUtils'
+
+const execFileMock = vi.hoisted(() => vi.fn())
+vi.mock('child_process', () => ({ execFile: execFileMock }))
 
 /**
  * #674: `tasklist` returns image NAMES with no path, so every "is my configured
@@ -140,5 +144,60 @@ describe('resolveConfiguredPathState (#674)', () => {
       })
     )
     expect(resolveConfiguredPathState(ambient, 'D:/ReproA/cmd.exe')).toBe('not-running')
+  })
+})
+
+/**
+ * The boundary where PowerShell output becomes a decision. The rule above is
+ * only as good as the instances handed to it, and two of the defaults in that
+ * parse are the kind that fail silently in the unsafe direction.
+ */
+describe('findProcessesByName parsing (#674)', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
+  function respondWith(error: Error | null, stdout: string) {
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => callback(error, stdout, '')
+    )
+  }
+
+  test('a record with no session is left undecidable, not dismissed as a service', async () => {
+    // Session 0 is the ONE value that lets an unreadable path be dismissed, so
+    // defaulting a malformed record to it would license a double launch on the
+    // strength of a field that was not there. The assertion is on the verdict
+    // rather than the number, because the verdict is what a caller acts on.
+    respondWith(null, JSON.stringify([{ name: 'overlay.exe', processId: 1000 }]))
+
+    const { instances, succeeded } = await findProcessesByName(['overlay.exe'])
+
+    expect(succeeded).toBe(true)
+    expect(resolveConfiguredPathState(instances, CONFIGURED)).toBe('unknown')
+  })
+
+  test('a failed enumeration is a failure, never an empty result', async () => {
+    // `succeeded: false` is what makes every candidate resolve `unknown`
+    // upstream. Reporting an empty instance list as a success would read as
+    // "nothing is running under that name" and un-skip a running app.
+    respondWith(new Error('The RPC server is unavailable.'), '')
+
+    await expect(findProcessesByName(['overlay.exe'])).resolves.toMatchObject({
+      instances: [],
+      succeeded: false
+    })
+  })
+
+  test('asking about nothing is a success with no spawn', async () => {
+    await expect(findProcessesByName([])).resolves.toMatchObject({
+      instances: [],
+      succeeded: true
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -26,6 +26,12 @@ function exeNameOf(appPath: string) {
   return appPath.split(/[\\/]/).pop()!.toLowerCase()
 }
 
+// Configured paths whose IMAGE NAME is in the tasklist but which nothing is
+// actually running at — the #674 collision shape, and the only thing this suite
+// can say about paths at all (see the mock below). Empty by default, so every
+// test that predates #674 keeps exactly its old meaning.
+const collidingPaths = new Set<string>()
+
 // Flushes the microtask queue via a macrotask boundary (setImmediate always
 // runs after every microtask already queued). Used to let an IPC handler
 // advance past a real `await` (e.g. readRunningProcessNames' default resolved
@@ -48,8 +54,19 @@ async function loadLaunchHandlers() {
     killProfileApps,
     killLaunchedApps: vi.fn(),
     readRunningProcessNames,
-    isRunningExePath: (processNames: Set<string>, appPath: string) =>
-      processNames.has(exeNameOf(appPath)),
+    // A COPY of the name-only half of the real helper, plus `collidingPaths` as
+    // the path dimension. This suite mocks the module that owns the #674
+    // decision rule, so it cannot pin the rule — that is
+    // configuredPathState.test.ts, against the real implementation. What it does
+    // pin is that ipc/launch.ts asks the PATH-verified question at all, which is
+    // observable here precisely because `collidingPaths` can disagree with the
+    // name set.
+    resolveRunningConfiguredPaths: async (processNames: Set<string>, appPaths: string[]) =>
+      new Set(
+        appPaths.filter(
+          (appPath) => processNames.has(exeNameOf(appPath)) && !collidingPaths.has(appPath)
+        )
+      ),
     getRunningApps: vi.fn(async () => []),
     subscribeRunningApps: vi.fn(),
     unsubscribeRunningApps: vi.fn(),
@@ -103,6 +120,7 @@ const event = { sender }
 beforeEach(() => {
   vi.resetModules()
   vi.clearAllMocks()
+  collidingPaths.clear()
   isAnyLaunchActive.mockReturnValue(false)
   readRunningProcessNames.mockResolvedValue({ processNames: new Set(), succeeded: true })
   launchProfileApps.mockResolvedValue({ success: true, launchedCount: 1, skippedCount: 0 })
@@ -569,6 +587,80 @@ test('switch-profile-apps unregisters its controller when nothing new needs to s
   expect(registerActiveLaunch).toHaveBeenCalledWith('iracing')
   const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
   expect(unregisterActiveLaunch).toHaveBeenCalledWith('iracing', controller)
+})
+
+// #674 wiring. Every "is this running?" question in this file used to be
+// answered from the tasklist NAME set alone, so an unrelated process sharing an
+// exe name spoke for a configured app. `collidingPaths` is how this suite says
+// "the name is in the tasklist, but nothing of ours is at that path"; the
+// decision rule that produces that answer for real is pinned in
+// configuredPathState.test.ts.
+test('relaunch-missing-profile relaunches an app a same-named stranger masked (#674)', async () => {
+  const handlers = await loadLaunchHandlers()
+  buildActiveProfileLaunchEntries.mockReturnValue([GAME_ENTRY, SIMHUB_ENTRY])
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'simhub.exe']),
+    succeeded: true
+  })
+  collidingPaths.add(SIMHUB_ENTRY.path)
+
+  await handlers['relaunch-missing-profile'](event, 'iracing')
+
+  const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
+  expect(launchProfileApps).toHaveBeenCalledWith(sender, 'iracing', [SIMHUB_ENTRY], { controller })
+})
+
+// The counts here are read out to the user in a confirmation dialog, so a
+// name-only answer promised to stop an app nothing was running and to start
+// nothing when a start was needed (#674).
+test('get-profile-switch-diff does not count a stranger as a running slot (#674)', async () => {
+  const handlers = await loadLaunchHandlers()
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe', 'utilb.exe']),
+    succeeded: true
+  })
+  // Neither utility is really running: something else on the system holds both
+  // names. So the outgoing slot needs no stop, and the incoming one needs a
+  // start that the name-only reading refused it.
+  collidingPaths.add(utilA.path)
+  collidingPaths.add(utilB.path)
+
+  await expect(
+    handlers['get-profile-switch-diff'](event, 'iracing', 'p-from', 'p-to')
+  ).resolves.toEqual({ toStopCount: 0, toStartCount: 1 })
+})
+
+// And the action has to agree with the dialog that announced it, or the user
+// confirms one thing and gets another.
+test('switch-profile-apps does not kill a slot only a stranger was running (#674)', async () => {
+  const handlers = await loadLaunchHandlers()
+  const utilA = { key: 'customapp1', path: 'C:/Tools/UtilA.exe' }
+  const utilB = { key: 'customapp2', path: 'C:/Tools/UtilB.exe' }
+  buildNamedProfileLaunchEntries.mockImplementation((_gameKey: string, profileId: string) =>
+    profileId === 'p-from' ? [GAME_ENTRY, utilA] : [GAME_ENTRY, utilB]
+  )
+  readRunningProcessNames.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'utila.exe', 'utilb.exe']),
+    succeeded: true
+  })
+  collidingPaths.add(utilA.path)
+  collidingPaths.add(utilB.path)
+
+  await handlers['switch-profile-apps'](event, 'iracing', 'p-from', 'p-to')
+
+  expect(killProfileApps).not.toHaveBeenCalled()
+  const controller = registerActiveLaunch.mock.results[0]!.value as AbortController
+  expect(launchProfileApps).toHaveBeenCalledWith(
+    sender,
+    'iracing',
+    [utilB],
+    expect.objectContaining({ controller })
+  )
 })
 
 test('get-profile-switch-diff counts stops/starts without the game executable', async () => {

--- a/tests/main/launch.test.ts
+++ b/tests/main/launch.test.ts
@@ -104,8 +104,18 @@ vi.mock('../../src/main/processes', async () => {
     ) => mocks.killProfileApps(gameKey, entries, options),
     killLaunchedApps: vi.fn(),
     getRunningApps: vi.fn(),
-    isRunningExePath: (processNames: Set<string>, appPath: string) =>
-      processNames.has(appPath.split(/[\\/]/).pop()?.toLowerCase() ?? ''),
+    // A COPY of the name-only half of the real helper. These tests are about
+    // the same-exe key swap (#357), which turns on entry IDENTITY and not on
+    // where the exe lives, so they model the tasklist the way it really is: a
+    // set of names. The #674 path rule is pinned against the real
+    // implementation in configuredPathState.test.ts, and its wiring into these
+    // handlers in ipcLaunch.test.ts.
+    resolveRunningConfiguredPaths: async (processNames: Set<string>, appPaths: string[]) =>
+      new Set(
+        appPaths.filter((appPath) =>
+          processNames.has(appPath.split(/[\\/]/).pop()?.toLowerCase() ?? '')
+        )
+      ),
     subscribeRunningApps: vi.fn(),
     unsubscribeRunningApps: vi.fn(),
     registerActiveLaunch: state.registerActiveLaunch,

--- a/tests/main/processEnumeration.win.test.ts
+++ b/tests/main/processEnumeration.win.test.ts
@@ -1,0 +1,93 @@
+import path from 'path'
+
+import { describe, expect, test } from 'vitest'
+
+import {
+  findProcessesByName,
+  resolveConfiguredPathState
+} from '../../src/main/processes/win32KillUtils'
+
+/**
+ * The only test in the suite that actually runs the PowerShell the app ships.
+ *
+ * Everything else mocks `child_process`, which means every assertion about the
+ * enumeration is really an assertion about the mock. That gap is not
+ * theoretical: the first version of this script used `ConvertTo-Json -AsArray`,
+ * a PowerShell 6+ parameter. On Windows PowerShell 5.1 — which is what
+ * `powershell.exe` always is — it fails at runtime with a parameter-binding
+ * error, `findProcessesByName` reports `succeeded: false`, every candidate
+ * resolves `unknown`, and the whole #674 discriminator degrades to exactly the
+ * name-only behaviour it exists to replace. 776 mocked tests were green.
+ *
+ * A failure here is therefore never cosmetic: it means the feature is off in
+ * production while the rest of the suite still passes.
+ *
+ * Windows-only by necessity, not by convenience. CI's `test` job runs on
+ * windows-latest, so this is a live gate there; a developer on another OS
+ * simply cannot exercise it.
+ */
+const describeWindows = process.platform === 'win32' ? describe : describe.skip
+
+describeWindows('findProcessesByName against the real PowerShell host (#674)', () => {
+  // PowerShell startup dominates; the production timeout is 3s per call and
+  // this makes several, so the ceiling is generous relative to that.
+  const TIMEOUT_MS = 30_000
+
+  test(
+    'the shipped script runs and returns an array for zero, one and many matches',
+    async () => {
+      // Zero. The name cannot exist, so this pins the empty shape rather than
+      // the absence of a spawn.
+      const none = await findProcessesByName(['simlauncher-no-such-process.exe'])
+      expect(none.succeeded).toBe(true)
+      expect(none.instances).toEqual([])
+
+      // One and many at once. The single-match case is the one PowerShell
+      // unrolls to a scalar if the array is not forced, so it is the reason
+      // this test exists in this shape.
+      const self = path.basename(process.execPath).toLowerCase()
+      const some = await findProcessesByName([self])
+      expect(some.succeeded).toBe(true)
+      expect(Array.isArray(some.instances)).toBe(true)
+      expect(some.instances.length).toBeGreaterThan(0)
+      expect(some.instances[0]).toMatchObject({
+        name: self,
+        processId: expect.any(Number),
+        sessionId: expect.any(Number)
+      })
+    },
+    TIMEOUT_MS
+  )
+
+  test(
+    'the decision rule finds this very process at its own path',
+    async () => {
+      // End to end: spawn, parse, normalize, decide. The test runner is itself
+      // a running process at a path we know exactly, so `running` is the only
+      // correct answer and any break in that chain produces a different one.
+      const self = path.basename(process.execPath).toLowerCase()
+      const { instances, succeeded } = await findProcessesByName([self])
+
+      expect(succeeded).toBe(true)
+      expect(resolveConfiguredPathState(instances, process.execPath)).toBe('running')
+    },
+    TIMEOUT_MS
+  )
+
+  test(
+    'a same-named process at another path is not running',
+    async () => {
+      // The collision, against live data. Same image name, a path nothing is
+      // at. `unknown` would be a failure here too: this process IS readable, so
+      // the rule has the evidence to decide.
+      const self = path.basename(process.execPath).toLowerCase()
+      const { instances, succeeded } = await findProcessesByName([self])
+
+      expect(succeeded).toBe(true)
+      expect(resolveConfiguredPathState(instances, `C:/SimLauncher-No-Such-Dir/${self}`)).toBe(
+        'not-running'
+      )
+    },
+    TIMEOUT_MS
+  )
+})

--- a/tests/main/processEnumeration.win.test.ts
+++ b/tests/main/processEnumeration.win.test.ts
@@ -29,8 +29,14 @@ import {
 const describeWindows = process.platform === 'win32' ? describe : describe.skip
 
 describeWindows('findProcessesByName against the real PowerShell host (#674)', () => {
-  // PowerShell startup dominates; the production timeout is 3s per call and
-  // this makes several, so the ceiling is generous relative to that.
+  // PowerShell startup dominates, so the budget is per CALL, not per test. The
+  // production budget is PROCESS_ENUMERATION_TIMEOUT_MS (10s), and the longest
+  // test below makes two calls, so the worst case a passing run can reach is
+  // 20s. The ceiling sits above that without being so high it hides a hang.
+  //
+  // Not the 3s WMI_LOOKUP_TIMEOUT_MS: that belongs to the path-scoped lookup,
+  // and this comment cited it until the enumeration was given its own budget
+  // (CodeRabbit on #845).
   const TIMEOUT_MS = 30_000
 
   test(

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -5439,6 +5439,132 @@ test('WMI returning 0 PIDs after taskkill is treated as closed (genuine exit) (#
   )
 })
 
+// #674, the kill half: the false "it must be running as administrator".
+//
+// A path-scoped kill correctly finds nothing at the configured path, but the
+// post-kill tasklist still shows the IMAGE, because something unrelated on the
+// system runs an exe with the same name. The pre-#674 code could not tell that
+// from #390's elevated-invisible process and blamed elevation, leaving a
+// leftover the user could not clear. In the field repro the "leftover SimHub"
+// was 20 ambient `cmd.exe` processes.
+test('a surviving same-named process at another path is not reported as elevated (#674)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  // The collider: same image name, readable, somewhere else entirely. It is
+  // still in the tasklist after the kill, which is what created the ambiguity.
+  registerProcess('C:/Other/SimHub.exe', 'simhub.exe', '4321')
+  processNames.add('simhub.exe')
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({
+    success: true,
+    closedCount: 0,
+    failedCount: 0,
+    failures: []
+  })
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
+})
+
+// #390 MUST NOT REGRESS, and this is the test that decides whether the fix
+// above widened the query or just inverted a predicate. The setup is identical
+// except that the survivor's path is unreadable in an interactive session,
+// which is exactly what a process running at higher integrity looks like. That
+// is genuinely undecidable, so the elevated leftover has to stay.
+test('a surviving same-named process with no readable path still reports elevated (#390)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerHiddenProcess('simhub.exe', '4321')
+  processNames.add('simhub.exe')
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({
+    success: false,
+    failedCount: 1
+  })
+  expect(unclosedProcesses.get('ac:c:\\tools\\simhub.exe')).toMatchObject({
+    reason: 'access_denied',
+    elevated: true
+  })
+})
+
+// The free half of the discriminator, on the kill path. Session 0 is the
+// non-interactive services session, so it cannot be the companion the user
+// launched — an unreadable path is still decidable there, and on a real machine
+// that covers 170 of the 187 processes WMI will not disclose a path for.
+test('a surviving same-named service in session 0 is not reported as elevated (#674)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerHiddenProcess('simhub.exe', '4321', 0)
+  processNames.add('simhub.exe')
+  const { killLaunchedApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  await expect(killLaunchedApps('ac')).resolves.toMatchObject({
+    success: true,
+    closedCount: 0,
+    failedCount: 0
+  })
+  expect(unclosedProcesses.has('ac:c:\\tools\\simhub.exe')).toBe(false)
+})
+
+// The cost rule, mirrored from the launch half: a close where everything asked
+// for actually died leaves no image in the post-kill tasklist, so no path needs
+// discriminating and no enumeration runs. Without this the fix would add a
+// PowerShell spawn to every Close Apps click.
+test('a close with nothing surviving runs no enumeration at all (#674)', async () => {
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+  processNamesGoneAfterKill.add('simhub.exe')
+  const { killLaunchedApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  await killLaunchedApps('ac')
+
+  const enumerations = execFileCalls.filter(
+    (call) =>
+      call.command === 'powershell.exe' &&
+      typeof (call.options.env as Record<string, string> | undefined)
+        ?.SIMLAUNCHER_TARGET_PROCESS_NAMES === 'string'
+  )
+  expect(enumerations).toHaveLength(0)
+})
+
+// hasClosableLaunchedApps answers "would Close Apps do anything?", so a
+// same-named stranger must not make it say yes — that would offer the user an
+// action that closes nothing (#674, pre-wiring for #673). Deliberately MORE
+// precise than killLaunchedApps' own scheduling, which stays name-gated
+// because attempting a doomed path-scoped kill is harmless.
+test('hasClosableLaunchedApps is false when only a same-named stranger runs (#674)', async () => {
+  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModules()
+  registerProcess('C:/Other/SimHub.exe', 'simhub.exe', '4321')
+  runningProcesses.set('c:\\tools\\simhub.exe', {
+    process: { pid: 1234 } as never,
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+  processNames.add('simhub.exe')
+
+  await expect(hasClosableLaunchedApps()).resolves.toBe(false)
+})
+
 test('killProfileApps falls back to /IM for non-full-path utility companions (#352)', async () => {
   // When the configured app path is an image-name only (e.g. a utility
   // companion that has no installed location), killProfileApps cannot use

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -5565,6 +5565,24 @@ test('hasClosableLaunchedApps is false when only a same-named stranger runs (#67
   await expect(hasClosableLaunchedApps()).resolves.toBe(false)
 })
 
+// The other direction, and the one that keeps the action reachable (CodeRabbit
+// on #845): pinning only the `false` answer would let a change that always
+// returns `false` hide Close Apps entirely and still pass.
+test('hasClosableLaunchedApps is true when the candidate runs at its own path (#674)', async () => {
+  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModules()
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  runningProcesses.set('c:\\tools\\simhub.exe', {
+    process: { pid: 1234 } as never,
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+  processNames.add('simhub.exe')
+
+  await expect(hasClosableLaunchedApps()).resolves.toBe(true)
+})
+
 test('killProfileApps falls back to /IM for non-full-path utility companions (#352)', async () => {
   // When the configured app path is an image-name only (e.g. a utility
   // companion that has no installed location), killProfileApps cannot use

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -145,6 +145,25 @@ type ProcessRegistryEntry = {
   pid: string
   processName: string
   executablePath: string
+  /**
+   * Windows session, 1 (interactive) unless a test says otherwise. Only the
+   * name-scoped enumeration reads it: session 0 is what makes an unreadable
+   * path decidable (#674).
+   */
+  sessionId: number
+}
+
+/**
+ * Processes whose path WMI will not disclose — a non-elevated SimLauncher
+ * looking at something running at higher integrity (#390). Registered
+ * separately because the path-keyed registry above cannot express "running,
+ * location unknown", and that shape is the one the #674 discriminator must
+ * NOT resolve.
+ */
+const hiddenProcesses: { processName: string; pid: string; sessionId: number }[] = []
+
+function registerHiddenProcess(processName: string, pid: string, sessionId = 1) {
+  hiddenProcesses.push({ processName: processName.toLowerCase(), pid, sessionId })
 }
 
 // Path-keyed registry that mirrors what WMI/Get-CimInstance would return for a
@@ -156,11 +175,12 @@ function normalizeRegistryKey(filePath: string) {
   return path.resolve(filePath).toLowerCase()
 }
 
-function registerProcess(executablePath: string, processName: string, pid: string) {
+function registerProcess(executablePath: string, processName: string, pid: string, sessionId = 1) {
   processRegistry.set(normalizeRegistryKey(executablePath), {
     pid,
     processName: processName.toLowerCase(),
-    executablePath
+    executablePath,
+    sessionId
   })
 }
 
@@ -295,6 +315,64 @@ async function loadProcessModules() {
           (options.env?.SIMLAUNCHER_TARGET_PROCESS_NAME as string | undefined) ??
           script.match(/\$name = '([^']+)'/)?.[1]
         )?.toLowerCase()
+
+        // The name-scoped enumeration behind the #674 discriminator. It asks
+        // about several names at once and gets no target path, so it has to be
+        // answered before the path-scoped branch below.
+        //
+        // Three sources, and the third is the load-bearing default. The path
+        // registry is authoritative when a test said WHERE a process runs.
+        // `hiddenProcesses` models the #390 shape, running with an unreadable
+        // path. And a bare `processNames.add(name)` — which most tests use,
+        // meaning only "something with this name is running" — yields an
+        // instance with a NULL path in an interactive session, i.e. `unknown`.
+        //
+        // That default is deliberate: an unmodelled location must not be
+        // silently read as "at the configured path", or every collision
+        // assertion in this file would pass without the discriminator existing.
+        // It also keeps those tests honest about what they pin, since `unknown`
+        // resolves to the same conservative answer they asserted before #674.
+        const namesEnv = options.env?.SIMLAUNCHER_TARGET_PROCESS_NAMES
+        if (typeof namesEnv === 'string' && namesEnv.length > 0) {
+          const wanted = new Set((JSON.parse(namesEnv) as string[]).map((n) => n.toLowerCase()))
+          const instances: {
+            name: string
+            processId: number
+            executablePath: string | null
+            sessionId: number
+          }[] = []
+          const modelled = new Set<string>()
+
+          processRegistry.forEach((entry) => {
+            if (!wanted.has(entry.processName)) return
+            modelled.add(entry.processName)
+            instances.push({
+              name: entry.processName,
+              processId: Number(entry.pid) || 0,
+              executablePath: entry.executablePath,
+              sessionId: entry.sessionId
+            })
+          })
+
+          hiddenProcesses.forEach((entry) => {
+            if (!wanted.has(entry.processName)) return
+            modelled.add(entry.processName)
+            instances.push({
+              name: entry.processName,
+              processId: Number(entry.pid) || 0,
+              executablePath: null,
+              sessionId: entry.sessionId
+            })
+          })
+
+          wanted.forEach((name) => {
+            if (modelled.has(name) || !processNames.has(name)) return
+            instances.push({ name, processId: 9000, executablePath: null, sessionId: 1 })
+          })
+
+          callback(null, JSON.stringify(instances), '')
+          return
+        }
 
         const targetPathEnv = options.env?.SIMLAUNCHER_TARGET_PROCESS_PATH
         if (typeof targetPathEnv !== 'string' || targetPathEnv.length === 0) {
@@ -742,6 +820,7 @@ beforeEach(async () => {
   tasklistReadFailArmed = false
   wmiLookupCounts.clear()
   processRegistry.clear()
+  hiddenProcesses.length = 0
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
@@ -1252,6 +1331,134 @@ test('launchProfileApps skips profile apps that are already running', async () =
     skippedCount: 1,
     message: 'All profile applications are already running.'
   })
+})
+
+// #674, the launch half. `tasklist` reports image NAMES with no path, so a
+// same-named process from anywhere on the system used to make this filter drop
+// a configured app that was not running at all. The user's companion silently
+// never started, was counted as "already running", and was later blamed on
+// elevation when Close Apps could not find it.
+//
+// The collider does not have to be related to anything the user configured: in
+// the field repro it was ambient `cmd.exe` instances belonging to a build tool.
+test('a same-named process at another path no longer blocks the launch (#674)', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  markExistingPath('C:/Tools/Overlay.exe')
+  // The collider: same image name, entirely different path, readable.
+  registerProcess('C:/UserApps/Overlay.exe', 'overlay.exe', '4321')
+  processNames.add('overlay.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Overlay.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1,
+    skippedCount: 0
+  })
+  expect(spawnCalls.map((call) => call.appPath)).toContain('C:/Tools/Overlay.exe')
+})
+
+// The other direction, and the one that must not regress: a process genuinely
+// running AT the configured path is still skipped. Getting this wrong would
+// start a second copy of every companion on every launch.
+test('a process at the configured path is still skipped (#674)', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  markExistingPath('C:/Tools/Overlay.exe')
+  registerProcess('C:/Tools/Overlay.exe', 'overlay.exe', '4321')
+  processNames.add('overlay.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Overlay.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 0,
+    skippedCount: 1
+  })
+})
+
+// #390 MUST NOT REGRESS. A process running at higher integrity than a
+// non-elevated SimLauncher hides its path, which is byte-identical to the
+// collision signal from a path-scoped query. That is the whole reason the fix
+// had to widen the query instead of inverting a predicate: here the answer is
+// genuinely unknown, so the app keeps its pre-#674 behaviour and skips.
+test('an elevated same-named process with no readable path is still skipped (#390)', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  markExistingPath('C:/Tools/Overlay.exe')
+  registerHiddenProcess('overlay.exe', '4321')
+  processNames.add('overlay.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Overlay.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 0,
+    skippedCount: 1
+  })
+})
+
+// The free half of the discriminator. Session 0 is the non-interactive services
+// session, so it cannot be hosting the companion the user launched, and that is
+// what makes an unreadable path decidable there. On a real machine this covers
+// 170 of the 187 processes whose path WMI will not disclose, at the cost of an
+// integer that is already in the tasklist output.
+test('a same-named service in session 0 does not block the launch (#674)', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  markExistingPath('C:/Tools/Overlay.exe')
+  registerHiddenProcess('overlay.exe', '4321', 0)
+  processNames.add('overlay.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Overlay.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1,
+    skippedCount: 0
+  })
+})
+
+// The cost guarantee, and the reason this fix does not fight the footprint
+// milestone. Verification is only reached for a path whose image name is
+// actually in the tasklist, so an ordinary launch with nothing colliding pays
+// for no enumeration at all. Without this the fix would add a PowerShell spawn
+// to every launch, which is the cost profile it was scoped to avoid.
+test('a launch with no name collision runs no enumeration at all (#674)', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  markExistingPath('C:/Tools/Overlay.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/Overlay.exe'])).resolves.toMatchObject({
+    success: true,
+    launchedCount: 1
+  })
+
+  const enumerations = execFileCalls.filter(
+    (call) =>
+      call.command === 'powershell.exe' &&
+      typeof (call.options.env as Record<string, string> | undefined)
+        ?.SIMLAUNCHER_TARGET_PROCESS_NAMES === 'string'
+  )
+  expect(enumerations).toHaveLength(0)
+})
+
+// ...and when it does collide, it is ONE spawn for the whole batch rather than
+// one per app. The cost is proportional to collisions, not to profile size.
+test('several colliding apps are verified in a single enumeration (#674)', async () => {
+  const { launchProfileApps } = await loadProcessModules()
+
+  markExistingPath('C:/Tools/Overlay.exe')
+  markExistingPath('C:/Tools/Launcher.exe')
+  registerProcess('C:/UserApps/Overlay.exe', 'overlay.exe', '1')
+  registerProcess('C:/UserApps/Launcher.exe', 'launcher.exe', '2')
+  processNames.add('overlay.exe')
+  processNames.add('launcher.exe')
+
+  await expect(
+    launchProfileApps(sender, 'ac', ['C:/Tools/Overlay.exe', 'C:/Tools/Launcher.exe'])
+  ).resolves.toMatchObject({ success: true, launchedCount: 2, skippedCount: 0 })
+
+  const enumerations = execFileCalls.filter(
+    (call) =>
+      call.command === 'powershell.exe' &&
+      typeof (call.options.env as Record<string, string> | undefined)
+        ?.SIMLAUNCHER_TARGET_PROCESS_NAMES === 'string'
+  )
+  expect(enumerations).toHaveLength(1)
 })
 
 // #739: the renderer concatenates the skip warning onto `message`, so a summary


### PR DESCRIPTION
First of two PRs for #674. **Deliberately does not close it**: this fixes every place a decision is made in response to a user action, and leaves the 2s running-apps poll (and the phantom strip icon it draws) for the follow-up.

## Summary

`tasklist` reports image NAMES with no path, so every "is this configured app already running?" answer in the app was name-only, and any process on the system sharing an exe name spoke for the user's configured app. In the field repro the collider was 20 ambient `C:\WINDOWS\system32\cmd.exe` processes, unrelated to anything configured.

New shared primitive in `win32KillUtils.ts`: a name-scoped `Get-CimInstance` enumeration returning each instance with its path and session, plus one decision rule over it.

1. **A path match wins outright**, including in session 0. Session may only ever dismiss an instance, never deny a positive match.
2. **Dismissible** = a readable path that differs, OR session 0. Session 0 is the non-interactive services session, so it cannot host a companion the user launched. That is what makes an unreadable path decidable there, and on a real machine it resolves 170 of the 187 processes WMI will not disclose a path for.
3. **Anything left** is an unreadable path in an interactive session, which is exactly #390's shape, so the answer is `unknown` and the caller keeps its pre-#674 behaviour.

The six sites now routed through it:

| Site | What was wrong |
|---|---|
| `spawn.ts` launch filter | the configured app silently never started, counted as "already running" |
| `finalizeKillAttempts` | told the user the app could not be closed and "may be running as administrator" |
| `relaunch-missing-profile` | refused to restart a crashed app a stranger was masking, the exact case that action exists for |
| `get-profile-switch-diff` | quoted stop/start counts in a confirmation dialog that no configured app backed |
| `switch-profile-apps` | stopped and started slots on the same evidence, so the action disagreed with its own dialog |
| `hasClosableLaunchedApps` | would have handed #673 a Close Apps control that closes nothing |

`resolveRunningConfiguredPaths` is the single definition, replacing `isRunningExePath`, which had no honest implementation left.

## Cost

Zero added spawns in the common case, by construction: a path whose image name is absent from the tasklist set cannot be running, so it is answered without enumerating. A collision costs exactly one spawn for the whole batch, not one per app. Both halves are pinned by tests rather than asserted here.

That matters because the enumeration would otherwise cut against 1.3.0 Performance and Footprint. It does not: none of these sites is on the poll, and every one of them already pays for at least one PowerShell or WMI spawn.

## Deliberately not changed

- **Kill scheduling in `killLaunchedApps` stays name-gated.** Scheduling a kill for a path nothing is running at costs a lookup and nothing else, because the kill is path-scoped and finalize now judges the empty result correctly. Verifying there would only buy a second spawn per close. Documented in place so it does not read as an oversight.
- **`hasClosableLaunchedApps` IS verified**, and that asymmetry is intentional: it answers "would this do anything?", where a wrong yes is user-visible.

## Also fixed

The enumeration parse defaulted a record with no session to session 0. That is the one value that lets an unreadable path be dismissed, so a malformed record could have licensed a double launch. It now defaults to a sentinel that leaves the record undecidable.

## Follow-ups filed

- #674 stays open for PR 2: the poll, and the strip icon that cannot be dismissed today because it is a derived view recomputed every tick rather than stored state.
- #844: a narrow residual in the sibling fallback that PR 1 leaves reachable, with the reason it could not be closed here.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (776 passing, 11 new)
- [x] Mutation pass, each new test proven to fire against a faithful reversion:
  - disable the kill-side discriminator: the two #674 kill tests fail, #390 stays green
  - revert `hasClosableLaunchedApps` to name-only: its new test fails
  - revert the three `ipc/launch.ts` sites to name-only: all three wiring tests fail
  - restore the session-0 parse default: the undecidable-record test fails
- [x] Guardrails held rather than edited: #390 (elevated-invisible must still report elevated) and "a process at the configured path is still skipped".
- [ ] Manual: batched into the 1.2.0 smoke run, which already carries the `cmd.exe` collision repro as item A.

Refs #674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application launch, relaunch, profile switching, and stopping by matching running processes to their configured executable paths.
  * Prevented unrelated applications with the same filename from blocking launches or being stopped.
  * Added safer handling for inaccessible process information and Windows system processes.
* **Tests**
  * Expanded coverage for same-name process collisions, path matching, session behavior, and unavailable process details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->