### PR TITLE
style(ui): make the unknown status dot a ring in every theme (#737)

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -821,6 +821,31 @@ button:focus-visible,
   outline: none;
 }
 
+/* The unknown-state status dot (#737): the game exited within 10s of launch, or
+   it handed off to a child process under a name nothing here can see, and
+   neither reading can be confirmed. It sits next to the confirmed-running dot,
+   which is a filled green disc of the same 12px.
+
+   A hollow RING rather than a filled amber disc, so the two differ in shape and
+   not only in hue. Colour alone fails WCAG 1.4.1, and green-versus-amber is the
+   specific pair that red-green colour vision deficiency compresses hardest —
+   roughly 8% of men, which for a sim-racing audience is not an edge case. At
+   12px the hue difference is a discrimination task; the hole is not.
+
+   The fill is `--bg-gradient`, the page's own background, so the ring reads as
+   the page showing through rather than a donut punched into the game artwork
+   the dot overlaps. On a 12px circle the gradient resolves to essentially a
+   solid, and it tracks the theme without a per-theme entry. This mirrors what
+   the forced-colors block below already does with `Canvas`, which needs its own
+   rule there because the OS overrides author colours in that mode.
+
+   The amber is still carried by the border and the glow, so nothing is lost:
+   the shape is added, not substituted. */
+.status-dot-unknown {
+  background: var(--bg-gradient);
+  border: 2px solid var(--status-warning);
+}
+
 /* Respect the OS "reduce motion" preference: neutralize transitions and stop
    the infinite loops (ping/pulse/spin, toast progress) for vestibular safety.
    Mirrors the marketing site's reduced-motion support. */

