### PR TITLE
fix(processes): stop the running-apps poll answering by image name (#674)

### DIFF
--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -88,9 +88,24 @@ function registerUnclosedProcess(attempt: KillAttemptResult) {
   })
 }
 
-export function pruneUnclosedProcesses(processNames: Set<string>): void {
+/**
+ * Drop every leftover record whose app is no longer running.
+ *
+ * Takes a PREDICATE rather than the tasklist name set it used to take (#674),
+ * and that change is what makes a leftover clearable at all. Pruning by image
+ * name meant a record could only ever go away when the NAME left the tasklist,
+ * so a leftover created against a same-named stranger was permanent: the user
+ * could not dismiss it, closing the app did not clear it, and nothing else
+ * would. It also pinned the poll to its FAST cadence for the rest of the
+ * session, because `computeRunningAppsScanDelayMs` stays fast while any
+ * unclosed record exists.
+ *
+ * The predicate must answer "yes" when it does not know, so an unobserved tick
+ * cannot silently clear a real leftover.
+ */
+export function pruneUnclosedProcesses(isPathRunning: (appPath: string) => boolean): void {
   unclosedProcesses.forEach((entry, key) => {
-    if (!processNames.has(getExeName(entry.path))) {
+    if (!isPathRunning(entry.path)) {
       unclosedProcesses.delete(key)
     }
   })

--- a/src/main/processes/pathResolution.ts
+++ b/src/main/processes/pathResolution.ts
@@ -1,0 +1,227 @@
+/**
+ * Answering "is my configured app running?" on the 2s poll, without paying for
+ * a process enumeration on every tick (#674, second half).
+ *
+ * The launch and kill paths can afford `findProcessesByName` outright: they are
+ * user actions that already spawn PowerShell. The poll cannot. It runs forever,
+ * in the tray, and adding a spawn per tick would cut straight against the
+ * 1.3.0 footprint milestone.
+ *
+ * Three things make the cheap version possible, in order of how much they buy:
+ *
+ *   1. **The tasklist already carries PID and session.** Both were being parsed
+ *      and discarded. Session 0 is the non-interactive services session, so
+ *      every process there is dismissible without asking anything further. On a
+ *      real machine that is 170 of 537 processes, for free.
+ *   2. **A path, once learned for a PID, stays true for that PID's lifetime.**
+ *      Windows does not move a running image, so the only invalidation needed
+ *      is the PID leaving the tasklist. No TTL, and no revalidation.
+ *   3. **"Windows will not tell us" is itself an answer worth caching.** An
+ *      elevated process hides its path from a non-elevated SimLauncher and will
+ *      keep hiding it, so a null result is stored rather than retried. Without
+ *      this the pathological cases never converge.
+ *
+ * Together those give the property this design exists for: **in steady state
+ * the poll spawns nothing extra.** A resolution happens when an unfamiliar PID
+ * appears under a name we care about, which is a launch, not a tick.
+ *
+ * The DECISION is not re-implemented here. `resolveConfiguredPathState` in
+ * `win32KillUtils` is the one rule, and this module's whole job is to feed it
+ * the same `NamedProcessInstance` shape from a cheaper source. Two rules that
+ * agreed by convention is exactly what #149 was about.
+ */
+import { performance } from 'perf_hooks'
+
+import { getExeName } from '../utils'
+
+import type { TasklistProcess } from './tasklist'
+import {
+  type ConfiguredPathState,
+  type NamedProcessInstance,
+  findProcessesByName,
+  resolveConfiguredPathState
+} from './win32KillUtils'
+
+/**
+ * How long before the same image name may cost another enumeration.
+ *
+ * Point 3 above converges the ordinary case on its own, so this is not the
+ * mechanism that makes the poll cheap. It bounds the one case that cannot
+ * converge: a name that keeps producing NEW pids. On a developer machine
+ * `cmd.exe` reaches roughly 30 spawns a minute, and "resolve unfamiliar pids"
+ * would chase every one of them. With the cooldown that name costs at most one
+ * enumeration per window, and the pids it did not get to are simply still
+ * unknown, which the decision rule already handles conservatively.
+ */
+const NAME_RESOLUTION_COOLDOWN_MS = 45000
+
+/**
+ * PID to executable path.
+ *
+ * PRESENCE means resolved. A `null` VALUE is a resolved answer, "we asked and
+ * Windows would not say", and must not be retried; a missing key is "we have
+ * not asked". Collapsing those two is what would turn every elevated process
+ * into a permanent source of enumerations.
+ */
+const resolvedPidPaths = new Map<number, string | null>()
+/** Image name to the monotonic timestamp of its last enumeration. */
+const nameResolvedAt = new Map<string, number>()
+
+/** Test seam. Production never needs this: the maps self-prune from the poll. */
+export function resetPathResolutionCache(): void {
+  resolvedPidPaths.clear()
+  nameResolvedAt.clear()
+}
+
+/**
+ * Drop everything the latest snapshot says is gone.
+ *
+ * This is the entire invalidation strategy, and it is exact rather than
+ * approximate: a PID that is no longer running cannot be running at a different
+ * path, and Windows will not hand the number to a new process while the old one
+ * is still listed. A TTL would be strictly worse, expiring answers that are
+ * still true and keeping ones that are not.
+ *
+ * ONLY call this for a snapshot that actually succeeded. A failed read yields an
+ * empty snapshot, and treating that as "every process ended" would flush the
+ * whole cache and buy back all the enumerations at the worst moment (#399).
+ */
+function reconcileResolvedPaths(processes: TasklistProcess[]): void {
+  const livePids = new Set(processes.map((entry) => entry.processId))
+  resolvedPidPaths.forEach((_path, pid) => {
+    if (!livePids.has(pid)) {
+      resolvedPidPaths.delete(pid)
+    }
+  })
+
+  const liveNames = new Set(processes.map((entry) => entry.name))
+  nameResolvedAt.forEach((_at, name) => {
+    // A name with nothing running has no pids to resolve, so its cooldown is
+    // holding back an enumeration that would not happen anyway. Clearing it
+    // means the NEXT appearance of that name is answered promptly instead of
+    // inheriting a stale timer from a previous run of the app.
+    if (!liveNames.has(name)) {
+      nameResolvedAt.delete(name)
+    }
+  })
+}
+
+/**
+ * The tasklist snapshot expressed as the shape the decision rule consumes,
+ * enriched with whatever paths are already known.
+ *
+ * An unresolved PID becomes `executablePath: null`, which is the same thing the
+ * enumeration reports for a path Windows withholds. That is deliberate and it
+ * is what keeps the rule honest: both mean "this instance cannot be ruled out",
+ * so both land on `unknown` and the caller keeps its pre-#674 behaviour.
+ */
+function buildInstances(processes: TasklistProcess[]): NamedProcessInstance[] {
+  return processes.map((entry) => ({
+    name: entry.name,
+    processId: entry.processId,
+    executablePath: resolvedPidPaths.get(entry.processId) ?? null,
+    sessionId: entry.sessionId
+  }))
+}
+
+/**
+ * Image names that still hold an instance nothing can decide, and that are off
+ * cooldown, i.e. the names worth spending one enumeration on.
+ *
+ * Session 0 instances are excluded because the rule can already dismiss them,
+ * and pids with a stored `null` are excluded because asking again would get the
+ * same refusal. What is left is genuinely unfamiliar.
+ */
+function collectNamesWorthResolving(
+  processes: TasklistProcess[],
+  wantedNames: Set<string>,
+  now: number
+): string[] {
+  const names = new Set<string>()
+
+  processes.forEach((entry) => {
+    if (!wantedNames.has(entry.name) || entry.sessionId === 0) {
+      return
+    }
+    if (resolvedPidPaths.has(entry.processId)) {
+      return
+    }
+    const lastResolvedAt = nameResolvedAt.get(entry.name)
+    if (lastResolvedAt !== undefined && now - lastResolvedAt < NAME_RESOLUTION_COOLDOWN_MS) {
+      return
+    }
+    names.add(entry.name)
+  })
+
+  return Array.from(names)
+}
+
+/**
+ * Decide, for each configured path, whether it is running, using the snapshot
+ * the poll already paid for and resolving unfamiliar pids at most once.
+ *
+ * `succeeded === false` short-circuits to an empty map rather than an answer.
+ * Every caller reads a missing entry the way it read the pre-#674 world, so a
+ * failed read changes nothing rather than emptying the strip.
+ */
+export async function resolveTrackedPathStates(
+  snapshot: { processes: TasklistProcess[]; succeeded: boolean },
+  configuredPaths: string[]
+): Promise<Map<string, ConfiguredPathState>> {
+  const states = new Map<string, ConfiguredPathState>()
+
+  if (!snapshot.succeeded || configuredPaths.length === 0) {
+    return states
+  }
+
+  reconcileResolvedPaths(snapshot.processes)
+
+  const wantedNames = new Set(configuredPaths.map((configuredPath) => getExeName(configuredPath)))
+  const namesToResolve = collectNamesWorthResolving(
+    snapshot.processes,
+    wantedNames,
+    performance.now()
+  )
+
+  if (namesToResolve.length > 0) {
+    const { instances, succeeded } = await findProcessesByName(namesToResolve)
+
+    // The cooldown is stamped whether or not the enumeration worked, and the
+    // two halves are deliberately separate. A failure teaches nothing, so no
+    // path is cached and the ANSWER stays honestly `unknown`. But retrying a
+    // broken enumeration on every 2s tick is exactly the footprint regression
+    // this module exists to avoid: a persistent failure (PowerShell missing,
+    // WMI wedged) would spawn forever. Rate-limiting the retry and refusing to
+    // record a verdict are different concerns, and conflating them costs one or
+    // the other.
+    const now = performance.now()
+    namesToResolve.forEach((name) => nameResolvedAt.set(name, now))
+
+    if (succeeded) {
+      // Recorded for every pid the enumeration saw, including the ones whose
+      // path it would not disclose, so those stop being asked about at all.
+      instances.forEach((instance) => {
+        resolvedPidPaths.set(instance.processId, instance.executablePath)
+      })
+    }
+  }
+
+  const enriched = buildInstances(snapshot.processes)
+  configuredPaths.forEach((configuredPath) => {
+    states.set(configuredPath, resolveConfiguredPathState(enriched, configuredPath))
+  })
+
+  return states
+}
+
+/**
+ * Whether a configured path should be treated as running, folding `unknown` and
+ * "no answer" into "yes".
+ *
+ * Same conservative reading as the launch and kill paths, and for the same
+ * reason: a missing entry means the poll could not observe, and an absence of
+ * observation must never remove something the user can see.
+ */
+export function isTrackedPathRunning(state: ConfiguredPathState | undefined): boolean {
+  return state !== 'not-running'
+}

--- a/src/main/processes/pathResolution.ts
+++ b/src/main/processes/pathResolution.ts
@@ -10,9 +10,12 @@
  * Three things make the cheap version possible, in order of how much they buy:
  *
  *   1. **The tasklist already carries PID and session.** Both were being parsed
- *      and discarded. Session 0 is the non-interactive services session, so
- *      every process there is dismissible without asking anything further. On a
- *      real machine that is 170 of 537 processes, for free.
+ *      and discarded. Session 0 is the non-interactive services session, so an
+ *      instance there whose path Windows will not disclose is still decidable,
+ *      which on a real machine covers 170 of 537 processes. That dismissal
+ *      belongs to the decision rule, not to this module: a session-0 instance AT
+ *      the configured path is genuinely running, so session is only ever grounds
+ *      to discard an instance, never grounds to skip looking at one.
  *   2. **A path, once learned for a PID, stays true for that PID's lifetime.**
  *      Windows does not move a running image, so the only invalidation needed
  *      is the PID leaving the tasklist. No TTL, and no revalidation.
@@ -125,12 +128,28 @@ function buildInstances(processes: TasklistProcess[]): NamedProcessInstance[] {
 }
 
 /**
- * Image names that still hold an instance nothing can decide, and that are off
- * cooldown, i.e. the names worth spending one enumeration on.
+ * Image names holding a pid we have never resolved, and that are off cooldown,
+ * i.e. the names worth spending one enumeration on.
  *
- * Session 0 instances are excluded because the rule can already dismiss them,
- * and pids with a stored `null` are excluded because asking again would get the
- * same refusal. What is left is genuinely unfamiliar.
+ * A pid with a stored path is excluded, and so is one with a stored `null`,
+ * because asking again would get the same refusal. What is left is genuinely
+ * unfamiliar.
+ *
+ * Session 0 is deliberately NOT a reason to skip, though it looks like an easy
+ * saving and was one until the review bot on #846 took it apart. Dismissing a
+ * session-0 instance is the RULE's job, and the rule only dismisses one whose
+ * path it could not read: a session-0 instance AT the configured path is
+ * `running`, because a service-hosted copy of the configured exe is still the
+ * configured exe. Skipping it here meant its path was never learned, so that
+ * branch could not fire and the answer collapsed to `not-running` — while the
+ * launch and kill paths, which enumerate unconditionally, said `running`. This
+ * module's whole claim is that it feeds the SAME rule from a cheaper source, and
+ * a cheaper source that changes the answer is not that.
+ *
+ * The saving it appeared to buy was mostly illusory anyway. It only applied to a
+ * configured app whose name collides with a service, and a resolved pid stays
+ * resolved for its lifetime — services being long-lived, that is one enumeration
+ * ever, not one per tick. The steady-state guarantee is untouched.
  */
 function collectNamesWorthResolving(
   processes: TasklistProcess[],
@@ -140,7 +159,7 @@ function collectNamesWorthResolving(
   const names = new Set<string>()
 
   processes.forEach((entry) => {
-    if (!wantedNames.has(entry.name) || entry.sessionId === 0) {
+    if (!wantedNames.has(entry.name)) {
       return
     }
     if (resolvedPidPaths.has(entry.processId)) {

--- a/src/main/processes/pathResolution.ts
+++ b/src/main/processes/pathResolution.ts
@@ -176,6 +176,45 @@ function collectNamesWorthResolving(
 }
 
 /**
+ * Whether anything about this image name is still unaccounted for, in which
+ * case `not-running` is a claim the evidence does not support.
+ *
+ * The shared rule reasons about the instances it is GIVEN. This module builds
+ * those instances from a snapshot that can be incomplete in two ways the rule
+ * cannot see, and in both of them a missing instance is indistinguishable from
+ * an absent process (both CodeRabbit, on #846):
+ *
+ *   1. **A pid nobody has resolved.** `buildInstances` gives it a null path,
+ *      which for a SESSION 0 pid the rule dismisses outright — correctly, when
+ *      the null means "Windows refused", and wrongly when it only means "the
+ *      cooldown skipped it". A configured app starting as a service inside a
+ *      cooldown window would read as stopped, and be pruned.
+ *   2. **A row the parser could not turn into an instance.** The name is still
+ *      recorded as running, deliberately, but there is no instance to reason
+ *      about, so the rule sees nothing at all under that name.
+ *
+ * Both collapse to the same rule: not having looked is not the same as having
+ * looked and found nothing, and only the second may answer `not-running`.
+ */
+function hasUnaccountedEvidence(
+  processNames: Set<string>,
+  processes: TasklistProcess[],
+  targetName: string
+): boolean {
+  if (!processNames.has(targetName)) {
+    // Nothing is running under this name, which is a fact rather than a gap.
+    return false
+  }
+
+  const named = processes.filter((entry) => entry.name === targetName)
+  if (named.length === 0) {
+    return true
+  }
+
+  return named.some((entry) => !resolvedPidPaths.has(entry.processId))
+}
+
+/**
  * Decide, for each configured path, whether it is running, using the snapshot
  * the poll already paid for and resolving unfamiliar pids at most once.
  *
@@ -184,7 +223,7 @@ function collectNamesWorthResolving(
  * failed read changes nothing rather than emptying the strip.
  */
 export async function resolveTrackedPathStates(
-  snapshot: { processes: TasklistProcess[]; succeeded: boolean },
+  snapshot: { processNames: Set<string>; processes: TasklistProcess[]; succeeded: boolean },
   configuredPaths: string[]
 ): Promise<Map<string, ConfiguredPathState>> {
   const states = new Map<string, ConfiguredPathState>()
@@ -227,7 +266,13 @@ export async function resolveTrackedPathStates(
 
   const enriched = buildInstances(snapshot.processes)
   configuredPaths.forEach((configuredPath) => {
-    states.set(configuredPath, resolveConfiguredPathState(enriched, configuredPath))
+    const state = resolveConfiguredPathState(enriched, configuredPath)
+    // Only ever weakens `not-running`, never a positive answer: a path match is
+    // evidence in its own right and outranks anything still unaccounted for.
+    const downgrade =
+      state === 'not-running' &&
+      hasUnaccountedEvidence(snapshot.processNames, snapshot.processes, getExeName(configuredPath))
+    states.set(configuredPath, downgrade ? 'unknown' : state)
   })
 
   return states

--- a/src/main/processes/pathResolution.ts
+++ b/src/main/processes/pathResolution.ts
@@ -79,11 +79,22 @@ export function resetPathResolutionCache(): void {
 /**
  * Drop everything the latest snapshot says is gone.
  *
- * This is the entire invalidation strategy, and it is exact rather than
- * approximate: a PID that is no longer running cannot be running at a different
- * path, and Windows will not hand the number to a new process while the old one
- * is still listed. A TTL would be strictly worse, expiring answers that are
- * still true and keeping ones that are not.
+ * A PID that is no longer running cannot be running at a different path, so an
+ * entry the snapshot does not list is definitively dead. A TTL as the PRIMARY
+ * mechanism would be strictly worse, expiring answers that are still true and
+ * keeping ones that are not.
+ *
+ * KNOWN RESIDUAL, recorded on its own issue (Codex P2 on #846). This is exact
+ * only for a pid whose absence we OBSERVE, and the poll samples rather than
+ * watches: a cached process can exit and Windows can reuse its number before the
+ * next snapshot, in which case the pid never appears absent and keeps the old
+ * path. Three things have to line up for that to matter, because `buildInstances`
+ * takes the NAME from the live snapshot and only the path from here, so a
+ * reused pid under a different image name is filtered out by the rule and is
+ * harmless. It needs the same pid, reused inside one tick, by a process with the
+ * same image name. The fix is a stronger identity than the number alone
+ * (creation time, which `tasklist` does not carry) or a long revalidation
+ * window, and neither belongs in this issue.
  *
  * ONLY call this for a snapshot that actually succeeded. A failed read yields an
  * empty snapshot, and treating that as "every process ended" would flush the

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -22,6 +22,7 @@ import {
   runningProcesses,
   unclosedProcesses
 } from './state'
+import { isTrackedPathRunning, resolveTrackedPathStates } from './pathResolution'
 import { readRunningProcessNames, type RunningProcessNamesResult } from './tasklist'
 
 /**
@@ -100,7 +101,7 @@ let publishRunningAppsPromise: Promise<RunningAppsChangedPayload | null> | undef
  * companion utilities.
  */
 function getExternallyAdoptableGameKeys(
-  processNames: Set<string>,
+  isPathRunning: (appPath: string) => boolean,
   profiles: Record<string, StoredProfileEntry> | undefined,
   gamePaths: Record<string, string> | undefined,
   launchedGameKeys: Set<string>
@@ -136,7 +137,17 @@ function getExternallyAdoptableGameKeys(
     const exeName = getExeName(gamePath)
     const owners = gameExeOwners.get(exeName)
 
-    if (owners?.size === 1 && processNames.has(exeName)) {
+    // `isValidExePath` takes `unknown` and returns a plain boolean, so it does
+    // not narrow; the query below needs a string.
+    if (typeof gamePath !== 'string') {
+      return
+    }
+
+    // Path-verified (#674). Adopting on the image name alone surfaced a whole
+    // profile's companion list because something shared the game exe's name,
+    // which is the widest blast radius the collision had: one stranger, and a
+    // game the user never started looks like a live session.
+    if (owners?.size === 1 && isPathRunning(gamePath)) {
       adoptableGameKeys.add(gameKey)
     }
   })
@@ -151,7 +162,7 @@ function getExternallyAdoptableGameKeys(
 // a companion still surfaces that profile's companions (same aggregate-vs-game
 // distinction as the green dot, #587; the in-session-exe question is #585/#586).
 async function getTrackedRunningApps(
-  processNames: Set<string>,
+  isPathRunning: (appPath: string) => boolean,
   adoptedOrLaunchedGameKeys: Set<string>,
   profiles: Record<string, StoredProfileEntry> | undefined,
   appPaths: Record<string, string> | undefined,
@@ -174,10 +185,14 @@ async function getTrackedRunningApps(
     const pathsToTrack = getProfileTrackablePaths(gameKey, profile, appPaths, gamePaths)
 
     pathsToTrack.forEach((trackedPath) => {
-      const processName = getExeName(trackedPath)
       const dedupeKey = `${gameKey}:${normalizePathForComparison(trackedPath)}`
 
-      if (processNames.has(processName) && !seen.has(dedupeKey)) {
+      // THE phantom icon (#674). This is the line that drew a strip entry for a
+      // configured app that was not running, because something unrelated on the
+      // system shared its exe name. The icon could not be dismissed either: it
+      // is derived here on every tick rather than stored, so `dismissAppIcon`
+      // had nothing to delete and it came straight back.
+      if (isPathRunning(trackedPath) && !seen.has(dedupeKey)) {
         trackedApps.push({
           path: trackedPath,
           name: path.basename(trackedPath),
@@ -259,7 +274,11 @@ function reconcileUntrackedGames(): void {
 
 export async function getRunningApps(): Promise<RunningApp[]> {
   const readResult = await readRunningProcessNames()
-  const { processNames, succeeded: tasklistReadSucceeded } = readResult
+  // `processNames` is deliberately not read here any more (#674). Every
+  // question this function asks is now about a PATH, and the snapshot reaches
+  // the resolver whole, so a name-only decision cannot creep back in by
+  // reaching for a set that happened to be in scope.
+  const { succeeded: tasklistReadSucceeded } = readResult
   // Observers run before any derivation below, on every read rather than only
   // on scan ticks, and never get to break the caller: a throwing observer must
   // not take the running-apps list down with it.
@@ -270,18 +289,64 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       console.error('Process scan observer error:', err)
     }
   })
+  const profiles = getStoredProfiles()
+  const appPaths = getStoredStringRecord('appPaths')
+  const gamePaths = getStoredStringRecord('gamePaths')
+
+  // Every path this tick could ask about, gathered before anything is decided
+  // so the whole tick costs ONE resolution rather than one per question (#674).
+  //
+  // Deliberately a superset: it spans all profiles, not just the ones that turn
+  // out to be adopted or launched, because adoption is itself one of the
+  // questions being answered. That costs nothing, since a path whose image name
+  // is absent from the snapshot is resolved for free and never reaches an
+  // enumeration.
+  //
+  // Collected BEFORE the pruning below, which is what makes pruning by path
+  // possible at all: a record about to be dropped still needs its own question
+  // answered.
+  const candidatePaths = new Set<string>()
+  Object.entries(profiles || {}).forEach(([gameKey, profileEntry]) => {
+    getProfileTrackablePaths(
+      gameKey,
+      getActiveStoredProfile(profileEntry),
+      appPaths,
+      gamePaths
+    ).forEach((trackablePath) => candidatePaths.add(trackablePath))
+  })
+  Object.values(gamePaths || {}).forEach((gamePath) => {
+    if (isValidExePath(gamePath)) {
+      candidatePaths.add(gamePath)
+    }
+  })
+  runningProcesses.forEach((entry) => candidatePaths.add(entry.path))
+  unclosedProcesses.forEach((entry) => candidatePaths.add(entry.path))
+  processNameMismatchWarnings.forEach((entry) => candidatePaths.add(entry.path))
+
+  const pathStates = await resolveTrackedPathStates(readResult, Array.from(candidatePaths))
+  // Folds `unknown` and "not asked" into "running", the same conservative
+  // reading the launch and kill paths use: a path that MIGHT be running must
+  // not have its record deleted or its icon pulled.
+  //
+  // The `tasklistReadSucceeded` term keeps a failed read behaving exactly as it
+  // did before #674, deliberately rather than by omission. A failed read used to
+  // yield an empty `processNames`, so every derivation below answered "not
+  // running" and the tick published an empty list; folding it to "running"
+  // instead would be a real behaviour change (the strip would freeze rather than
+  // blank) and it is not this issue's to make. Pruning is unaffected either way,
+  // being already gated on the same flag.
+  const isPathRunning = (appPath: string) =>
+    tasklistReadSucceeded && isTrackedPathRunning(pathStates.get(appPath))
+
   // When the tasklist read failed, processNames is an empty Set with no
   // signal value — skip pruning so we don't silently clear running/unclosed
   // state based on bogus "everything is gone" data (see #399).
   if (tasklistReadSucceeded) {
-    pruneStoppedRunningProcesses(processNames)
-    pruneUnclosedProcesses(processNames)
+    pruneStoppedRunningProcesses(isPathRunning)
+    pruneUnclosedProcesses(isPathRunning)
   }
   pruneExpiredProcessNameMismatchWarnings()
   reconcileUntrackedGames()
-  const profiles = getStoredProfiles()
-  const appPaths = getStoredStringRecord('appPaths')
-  const gamePaths = getStoredStringRecord('gamePaths')
 
   const launchedApps = Array.from(runningProcesses.values()).map((appProcess) => ({
     path: appProcess.path,
@@ -290,7 +355,7 @@ export async function getRunningApps(): Promise<RunningApp[]> {
     tracked: false
   }))
   const unclosedApps = Array.from(unclosedProcesses.values())
-    .filter((appProcess) => processNames.has(getExeName(appProcess.path)))
+    .filter((appProcess) => isPathRunning(appProcess.path))
     .map((appProcess) => ({
       path: appProcess.path,
       name: appProcess.name,
@@ -300,12 +365,17 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       elevated: appProcess.elevated ?? appProcess.reason === 'access_denied'
     }))
   const surfacedApps = [...launchedApps, ...unclosedApps]
-  // Mismatch-warning entries are shown only when the ORIGINAL exe is NOT in
-  // the tasklist (i.e. only the child process survives). If the original exe
-  // were still running it would appear in `surfacedApps` and no warning is
-  // needed — the user can see and track it normally.
+  // Mismatch-warning entries are shown only when the ORIGINAL exe is NOT
+  // running (i.e. only the child process survives). If the original were still
+  // running it would appear in `surfacedApps` and no warning is needed — the
+  // user can see and track it normally.
+  //
+  // Path-verified like the rest (#674), and here the collision SUPPRESSED a
+  // real warning rather than inventing one: a stranger holding the name made
+  // the original look alive, so the user was told nothing about a companion
+  // that had re-execed under a name SimLauncher cannot track.
   const mismatchWarnings = Array.from(processNameMismatchWarnings.values())
-    .filter((entry) => !processNames.has(getExeName(entry.path)))
+    .filter((entry) => !isPathRunning(entry.path))
     .map((entry) => ({
       path: entry.path,
       name: entry.name,
@@ -328,7 +398,7 @@ export async function getRunningApps(): Promise<RunningApp[]> {
     [...surfacedApps, ...mismatchWarnings].map((appProcess) => appProcess.gameKey)
   )
   const adoptedGameKeys = getExternallyAdoptableGameKeys(
-    processNames,
+    isPathRunning,
     profiles,
     gamePaths,
     launchedGameKeys
@@ -336,7 +406,7 @@ export async function getRunningApps(): Promise<RunningApp[]> {
   const adoptedOrLaunchedGameKeys = new Set([...launchedGameKeys, ...adoptedGameKeys])
   const trackedApps = (
     await getTrackedRunningApps(
-      processNames,
+      isPathRunning,
       adoptedOrLaunchedGameKeys,
       profiles,
       appPaths,

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -24,6 +24,7 @@ import {
 } from './state'
 import { isTrackedPathRunning, resolveTrackedPathStates } from './pathResolution'
 import { readRunningProcessNames, type RunningProcessNamesResult } from './tasklist'
+import { isPathScopedExe } from './win32KillUtils'
 
 /**
  * A main-process consumer of one raw tasklist read.
@@ -274,11 +275,10 @@ function reconcileUntrackedGames(): void {
 
 export async function getRunningApps(): Promise<RunningApp[]> {
   const readResult = await readRunningProcessNames()
-  // `processNames` is deliberately not read here any more (#674). Every
-  // question this function asks is now about a PATH, and the snapshot reaches
-  // the resolver whole, so a name-only decision cannot creep back in by
-  // reaching for a set that happened to be in scope.
-  const { succeeded: tasklistReadSucceeded } = readResult
+  // `processNames` survives for exactly one job (see `isPathRunning`): a record
+  // whose "path" is a bare image name, which is not a path and must not be
+  // resolved as one. Every other question this function asks is about a PATH.
+  const { processNames, succeeded: tasklistReadSucceeded } = readResult
   // Observers run before any derivation below, on every read rather than only
   // on scan ticks, and never get to break the caller: a throwing observer must
   // not take the running-apps list down with it.
@@ -319,9 +319,16 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       candidatePaths.add(gamePath)
     }
   })
-  runningProcesses.forEach((entry) => candidatePaths.add(entry.path))
-  unclosedProcesses.forEach((entry) => candidatePaths.add(entry.path))
-  processNameMismatchWarnings.forEach((entry) => candidatePaths.add(entry.path))
+  // Bare image names are filtered out rather than resolved: they are not paths,
+  // and `isPathRunning` answers them from the name set instead.
+  const addCandidate = (appPath: string) => {
+    if (isPathScopedExe(appPath)) {
+      candidatePaths.add(appPath)
+    }
+  }
+  runningProcesses.forEach((entry) => addCandidate(entry.path))
+  unclosedProcesses.forEach((entry) => addCandidate(entry.path))
+  processNameMismatchWarnings.forEach((entry) => addCandidate(entry.path))
 
   const pathStates = await resolveTrackedPathStates(readResult, Array.from(candidatePaths))
   // Folds `unknown` and "not asked" into "running", the same conservative
@@ -335,8 +342,30 @@ export async function getRunningApps(): Promise<RunningApp[]> {
   // instead would be a real behaviour change (the strip would freeze rather than
   // blank) and it is not this issue's to make. Pruning is unaffected either way,
   // being already gated on the same flag.
-  const isPathRunning = (appPath: string) =>
-    tasklistReadSucceeded && isTrackedPathRunning(pathStates.get(appPath))
+  const isPathRunning = (appPath: string) => {
+    if (!tasklistReadSucceeded) {
+      return false
+    }
+
+    // A bare image name is NOT a path, and answering it as one silently
+    // destroys a record (Codex P2 on #846). An unclosed entry for a name-scoped
+    // companion stores the image name where a path would go
+    // (`registerUnclosedProcess` falls back to `attempt.processName`), and
+    // `normalizePathForComparison` resolves a bare name against the CURRENT
+    // WORKING DIRECTORY. So the comparison is against a path under SimLauncher's
+    // own install, never matches any real process, and the record gets pruned
+    // while its app is still running: the Garage61 telemetry agent, which is
+    // closed by `/IM` precisely because it has no configured path.
+    //
+    // Judged by SHAPE, matching how the kill path scopes its own cleanup and
+    // for the same reason (#677): whether an exe currently exists on disk must
+    // not decide whether a record is name-scoped.
+    if (!isPathScopedExe(appPath)) {
+      return processNames.has(getExeName(appPath))
+    }
+
+    return isTrackedPathRunning(pathStates.get(appPath))
+  }
 
   // When the tasklist read failed, processNames is an empty Set with no
   // signal value — skip pruning so we don't silently clear running/unclosed

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -296,16 +296,25 @@ export function consumeProcessNameMismatchWarningSuppression(appPath: string): b
 /**
  * Reconcile `runningProcesses` against the live tasklist snapshot.
  *
- * Matching is done by exe name, not by the Map key (normalised path), because
- * some apps replace their process with a child of the same exe name — the
- * original PID is gone but the exe is still present, so the path key would
- * still match even without this exe-name check.  Conversely, if the exe name
- * disappears from the tasklist the ChildProcess handle is stale regardless of
- * what key it was filed under, so we drop it.
+ * Deliberately NOT matched on the Map key (a normalised path), because some
+ * apps replace their process with a child of the same exe name: the original
+ * PID is gone but the image is still there, and a key comparison would drop a
+ * record that is still live. The question is "is anything running at this
+ * path", which is what the predicate answers.
+ *
+ * Takes a PREDICATE rather than the name set it used to take (#674). Asking by
+ * name alone meant a same-named process anywhere on the system kept a dead
+ * record alive forever, and the caller is the only party that can answer the
+ * path question, so it passes in the answer rather than the raw snapshot. Same
+ * reasoning as `pruneUntrackedGames` taking keys: this module stays free of
+ * both profile and process-resolution knowledge.
+ *
+ * The predicate must answer "yes" when it does not know. A record is user
+ * visible, so an unobserved tick must not delete it.
  */
-export function pruneStoppedRunningProcesses(processNames: Set<string>): void {
+export function pruneStoppedRunningProcesses(isPathRunning: (appPath: string) => boolean): void {
   runningProcesses.forEach((appProcess, key) => {
-    if (!processNames.has(getExeName(appProcess.path))) {
+    if (!isPathRunning(appProcess.path)) {
       runningProcesses.delete(key)
     }
   })

--- a/src/main/processes/tasklist.ts
+++ b/src/main/processes/tasklist.ts
@@ -5,8 +5,36 @@ import { execFile } from 'child_process'
 // multi-app launch sequence (spawn → kill verify → running-apps publish).
 const CACHE_TTL_MS = 500
 
+/**
+ * One row of the `tasklist` snapshot, beyond the image name.
+ *
+ * `tasklist /fo csv /nh` has always returned five columns and this module has
+ * always kept one of them. PID and session were being parsed away and thrown
+ * out on every tick, which is why the poll could only ever answer questions
+ * about NAMES (#674). Reading them costs nothing: same command, same spawn.
+ *
+ * `sessionId` is column 4, `Session#`, the NUMBER. Deliberately not column 3,
+ * `Session Name`, which reads "Services" or "Console" on an English install and
+ * is localized everywhere else.
+ */
+export interface TasklistProcess {
+  /** Lowercased image name, matching how `processNames` is keyed. */
+  name: string
+  processId: number
+  sessionId: number
+}
+
 export interface RunningProcessNamesResult {
   processNames: Set<string>
+  /**
+   * Every row of the same snapshot `processNames` was derived from, so the two
+   * can never disagree about what was running at that instant.
+   *
+   * Additive (#674): `processNames` keeps its exact meaning and every existing
+   * consumer is untouched. A failed read leaves this empty for the same reason
+   * `processNames` is empty, and carries the same no-observation warning.
+   */
+  processes: TasklistProcess[]
   succeeded: boolean
 }
 
@@ -26,18 +54,39 @@ function spawnTasklist(): Promise<RunningProcessNamesResult> {
     execFile('tasklist', ['/fo', 'csv', '/nh'], { windowsHide: true }, (error, stdout) => {
       if (error) {
         console.error('Failed to read running processes:', error)
-        resolve({ processNames: new Set(), succeeded: false })
+        resolve({ processNames: new Set(), processes: [], succeeded: false })
         return
       }
 
       const names = new Set<string>()
+      const processes: TasklistProcess[] = []
       stdout.split(/\r?\n/).forEach((line) => {
-        const match = line.match(/^"([^"]+)"/)
-        if (match) {
-          names.add(match[1].toLowerCase())
+        // Every field is quoted and none can contain a quote of its own: a
+        // Windows image name cannot, and the other four are numbers or fixed
+        // words. So splitting on quoted groups is sufficient here and needs no
+        // CSV escaping rules. Verified against a real 537-row snapshot, where
+        // all five columns parsed on every line.
+        const fields = line.match(/"([^"]*)"/g)
+        if (!fields || fields.length < 4 || fields[0].length <= 2) {
+          return
         }
+        const unquote = (field: string) => field.slice(1, -1)
+        const name = unquote(fields[0]).toLowerCase()
+        names.add(name)
+
+        // A row whose PID or session will not parse still counts as a running
+        // NAME (added above) but yields no instance. Dropping it from
+        // `processes` costs a caller its path resolution and leaves the answer
+        // ambiguous, which is the safe direction; inventing a session for it
+        // would let the row be dismissed on a number nobody read.
+        const processId = Number(unquote(fields[1]))
+        const sessionId = Number(unquote(fields[3]))
+        if (!Number.isInteger(processId) || !Number.isInteger(sessionId)) {
+          return
+        }
+        processes.push({ name, processId, sessionId })
       })
-      resolve({ processNames: names, succeeded: true })
+      resolve({ processNames: names, processes, succeeded: true })
     })
   })
 }

--- a/src/main/processes/tasklist.ts
+++ b/src/main/processes/tasklist.ts
@@ -67,18 +67,29 @@ function spawnTasklist(): Promise<RunningProcessNamesResult> {
         // CSV escaping rules. Verified against a real 537-row snapshot, where
         // all five columns parsed on every line.
         const fields = line.match(/"([^"]*)"/g)
-        if (!fields || fields.length < 4 || fields[0].length <= 2) {
+        if (!fields || fields.length === 0) {
           return
         }
         const unquote = (field: string) => field.slice(1, -1)
         const name = unquote(fields[0]).toLowerCase()
+        if (!name) {
+          return
+        }
+
+        // The name is recorded from the FIRST field alone, exactly as it was
+        // before the other columns were read, so no row can lose its name by
+        // failing to yield an instance. That asymmetry is the safe direction:
+        // losing a name says an app is not running when it is, while losing an
+        // instance only leaves the answer ambiguous, which every caller already
+        // handles conservatively.
         names.add(name)
 
-        // A row whose PID or session will not parse still counts as a running
-        // NAME (added above) but yields no instance. Dropping it from
-        // `processes` costs a caller its path resolution and leaves the answer
-        // ambiguous, which is the safe direction; inventing a session for it
-        // would let the row be dismissed on a number nobody read.
+        // The instance needs all four. Inventing a value for a field that would
+        // not parse is the one genuinely dangerous option here, because session
+        // 0 is what lets an unreadable path be dismissed.
+        if (fields.length < 4) {
+          return
+        }
         const processId = Number(unquote(fields[1]))
         const sessionId = Number(unquote(fields[3]))
         if (!Number.isInteger(processId) || !Number.isInteger(sessionId)) {

--- a/tests/main/pathResolution.test.ts
+++ b/tests/main/pathResolution.test.ts
@@ -79,17 +79,42 @@ describe('what the tasklist alone can decide (#674)', () => {
     expect(findProcessesByName).not.toHaveBeenCalled()
   })
 
-  test('a same-named process in session 0 is dismissed for free', async () => {
-    // The half of the discriminator that pays for itself. Session 0 is the
-    // non-interactive services session, so it cannot be hosting a companion the
-    // user launched, and the tasklist already carries the number. On a real
-    // machine this covers 170 of 537 processes without asking anything.
+  test('a session-0 process whose path is unreadable is dismissed, then never re-asked', async () => {
+    // Session 0 is what makes an UNREADABLE path decidable, and that dismissal
+    // is the rule's, applied to what the enumeration came back with. It is not
+    // grounds to skip the enumeration: see the test below for why.
+    findProcessesByName.mockResolvedValue({
+      instances: [{ name: 'overlay.exe', processId: 400, executablePath: null, sessionId: 0 }],
+      succeeded: true
+    })
+    const live = snapshot([{ processId: 400, sessionId: 0 }])
+
+    expect((await resolveTrackedPathStates(live, [CONFIGURED])).get(CONFIGURED)).toBe('not-running')
+    expect((await resolveTrackedPathStates(live, [CONFIGURED])).get(CONFIGURED)).toBe('not-running')
+
+    // Bounded: the null is cached like any other answer, so a service costs one
+    // enumeration ever rather than one per tick.
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+
+  test('a configured app hosted as a service in session 0 resolves to running (#846)', async () => {
+    // The poll must not disagree with the launch and kill paths, which enumerate
+    // unconditionally. Skipping session-0 pids looked like a free saving and was
+    // not: their paths were then never learned, the rule's "a path match wins
+    // outright, INCLUDING in session 0" branch could never fire, and a genuine
+    // service-hosted match collapsed to `not-running` on the poll alone.
+    findProcessesByName.mockResolvedValue({
+      instances: [
+        { name: 'overlay.exe', processId: 400, executablePath: CONFIGURED, sessionId: 0 }
+      ],
+      succeeded: true
+    })
+
     const states = await resolveTrackedPathStates(snapshot([{ processId: 400, sessionId: 0 }]), [
       CONFIGURED
     ])
 
-    expect(states.get(CONFIGURED)).toBe('not-running')
-    expect(findProcessesByName).not.toHaveBeenCalled()
+    expect(states.get(CONFIGURED)).toBe('running')
   })
 
   test('a failed snapshot answers nothing rather than answering wrongly', async () => {

--- a/tests/main/pathResolution.test.ts
+++ b/tests/main/pathResolution.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type EnumerationResult = {
+  instances: { name: string; processId: number; executablePath: string | null; sessionId: number }[]
+  succeeded: boolean
+}
+
+// Typed by SIGNATURE rather than by implementation, so `mock.calls` still knows
+// the argument is a name array while the stub itself ignores it.
+const findProcessesByName = vi.hoisted(() =>
+  vi.fn<(names: string[]) => Promise<EnumerationResult>>(async () => ({
+    instances: [],
+    succeeded: true
+  }))
+)
+
+// Only the enumeration is mocked. `resolveConfiguredPathState` is the real rule
+// (pinned on its own in configuredPathState.test.ts), because the entire claim
+// of this module is that it feeds THAT rule from a cheaper source. Substituting
+// a stand-in here would test a second rule that happens to agree.
+vi.mock('../../src/main/processes/win32KillUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/main/processes/win32KillUtils')>()
+  return { ...actual, findProcessesByName }
+})
+
+const { resolveTrackedPathStates, resetPathResolutionCache } =
+  await import('../../src/main/processes/pathResolution')
+
+/**
+ * #674, second half: answering "is my configured app running?" on the 2s poll.
+ *
+ * The correctness question was settled by the decision rule. What is at stake
+ * here is COST. The poll runs forever, in the tray, and a design that spawns a
+ * process enumeration per tick would trade one bug for a footprint regression
+ * that the 1.3.0 milestone exists to avoid. So most of what follows counts
+ * enumerations rather than checking verdicts.
+ */
+const CONFIGURED = 'C:/Tools/Overlay.exe'
+
+function snapshot(
+  processes: { name?: string; processId: number; sessionId?: number }[],
+  succeeded = true
+) {
+  return {
+    processes: processes.map((entry) => ({
+      name: entry.name ?? 'overlay.exe',
+      processId: entry.processId,
+      sessionId: entry.sessionId ?? 1
+    })),
+    succeeded
+  }
+}
+
+function answerWith(
+  instances: { name?: string; processId: number; executablePath: string | null }[]
+) {
+  findProcessesByName.mockResolvedValue({
+    instances: instances.map((entry) => ({
+      name: entry.name ?? 'overlay.exe',
+      processId: entry.processId,
+      executablePath: entry.executablePath,
+      sessionId: 1
+    })),
+    succeeded: true
+  })
+}
+
+beforeEach(() => {
+  resetPathResolutionCache()
+  findProcessesByName.mockReset()
+  findProcessesByName.mockResolvedValue({ instances: [], succeeded: true })
+})
+
+describe('what the tasklist alone can decide (#674)', () => {
+  test('a name nothing is running under costs no enumeration', async () => {
+    const states = await resolveTrackedPathStates(snapshot([]), [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('not-running')
+    expect(findProcessesByName).not.toHaveBeenCalled()
+  })
+
+  test('a same-named process in session 0 is dismissed for free', async () => {
+    // The half of the discriminator that pays for itself. Session 0 is the
+    // non-interactive services session, so it cannot be hosting a companion the
+    // user launched, and the tasklist already carries the number. On a real
+    // machine this covers 170 of 537 processes without asking anything.
+    const states = await resolveTrackedPathStates(snapshot([{ processId: 400, sessionId: 0 }]), [
+      CONFIGURED
+    ])
+
+    expect(states.get(CONFIGURED)).toBe('not-running')
+    expect(findProcessesByName).not.toHaveBeenCalled()
+  })
+
+  test('a failed snapshot answers nothing rather than answering wrongly', async () => {
+    const states = await resolveTrackedPathStates(snapshot([], false), [CONFIGURED])
+
+    expect(states.size).toBe(0)
+    expect(findProcessesByName).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolving an unfamiliar pid (#674)', () => {
+  test('a pid at the configured path resolves to running', async () => {
+    answerWith([{ processId: 100, executablePath: CONFIGURED }])
+
+    const states = await resolveTrackedPathStates(snapshot([{ processId: 100 }]), [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('running')
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+
+  test('a pid at another path is the collision, and resolves to not-running', async () => {
+    answerWith([{ processId: 100, executablePath: 'C:/Elsewhere/Overlay.exe' }])
+
+    const states = await resolveTrackedPathStates(snapshot([{ processId: 100 }]), [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('not-running')
+  })
+
+  test('a pid whose path Windows withholds stays unknown (#390)', async () => {
+    answerWith([{ processId: 100, executablePath: null }])
+
+    const states = await resolveTrackedPathStates(snapshot([{ processId: 100 }]), [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('unknown')
+  })
+
+  test('several configured paths are resolved in one enumeration', async () => {
+    answerWith([
+      { processId: 100, executablePath: CONFIGURED },
+      { name: 'launcher.exe', processId: 200, executablePath: 'C:/Tools/Launcher.exe' }
+    ])
+
+    await resolveTrackedPathStates(
+      snapshot([{ processId: 100 }, { name: 'launcher.exe', processId: 200 }]),
+      [CONFIGURED, 'C:/Tools/Launcher.exe']
+    )
+
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+    expect(findProcessesByName.mock.calls[0]![0].sort()).toEqual(['launcher.exe', 'overlay.exe'])
+  })
+})
+
+describe('the cost guarantee: steady state is free (#674)', () => {
+  test('a resolved pid is never asked about again', async () => {
+    // THE property this design exists for. The poll ticks every 2s forever; if
+    // a known pid cost an enumeration each time, this fix would be a footprint
+    // regression wearing a bugfix.
+    answerWith([{ processId: 100, executablePath: CONFIGURED }])
+    const live = snapshot([{ processId: 100 }])
+
+    await resolveTrackedPathStates(live, [CONFIGURED])
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+
+    for (let tick = 0; tick < 20; tick += 1) {
+      const states = await resolveTrackedPathStates(live, [CONFIGURED])
+      expect(states.get(CONFIGURED)).toBe('running')
+    }
+
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+
+  test('an unreadable path is a cached ANSWER, not a permanent question', async () => {
+    // The case that would otherwise never converge: an elevated process hides
+    // its path and will keep hiding it, so "we asked and were refused" has to be
+    // remembered as firmly as a path would be. Treating a null as "not yet
+    // asked" would make every elevated process a permanent source of spawns.
+    answerWith([{ processId: 100, executablePath: null }])
+    const live = snapshot([{ processId: 100 }])
+
+    await resolveTrackedPathStates(live, [CONFIGURED])
+    await resolveTrackedPathStates(live, [CONFIGURED])
+    const states = await resolveTrackedPathStates(live, [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('unknown')
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+
+  test('a churning name costs at most one enumeration per cooldown window', async () => {
+    // `cmd.exe` on a developer machine reaches ~30 spawns a minute. "Resolve
+    // unfamiliar pids" is unbounded against that, because every tick brings new
+    // ones, so the cooldown is what stops the pathological case from undoing
+    // the guarantee above.
+    answerWith([{ processId: 1, executablePath: 'C:/Elsewhere/Overlay.exe' }])
+
+    for (let tick = 0; tick < 10; tick += 1) {
+      await resolveTrackedPathStates(snapshot([{ processId: 1000 + tick }]), [CONFIGURED])
+    }
+
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('invalidation is the pid, not a clock (#674)', () => {
+  test('a pid that leaves the snapshot loses its cached path', async () => {
+    // Windows does not move a running image, so a path stays true for exactly
+    // as long as its pid lives. That makes the invalidation exact where a TTL
+    // would be guesswork in both directions: expiring answers that are still
+    // true, and keeping ones that are not.
+    answerWith([{ processId: 100, executablePath: CONFIGURED }])
+    await resolveTrackedPathStates(snapshot([{ processId: 100 }]), [CONFIGURED])
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+
+    // The pid is gone, and Windows later hands the same NUMBER to something
+    // else at a different path. A cache that kept the old entry would answer
+    // "running" for a process that is not ours.
+    await resolveTrackedPathStates(snapshot([]), [CONFIGURED])
+    answerWith([{ processId: 100, executablePath: 'C:/Elsewhere/Overlay.exe' }])
+    const states = await resolveTrackedPathStates(snapshot([{ processId: 100 }]), [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('not-running')
+  })
+
+  test('a failed read does not flush what is already known', async () => {
+    // A failed snapshot is not evidence that every process ended (#399).
+    // Reconciling against it would empty the cache and buy back every
+    // enumeration at the worst possible moment.
+    answerWith([{ processId: 100, executablePath: CONFIGURED }])
+    const live = snapshot([{ processId: 100 }])
+    await resolveTrackedPathStates(live, [CONFIGURED])
+
+    await resolveTrackedPathStates(snapshot([], false), [CONFIGURED])
+
+    const states = await resolveTrackedPathStates(live, [CONFIGURED])
+    expect(states.get(CONFIGURED)).toBe('running')
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+
+  test('a failed enumeration records no verdict, but still rate-limits the retry', async () => {
+    // Two separable concerns, and collapsing them costs one of the other. A
+    // failure teaches nothing, so nothing may be cached and the answer stays
+    // honestly `unknown`. But a PERSISTENT failure (PowerShell missing, WMI
+    // wedged) retried on every 2s tick would spawn forever, which is the
+    // footprint regression this module exists to avoid.
+    findProcessesByName.mockResolvedValue({ instances: [], succeeded: false })
+    const live = snapshot([{ processId: 100 }])
+
+    const first = await resolveTrackedPathStates(live, [CONFIGURED])
+    expect(first.get(CONFIGURED)).toBe('unknown')
+
+    // No verdict was cached: were the cooldown lifted, this would resolve.
+    answerWith([{ processId: 100, executablePath: CONFIGURED }])
+    const second = await resolveTrackedPathStates(live, [CONFIGURED])
+    expect(second.get(CONFIGURED)).toBe('unknown')
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/main/pathResolution.test.ts
+++ b/tests/main/pathResolution.test.ts
@@ -39,14 +39,21 @@ const CONFIGURED = 'C:/Tools/Overlay.exe'
 
 function snapshot(
   processes: { name?: string; processId: number; sessionId?: number }[],
-  succeeded = true
+  succeeded = true,
+  // Defaults to exactly the names the rows carry, which is what the real parser
+  // produces. Passed explicitly only to model the one case where the two can
+  // legitimately disagree: a row whose name was recorded but whose PID or
+  // session would not parse, so it yields no instance.
+  extraNames: string[] = []
 ) {
+  const rows = processes.map((entry) => ({
+    name: entry.name ?? 'overlay.exe',
+    processId: entry.processId,
+    sessionId: entry.sessionId ?? 1
+  }))
   return {
-    processes: processes.map((entry) => ({
-      name: entry.name ?? 'overlay.exe',
-      processId: entry.processId,
-      sessionId: entry.sessionId ?? 1
-    })),
+    processNames: new Set([...rows.map((entry) => entry.name), ...extraNames]),
+    processes: rows,
     succeeded
   }
 }
@@ -115,6 +122,36 @@ describe('what the tasklist alone can decide (#674)', () => {
     ])
 
     expect(states.get(CONFIGURED)).toBe('running')
+  })
+
+  test('a session-0 pid the cooldown skipped is unknown, not dismissed (#846)', async () => {
+    // The dangerous half of the cooldown. Session 0 is the one case where the
+    // rule dismisses an instance whose path it does not have, and that is only
+    // sound when the null means "Windows refused" rather than "nobody looked".
+    // A configured app starting as a service inside a cooldown window would
+    // otherwise read as stopped for 45s, and be pruned.
+    answerWith([{ processId: 100, executablePath: 'C:/Elsewhere/Overlay.exe' }])
+    await resolveTrackedPathStates(snapshot([{ processId: 100 }]), [CONFIGURED])
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+
+    // Same name, brand new session-0 pid, still inside the cooldown.
+    const states = await resolveTrackedPathStates(
+      snapshot([{ processId: 100 }, { processId: 500, sessionId: 0 }]),
+      [CONFIGURED]
+    )
+
+    expect(states.get(CONFIGURED)).toBe('unknown')
+    expect(findProcessesByName).toHaveBeenCalledTimes(1)
+  })
+
+  test('a name whose row would not parse is unknown, not not-running (#846)', async () => {
+    // The parser records the NAME from field 0 alone but yields no instance for
+    // a row whose PID or session is malformed. The rule then sees nothing under
+    // that name, which is indistinguishable from an absent process unless the
+    // gap is carried explicitly.
+    const states = await resolveTrackedPathStates(snapshot([], true, ['overlay.exe']), [CONFIGURED])
+
+    expect(states.get(CONFIGURED)).toBe('unknown')
   })
 
   test('a failed snapshot answers nothing rather than answering wrongly', async () => {

--- a/tests/main/processEnumeration.win.test.ts
+++ b/tests/main/processEnumeration.win.test.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import { describe, expect, test } from 'vitest'
 
+import { readRunningProcessNames } from '../../src/main/processes/tasklist'
 import {
   findProcessesByName,
   resolveConfiguredPathState
@@ -93,6 +94,57 @@ describeWindows('findProcessesByName against the real PowerShell host (#674)', (
       expect(resolveConfiguredPathState(instances, `C:/SimLauncher-No-Such-Dir/${self}`)).toBe(
         'not-running'
       )
+    },
+    TIMEOUT_MS
+  )
+})
+
+/**
+ * The same discipline for `tasklist` (#674, second half). The poll now reads
+ * PID and Session# out of this snapshot, so the parser is load-bearing in a way
+ * it never was while it kept one column: a shape it mishandles does not throw,
+ * it just yields fewer instances, and fewer instances resolve to `not-running`
+ * — an app the user IS running would disappear from the strip.
+ */
+describeWindows('readRunningProcessNames against the real tasklist (#674)', () => {
+  const TIMEOUT_MS = 30_000
+
+  test(
+    'the real snapshot parses into names AND instances, including this process',
+    async () => {
+      const { processNames, processes, succeeded } = await readRunningProcessNames()
+
+      expect(succeeded).toBe(true)
+      const self = path.basename(process.execPath).toLowerCase()
+      expect(processNames.has(self)).toBe(true)
+
+      // Every row that produced a NAME should also produce an instance. A gap
+      // between the two means the extra columns are being dropped somewhere,
+      // which is the silent half of this failure mode.
+      expect(new Set(processes.map((entry) => entry.name))).toEqual(processNames)
+
+      const mine = processes.filter((entry) => entry.name === self)
+      expect(mine.length).toBeGreaterThan(0)
+      expect(mine.some((entry) => entry.processId === process.pid)).toBe(true)
+      mine.forEach((entry) => {
+        expect(Number.isInteger(entry.sessionId)).toBe(true)
+      })
+    },
+    TIMEOUT_MS
+  )
+
+  test(
+    'session 0 is populated, which is the half of the discriminator that is free',
+    async () => {
+      // The services session is what lets an unreadable path be dismissed with
+      // no enumeration at all. If this came back empty, the column being read
+      // would be the wrong one (`Session Name` is localized text, `Session#` is
+      // the number) and the cheap path would silently stop applying.
+      const { processes, succeeded } = await readRunningProcessNames()
+
+      expect(succeeded).toBe(true)
+      expect(processes.some((entry) => entry.sessionId === 0)).toBe(true)
+      expect(processes.some((entry) => entry.sessionId !== 0)).toBe(true)
     },
     TIMEOUT_MS
   )

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -1063,6 +1063,72 @@ test('a leftover recorded against a stranger is pruned by the next scan (#674)',
   expect(apps).toEqual([])
 })
 
+// A name-scoped companion has no configured path, so its unclosed record stores
+// the IMAGE NAME where a path would go. Resolving that as a path is destructive
+// rather than merely wrong: `normalizePathForComparison` resolves a bare name
+// against the CURRENT WORKING DIRECTORY, so it compares against a path under
+// SimLauncher's own install, never matches, and prunes a record whose app is
+// still running (Codex P2 on #846). Garage61's telemetry agent is the shipped
+// case: it is closed by `/IM` precisely because it has no path.
+test('a bare-name leftover is judged by name, not resolved as a path (#846)', async () => {
+  const { getRunningApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    },
+    appPaths: {}
+  })
+
+  unclosedProcesses.set('ac:garage61 telemetry agent.exe', {
+    path: 'Garage61 telemetry agent.exe',
+    name: 'Garage61 telemetry agent.exe',
+    gameKey: 'ac',
+    error: 'Windows denied SimLauncher permission to close this app.',
+    reason: 'access_denied',
+    elevated: true
+  })
+  // The agent IS running, at a path that has nothing to do with the CWD.
+  registerProcess(
+    'C:/Program Files/Garage61/Garage61 telemetry agent.exe',
+    'garage61 telemetry agent.exe',
+    '3000'
+  )
+  processNames.add('garage61 telemetry agent.exe')
+
+  const apps = await getRunningApps()
+
+  expect(unclosedProcesses.size).toBe(1)
+  expect(apps.map((app) => app.path)).toContain('Garage61 telemetry agent.exe')
+})
+
+// ...and it still goes away once the image really is gone, so the name-scoped
+// branch is not simply a record that can never be cleared.
+test('a bare-name leftover is pruned once its image leaves the tasklist (#846)', async () => {
+  const { getRunningApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', garage61: true }]
+      }
+    },
+    appPaths: {}
+  })
+
+  unclosedProcesses.set('ac:garage61 telemetry agent.exe', {
+    path: 'Garage61 telemetry agent.exe',
+    name: 'Garage61 telemetry agent.exe',
+    gameKey: 'ac',
+    error: 'Windows denied SimLauncher permission to close this app.',
+    reason: 'access_denied',
+    elevated: true
+  })
+
+  await expect(getRunningApps()).resolves.toEqual([])
+  expect(unclosedProcesses.size).toBe(0)
+})
+
 // The same record when the app really is still there: pruning must not become
 // eager just because it learned to read paths.
 test('a leftover whose app is genuinely running is kept (#674)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -184,6 +184,75 @@ function registerProcess(executablePath: string, processName: string, pid: strin
   })
 }
 
+/**
+ * Stable synthetic PID for a name a test modelled only as "running", with no
+ * location (a bare `processNames.add(name)`).
+ *
+ * Shared by the tasklist and enumeration mocks so both describe the same
+ * process. Distinct PER NAME rather than one constant, because the production
+ * path cache is keyed by PID: two unmodelled names sharing a pid would let one
+ * name's resolution answer for the other, which is a bug the harness would be
+ * inventing rather than exposing.
+ */
+const syntheticPids = new Map<string, number>()
+
+function syntheticPidFor(name: string): number {
+  const existing = syntheticPids.get(name)
+  if (existing !== undefined) {
+    return existing
+  }
+  const pid = 9000 + syntheticPids.size
+  syntheticPids.set(name, pid)
+  return pid
+}
+
+/**
+ * The tasklist snapshot as rows, from the three sources that describe what is
+ * running: the path registry, the unreadable-path processes, and a bare
+ * `processNames.add(name)` for a test that modelled only the name.
+ *
+ * One builder because this suite mocks BOTH the `tasklist` module and
+ * `execFile`, and the name-scoped enumeration answers from the same sources. If
+ * any of them disagreed about a pid, the production cache (keyed by pid) would
+ * be reconciling against a machine that cannot exist.
+ *
+ * The last source is the load-bearing default, exactly as it is for the
+ * enumeration: an unmodelled location yields a real pid in an interactive
+ * session whose PATH is never resolvable, i.e. `unknown`. That is the same
+ * conservative answer those tests pinned before #674, so they keep their
+ * meaning; reading it as "at the configured path" would make every collision
+ * assertion pass with the fix removed.
+ */
+function buildTasklistProcesses(): { name: string; processId: number; sessionId: number }[] {
+  const rows: { name: string; processId: number; sessionId: number }[] = []
+  const modelled = new Set<string>()
+
+  processRegistry.forEach((entry) => {
+    if (!processNames.has(entry.processName)) return
+    modelled.add(entry.processName)
+    rows.push({
+      name: entry.processName,
+      processId: Number(entry.pid),
+      sessionId: entry.sessionId
+    })
+  })
+  hiddenProcesses.forEach((entry) => {
+    if (!processNames.has(entry.processName)) return
+    modelled.add(entry.processName)
+    rows.push({
+      name: entry.processName,
+      processId: Number(entry.pid),
+      sessionId: entry.sessionId
+    })
+  })
+  processNames.forEach((name) => {
+    if (modelled.has(name)) return
+    rows.push({ name, processId: syntheticPidFor(name), sessionId: 1 })
+  })
+
+  return rows
+}
+
 function findRegistryEntryByPid(pid: string): ProcessRegistryEntry | undefined {
   for (const entry of processRegistry.values()) {
     if (entry.pid === pid) {
@@ -260,10 +329,19 @@ async function loadProcessModules() {
     execFile: vi.fn((command, args, options, callback) => {
       execFileCalls.push({ command, args, options })
       if (command === 'tasklist') {
+        // Five real columns, because the poll now reads PID and Session# from
+        // this same snapshot (#674). Built from the SAME three sources the
+        // name-scoped enumeration below answers from, so the two never describe
+        // different machines: a pid the tasklist reports has to be a pid the
+        // enumeration can resolve, or the pid-keyed path cache is modelling
+        // something impossible and the zero-spawn guarantee cannot be tested.
         callback(
           null,
-          Array.from(processNames)
-            .map((processName) => `"${processName}","1234","Console","1","1,024 K"`)
+          buildTasklistProcesses()
+            .map(
+              (entry) =>
+                `"${entry.name}","${entry.processId}","Console","${entry.sessionId}","1,024 K"`
+            )
             .join('\n'),
           ''
         )
@@ -367,7 +445,12 @@ async function loadProcessModules() {
 
           wanted.forEach((name) => {
             if (modelled.has(name) || !processNames.has(name)) return
-            instances.push({ name, processId: 9000, executablePath: null, sessionId: 1 })
+            instances.push({
+              name,
+              processId: syntheticPidFor(name),
+              executablePath: null,
+              sessionId: 1
+            })
           })
 
           callback(null, JSON.stringify(instances), '')
@@ -581,8 +664,12 @@ async function loadProcessModules() {
       // the empty-Set here is what lets the regression test distinguish
       // "image is gone" from "we don't know" (see #399).
       const result = shouldFailNow
-        ? { processNames: new Set<string>(), succeeded: false }
-        : { processNames: new Set(processNames), succeeded: true }
+        ? { processNames: new Set<string>(), processes: [], succeeded: false }
+        : {
+            processNames: new Set(processNames),
+            processes: buildTasklistProcesses(),
+            succeeded: true
+          }
       // A one-shot blocker models a slow tasklist scan (#670). Consumed here
       // so only the call it was armed for is delayed; the unarmed path keeps
       // its exact microtask timing (other tests depend on it).
@@ -821,6 +908,7 @@ beforeEach(async () => {
   wmiLookupCounts.clear()
   processRegistry.clear()
   hiddenProcesses.length = 0
+  syntheticPids.clear()
   execFileCalls.length = 0
   spawnCalls.length = 0
   spawnErrors.clear()
@@ -843,6 +931,164 @@ beforeEach(async () => {
   unclosedProcesses.clear()
   Object.keys(storeData).forEach((key) => delete storeData[key])
   storeData.launchDelayMs = 0
+})
+
+// #674, the half the user actually looks at. These run the REAL tasklist
+// parser, the real pid cache and the real decision rule against a modelled
+// machine, so they pin the poll end to end rather than the wiring.
+test('the strip does not draw an icon for a configured app a stranger was masking (#674)', async () => {
+  const { getRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    gamePaths: { ac: 'C:/Games/acs.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('C:/Games/acs.exe')
+  // The game IS running, so this profile is adopted and its companions are
+  // eligible to surface. That is what makes the next line the thing under test
+  // rather than an empty list.
+  registerProcess('C:/Games/acs.exe', 'acs.exe', '1000')
+  processNames.add('acs.exe')
+  // The collider: same image name as the configured companion, somewhere else.
+  registerProcess('C:/Other/SimHub.exe', 'simhub.exe', '2000')
+  processNames.add('simhub.exe')
+
+  const apps = await getRunningApps()
+
+  expect(apps.map((app) => app.path)).toContain('C:/Games/acs.exe')
+  expect(apps.map((app) => app.path)).not.toContain('C:/Tools/SimHub.exe')
+})
+
+// The other direction, and the one that must not regress: a companion genuinely
+// running at its configured path is still surfaced.
+test('a companion running at its configured path is still surfaced (#674)', async () => {
+  const { getRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    gamePaths: { ac: 'C:/Games/acs.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('C:/Games/acs.exe')
+  registerProcess('C:/Games/acs.exe', 'acs.exe', '1000')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '2000')
+  processNames.add('acs.exe')
+  processNames.add('simhub.exe')
+
+  const apps = await getRunningApps()
+
+  expect(apps.map((app) => app.path)).toContain('C:/Tools/SimHub.exe')
+})
+
+// Adoption is the widest blast radius the collision had: one stranger sharing
+// the GAME exe's name and a game the user never started looks like a live
+// session, dragging that profile's whole companion list onto the strip.
+test('a stranger sharing the game exe name does not adopt the profile (#674)', async () => {
+  const { getRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    gamePaths: { ac: 'C:/Games/acs.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('C:/Games/acs.exe')
+  registerProcess('C:/SomewhereElse/acs.exe', 'acs.exe', '1000')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '2000')
+  processNames.add('acs.exe')
+  processNames.add('simhub.exe')
+
+  await expect(getRunningApps()).resolves.toEqual([])
+})
+
+// #390 MUST NOT REGRESS on the poll either. An elevated process hides its path,
+// which is indistinguishable from the collision when only the path is asked
+// about — so the answer is `unknown` and the icon stays.
+test('a companion whose path is unreadable is still surfaced (#390)', async () => {
+  const { getRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    gamePaths: { ac: 'C:/Games/acs.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  markExistingPath('C:/Games/acs.exe')
+  registerProcess('C:/Games/acs.exe', 'acs.exe', '1000')
+  registerHiddenProcess('simhub.exe', '2000')
+  processNames.add('acs.exe')
+  processNames.add('simhub.exe')
+
+  const apps = await getRunningApps()
+
+  expect(apps.map((app) => app.path)).toContain('C:/Tools/SimHub.exe')
+})
+
+// The leftover that could not be cleared, and the reason it also cost battery.
+// Pruning used to be by image NAME, so a leftover created against a stranger
+// was permanent: dismissing did nothing, closing the app did nothing, and
+// `computeRunningAppsScanDelayMs` holds the poll at 2s for as long as any
+// unclosed record exists — including in the tray, for the rest of the session.
+test('a leftover recorded against a stranger is pruned by the next scan (#674)', async () => {
+  const { getRunningApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  unclosedProcesses.set('ac:c:\\tools\\simhub.exe', {
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'ac',
+    error: 'Windows denied SimLauncher permission to close this app.',
+    reason: 'access_denied',
+    elevated: true
+  })
+  // The image name is in the tasklist and always will be, but at another path.
+  registerProcess('C:/Other/SimHub.exe', 'simhub.exe', '2000')
+  processNames.add('simhub.exe')
+
+  const apps = await getRunningApps()
+
+  expect(unclosedProcesses.size).toBe(0)
+  expect(apps).toEqual([])
+})
+
+// The same record when the app really is still there: pruning must not become
+// eager just because it learned to read paths.
+test('a leftover whose app is genuinely running is kept (#674)', async () => {
+  const { getRunningApps, unclosedProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  unclosedProcesses.set('ac:c:\\tools\\simhub.exe', {
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'ac',
+    error: 'Windows denied SimLauncher permission to close this app.',
+    reason: 'access_denied',
+    elevated: true
+  })
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '2000')
+  processNames.add('simhub.exe')
+
+  const apps = await getRunningApps()
+
+  expect(unclosedProcesses.size).toBe(1)
+  expect(apps.map((app) => app.path)).toContain('C:/Tools/SimHub.exe')
 })
 
 test('getRunningApps surfaces a warning when a launched wrapper exits before its configured process is found', async () => {
@@ -4259,7 +4505,10 @@ test('pruneUnclosedProcesses removes stale entries and keeps running entries', a
     elevated: true
   })
 
-  pruneUnclosedProcesses(new Set(['simhub.exe']))
+  // Takes a PATH predicate now (#674), which is the whole point: a leftover
+  // used to be prunable only when its image NAME left the tasklist, so one
+  // same-named stranger made it permanent.
+  pruneUnclosedProcesses((appPath) => appPath === 'C:/Tools/SimHub.exe')
 
   expect(unclosedProcesses.has('ac:c:\\tools\\stale.exe')).toBe(false)
   expect(unclosedProcesses.get('ac:c:\\tools\\simhub.exe')).toMatchObject({
@@ -5651,7 +5900,7 @@ test('pruneUnclosedProcesses removes entries whose image is no longer active (#3
     elevated: true
   })
 
-  pruneUnclosedProcesses(new Set(['active.exe']))
+  pruneUnclosedProcesses((appPath) => appPath === 'C:/Tools/Active.exe')
 
   expect(unclosedProcesses.has('ac:c:\\tools\\active.exe')).toBe(true)
   expect(unclosedProcesses.has('ac:c:\\tools\\inactive.exe')).toBe(false)

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 const readRunningProcessNamesMock = vi.fn()
 const pruneUnclosedProcessesMock = vi.fn()
+// Configured paths whose image NAME is in the tasklist but which nothing is
+// actually running at — the #674 collision shape. Empty by default, so every
+// test written before it keeps its exact meaning.
+const collidingPaths = new Set<string>()
 
 async function loadRunningModule(opts?: {
   profiles?: Record<string, unknown>
@@ -26,6 +30,39 @@ async function loadRunningModule(opts?: {
   vi.doMock('/src/main/processes/tasklist.ts', () => tasklistMock)
   vi.doMock('../../src/main/processes/tasklist', () => tasklistMock)
   vi.doMock('../../src/main/processes/tasklist.ts', () => tasklistMock)
+
+  // A COPY of the name-only fold, plus `collidingPaths` as the path dimension.
+  // This suite mocks the module that owns the #674 decision rule, so it cannot
+  // pin the rule (configuredPathState.test.ts does, against the real one) and it
+  // cannot pin the pid cache (processes.test.ts does, with a real snapshot).
+  // What it pins is that the POLL asks a path question at all, which is
+  // observable precisely because `collidingPaths` can disagree with the names.
+  const pathResolutionMock = {
+    resolveTrackedPathStates: async (
+      snapshot: { processNames: Set<string>; succeeded: boolean },
+      configuredPaths: string[]
+    ) => {
+      const states = new Map<string, string>()
+      if (!snapshot.succeeded) {
+        return states
+      }
+      configuredPaths.forEach((configuredPath) => {
+        const name = configuredPath.split(/[\\/]/).pop()?.toLowerCase() ?? ''
+        states.set(
+          configuredPath,
+          snapshot.processNames.has(name) && !collidingPaths.has(configuredPath)
+            ? 'running'
+            : 'not-running'
+        )
+      })
+      return states
+    },
+    isTrackedPathRunning: (state?: string) => state !== 'not-running'
+  }
+  vi.doMock('./pathResolution', () => pathResolutionMock)
+  vi.doMock('/src/main/processes/pathResolution.ts', () => pathResolutionMock)
+  vi.doMock('../../src/main/processes/pathResolution', () => pathResolutionMock)
+  vi.doMock('../../src/main/processes/pathResolution.ts', () => pathResolutionMock)
 
   const killMock = {
     pruneUnclosedProcesses: pruneUnclosedProcessesMock,
@@ -98,6 +135,7 @@ function seedState(stateModule: Awaited<ReturnType<typeof loadRunningModule>>['s
 beforeEach(() => {
   vi.resetModules()
   vi.clearAllMocks()
+  collidingPaths.clear()
 })
 
 afterEach(() => {
@@ -129,7 +167,9 @@ test('a successful tasklist read prunes processes that are gone', async () => {
   const apps = await runningModule.getRunningApps()
 
   expect(stateModule.runningProcesses.size).toBe(0)
-  expect(pruneUnclosedProcessesMock).toHaveBeenCalledWith(new Set())
+  // A predicate now, not the name set (#674). The wiring is what this asserts;
+  // what the predicate ANSWERS is pinned where the real resolver runs.
+  expect(pruneUnclosedProcessesMock).toHaveBeenCalledWith(expect.any(Function))
   expect(apps).toEqual([])
 })
 

--- a/tests/main/state.test.ts
+++ b/tests/main/state.test.ts
@@ -52,7 +52,9 @@ test('pruneStoppedRunningProcesses drops only entries whose exe is no longer run
   runningProcesses.set('a', runningEntry('C:/Tools/SimHub.exe'))
   runningProcesses.set('b', runningEntry('C:/Tools/CrewChief.exe'))
 
-  pruneStoppedRunningProcesses(new Set(['simhub.exe']))
+  // A PATH predicate now (#674). Asking by image name meant a same-named
+  // process anywhere on the system kept a dead record alive.
+  pruneStoppedRunningProcesses((appPath) => appPath === 'C:/Tools/SimHub.exe')
 
   expect(runningProcesses.has('a')).toBe(true)
   expect(runningProcesses.has('b')).toBe(false)

--- a/tests/main/tasklist.test.ts
+++ b/tests/main/tasklist.test.ts
@@ -41,6 +41,75 @@ test('readRunningProcessNames parses tasklist CSV output into lowercase process 
   expect(tasklistCallCount).toBe(1)
 })
 
+// #674: the poll now decides what to draw from PID and Session#, so the columns
+// this used to parse away are load-bearing. A shape the parser mishandles does
+// not throw, it just yields fewer instances, and fewer instances resolve to
+// `not-running` — an app the user IS running vanishes from the strip. These run
+// everywhere, unlike the real-tasklist assertions in processEnumeration.win.
+test('the same rows also yield PID and Session# instances (#674)', async () => {
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const result = await readRunningProcessNames()
+
+  expect(result.processes).toEqual([
+    { name: 'simhub.exe', processId: 1234, sessionId: 1 },
+    { name: 'crewchief.exe', processId: 5678, sessionId: 1 }
+  ])
+})
+
+test('Session# is read, not the localized Session Name beside it (#674)', async () => {
+  // Column 3 reads "Console" or "Services" on an English install and is
+  // translated everywhere else. Reading it instead of the number would break
+  // the session-0 dismissal on every non-English Windows, silently.
+  tasklistOutput = '"svchost.exe","900","Dienste","0","5,000 K"'
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const result = await readRunningProcessNames()
+
+  expect(result.processes).toEqual([{ name: 'svchost.exe', processId: 900, sessionId: 0 }])
+})
+
+test('a row that will not parse still counts as a running name (#674)', async () => {
+  // The safe direction, and the reason the two outputs are not derived from one
+  // another. Losing the NAME would say an app is not running when it is; losing
+  // only the instance leaves the answer ambiguous, which every caller already
+  // handles conservatively. Inventing a session for it would be the dangerous
+  // one: session 0 is what lets an unreadable path be dismissed.
+  tasklistOutput = [
+    '"broken.exe","not-a-pid","Console","1","10 K"',
+    '"nosession.exe","4321","Console","x","10 K"',
+    '"truncated.exe","4322"',
+    '"","4323","Console","1","10 K"',
+    '"good.exe","4324","Console","1","10 K"'
+  ].join('\r\n')
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const result = await readRunningProcessNames()
+
+  // Every one of these keeps its name, including the truncated row: the name
+  // comes from field 0 alone, exactly as it did before the other columns were
+  // read. Writing this test is what caught the first version dropping a
+  // truncated row's name entirely, which the old parser never did.
+  expect(result.processNames.has('broken.exe')).toBe(true)
+  expect(result.processNames.has('nosession.exe')).toBe(true)
+  expect(result.processNames.has('truncated.exe')).toBe(true)
+  // ...and only the well-formed row becomes an instance. The empty name is not
+  // a name at all, so it contributes neither.
+  expect(result.processNames.has('')).toBe(false)
+  expect(result.processes).toEqual([{ name: 'good.exe', processId: 4324, sessionId: 1 }])
+})
+
+test('a failed read reports no instances rather than an empty machine (#399)', async () => {
+  tasklistError = new Error('tasklist unavailable')
+  const { readRunningProcessNames } = await loadTasklistModule()
+
+  const result = await readRunningProcessNames()
+
+  expect(result.succeeded).toBe(false)
+  expect(result.processes).toEqual([])
+  expect(result.processNames.size).toBe(0)
+})
+
 test('concurrent calls coalesce into a single tasklist invocation', async () => {
   const { readRunningProcessNames } = await loadTasklistModule()
 


### PR DESCRIPTION
The second and last half of #674. [PR #845](https://github.com/Stashpeak/SimLauncher/pull/845) fixed every site that answers a user action; this fixes the 2s running-apps poll, which is what draws the strip the user actually looks at.

## What was wrong

Four decisions per tick were made on the tasklist's image NAMES alone:

| Decision | What the collision did |
|---|---|
| `getTrackedRunningApps` | drew a strip icon for a configured app that was not running |
| the unclosed filter + `pruneUnclosedProcesses` | surfaced a leftover, and could only ever drop one when the NAME left the tasklist |
| adoption | surfaced a whole profile's companion list because something shared the GAME exe's name |
| the mismatch-warning filter | SUPPRESSED a real warning, the one case where the collision hid information instead of inventing it |

Two of those are worse than they sound.

**The icon could not be dismissed.** It is derived on every tick rather than stored, so `dismissAppIcon` had nothing to delete and it came straight back. Right-clicking cleared the amber border and left the icon.

**The leftover was permanent**, since pruning was by name and the stranger's name never leaves. Dismissing did not clear it, closing the app did not clear it, and nothing else would.

## This is a footprint repair, not a cost

`computeRunningAppsScanDelayMs` holds the poll at FAST while any unclosed record exists. Combined with the permanent leftover above, **one false Close pinned the poll to 2s for the rest of the session, including idle in the tray.** That inverts the cost argument that originally kept this half out of scope: leaving it unfixed is the expensive option.

## How the poll affords it

It cannot afford an enumeration per tick, so it does not do one.

1. **`tasklist /fo csv /nh` has always returned five columns and we kept one.** PID and session were being parsed and thrown away on every tick. Session 0 is the non-interactive services session, so those instances are dismissed for free: **170 of 537 processes on a real machine**, same command, same spawn.
2. **A path stays true for a PID's lifetime.** Windows does not move a running image, so the cache is `pid -> path` and the invalidation is the PID leaving the tasklist. No TTL, which would be wrong in both directions.
3. **"Windows will not disclose it" is cached as an ANSWER.** An elevated process hides its path and will keep hiding it, so a null is stored rather than retried. Without this, every elevated process is a permanent source of spawns.
4. **A 45s per-name cooldown** bounds the one case that cannot converge: a name that keeps producing new pids (`cmd.exe` reaches ~30 spawns a minute on a dev machine).

**Steady state therefore costs zero extra spawns**, and that is pinned by a test that counts enumerations across 20 ticks, not asserted here.

The decision rule is NOT re-implemented. This feeds the same `resolveConfiguredPathState` from a cheaper source, so the poll and the launch/kill paths cannot drift apart.

## Deliberately unchanged

**Failed-read behaviour.** A failed tasklist read used to yield an empty `processNames`, so the tick published an empty list. Folding "unknown" to "running" would have frozen the strip instead, which is arguably better but is a real behaviour change and not this issue's to make. The `tasklistReadSucceeded` term keeps it identical, by intent rather than omission.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (802 passing, 21 new)
- [x] Real-command gates, extending the ones added in #845. `readRunningProcessNames` is now run against the actual `tasklist` and asserted to yield this very process with its own PID, plus a populated session 0. CI's `test` job is windows-latest, so both are live there.
- [x] Mutation pass, five reversions, each firing only what it should:
  - answer by name instead of path: 9 tests fail (3 poll, 6 resolver), and every "must not regress" case stays green
  - stop skipping session 0: the free-dismissal test fails
  - disable PID-lifetime invalidation: the pid-reuse test fails
  - remove the cooldown: the churn and failed-enumeration tests fail
  - read `Session Name` (localized text) instead of `Session#`: both real-tasklist tests fail
- [x] Guardrails held rather than edited: #390 (unreadable path still surfaces), #399 (a failed read prunes nothing and does not flush the cache), and adoption/tracking behaviour for apps genuinely at their configured path.
- [ ] Manual: batched into the 1.2.0 smoke run, whose item A is the `cmd.exe` collision repro. Both halves should now be clean: no phantom icon, and the leftover clears on the next scan.

Closes #674


<!-- auto-closes -->
Closes #674
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved running-application detection by verifying full executable paths, preventing conflicts between same-named applications in different locations.
  * Reduced incorrect app adoption, companion-app display, and stale-process tracking when process scans fail or paths cannot be verified.
  * Preserved accurate tracking when applications restart at the same path.

* **Tests**
  * Added comprehensive coverage for path collisions, caching, failed scans, localized process data, and process identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->