### PR TITLE
style(copy): no em dashes in user-facing strings (#848)

### DIFF
--- a/src/main/ipc/launch.ts
+++ b/src/main/ipc/launch.ts
@@ -321,7 +321,7 @@ export function registerLaunchHandlers(): void {
             return {
               success: false,
               cancelled: true,
-              message: 'Launch cancelled — closed apps instead.',
+              message: 'Launch cancelled: closed apps instead.',
               launchedCount: 0,
               skippedCount: 0,
               failedCount: killResult?.failedCount,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -278,7 +278,7 @@ export async function launchProfileApps(
       return {
         success: false,
         cancelled: true,
-        message: 'Launch cancelled — closed apps instead.',
+        message: 'Launch cancelled: closed apps instead.',
         launchedCount: 0,
         skipped
       }
@@ -457,7 +457,7 @@ export async function launchProfileApps(
       return {
         success: false,
         cancelled: true,
-        message: `Launch cancelled — closed apps instead.${survivedNote}${unknownNote}`,
+        message: `Launch cancelled: closed apps instead.${survivedNote}${unknownNote}`,
         launchedCount,
         skippedCount,
         elevatedCount: survivedCount + unknownCount,
@@ -1124,7 +1124,7 @@ export async function spawnDetachedApp(
         const stillTracked = isTracked && isProcessTrackingEnabled(getActiveProfileForGame(gameKey))
 
         if (stillTracked && exitedDuringPostLaunchWindow && !wasClosedBySimLauncher) {
-          const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name — SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add it under "Secondary executables to watch" in the profile editor. Right-click the icon to dismiss this warning.`
+          const warning = `${path.basename(appPath)} exited shortly after launch. It likely spawned a child process under a different name. SimLauncher can no longer detect when you close it. To restore tracking, find the child process name in Task Manager and add it under "Secondary executables to watch" in the profile editor. Right-click the icon to dismiss this warning.`
 
           processNameMismatchWarnings.set(normalizePathForComparison(appPath), {
             path: appPath,

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -102,7 +102,7 @@ export function formatConfigRecoveryNotice(notice: ConfigRecoveryNotice): {
     return {
       type: 'warn',
       message:
-        "Your saved settings couldn't be opened — they may be locked by another program. SimLauncher started with defaults for now; your saved settings are untouched and will load next time."
+        "Your saved settings couldn't be opened. They may be locked by another program. SimLauncher started with defaults for now; your saved settings are untouched and will load next time."
     }
   }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -142,7 +142,7 @@ function AppContent() {
   // two views were otherwise indistinguishable.
   const viewLabel = view === 'settings' ? 'Settings' : 'Games'
   useEffect(() => {
-    document.title = `SimLauncher — ${viewLabel}`
+    document.title = `SimLauncher: ${viewLabel}`
   }, [viewLabel])
 
   // Re-home keyboard focus into the now-visible view whenever the view changes
@@ -411,7 +411,7 @@ function AppContent() {
       className={`h-screen overflow-hidden relative transition-colors duration-500 ${accentBgTint ? 'bg-tinted' : ''}`}
     >
       <header className="absolute top-0 left-0 w-full z-20 header-glass">
-        <h1 className="sr-only">SimLauncher — {viewLabel}</h1>
+        <h1 className="sr-only">SimLauncher: {viewLabel}</h1>
         <WindowControls view={view} onNavigate={handleNavigate} updateInfo={updateInfo} />
       </header>
 

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -286,7 +286,7 @@ export function GameRow({
           // an error; the switch is not saved and can simply be retried.
           if (result.cancelled) {
             notify(
-              [result.message || 'Launch cancelled — closed apps instead.', strandedNote]
+              [result.message || 'Launch cancelled: closed apps instead.', strandedNote]
                 .filter(Boolean)
                 .join(' '),
               'warn'
@@ -420,7 +420,7 @@ export function GameRow({
       // everything (#670) — this is neither a success nor a failure, so it
       // gets its own toast rather than falling into either branch below.
       if (result.cancelled) {
-        notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+        notify(result.message || 'Launch cancelled: closed apps instead.', 'warn')
         return
       }
 
@@ -510,7 +510,7 @@ export function GameRow({
 
       // Same cancellation case as handleLaunch above (#670).
       if (result.cancelled) {
-        notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+        notify(result.message || 'Launch cancelled: closed apps instead.', 'warn')
         return
       }
 

--- a/src/renderer/src/components/settings/AboutSection.tsx
+++ b/src/renderer/src/components/settings/AboutSection.tsx
@@ -161,7 +161,7 @@ export function AboutSection({
         )}
         {updateStatus === 'offline' && (
           <p className="text-[10px] text-center text-(--text-muted) animate-fade-slide">
-            Can&apos;t reach the update server — check your connection.
+            Can&apos;t reach the update server. Check your connection.
           </p>
         )}
       </div>

--- a/src/renderer/src/components/settings/useUpdateStatus.ts
+++ b/src/renderer/src/components/settings/useUpdateStatus.ts
@@ -95,8 +95,8 @@ export function useUpdateStatus({
       if (
         window.confirm(
           `Update${versionSuffix} is ready to install. Restart now to apply it? ` +
-            'Your unsaved changes will be lost. Choose Cancel to keep working, ' +
-            'you can install later from Settings.'
+            'Your unsaved changes will be lost. Choose Cancel to keep working. ' +
+            'You can install later from Settings.'
         )
       ) {
         installUpdate().catch((err: unknown) => {

--- a/src/renderer/src/components/settings/useUpdateStatus.ts
+++ b/src/renderer/src/components/settings/useUpdateStatus.ts
@@ -95,7 +95,7 @@ export function useUpdateStatus({
       if (
         window.confirm(
           `Update${versionSuffix} is ready to install. Restart now to apply it? ` +
-            'Your unsaved changes will be lost. Choose Cancel to keep working — ' +
+            'Your unsaved changes will be lost. Choose Cancel to keep working, ' +
             'you can install later from Settings.'
         )
       ) {

--- a/src/renderer/src/hooks/useProfileEditor.tsx
+++ b/src/renderer/src/hooks/useProfileEditor.tsx
@@ -454,7 +454,7 @@ export function useProfileEditor({
       // everything (#670) — neither a success nor a failure, so it gets its
       // own toast rather than the error/success branches below.
       if (result.cancelled) {
-        notify(result.message || 'Launch cancelled — closed apps instead.', 'warn')
+        notify(result.message || 'Launch cancelled: closed apps instead.', 'warn')
       } else if (!result.success) {
         const failedSkippedDetail =
           result.skipped && result.skipped.length > 0

--- a/tests/main/ipcLaunch.test.ts
+++ b/tests/main/ipcLaunch.test.ts
@@ -561,7 +561,7 @@ test('switch-profile-apps with nothing to start reports cancelled when Close App
   await expect(resultPromise).resolves.toMatchObject({
     success: false,
     cancelled: true,
-    message: 'Launch cancelled — closed apps instead.',
+    message: 'Launch cancelled: closed apps instead.',
     launchedCount: 0
   })
   expect(launchProfileApps).not.toHaveBeenCalled()

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -5395,7 +5395,7 @@ test('the cancellation message names elevated apps the kill cannot close (#670)'
     cancelled: true,
     elevatedCount: 1,
     message:
-      'Launch cancelled — closed apps instead. One app started with administrator permission and cannot be closed from here.'
+      'Launch cancelled: closed apps instead. One app started with administrator permission and cannot be closed from here.'
   })
 })
 

--- a/tests/renderer/gameRowLaunchCancelled.test.tsx
+++ b/tests/renderer/gameRowLaunchCancelled.test.tsx
@@ -7,7 +7,7 @@
  *
  * Pinned here: when `launchProfile`/`relaunchMissingProfile` resolves with
  * `cancelled: true`, the row's toast must read as a neutral cancellation
- * ("Launch cancelled — closed apps instead.") — never the success toast, and
+ * ("Launch cancelled: closed apps instead.") — never the success toast, and
  * never the plain error toast either.
  */
 
@@ -157,13 +157,13 @@ describe('GameRow launch cancellation toast (#670)', () => {
       success: false,
       cancelled: true,
       launchedCount: 1,
-      message: 'Launch cancelled — closed apps instead.'
+      message: 'Launch cancelled: closed apps instead.'
     })
 
     await renderRow()
     await clickPlayButton()
 
-    expect(notifyMock).toHaveBeenCalledWith('Launch cancelled — closed apps instead.', 'warn')
+    expect(notifyMock).toHaveBeenCalledWith('Launch cancelled: closed apps instead.', 'warn')
     // Arg-shape-independent: a cancellation must not produce ANY success
     // toast, however many args the call carries.
     expect(notifyMock.mock.calls.some((call) => call[1] === 'success')).toBe(false)
@@ -179,7 +179,7 @@ describe('GameRow launch cancellation toast (#670)', () => {
     await renderRow()
     await clickPlayButton()
 
-    expect(notifyMock).toHaveBeenCalledWith('Launch cancelled — closed apps instead.', 'warn')
+    expect(notifyMock).toHaveBeenCalledWith('Launch cancelled: closed apps instead.', 'warn')
   })
 
   // cancelled must be checked before the plain failure branch — otherwise a
@@ -189,7 +189,7 @@ describe('GameRow launch cancellation toast (#670)', () => {
       success: false,
       cancelled: true,
       launchedCount: 1,
-      message: 'Launch cancelled — closed apps instead.'
+      message: 'Launch cancelled: closed apps instead.'
     })
 
     await renderRow()


### PR DESCRIPTION
Spotted by David in the #737 mismatch-warning tooltip. It turned out not to be one string.

## Summary

11 user-facing strings across 8 files used an em dash. Each is replaced with the punctuation that sentence actually wanted rather than a mechanical swap: a full stop where two independent clauses were being joined, a colon where the second half explains the first, a comma where the sentence continues.

| Where | Before → after |
|---|---|
| the #737 tooltip | `…under a different name — SimLauncher can no longer detect…` → full stop |
| `store.ts` settings-load warning | `…couldn't be opened — they may be locked…` → full stop |
| "Launch cancelled — closed apps instead." ×6 | → `Launch cancelled: closed apps instead.` |
| window title + its `sr-only` heading | `SimLauncher — Settings` → `SimLauncher: Settings` |
| update-server offline note | `…update server — check your connection.` → full stop |
| restart-to-update confirm | `…to keep working — you can install later…` → comma |

Code comments keep their em dashes: the house rule is about public copy, and rewriting hundreds of comments would bury the change that matters.

## Worth knowing

**"Launch cancelled: closed apps instead." exists in six places** — three in main, three as renderer fallbacks for when main supplies no message. Main and the renderer are separate bundles so a shared constant is not free, but six hand-copied instances of one user-visible sentence is exactly how wording drifts. Not changed here; recorded in #848 so the next person editing it greps instead of editing one.

The window title change is the only one a user could notice as a change rather than a fix. `SimLauncher: Settings` reads correctly and matches the sr-only heading, which had the same em dash.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (811 passing; 3 suites assert on the changed sentences and were updated with them)
- [x] Swept the whole of `src/` for U+2014 afterwards: the only remaining occurrences are continuation lines inside code comments.
- [ ] Manual: none needed. Copy only, no logic and no layout.

Closes #848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized punctuation across launch, cancellation, recovery, update, and offline status messages.
  * Improved consistency in the application title and screen-reader heading.
  * Refined update confirmation wording for unsaved changes.

* **Tests**
  * Updated automated test expectations to match the revised user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #848
<!-- auto-closes -->