--- a/src/renderer/src/components/game-list/GameIcon.tsx
+++ b/src/renderer/src/components/game-list/GameIcon.tsx
@@ -30,11 +30,19 @@ const STATUS_DOT_CLASS = `${STATUS_DOT_BASE_CLASS} bg-(--status-running) shadow-
 // the amber already used for the strip's elevated-companion triangle, and it
 // aliases `--warning-text`, so it follows the theme without a per-theme entry
 // (same as --status-danger / --status-success).
-// `status-dot-unknown` carries no styling of its own outside Windows High
-// Contrast, where App.css turns it into a hollow ring: that mode strips every
-// status dot to one system colour, which would otherwise make this state
-// indistinguishable from a running one (Codex P2 on #829).
-const STATUS_DOT_UNKNOWN_CLASS = `${STATUS_DOT_BASE_CLASS} status-dot-unknown bg-(--status-warning) shadow-[0_0_8px_var(--status-warning)]`
+// `status-dot-unknown` is styled in App.css as a hollow RING, in every theme
+// rather than only in Windows High Contrast. Colour alone fails WCAG 1.4.1, and
+// green-versus-amber is the pair red-green colour vision deficiency compresses
+// hardest, so at 12px the hue difference was a discrimination task rather than a
+// glance. High Contrast keeps its own copy of the rule because the OS overrides
+// author colours there (Codex P2 on #829); this is the general case (#737).
+//
+// The fill deliberately does NOT appear here: App.css owns it, because the ring
+// needs `background: var(--bg-gradient)` (the page showing through) and a
+// Tailwind `bg-(…)` utility would set `background-color`, which cannot take a
+// gradient — and would race the CSS rule on equal specificity. The amber is
+// still carried, by the border and the glow.
+const STATUS_DOT_UNKNOWN_CLASS = `${STATUS_DOT_BASE_CLASS} status-dot-unknown shadow-[0_0_8px_var(--status-warning)]`
 
 export function GameIcon({
   game,

--- a/tests/renderer/gameIconDismiss.test.tsx
+++ b/tests/renderer/gameIconDismiss.test.tsx
@@ -181,7 +181,11 @@ describe('GameIcon dismiss menu (#737)', () => {
         dismissPath={GAME_PATH}
       />
     )
-    expect(dotClass()).toContain('bg-(--status-warning)')
+    // The unknown state is carried by `status-dot-unknown`, whose ring and amber
+    // border live in App.css. It deliberately has NO `bg-` utility: the ring's
+    // fill is a gradient (the page showing through), which `background-color`
+    // cannot take, and a utility would race the stylesheet on equal specificity.
+    expect(dotClass()).toContain('status-dot-unknown')
     expect(dotClass()).not.toContain('bg-(--status-running)')
   })
 
@@ -199,13 +203,51 @@ describe('GameIcon dismiss menu (#737)', () => {
       />
     )
     expect(dotClass()).toContain('bg-(--status-running)')
-    expect(dotClass()).not.toContain('bg-(--status-warning)')
+    expect(dotClass()).not.toContain('status-dot-unknown')
   })
 
   test('a plain running game keeps the running dot (#737)', async () => {
     await render(<GameIcon game={GAME} isRunning={true} iconUrl={ICON} />)
     expect(dotClass()).toContain('bg-(--status-running)')
-    expect(dotClass()).not.toContain('bg-(--status-warning)')
+    expect(dotClass()).not.toContain('status-dot-unknown')
+  })
+
+  // The general case, and the reason the dot is not amber-only: colour alone
+  // fails WCAG 1.4.1, and green-versus-amber is the pair red-green colour vision
+  // deficiency compresses hardest, so at 12px the hue difference was a
+  // discrimination task rather than a glance (David's call on #737).
+  //
+  // Pinned the same way as the forced-colors rule below and for the same reason:
+  // jsdom applies no stylesheet, so no rendering assertion can see a ring. A
+  // class name in a component and a selector in a stylesheet drift apart
+  // silently, and this asserts both ends plus the two declarations that make it
+  // a ring rather than a disc.
+  test('the unknown dot is a ring in every theme, not only in forced-colors (#737)', async () => {
+    await render(
+      <GameIcon
+        game={GAME}
+        isRunning={true}
+        iconUrl={ICON}
+        warning={WARNING}
+        dismissPath={GAME_PATH}
+      />
+    )
+    expect(dotClass()).toContain('status-dot-unknown')
+
+    const css = readFileSync(path.join(process.cwd(), 'src/renderer/src/App.css'), 'utf8')
+    const forcedColorsAt = css.indexOf('@media (forced-colors: active)')
+    const generalAt = css.indexOf('.status-dot-unknown {')
+
+    // BEFORE the media query, i.e. not inside it. A rule that only exists in
+    // forced-colors is what this test exists to rule out.
+    expect(generalAt).toBeGreaterThan(-1)
+    expect(generalAt).toBeLessThan(forcedColorsAt)
+
+    const rule = css.slice(generalAt, css.indexOf('}', generalAt))
+    // The border is what makes it a shape; the gradient fill is what keeps the
+    // hole reading as the page rather than a hole punched in the game artwork.
+    expect(rule).toContain('border: 2px solid var(--status-warning)')
+    expect(rule).toContain('background: var(--bg-gradient)')
   })
 
   // Windows High Contrast strips every `.status-dot` to a single system colour,


### PR DESCRIPTION
David's call on the one decision #829 deliberately left open. Not a defect: the amber was already approved, so this was a taste question until the accessibility side of it was weighed.

## What changed

The unknown-state dot (the game exited within 10s of launch, or handed off to a child process under a name nothing here can see) sat beside the confirmed-running dot and differed from it **only by hue**: two filled 12px discs, green and amber.

```
before          after
● green         ● green      confirmed running
● amber         ◉ amber      "we cannot tell"   ← now a hollow ring
```

## Why, and only the third reason is a preference

- **Green versus amber is the worst possible pair.** It is the axis red-green colour vision deficiency compresses hardest: roughly 8% of men, which for a sim-racing audience is not an edge case.
- **12px with a glow.** Even with unimpaired colour vision, a hue difference at that size is a discrimination task rather than a glance.
- **WCAG 1.4.1** requires colour not be the only visual carrier. The tooltip and the Dismiss menu do differ, but both need hover or focus, and the criterion is about the resting state.

## Not a new idea, a generalised one

The hollow ring already existed, in the `forced-colors` block, because Windows High Contrast collapses every dot to one system colour and the two states would otherwise be identical. That was the right instinct applied to the one mode almost nobody runs. Shape is what the OS could not take away; it turns out to be what colour vision cannot take away either.

## Two implementation notes worth reviewing

**The fill is `--bg-gradient`, the page's own background, not `transparent`.** The dot overlaps the bottom-right of a 48px game icon, so a transparent centre would show the artwork through the hole and read as a donut rather than a ring. On a 12px circle the gradient resolves to essentially a solid, and it tracks light/dark with no per-theme entry. This mirrors what the forced-colors rule does with `Canvas`; that rule stays, because the OS overrides author colours there.

**The `bg-` utility moved out of the component into App.css.** A background gradient cannot be a `background-color`, which is what Tailwind's `bg-(…)` sets, and leaving the utility in place would race the stylesheet on equal specificity. The amber is not replaced, only joined: it still comes through the border and the glow.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (812 passing, 1 new)
- [x] Mutation: reverting the rule to a filled amber disc fails the new test, and only that test.
- [x] The three existing dot tests were re-pointed at `status-dot-unknown`, which is now the real discriminator — they asserted a `bg-` utility that this PR removes, and would otherwise have passed vacuously.
- [ ] Manual (David, ~2 min): produce the dot by clicking Launch and closing the game within 10s, then put it beside a genuinely running game. Both themes if convenient.

The new test pins the component class AND the stylesheet rule, the way the forced-colors one does and for the same reason: jsdom applies no stylesheet, so nothing rendered can see a ring, and a class name in a component and a selector in a CSS file drift apart silently.

Refs #737
