### PR TITLE
fix(processes): give the row back its Close Apps after a restart (#673)

### DIFF
--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -1,5 +1,5 @@
 export { AUTO_CLOSE_GRACE_MS, initAutoClose } from './processes/autoClose'
-export { hasClosableLaunchedApps, killLaunchedApps, killProfileApps } from './processes/kill'
+export { killLaunchedApps, killProfileApps } from './processes/kill'
 export {
   getRunningApps,
   publishRunningApps,

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -114,8 +114,17 @@ export function pruneUnclosedProcesses(isPathRunning: (appPath: string) => boole
   // cannot drop a live claim. Dropping the claim of an app that has exited is
   // what stops a stale owner surviving until the next launch and swallowing a
   // hand-started copy the other profiles should be able to close (#853).
+  //
+  // A claim is made before its app is up, so "not running" means "not yet"
+  // until the poll has seen it once. Pruning on the first answer instead
+  // deleted every claim seconds after it was made: measured on a real machine,
+  // the map was empty on every single tick.
   adoptedCompanionOwners.forEach((owner, ownedKey) => {
-    if (!isPathRunning(owner.path)) {
+    if (isPathRunning(owner.path)) {
+      owner.seenRunning = true
+      return
+    }
+    if (owner.seenRunning) {
       adoptedCompanionOwners.delete(ownedKey)
     }
   })

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -894,17 +894,28 @@ export function getClosableLaunchedAppGameKeys(
 ): Set<string> {
   const closableGameKeys = new Set<string>()
   const gameExePaths = getConfiguredGameExePaths()
+  // What a launch of ours already accounts for. A companion SimLauncher started
+  // as part of one profile belongs to THAT profile, so the configured-target
+  // pass below must not hand it to every other profile that merely lists the
+  // same app: launching one game otherwise put a close control on every other
+  // row sharing a companion, and each of those clicks would have closed the
+  // running game's own companion (#853). This is not inventing attribution, it
+  // is keeping the attribution the launch already recorded. Ownership is
+  // genuinely unknown only for companions nobody started through us, which is
+  // the cohort #851 is about; those still fall through to every owner below.
+  const launchOwnedPaths = new Set<string>()
+  const launchOwnedNames = new Set<string>()
 
   for (const appProcess of runningProcesses.values()) {
-    if (closableGameKeys.has(appProcess.gameKey)) {
-      continue
-    }
     if (appProcess.isGame || gameExePaths.has(normalizePathForComparison(appProcess.path))) {
       continue
     }
-    if (isPathRunning(appProcess.path)) {
-      closableGameKeys.add(appProcess.gameKey)
+    if (!isPathRunning(appProcess.path)) {
+      continue
     }
+    launchOwnedPaths.add(normalizePathForComparison(appProcess.path))
+    launchOwnedNames.add(appProcess.name.toLowerCase())
+    closableGameKeys.add(appProcess.gameKey)
   }
 
   for (const target of getProfileCompanionTargets().values()) {
@@ -915,9 +926,20 @@ export function getClosableLaunchedAppGameKeys(
     const isRunning =
       target.scope === 'name' ? processNames.has(target.processName) : isPathRunning(target.appPath)
 
-    if (isRunning) {
-      target.gameKeys.forEach((owner) => closableGameKeys.add(owner))
+    if (!isRunning) {
+      continue
     }
+    // Already owned by a launch of ours, so it is not up for adoption by the
+    // other profiles that configure it. See `launchOwnedPaths` above.
+    const isLaunchOwned =
+      target.scope === 'name'
+        ? launchOwnedNames.has(target.processName)
+        : launchOwnedPaths.has(normalizePathForComparison(target.appPath))
+    if (isLaunchOwned) {
+      continue
+    }
+
+    target.gameKeys.forEach((owner) => closableGameKeys.add(owner))
   }
 
   return closableGameKeys

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -951,15 +951,22 @@ export function getClosableLaunchedAppGameKeys(
   // profiles with tracking off, so a claim made while tracking was on goes
   // quiet while it is off and comes back after, with nothing deleted.
   for (const [ownedKey, owner] of adoptedCompanionOwners) {
-    const isStillConfigured = companionTargets.some(
+    const configuredTarget = companionTargets.find(
       (target) =>
         target.scope === 'path' &&
         normalizePathForComparison(target.appPath) === ownedKey &&
         target.gameKeys.includes(owner.gameKey)
     )
-    if (!isStillConfigured) {
+    if (!configuredTarget) {
       continue
     }
+    // Ask about the path AS CONFIGURED NOW, not as it was spelled when the
+    // claim was made (Codex on #853). The two match after normalization but the
+    // tick keys its answers by the raw string, so a re-saved path in a
+    // different case or slash style would go unanswered, and an unanswered path
+    // reads as running: the claim would outlive its process forever. Healing
+    // the record here also fixes the prune, which has no targets of its own.
+    owner.path = configuredTarget.appPath
     if (!isPathRunning(owner.path)) {
       continue
     }

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -13,6 +13,7 @@ import { getExeName, isValidExePath, normalizePathForComparison, pathsEqual, wai
 
 import {
   abortActiveLaunches,
+  adoptedCompanionOwners,
   cancelPendingElevatedHandoffs,
   drainStrandedConsentPrompts,
   processNameMismatchWarnings,
@@ -106,6 +107,16 @@ export function pruneUnclosedProcesses(isPathRunning: (appPath: string) => boole
   unclosedProcesses.forEach((entry, key) => {
     if (!isPathRunning(entry.path)) {
       unclosedProcesses.delete(key)
+    }
+  })
+
+  // Same predicate, same "yes when unsure" contract, so an unobserved tick
+  // cannot drop a live claim. Dropping the claim of an app that has exited is
+  // what stops a stale owner surviving until the next launch and swallowing a
+  // hand-started copy the other profiles should be able to close (#853).
+  adoptedCompanionOwners.forEach((_gameKey, ownedPath) => {
+    if (!isPathRunning(ownedPath)) {
+      adoptedCompanionOwners.delete(ownedPath)
     }
   })
 }
@@ -916,6 +927,24 @@ export function getClosableLaunchedAppGameKeys(
     launchOwnedPaths.add(normalizePathForComparison(appProcess.path))
     launchOwnedNames.add(appProcess.name.toLowerCase())
     closableGameKeys.add(appProcess.gameKey)
+  }
+
+  // The other way a launch establishes ownership: the app was already running
+  // when the launch reached it, so there is no child handle but the profile
+  // asked for it all the same (`adoptedCompanionOwners`). Tracking is rechecked
+  // at read time rather than trusted from record time, because #591 must be
+  // able to take the affordance away without deleting anything: a claim made
+  // while tracking was on is void while it is off, and live again after.
+  for (const [ownedPath, gameKey] of adoptedCompanionOwners) {
+    if (!isPathRunning(ownedPath)) {
+      continue
+    }
+    if (!isProcessTrackingEnabled(getActiveStoredProfile(getStoredProfiles()[gameKey]))) {
+      continue
+    }
+    launchOwnedPaths.add(ownedPath)
+    launchOwnedNames.add(getExeName(ownedPath).toLowerCase())
+    closableGameKeys.add(gameKey)
   }
 
   for (const target of getProfileCompanionTargets().values()) {

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -41,8 +41,7 @@ import {
   killProcessByImageName,
   killProcessTree,
   requestGracefulClose,
-  resolveConfiguredPathStates,
-  resolveRunningConfiguredPaths
+  resolveConfiguredPathStates
 } from './win32KillUtils'
 
 // Hardcoded list of companion process names for utilities that spawn background
@@ -571,8 +570,10 @@ function getProfileCompanionTargets(gameKey?: string) {
     // enough on its own: this function rebuilds targets from the stored profile
     // rather than from what was launched, so without this guard the tray's
     // always-enabled Close Apps would still find and kill apps the user
-    // explicitly opted out of us touching. `hasClosableLaunchedApps` reads the
-    // same map, so this also stops the action being offered for that profile.
+    // explicitly opted out of us touching. `getClosableLaunchedAppGameKeys`
+    // reads the same map, so this also stops the action being OFFERED for that
+    // profile. Gating here rather than storing the toggle's effect is what lets
+    // turning tracking back on restore the affordance with no relaunch (#591).
     if (!isProcessTrackingEnabled(profile)) {
       return
     }
@@ -851,24 +852,27 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
 }
 
 /**
- * Whether killLaunchedApps(gameKey) currently has at least one target it would
- * try to close: a tracked non-game process whose exe is running, or a configured
- * / hardcoded companion whose process is running.
+ * Which game keys killLaunchedApps(gameKey) currently has at least one target
+ * for: a tracked non-game process whose exe is running, or a configured /
+ * hardcoded companion whose process is running.
  *
- * NOT currently called from production. It was written for a tray "Close Apps"
- * item whose enabled state was cached and kept fresh by listeners; that design
- * was replaced by an always-enabled item, and the re-land in #519 does not use a
- * pre-check at all, because deciding "nothing to close" before reaching
- * killLaunchedApps skips the abort/cancel prologue and lets an in-flight launch
- * carry on (Codex P1 on #819). Kept because #673 plans to expose it over IPC for
- * the missing Close Apps affordance after a restart. If that changes, delete it
- * rather than leaving it to look load-bearing again.
+ * This drives the secondary Close Apps control (#673), the affordance that is
+ * otherwise lost when the in-memory maps do not survive a restart. Its
+ * predecessor answered one game key at a time and ran its own enumeration, and
+ * its JSDoc forbade calling it from a timer for that reason: one PowerShell
+ * spawn is fine for a click and is not fine once per poll, let alone once per
+ * ROW per poll. The affordance has to appear and clear on its own as processes
+ * come and go, so an on-demand shape could not drive it. Hence the inversion:
+ * answer every key at once, from a resolver the caller already paid for, which
+ * is zero extra spawns in the steady state (#846).
  *
  * KEEP IN SYNC with killLaunchedApps above — the two membership conditions here
  * mirror its two kill-task branches. Deliberately NOT derived from
  * getRunningApps(): that list gates companions on the owning game being launched
  * or adopted, while killLaunchedApps closes configured companions regardless, so
- * the surfaced list would under-report closable targets.
+ * the surfaced list would under-report closable targets. That difference is the
+ * whole point here, because the profile whose companions are invisible is
+ * exactly the one this control exists for.
  *
  * One deliberate asymmetry with killLaunchedApps, and it is not drift: this
  * verifies a candidate against its PATH (#674) where the scheduling there stays
@@ -876,51 +880,47 @@ export async function killLaunchedApps(gameKey?: string): Promise<KillResult> {
  * nothing is running at costs a lookup and nothing else, because the kill is
  * path-scoped and finalizeKillAttempts now judges the empty result correctly.
  * Telling the user there is something to close when there is not is the defect
- * this function would otherwise ship to #673, so it pays for the enumeration and
- * the scheduling does not.
+ * this would otherwise ship to #673.
  *
- * On-demand only. This is one PowerShell spawn in the collision case, which is
- * fine for a click and is not fine on the running-apps poll — do not call it
- * from a timer.
+ * A target owned by SEVERAL profiles marks all of them. That is honest rather
+ * than convenient: one SimHub configured in three profiles genuinely is closable
+ * from any of the three, and a click on any one of them closes the same process.
+ * The strip is what distinguishes "this profile's session" from "this profile
+ * could close it", and the strip is deliberately untouched here (#794 owns it).
  */
-export async function hasClosableLaunchedApps(gameKey?: string): Promise<boolean> {
-  const { processNames } = await readRunningProcessNames()
+export function getClosableLaunchedAppGameKeys(
+  processNames: Set<string>,
+  isPathRunning: (appPath: string) => boolean
+): Set<string> {
+  const closableGameKeys = new Set<string>()
   const gameExePaths = getConfiguredGameExePaths()
 
-  const candidatePaths: string[] = []
   for (const appProcess of runningProcesses.values()) {
-    if (gameKey && appProcess.gameKey !== gameKey) {
+    if (closableGameKeys.has(appProcess.gameKey)) {
       continue
     }
     if (appProcess.isGame || gameExePaths.has(normalizePathForComparison(appProcess.path))) {
       continue
     }
-    candidatePaths.push(appProcess.path)
+    if (isPathRunning(appProcess.path)) {
+      closableGameKeys.add(appProcess.gameKey)
+    }
   }
 
-  const companionTargets = getProfileCompanionTargets(gameKey)
-  for (const target of companionTargets.values()) {
+  for (const target of getProfileCompanionTargets().values()) {
     // A curated name-scoped target has no path to verify against, so it keeps
     // the name-only answer. That is not a gap being tolerated: `/IM` is how such
     // a target would be closed too, so name membership is exactly the condition
     // under which closing it would do something.
-    if (target.scope === 'name') {
-      if (processNames.has(target.processName)) {
-        return true
-      }
-      continue
+    const isRunning =
+      target.scope === 'name' ? processNames.has(target.processName) : isPathRunning(target.appPath)
+
+    if (isRunning) {
+      target.gameKeys.forEach((owner) => closableGameKeys.add(owner))
     }
-    candidatePaths.push(target.appPath)
   }
 
-  if (candidatePaths.length === 0) {
-    return false
-  }
-
-  // One enumeration for both branches, and none at all unless some candidate's
-  // image is actually in the tasklist.
-  const runningPaths = await resolveRunningConfiguredPaths(processNames, candidatePaths)
-  return candidatePaths.some((candidatePath) => runningPaths.has(candidatePath))
+  return closableGameKeys
 }
 
 /**

--- a/src/main/processes/kill.ts
+++ b/src/main/processes/kill.ts
@@ -114,9 +114,9 @@ export function pruneUnclosedProcesses(isPathRunning: (appPath: string) => boole
   // cannot drop a live claim. Dropping the claim of an app that has exited is
   // what stops a stale owner surviving until the next launch and swallowing a
   // hand-started copy the other profiles should be able to close (#853).
-  adoptedCompanionOwners.forEach((_gameKey, ownedPath) => {
-    if (!isPathRunning(ownedPath)) {
-      adoptedCompanionOwners.delete(ownedPath)
+  adoptedCompanionOwners.forEach((owner, ownedKey) => {
+    if (!isPathRunning(owner.path)) {
+      adoptedCompanionOwners.delete(ownedKey)
     }
   })
 }
@@ -916,6 +916,7 @@ export function getClosableLaunchedAppGameKeys(
   // the cohort #851 is about; those still fall through to every owner below.
   const launchOwnedPaths = new Set<string>()
   const launchOwnedNames = new Set<string>()
+  const companionTargets = Array.from(getProfileCompanionTargets().values())
 
   for (const appProcess of runningProcesses.values()) {
     if (appProcess.isGame || gameExePaths.has(normalizePathForComparison(appProcess.path))) {
@@ -929,25 +930,36 @@ export function getClosableLaunchedAppGameKeys(
     closableGameKeys.add(appProcess.gameKey)
   }
 
-  // The other way a launch establishes ownership: the app was already running
-  // when the launch reached it, so there is no child handle but the profile
-  // asked for it all the same (`adoptedCompanionOwners`). Tracking is rechecked
-  // at read time rather than trusted from record time, because #591 must be
-  // able to take the affordance away without deleting anything: a claim made
-  // while tracking was on is void while it is off, and live again after.
-  for (const [ownedPath, gameKey] of adoptedCompanionOwners) {
-    if (!isPathRunning(ownedPath)) {
+  // The other way a launch establishes ownership: it handled the app but holds
+  // no child handle for it, because the app was already running, was handed off
+  // elevated, or replaced the process we started (`adoptedCompanionOwners`).
+  //
+  // Re-derived from the store on every read rather than trusted from record
+  // time, and the claim is worth nothing unless the profile STILL configures
+  // that path. Close Apps builds its targets from the store too, so a claim on
+  // an app the profile has since dropped would offer a close that targets
+  // nothing. That check also subsumes #591: `getProfileCompanionTargets` omits
+  // profiles with tracking off, so a claim made while tracking was on goes
+  // quiet while it is off and comes back after, with nothing deleted.
+  for (const [ownedKey, owner] of adoptedCompanionOwners) {
+    const isStillConfigured = companionTargets.some(
+      (target) =>
+        target.scope === 'path' &&
+        normalizePathForComparison(target.appPath) === ownedKey &&
+        target.gameKeys.includes(owner.gameKey)
+    )
+    if (!isStillConfigured) {
       continue
     }
-    if (!isProcessTrackingEnabled(getActiveStoredProfile(getStoredProfiles()[gameKey]))) {
+    if (!isPathRunning(owner.path)) {
       continue
     }
-    launchOwnedPaths.add(ownedPath)
-    launchOwnedNames.add(getExeName(ownedPath).toLowerCase())
-    closableGameKeys.add(gameKey)
+    launchOwnedPaths.add(ownedKey)
+    launchOwnedNames.add(getExeName(owner.path).toLowerCase())
+    closableGameKeys.add(owner.gameKey)
   }
 
-  for (const target of getProfileCompanionTargets().values()) {
+  for (const target of companionTargets) {
     // A curated name-scoped target has no path to verify against, so it keeps
     // the name-only answer. That is not a gap being tolerated: `/IM` is how such
     // a target would be closed too, so name membership is exactly the condition

--- a/src/main/processes/running.ts
+++ b/src/main/processes/running.ts
@@ -12,7 +12,7 @@ import {
 import { getStoredStringRecord } from '../store'
 import { getExeName, isValidExePath, normalizePathForComparison } from '../utils'
 
-import { pruneUnclosedProcesses } from './kill'
+import { getClosableLaunchedAppGameKeys, pruneUnclosedProcesses } from './kill'
 import {
   isLaunchActiveForGame,
   processNameMismatchWarnings,
@@ -50,6 +50,14 @@ export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | '
 
 export interface RunningAppsChangedPayload {
   apps: RunningApp[]
+  /**
+   * Game keys whose companions `killLaunchedApps` would currently close, which
+   * is NOT the same question as which apps are surfaced in `apps` (#673). A
+   * profile can have live, closable companions and an empty strip: after a
+   * restart, after the process-tracking toggle is cycled, or whenever its game
+   * is closed. Those are the rows that used to offer the user nothing at all.
+   */
+  closableGameKeys: string[]
   reason: RunningAppsChangeReason
   updatedAt: number
 }
@@ -273,7 +281,21 @@ function reconcileUntrackedGames(): void {
   )
 }
 
-export async function getRunningApps(): Promise<RunningApp[]> {
+/**
+ * One tick's worth of answers. `apps` is what the strip renders; the closable
+ * set is deliberately NOT derived from it, because the whole point of #673 is
+ * the profile whose companions are alive and absent from that list.
+ */
+interface RunningAppsSnapshot {
+  apps: RunningApp[]
+  closableGameKeys: Set<string>
+}
+
+// Exported for tests, which assert the closable set through the real tick
+// rather than against a hand-built resolver: the #674 precision this relies on
+// lives in how `isPathRunning` is assembled below, so a test that supplied its
+// own would be asserting against a copy of the logic under test.
+export async function collectRunningAppsSnapshot(): Promise<RunningAppsSnapshot> {
   const readResult = await readRunningProcessNames()
   // `processNames` survives for exactly one job (see `isPathRunning`): a record
   // whose "path" is a bare image name, which is not a path and must not be
@@ -447,7 +469,7 @@ export async function getRunningApps(): Promise<RunningApp[]> {
       !launchedExeNames.has(getExeName(appProcess.path))
   )
 
-  return [
+  const apps = [
     ...surfacedApps,
     ...mismatchWarnings.filter(
       (appProcess) =>
@@ -458,19 +480,38 @@ export async function getRunningApps(): Promise<RunningApp[]> {
         !warningKeys.has(`${appProcess.gameKey}:${normalizePathForComparison(appProcess.path)}`)
     )
   ]
+
+  // Answered from THIS tick's resolver, so it costs no spawn of its own (#673).
+  // A failed read makes `isPathRunning` answer false for everything, so the
+  // control blanks exactly as the strip does rather than freezing on a stale
+  // yes: same conservative reading, and it recovers on the next good tick.
+  return { apps, closableGameKeys: getClosableLaunchedAppGameKeys(processNames, isPathRunning) }
 }
 
-function normalizeRunningAppsSnapshot(apps: RunningApp[]) {
-  return JSON.stringify(
-    apps.map((app) => ({
+export async function getRunningApps(): Promise<RunningApp[]> {
+  return (await collectRunningAppsSnapshot()).apps
+}
+
+// The change-gate below suppresses a 'scan' publish whose snapshot is identical
+// to the last one, so anything the renderer RENDERS has to be in here. The
+// closable set qualifies and the app list cannot stand in for it: the state
+// #673 is about is precisely one where companions are closable and the list is
+// empty, so a companion appearing or exiting moves the set while leaving `apps`
+// byte-identical. Sorted because set iteration order follows insertion, and an
+// unsorted join would publish a spurious change whenever a profile happened to
+// be visited in a different order.
+function normalizeRunningAppsSnapshot({ apps, closableGameKeys }: RunningAppsSnapshot) {
+  return JSON.stringify({
+    apps: apps.map((app) => ({
       elevated: app.elevated ?? false,
       gameKey: app.gameKey,
       name: app.name,
       path: app.path,
       tracked: app.tracked ?? false,
       warning: app.warning ?? ''
-    }))
-  )
+    })),
+    closableGameKeys: Array.from(closableGameKeys).sort()
+  })
 }
 
 function removeRunningAppsSubscriber(webContents: WebContents) {
@@ -503,18 +544,28 @@ async function publishRunningAppsInternal(
     return null
   }
 
-  const apps = await getRunningApps()
+  const { apps, closableGameKeys } = await collectRunningAppsSnapshot()
   // Refresh on every scan (before the change-gate below) so the cadence always
   // reflects what's actually surfaced, including adopted external apps.
+  //
+  // Deliberately still the SURFACED count, not widened by the closable set: a
+  // closable-but-unsurfaced companion is the chronic, ambient state this feature
+  // exists to report, and holding the FAST 2s tasklist poll open for it would
+  // reverse #672 for every profile that has SimHub enabled.
   lastPublishedRunningAppsCount = apps.length
-  const snapshot = normalizeRunningAppsSnapshot(apps)
+  const snapshot = normalizeRunningAppsSnapshot({ apps, closableGameKeys })
 
   if (snapshot === lastRunningAppsSnapshot && reason === 'scan') {
     return null
   }
 
   lastRunningAppsSnapshot = snapshot
-  const payload = { apps, reason, updatedAt: Date.now() }
+  const payload = {
+    apps,
+    closableGameKeys: Array.from(closableGameKeys),
+    reason,
+    updatedAt: Date.now()
+  }
   emitRunningAppsChanged(payload)
   return payload
 }
@@ -668,7 +719,7 @@ export async function subscribeRunningApps(
   runningAppsSubscribers.add(webContents)
   webContents.once('destroyed', () => removeRunningAppsSubscriber(webContents))
 
-  const apps = await getRunningApps()
+  const { apps, closableGameKeys } = await collectRunningAppsSnapshot()
   // Seed the cadence-gating count from this bootstrap read BEFORE starting the
   // monitor (#708). Previously the monitor started first and scheduled its
   // first scan off the pre-subscription (stale, often 0) count, so a
@@ -676,10 +727,18 @@ export async function subscribeRunningApps(
   // bootstrap on the SLOW cadence for one tick (<=12s) before the first scan
   // self-corrected it. One-time and self-healing, but avoidable.
   lastPublishedRunningAppsCount = apps.length
-  lastRunningAppsSnapshot = normalizeRunningAppsSnapshot(apps)
+  lastRunningAppsSnapshot = normalizeRunningAppsSnapshot({ apps, closableGameKeys })
   startRunningAppsMonitor()
 
-  return { apps, reason: 'initial', updatedAt: Date.now() } satisfies RunningAppsChangedPayload
+  // This bootstrap answer is the one that matters most for #673: after a
+  // restart it is the FIRST thing the row learns, and before this change it
+  // could only ever say "nothing here".
+  return {
+    apps,
+    closableGameKeys: Array.from(closableGameKeys),
+    reason: 'initial',
+    updatedAt: Date.now()
+  } satisfies RunningAppsChangedPayload
 }
 
 export function unsubscribeRunningApps(webContents: WebContents): void {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -330,6 +330,12 @@ export async function launchProfileApps(
       validApps.forEach((entry) => {
         if (gamePath && pathsEqual(entry.path, gamePath)) return
         const claimKey = normalizePathForComparison(entry.path)
+        // A live handle outranks a claim, and a second profile finding the app
+        // already running is exactly the case where it must (CodeRabbit on
+        // #853). Whoever started it holds the handle; claiming it here would
+        // give BOTH rows the control and let this profile close the other
+        // profile's companion, which is the bug the claim exists to fix.
+        if (runningProcesses.has(claimKey)) return
         adoptedCompanionOwners.set(claimKey, {
           path: entry.path,
           gameKey,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -329,9 +329,14 @@ export async function launchProfileApps(
     if (trackingEnabled) {
       validApps.forEach((entry) => {
         if (gamePath && pathsEqual(entry.path, gamePath)) return
-        adoptedCompanionOwners.set(normalizePathForComparison(entry.path), {
+        const claimKey = normalizePathForComparison(entry.path)
+        adoptedCompanionOwners.set(claimKey, {
           path: entry.path,
-          gameKey
+          gameKey,
+          // Pending until the poll sees it. The app may be seconds away (the
+          // launch is sequential) or minutes away (an elevated one waits on a
+          // consent prompt), and the tick runs throughout.
+          seenRunning: adoptedCompanionOwners.get(claimKey)?.seenRunning ?? false
         })
       })
     }

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -330,12 +330,18 @@ export async function launchProfileApps(
       validApps.forEach((entry) => {
         if (gamePath && pathsEqual(entry.path, gamePath)) return
         const claimKey = normalizePathForComparison(entry.path)
-        // A live handle outranks a claim, and a second profile finding the app
-        // already running is exactly the case where it must (CodeRabbit on
-        // #853). Whoever started it holds the handle; claiming it here would
-        // give BOTH rows the control and let this profile close the other
-        // profile's companion, which is the bug the claim exists to fix.
-        if (runningProcesses.has(claimKey)) return
+        // A launch claims what it handles even when another profile already
+        // owns the same running app, and the resulting overlap is deliberate
+        // (CodeRabbit on #853 argued the opposite; see the test).
+        //
+        // Refusing the claim looks safer and is worse for the sequence people
+        // actually perform: finish one sim, close the game, leave the
+        // companions up, start another. The first profile still holds the
+        // handle, so the close control would stay on the row of the game that
+        // is over and the game now being played would have none. The overlap
+        // costs a second control on a row that also legitimately configures the
+        // app; the alternative costs the control on the only row the user is
+        // looking at.
         adoptedCompanionOwners.set(claimKey, {
           path: entry.path,
           gameKey,

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -412,6 +412,34 @@ export async function launchProfileApps(
         result.status === 'failed'
     )
 
+    // The claim above was made for everything this launch INTENDED to handle,
+    // because a claim has to exist before its app does. Now that the outcomes
+    // are known, take back the ones the launch did not earn: an app that failed
+    // to start, and one the loop never reached because a kill aborted it. Left
+    // standing, such a claim would attach this profile to a copy somebody else
+    // started, and silently take the close control away from the profiles that
+    // legitimately share it. Only a claim this launch made and that has never
+    // been seen running is withdrawn: one the poll has already confirmed is a
+    // fact about a live process, not a prediction that turned out wrong.
+    if (trackingEnabled) {
+      const reached = new Set(
+        launchResults.map((result) => normalizePathForComparison(result.appPath))
+      )
+      const failed = new Set(
+        spawnFailedResults.map((result) => normalizePathForComparison(result.appPath))
+      )
+      appsToLaunch.forEach((entry) => {
+        const claimKey = normalizePathForComparison(entry.path)
+        if (reached.has(claimKey) && !failed.has(claimKey)) {
+          return
+        }
+        const claim = adoptedCompanionOwners.get(claimKey)
+        if (claim?.gameKey === gameKey && !claim.seenRunning) {
+          adoptedCompanionOwners.delete(claimKey)
+        }
+      })
+    }
+
     // An elevated result is only trustworthy if the handoff was OBSERVED. When
     // the grace window expired first (#675) the promise said `elevated` on spec,
     // and the truth may have arrived afterwards through lateElevatedOutcomes

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -21,6 +21,7 @@ import {
 
 import { execFileUnlessAborted, spawnUnlessAborted } from './guardedStart'
 import {
+  adoptedCompanionOwners,
   consumeProcessNameMismatchWarningSuppression,
   noteStrandedConsentPrompt,
   hasOtherActiveLaunchControllers,
@@ -309,6 +310,20 @@ export async function launchProfileApps(
     )
     const appsToLaunch = validApps.filter((entry) => !runningPaths.has(entry.path))
     const skippedCount = validApps.length - appsToLaunch.length
+
+    // A companion that was already up when this launch reached it is this
+    // profile's just as much as one we spawned: the profile asked for it, and
+    // Close Apps closes it by path either way. Recording that is what stops one
+    // such app putting a close control on every OTHER row that merely
+    // configures it (#853). Gated on tracking for the same reason the spawn
+    // recording is (#591): a profile that opted out is not claiming anything.
+    if (trackingEnabled) {
+      validApps.forEach((entry) => {
+        if (!runningPaths.has(entry.path)) return
+        if (gamePath && pathsEqual(entry.path, gamePath)) return
+        adoptedCompanionOwners.set(normalizePathForComparison(entry.path), gameKey)
+      })
+    }
 
     if (appsToLaunch.length === 0) {
       return {

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -92,6 +92,29 @@ function nextElevatedHandoffId(): number {
   return elevatedHandoffSeq
 }
 
+/**
+ * Drop this profile's claim on an app that turned out never to have started.
+ *
+ * Only an UNOBSERVED claim, and only this profile's: one the poll has already
+ * confirmed is a fact about a live process, not a prediction that turned out
+ * wrong, and another profile's is not ours to withdraw.
+ *
+ * A pending claim never expires by design (`adoptedCompanionOwners`), so every
+ * way a launch can end without starting something has to say so, or the claim
+ * outlives the attempt and attributes a later hand-started copy to this game
+ * while the profiles that share it lose their close control.
+ */
+function withdrawUnobservedClaim(appPath: string, gameKey: string | undefined): void {
+  if (!gameKey) {
+    return
+  }
+  const claimKey = normalizePathForComparison(appPath)
+  const claim = adoptedCompanionOwners.get(claimKey)
+  if (claim?.gameKey === gameKey && !claim.seenRunning) {
+    adoptedCompanionOwners.delete(claimKey)
+  }
+}
+
 function recordLateElevatedOutcome(
   runId: number,
   handoffId: number,
@@ -454,10 +477,7 @@ export async function launchProfileApps(
         if (reached.has(claimKey) && !failed.has(claimKey)) {
           return
         }
-        const claim = adoptedCompanionOwners.get(claimKey)
-        if (claim?.gameKey === gameKey && !claim.seenRunning) {
-          adoptedCompanionOwners.delete(claimKey)
-        }
+        withdrawUnobservedClaim(entry.path, gameKey)
       })
     }
 
@@ -897,6 +917,10 @@ function launchElevated(
     const noteHandoffCancelled = (): void => {
       if (timedOut) {
         recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
+        // The sequence's own withdrawal pass has already run by now: it happens
+        // when the summary is built, and `timedOut` means the promise settled
+        // before this truth arrived (#853).
+        withdrawUnobservedClaim(appPath, gameKey)
       }
     }
     const handoffTimer = setTimeout(() => {
@@ -968,6 +992,7 @@ function launchElevated(
           if (signal?.aborted || cancelledByKill) {
             if (timedOut) {
               recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
+              withdrawUnobservedClaim(appPath, gameKey)
             }
             resolve({ status: 'cancelled', appPath })
             return
@@ -988,6 +1013,7 @@ function launchElevated(
               outcome: 'failed',
               error: message
             })
+            withdrawUnobservedClaim(appPath, gameKey)
           }
           resolve({ status: 'failed', appPath, error: message })
           return

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -25,6 +25,7 @@ import {
   consumeProcessNameMismatchWarningSuppression,
   noteStrandedConsentPrompt,
   hasOtherActiveLaunchControllers,
+  hasPendingElevatedHandoffForPath,
   processNameMismatchWarnings,
   registerActiveLaunch,
   registerPendingElevatedHandoff,
@@ -108,6 +109,13 @@ function withdrawUnobservedClaim(appPath: string, gameKey: string | undefined): 
   if (!gameKey) {
     return
   }
+  // Another slot may still be waiting on its own prompt for the same exe
+  // (#357). Ownership is per path, so this one settling says nothing about
+  // that one, and withdrawing here would throw away the claim it is about to
+  // need.
+  if (hasPendingElevatedHandoffForPath(appPath)) {
+    return
+  }
   const claimKey = normalizePathForComparison(appPath)
   const claim = adoptedCompanionOwners.get(claimKey)
   if (claim?.gameKey === gameKey && !claim.seenRunning) {
@@ -119,11 +127,12 @@ function recordLateElevatedOutcome(
   runId: number,
   handoffId: number,
   outcome: LateElevatedOutcome
-): void {
+): boolean {
   if (runId !== launchRunId) {
-    return
+    return false
   }
   lateElevatedOutcomes.set(handoffId, outcome)
+  return true
 }
 
 /**
@@ -478,6 +487,24 @@ export async function launchProfileApps(
           return
         }
         withdrawUnobservedClaim(entry.path, gameKey)
+      })
+      // And the other side of the same invariant (Codex on #853): a child that
+      // emitted `spawn` was positively observed, by us, so its claim is not
+      // pending. Leaving it pending made it unprunable, and an app that then
+      // exited before the first successful scan left a claim that outlived it
+      // and would attribute a later hand-started copy to this profile.
+      //
+      // Deliberately not the elevated results: a handoff whose grace window
+      // expired is exactly the case where we do NOT know, and saying we looked
+      // would let the prune delete a claim for an app still behind a prompt.
+      launchResults.forEach((result) => {
+        if (result.status !== 'launched') {
+          return
+        }
+        const claim = adoptedCompanionOwners.get(normalizePathForComparison(result.appPath))
+        if (claim?.gameKey === gameKey) {
+          claim.seenRunning = true
+        }
       })
     }
 
@@ -916,11 +943,15 @@ function launchElevated(
      */
     const noteHandoffCancelled = (): void => {
       if (timedOut) {
-        recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
         // The sequence's own withdrawal pass has already run by now: it happens
         // when the summary is built, and `timedOut` means the promise settled
-        // before this truth arrived (#853).
-        withdrawUnobservedClaim(appPath, gameKey)
+        // before this truth arrived (#853). Gated on the outcome APPLYING: a
+        // callback from an abandoned earlier run is ignored by the recorder and
+        // must not withdraw the CURRENT run's claim for the same path either,
+        // which is the #779 cross-run hazard one rung along.
+        if (recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })) {
+          withdrawUnobservedClaim(appPath, gameKey)
+        }
       }
     }
     const handoffTimer = setTimeout(() => {
@@ -991,8 +1022,14 @@ function launchElevated(
           // after the sequence ended, when the abort signal is no longer wired.
           if (signal?.aborted || cancelledByKill) {
             if (timedOut) {
-              recordLateElevatedOutcome(handoffRunId, handoffId, { appPath, outcome: 'cancelled' })
-              withdrawUnobservedClaim(appPath, gameKey)
+              if (
+                recordLateElevatedOutcome(handoffRunId, handoffId, {
+                  appPath,
+                  outcome: 'cancelled'
+                })
+              ) {
+                withdrawUnobservedClaim(appPath, gameKey)
+              }
             }
             resolve({ status: 'cancelled', appPath })
             return
@@ -1008,12 +1045,15 @@ function launchElevated(
             `${gameKey ? `[${gameKey}] ` : ''}Error launching ${appPath} as administrator${code ? ` (${code})` : ''}`
           )
           if (timedOut) {
-            recordLateElevatedOutcome(handoffRunId, handoffId, {
-              appPath,
-              outcome: 'failed',
-              error: message
-            })
-            withdrawUnobservedClaim(appPath, gameKey)
+            if (
+              recordLateElevatedOutcome(handoffRunId, handoffId, {
+                appPath,
+                outcome: 'failed',
+                error: message
+              })
+            ) {
+              withdrawUnobservedClaim(appPath, gameKey)
+            }
           }
           resolve({ status: 'failed', appPath, error: message })
           return

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -329,7 +329,10 @@ export async function launchProfileApps(
     if (trackingEnabled) {
       validApps.forEach((entry) => {
         if (gamePath && pathsEqual(entry.path, gamePath)) return
-        adoptedCompanionOwners.set(normalizePathForComparison(entry.path), gameKey)
+        adoptedCompanionOwners.set(normalizePathForComparison(entry.path), {
+          path: entry.path,
+          gameKey
+        })
       })
     }
 

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -311,15 +311,23 @@ export async function launchProfileApps(
     const appsToLaunch = validApps.filter((entry) => !runningPaths.has(entry.path))
     const skippedCount = validApps.length - appsToLaunch.length
 
-    // A companion that was already up when this launch reached it is this
-    // profile's just as much as one we spawned: the profile asked for it, and
-    // Close Apps closes it by path either way. Recording that is what stops one
-    // such app putting a close control on every OTHER row that merely
-    // configures it (#853). Gated on tracking for the same reason the spawn
-    // recording is (#591): a profile that opted out is not claiming anything.
+    // Every companion this launch handles belongs to this profile, and the
+    // claim has to survive losing the child handle (#853). `runningProcesses`
+    // can only own what we still hold a handle for, which excludes three cases
+    // that all reach the same wrong end: an app that was already running (never
+    // spawned), an app handed off elevated (spawned by a PowerShell host we do
+    // not own, the case the "cannot close it from here" warning is about), and
+    // an app whose own process replaced the one we started. Each of those left
+    // one running companion unowned, and an unowned companion is claimed by
+    // EVERY profile that configures it, which is what put a close control on
+    // rows the user never touched.
+    //
+    // Attribution only: `runningProcesses` stays the authority for the strip
+    // and for killing, this map only answers "whose is it". Gated on tracking
+    // for the same reason the spawn recording is (#591): a profile that opted
+    // out is not claiming anything.
     if (trackingEnabled) {
       validApps.forEach((entry) => {
-        if (!runningPaths.has(entry.path)) return
         if (gamePath && pathsEqual(entry.path, gamePath)) return
         adoptedCompanionOwners.set(normalizePathForComparison(entry.path), gameKey)
       })

--- a/src/main/processes/spawn.ts
+++ b/src/main/processes/spawn.ts
@@ -348,7 +348,16 @@ export async function launchProfileApps(
           // Pending until the poll sees it. The app may be seconds away (the
           // launch is sequential) or minutes away (an elevated one waits on a
           // consent prompt), and the tick runs throughout.
-          seenRunning: adoptedCompanionOwners.get(claimKey)?.seenRunning ?? false
+          //
+          // Except when this launch has just seen it itself: an app in
+          // `runningPaths` was observed running a moment ago, and recording
+          // that as still-pending would make the claim unprunable if the app
+          // exits before the next successful scan (Codex on #853). A pending
+          // claim never expires by design, so it must only ever mean "we have
+          // not looked yet".
+          seenRunning:
+            runningPaths.has(entry.path) ||
+            (adoptedCompanionOwners.get(claimKey)?.seenRunning ?? false)
         })
       })
     }

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -146,6 +146,21 @@ export function unregisterPendingElevatedHandoff(handoffId: number): void {
 }
 
 /**
+ * Whether any handoff still waiting on a consent prompt targets this path.
+ *
+ * Two profile slots may point at one exe (#357), so one slot's denial says
+ * nothing about the other's prompt. Ownership of a companion is per PATH, so
+ * acting on the first slot to settle would throw away a claim the still-pending
+ * slot is about to need (#853).
+ */
+export function hasPendingElevatedHandoffForPath(appPath: string): boolean {
+  const wanted = normalizePathForComparison(appPath)
+  return Array.from(pendingElevatedHandoffs.values()).some(
+    (handoff) => normalizePathForComparison(handoff.appPath) === wanted
+  )
+}
+
+/**
  * Cancel every still-pending elevated handoff for `gameKey`, or all of them when
  * `gameKey` is undefined (the global "close everything" kill). Each entry
  * removes itself as its callback settles, so this is safe to call on every kill.

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -11,6 +11,23 @@ import type {
 
 export const runningProcesses = new Map<string, RunningProcessEntry>()
 export const unclosedProcesses = new Map<string, UnclosedProcessEntry>()
+
+/**
+ * Normalized companion path -> the game key whose launch claimed it, for
+ * companions that were ALREADY RUNNING when that launch reached them (#853).
+ *
+ * `runningProcesses` cannot hold these: it is keyed on a live `ChildProcess`
+ * handle, and a process we did not spawn has none. But the profile did ask for
+ * the app, it is up, and `killLaunchedApps` closes it by path, so the launch
+ * establishes ownership just as much as a spawn does. Without that, one already
+ * running companion put a Close Apps control on every OTHER row whose profile
+ * merely configures the same app.
+ *
+ * Attribution only, never a kill handle. In memory only, so a restart drops it
+ * and every configuring profile claims the app again, which is the state #851
+ * replaces with a persisted memory.
+ */
+export const adoptedCompanionOwners = new Map<string, string>()
 export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWarningEntry>()
 export const suppressedProcessNameMismatchWarnings = new Set<string>()
 

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -32,8 +32,20 @@ export const unclosedProcesses = new Map<string, UnclosedProcessEntry>()
  * about: its path states are keyed by the path as configured, and an unresolved
  * path reads as RUNNING by design. A normalized key handed to that resolver
  * therefore never matches and the claim would outlive the process forever.
+ *
+ * `seenRunning` is what makes the claim survive its own launch. A claim is made
+ * when the launch decides the app is this profile's, which is BEFORE the app is
+ * up: companions start one at a time with delays between them, and an elevated
+ * one waits on a consent prompt that can sit on screen for two minutes. The
+ * scan ticks throughout. Pruning a claim for something not running yet deleted
+ * every claim within a tick or two of being made, which is why the mechanism
+ * measured as completely inert on a real machine. So a claim is pending until
+ * the poll has seen its app once, and only then does its exit end it.
  */
-export const adoptedCompanionOwners = new Map<string, { path: string; gameKey: string }>()
+export const adoptedCompanionOwners = new Map<
+  string,
+  { path: string; gameKey: string; seenRunning: boolean }
+>()
 export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWarningEntry>()
 export const suppressedProcessNameMismatchWarnings = new Set<string>()
 

--- a/src/main/processes/state.ts
+++ b/src/main/processes/state.ts
@@ -26,8 +26,14 @@ export const unclosedProcesses = new Map<string, UnclosedProcessEntry>()
  * Attribution only, never a kill handle. In memory only, so a restart drops it
  * and every configuring profile claims the app again, which is the state #851
  * replaces with a persisted memory.
+ *
+ * Keyed by the normalized path so one app is claimed once, but it keeps the RAW
+ * path too, because that is the only form the running-apps tick can answer
+ * about: its path states are keyed by the path as configured, and an unresolved
+ * path reads as RUNNING by design. A normalized key handed to that resolver
+ * therefore never matches and the claim would outlive the process forever.
  */
-export const adoptedCompanionOwners = new Map<string, string>()
+export const adoptedCompanionOwners = new Map<string, { path: string; gameKey: string }>()
 export const processNameMismatchWarnings = new Map<string, ProcessNameMismatchWarningEntry>()
 export const suppressedProcessNameMismatchWarnings = new Set<string>()
 

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -95,6 +95,12 @@ export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | '
 
 export interface RunningAppsChangedPayload {
   apps: RunningApp[]
+  /**
+   * Game keys whose companions a Close Apps click would currently close (#673).
+   * Not derivable from `apps`: a profile can have live companions and an empty
+   * strip, which is exactly the state this exists to report.
+   */
+  closableGameKeys: string[]
   reason: RunningAppsChangeReason
   updatedAt: number
 }

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -54,7 +54,8 @@ export function GameList({
   const [gamePaths, setGamePaths] = useState<Record<string, string>>({})
   const [focusActiveTitle, setFocusActiveTitle] = useState(true)
   const { announce } = useNotify()
-  const { runningApps, runningStatus, refreshRunningState } = useRunningApps(configuredGames)
+  const { runningApps, runningStatus, closableGameKeys, refreshRunningState } =
+    useRunningApps(configuredGames)
   // Announce "X is now running" once a launch cooldown settles — but only if the
   // game EXECUTABLE itself is detected running by then. The cooldown also runs on
   // partial failures (a companion app started while the game exe failed), and
@@ -315,6 +316,7 @@ export function GameList({
               gameStatusDismissPath={gameRunningApp?.path}
               gameStatusTracked={gameRunningApp?.tracked}
               runningAppIcons={runningAppIcons}
+              hasClosableApps={closableGameKeys.has(game.key)}
               isDimmed={hasActiveTitle && !runningStatus[game.key]}
               isLaunching={launchingGameKey === game.key}
               isLaunchBlocked={launchingGameKey !== null}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -39,6 +39,7 @@ export function GameRow({
   gameStatusDismissPath,
   gameStatusTracked,
   runningAppIcons,
+  hasClosableApps,
   gameIconUrl,
   isDimmed,
   isLaunching,
@@ -69,6 +70,11 @@ export function GameRow({
   gameStatusDismissPath?: string
   gameStatusTracked?: boolean
   runningAppIcons: RunningAppIcon[]
+  // This profile has companion apps a Close Apps click would close, even though
+  // none of them are in `runningAppIcons` (#673). Chronic and ambient rather
+  // than session state: after a restart, after the process-tracking toggle is
+  // cycled, or whenever a companion autostarts with Windows.
+  hasClosableApps: boolean
   gameIconUrl?: string
   isDimmed: boolean
   isLaunching: boolean
@@ -580,6 +586,13 @@ export function GameRow({
   }
 
   const canKill = runningAppIcons.length > 0 && profileState.killControlsEnabled
+  // Deliberately NOT folded into `canKill`, which swaps the primary button
+  // rather than adding to it (`GameRowActions.tsx`): folding it in would hand a
+  // user with an autostarted SimHub a red Close Apps primary and NO way to
+  // launch the game from the row, removing the one in-app recovery this bug
+  // leaves intact. Close Apps displaces Launch only when there is visible
+  // session state; ambient closable state gets a secondary control instead.
+  const canCloseLeftovers = !canKill && hasClosableApps && profileState.killControlsEnabled
   const canRelaunch = isRunning && profileState.relaunchControlsEnabled
   const activeProfile = getActiveGameProfile(profileSet)
 
@@ -621,6 +634,7 @@ export function GameRow({
           isLaunching={isLaunching}
           isLaunchBlocked={isLaunchBlocked}
           canKill={canKill}
+          canCloseLeftovers={canCloseLeftovers}
           canRelaunch={canRelaunch}
           onPrimary={handleLaunch}
           onKill={handleKill}

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -9,6 +9,10 @@ export interface GameRowActionsProps {
   isLaunching: boolean
   isLaunchBlocked: boolean
   canKill: boolean
+  // Ambient closable state: this profile's companions are running but none of
+  // them is in the strip (#673). Renders a SECONDARY control and must never
+  // reach `primaryAction` — see the comment on it below.
+  canCloseLeftovers: boolean
   canRelaunch: boolean
   onPrimary: () => void
   onKill: () => void
@@ -28,6 +32,7 @@ export function GameRowActions({
   isLaunching,
   isLaunchBlocked,
   canKill,
+  canCloseLeftovers,
   canRelaunch,
   onPrimary,
   onKill,
@@ -38,6 +43,12 @@ export function GameRowActions({
   editorId,
   profileMenuProps
 }: GameRowActionsProps): ReactNode {
+  // `canKill` REPLACES the primary action, it does not add to it, which is why
+  // ambient closable state (#673) must not feed it: a user whose SimHub
+  // autostarts would get a red Close Apps here on every app start, on every row
+  // whose profile enables SimHub, and no way to launch the game from that row.
+  // Launch is the recovery path for that state, so it stays primary and the
+  // close goes in the secondary slot below.
   const primaryAction = canKill ? onKill : onPrimary
   const primaryButtonClass = canKill ? 'danger-action' : 'accent-surface-action'
   // What will actually start: the game AND its active profile — the profile
@@ -63,7 +74,11 @@ export function GameRowActions({
   return (
     <div className="flex items-center gap-3 no-drag">
       <div className="flex h-9 w-9 items-center justify-center">
-        {canRelaunch && (
+        {/* One slot, two mutually exclusive occupants, relaunch first. They
+            cannot both apply: relaunch needs a running profile, and a running
+            profile has strip icons, which makes this a `canKill` row instead.
+            Ordered explicitly anyway so the slot never has to render both. */}
+        {canRelaunch ? (
           <Tooltip label={isLaunchBlocked ? blockedReason : 'Relaunch missing apps'}>
             <button
               type="button"
@@ -90,6 +105,34 @@ export function GameRowActions({
               />
             </button>
           </Tooltip>
+        ) : (
+          canCloseLeftovers && (
+            // Says what is true and no more. It does NOT say "from a previous
+            // session": the same state is reached by cycling the process
+            // tracking toggle, and by a companion that autostarts with Windows
+            // and was never ours to begin with. What the predicate proves is
+            // only that this profile's companions are running and that clicking
+            // would close them.
+            <Tooltip label="Close companion apps that are still running">
+              <button
+                type="button"
+                onClick={onKill}
+                // `icon-action danger-action`: transparent at rest, danger on
+                // hover, matching the window close button. A destructive action
+                // should not look identical to the benign one that shares this
+                // slot, and this pair already exists rather than being invented
+                // here.
+                className="icon-action danger-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
+                aria-label={`Close companion apps for ${gameName} that are still running`}
+              >
+                <KillIcon
+                  width={18}
+                  height={18}
+                  className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+                />
+              </button>
+            </Tooltip>
+          )
         )}
       </div>
 

--- a/src/renderer/src/components/game-list/GameRowActions.tsx
+++ b/src/renderer/src/components/game-list/GameRowActions.tsx
@@ -71,69 +71,78 @@ export function GameRowActions({
       ? blockedReason
       : `Launch ${launchTarget}`
 
+  const relaunchButton = canRelaunch ? (
+    <Tooltip label={isLaunchBlocked ? blockedReason : 'Relaunch missing apps'}>
+      <button
+        type="button"
+        // aria-disabled rather than `disabled`, for both buttons here
+        // (#830). A `disabled` button is removed from the tab order AND
+        // is dispatched no mouse events, so the very tooltip that
+        // explains the block is the one thing a blocked user cannot
+        // reach, by hover or by keyboard. Dropping the handler is what
+        // makes the click inert; the attribute is what announces it.
+        onClick={isLaunchBlocked ? undefined : onRelaunchMissing}
+        aria-disabled={isLaunchBlocked || undefined}
+        className="icon-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
+        aria-label={
+          isLaunchBlocked
+            ? `Relaunch missing apps for ${gameName}. ${blockedReason}`
+            : `Relaunch missing apps for ${gameName}`
+        }
+      >
+        <RefreshIcon
+          width={18}
+          height={18}
+          strokeWidth="2.2"
+          className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+        />
+      </button>
+    </Tooltip>
+  ) : null
+
+  const closeLeftoversButton = canCloseLeftovers ? (
+    // Says what is true and no more. It does NOT say "from a previous
+    // session": the same state is reached by cycling the process tracking
+    // toggle, and by a companion that autostarts with Windows and was never
+    // ours to begin with. What the predicate proves is only that this
+    // profile's companions are running and that clicking would close them.
+    <Tooltip label="Close companion apps that are still running">
+      <button
+        type="button"
+        onClick={onKill}
+        // `icon-action danger-action`: transparent at rest, danger on
+        // hover, matching the window close button. A destructive action
+        // should not look identical to the benign one beside it, and this
+        // pair already exists rather than being invented here.
+        className="icon-action danger-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
+        aria-label={`Close companion apps for ${gameName} that are still running`}
+      >
+        <KillIcon
+          width={18}
+          height={18}
+          className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
+        />
+      </button>
+    </Tooltip>
+  ) : null
+
   return (
     <div className="flex items-center gap-3 no-drag">
+      {/* The two CAN both apply (Codex on #853), which an earlier reading of
+          this file denied: relaunch keys off the aggregate running state, which
+          the game's own exe satisfies on its own, while the strip behind
+          `canKill` deliberately excludes that exe. A profile whose companion
+          runs ambiently — never ours to launch, so never in the strip — while
+          the game is up therefore reaches both, and collapsing them into one
+          slot would put the close out of reach in exactly the state #673 is
+          about. So the close gets a slot of its own in that overlap, and the
+          reserved slot below keeps its existing occupant so row alignment does
+          not move for every other row. */}
+      {relaunchButton && closeLeftoversButton && (
+        <div className="flex h-9 w-9 items-center justify-center">{closeLeftoversButton}</div>
+      )}
       <div className="flex h-9 w-9 items-center justify-center">
-        {/* One slot, two mutually exclusive occupants, relaunch first. They
-            cannot both apply: relaunch needs a running profile, and a running
-            profile has strip icons, which makes this a `canKill` row instead.
-            Ordered explicitly anyway so the slot never has to render both. */}
-        {canRelaunch ? (
-          <Tooltip label={isLaunchBlocked ? blockedReason : 'Relaunch missing apps'}>
-            <button
-              type="button"
-              // aria-disabled rather than `disabled`, for both buttons here
-              // (#830). A `disabled` button is removed from the tab order AND
-              // is dispatched no mouse events, so the very tooltip that
-              // explains the block is the one thing a blocked user cannot
-              // reach, by hover or by keyboard. Dropping the handler is what
-              // makes the click inert; the attribute is what announces it.
-              onClick={isLaunchBlocked ? undefined : onRelaunchMissing}
-              aria-disabled={isLaunchBlocked || undefined}
-              className="icon-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
-              aria-label={
-                isLaunchBlocked
-                  ? `Relaunch missing apps for ${gameName}. ${blockedReason}`
-                  : `Relaunch missing apps for ${gameName}`
-              }
-            >
-              <RefreshIcon
-                width={18}
-                height={18}
-                strokeWidth="2.2"
-                className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
-              />
-            </button>
-          </Tooltip>
-        ) : (
-          canCloseLeftovers && (
-            // Says what is true and no more. It does NOT say "from a previous
-            // session": the same state is reached by cycling the process
-            // tracking toggle, and by a companion that autostarts with Windows
-            // and was never ours to begin with. What the predicate proves is
-            // only that this profile's companions are running and that clicking
-            // would close them.
-            <Tooltip label="Close companion apps that are still running">
-              <button
-                type="button"
-                onClick={onKill}
-                // `icon-action danger-action`: transparent at rest, danger on
-                // hover, matching the window close button. A destructive action
-                // should not look identical to the benign one that shares this
-                // slot, and this pair already exists rather than being invented
-                // here.
-                className="icon-action danger-action flex h-9 w-9 cursor-pointer items-center justify-center rounded-full"
-                aria-label={`Close companion apps for ${gameName} that are still running`}
-              >
-                <KillIcon
-                  width={18}
-                  height={18}
-                  className="transition-transform group-hover/btn:scale-110 group-active/btn:scale-95"
-                />
-              </button>
-            </Tooltip>
-          )
-        )}
+        {relaunchButton || closeLeftoversButton}
       </div>
 
       <div className="no-drag glass-surface flex items-center rounded-full p-0.5">

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -63,18 +63,22 @@ export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
         newStatus[game.key] = nextApps.some((app) => app.gameKey === game.key)
       })
       setRunningStatus(newStatus)
-      // Absent rather than empty means the caller could not ask (the one-shot
-      // `getRunningApps` fallback below returns apps only), so the affordance
-      // stays hidden rather than being cleared on a guess. Both readings hide
-      // it; keeping them distinct is what stops a future caller reading the
-      // fallback's silence as a confirmed "nothing to close".
-      setClosableGameKeys((current) => {
-        const next = new Set(closable || [])
-        if (next.size === current.size && [...next].every((key) => current.has(key))) {
-          return current
-        }
-        return next
-      })
+      // Absent rather than empty means the caller could not ask: the one-shot
+      // `getRunningApps` fallback below returns apps only. Leave the last
+      // pushed answer alone rather than overwriting it with a guess, because
+      // `refreshRunningState` runs right after every kill and profile switch —
+      // and `killLaunchedApps` has already published the authoritative set by
+      // then, so clearing here would throw away the newer truth and hide the
+      // control until the next scan tick, even when targets are still closable.
+      if (closable !== undefined) {
+        setClosableGameKeys((current) => {
+          const next = new Set(closable)
+          if (next.size === current.size && [...next].every((key) => current.has(key))) {
+            return current
+          }
+          return next
+        })
+      }
     },
     [configuredGames]
   )

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -22,6 +22,7 @@ export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | '
 
 export interface RunningAppsChangedPayload {
   apps: RunningApp[]
+  closableGameKeys?: string[]
   reason: RunningAppsChangeReason
   updatedAt: number
 }
@@ -29,12 +30,19 @@ export interface RunningAppsChangedPayload {
 export interface UseRunningAppsResult {
   runningApps: RunningApp[]
   runningStatus: Record<string, boolean>
+  /** Game keys a Close Apps click would currently act on (#673). */
+  closableGameKeys: Set<string>
   refreshRunningState: (isMounted?: () => boolean) => Promise<void>
 }
+
+const EMPTY_CLOSABLE_GAME_KEYS: ReadonlySet<string> = new Set<string>()
 
 export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
   const [runningApps, setRunningApps] = useState<RunningApp[]>([])
   const [runningStatus, setRunningStatus] = useState<Record<string, boolean>>({})
+  const [closableGameKeys, setClosableGameKeys] = useState<Set<string>>(
+    EMPTY_CLOSABLE_GAME_KEYS as Set<string>
+  )
 
   const clearRunningState = useCallback(() => {
     // Referential stability: avoid triggering downstream re-renders when
@@ -42,10 +50,11 @@ export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
     // React bails out of the update.
     setRunningApps((current) => (current.length === 0 ? current : []))
     setRunningStatus((current) => (Object.keys(current).length === 0 ? current : {}))
+    setClosableGameKeys((current) => (current.size === 0 ? current : new Set<string>()))
   }, [])
 
   const applyRunningApps = useCallback(
-    (apps: RunningApp[] | undefined) => {
+    (apps: RunningApp[] | undefined, closable?: string[]) => {
       const nextApps: RunningApp[] = apps || []
       setRunningApps(nextApps)
 
@@ -54,6 +63,18 @@ export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
         newStatus[game.key] = nextApps.some((app) => app.gameKey === game.key)
       })
       setRunningStatus(newStatus)
+      // Absent rather than empty means the caller could not ask (the one-shot
+      // `getRunningApps` fallback below returns apps only), so the affordance
+      // stays hidden rather than being cleared on a guess. Both readings hide
+      // it; keeping them distinct is what stops a future caller reading the
+      // fallback's silence as a confirmed "nothing to close".
+      setClosableGameKeys((current) => {
+        const next = new Set(closable || [])
+        if (next.size === current.size && [...next].every((key) => current.has(key))) {
+          return current
+        }
+        return next
+      })
     },
     [configuredGames]
   )
@@ -94,7 +115,7 @@ export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
     // any events emitted synchronously during subscription are not lost.
     const unsubscribe = onRunningAppsChanged((payload: RunningAppsChangedPayload) => {
       if (isMounted()) {
-        applyRunningApps(payload.apps)
+        applyRunningApps(payload.apps, payload.closableGameKeys)
       }
     })
 
@@ -105,7 +126,7 @@ export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
     subscribeRunningApps()
       .then((payload: RunningAppsChangedPayload) => {
         if (isMounted()) {
-          applyRunningApps(payload.apps)
+          applyRunningApps(payload.apps, payload.closableGameKeys)
         }
       })
       .catch((err: unknown) => {
@@ -122,5 +143,5 @@ export function useRunningApps(configuredGames: Game[]): UseRunningAppsResult {
     }
   }, [applyRunningApps, clearRunningState, configuredGames.length, refreshRunningState])
 
-  return { runningApps, runningStatus, refreshRunningState }
+  return { runningApps, runningStatus, closableGameKeys, refreshRunningState }
 }

--- a/src/renderer/src/hooks/useRunningApps.ts
+++ b/src/renderer/src/hooks/useRunningApps.ts
@@ -22,6 +22,14 @@ export type RunningAppsChangeReason = 'initial' | 'launch' | 'exit' | 'kill' | '
 
 export interface RunningAppsChangedPayload {
   apps: RunningApp[]
+  /**
+   * Game keys whose companions a Close Apps click would currently close (#673).
+   * Absent and empty are NOT the same answer: `[]` is a measured "nothing to
+   * close" and clears the state, while omitting the field means the caller had
+   * no way to ask (the one-shot `getRunningApps` returns apps only) and leaves
+   * the last pushed answer standing. A consumer that folds the two together
+   * hides the control on every refresh that follows a kill.
+   */
   closableGameKeys?: string[]
   reason: RunningAppsChangeReason
   updatedAt: number

--- a/tests/main/autoClose.test.ts
+++ b/tests/main/autoClose.test.ts
@@ -64,7 +64,7 @@ async function loadAutoCloseModule(opts?: {
   const killMock = {
     killLaunchedApps: killLaunchedAppsMock,
     killProfileApps: vi.fn(),
-    hasClosableLaunchedApps: vi.fn(),
+    getClosableLaunchedAppGameKeys: vi.fn(() => new Set<string>()),
     pruneUnclosedProcesses: vi.fn()
   }
   vi.doMock('./kill', () => killMock)

--- a/tests/main/closeApps.test.ts
+++ b/tests/main/closeApps.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 
 // Codex P1 on PR #819. The kill must run even when nothing looks closable,
 // because its prologue is what aborts an in-flight launch and cancels a pending
-// elevated handoff. An earlier version checked hasClosableLaunchedApps() first
+// elevated handoff. An earlier version checked a closable-targets predicate first
 // and returned, so a launch still in its pre-spawn scan, in an inter-app delay,
 // or parked on an unanswered UAC prompt carried on and started companions right
 // after the user had been told there were none.

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3496,6 +3496,38 @@ test('a claim survives the ticks before its app is up, and ends when it goes (#8
   expect(adoptedCompanionOwners.size).toBe(0)
 })
 
+// The inverse failure the claim can cause, found by an adversarial review pass
+// on #853: a claim is made for everything the launch INTENDS to handle, so an
+// app that then fails to start would still attach this profile to whatever is
+// running at that path. The other profiles that legitimately share it would
+// lose their control over somebody else's copy.
+test('a launch does not keep a claim on an app it failed to start (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot, adoptedCompanionOwners } =
+    await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+        iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+    })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  spawnErrors.set('C:/Tools/SimHub.exe', Object.assign(new Error('boom'), { code: 'ENOENT' }))
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  expect(adoptedCompanionOwners.size).toBe(0)
+
+  // Somebody else's copy is running at that path. Both profiles configure it
+  // and neither started it, so both keep the control.
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '9999')
+  processNames.add('simhub.exe')
+
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys).sort()).toEqual([
+    'ac',
+    'iracing'
+  ])
+})
+
 // The case that survived the first fix (#853): the app WAS launched by us, but
 // elevated, so it runs under a PowerShell host we hold no handle to and
 // `runningProcesses` never records it. It is the same app the launch warns it

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3479,6 +3479,61 @@ test('an elevated companion still belongs to the profile that launched it (#853)
   expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
+// The claim has to end when the app does (#853, found on a real machine: close
+// the apps, close the game, and the control came BACK on the launching row with
+// nothing left running). An unresolved path reads as running by design, so a
+// claim the tick is never asked about is a claim that never expires.
+test('a claimed companion stops being closable once it exits (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+
+  processRegistry.delete(normalizeRegistryKey('C:/Tools/SimHub.exe'))
+  processNames.delete('simhub.exe')
+
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
+})
+
+// And it has to end when the app leaves the PROFILE too, which is the one case
+// the claim is not covered by the store-derived candidate list: nothing else
+// asks about a path the profile no longer configures, and an unasked path reads
+// as running (#853).
+test('a claimed companion stops being closable once the profile drops it (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: {
+        activeProfileId: 'default',
+        profiles: [{ id: 'default', name: 'Default', trackedProcessPaths: ['C:/Tools/SimHub.exe'] }]
+      }
+    }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+
+  // The user removes it from the profile while it keeps running. Close Apps
+  // builds its targets from the store, so it would no longer touch this app.
+  storeData.profiles = {
+    ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+  }
+
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
+})
+
 // The other half of the same rule: nobody launched this one, so no profile has
 // a better claim than any other and all of them keep it. Narrowing here would
 // be a guess, which is what #851 exists to replace with a memory.

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3561,6 +3561,46 @@ test('a claim survives the path being re-saved in another spelling (#853)', asyn
   expect(adoptedCompanionOwners.size).toBe(0)
 })
 
+// CodeRabbit on #853, the last way a launch can end without starting anything.
+// When the grace window expires the promise says `elevated` on spec (#675), so
+// the sequence's own withdrawal pass keeps the claim. If the user then DENIES
+// the prompt, the truth arrives long after that pass has run, and a pending
+// claim never expires, so it would sit there attributing a later hand-started
+// copy to this game.
+test('a claim goes when the UAC prompt is denied after the grace window (#853)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+
+    const { launchProfileApps, adoptedCompanionOwners } = await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { admin: 'C:/Tools/Admin Tool.exe' }
+    })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    const launchPromise = launchProfileApps(sender, 'ac', ['C:/Tools/Admin Tool.exe'])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    await launchPromise
+
+    // Still claimed: the prompt is unanswered, which is exactly the state a
+    // pending claim is for.
+    expect(adoptedCompanionOwners.size).toBe(1)
+
+    const heldCallback = heldElevatedCallback
+    expect(heldCallback).not.toBeNull()
+    heldCallback?.(makeAccessDeniedError())
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(adoptedCompanionOwners.size).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
 // A DELIBERATE overlap, and the one place this mechanism does not narrow.
 // CodeRabbit on #853 asked for the opposite: refuse the second claim, because
 // the first profile still holds the handle and two rows offering a close means

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3496,12 +3496,18 @@ test('a claim survives the ticks before its app is up, and ends when it goes (#8
   expect(adoptedCompanionOwners.size).toBe(0)
 })
 
-// CodeRabbit on #853: a live handle outranks a claim. One profile launches a
-// shared companion, a second profile then finds it already running. Letting the
-// second one claim it would put the control on BOTH rows and let the second
-// close the first's companion, which is the exact bug this whole mechanism
-// exists to fix, reintroduced from the other direction.
-test('a second profile does not claim a companion the first one launched (#853)', async () => {
+// A DELIBERATE overlap, and the one place this mechanism does not narrow.
+// CodeRabbit on #853 asked for the opposite: refuse the second claim, because
+// the first profile still holds the handle and two rows offering a close means
+// one game can close the other's companion. That is right about two games
+// running at once, which does not happen: sims are too heavy to run in pairs.
+//
+// It is wrong about the sequence people do perform. Finish one sim, close the
+// game, leave the companions up, start another. The first profile still holds
+// the handle, so refusing the claim leaves the control on the row of the game
+// that is OVER and gives none to the game now being played. Two controls beat
+// zero on the row the user is looking at.
+test('both profiles can close a companion each of them handled (#853)', async () => {
   const { launchProfileApps, collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
     profiles: {
       ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
@@ -3521,15 +3527,20 @@ test('a second profile does not claim a companion the first one launched (#853)'
     // and the test would pass without ever exercising the claim.
     await vi.advanceTimersByTimeAsync(11000)
 
-    // iRacing's launch finds it already up and skips it.
+    // iRacing's launch finds it already up and skips it. Asserted rather than
+    // assumed: a refused launch writes no claim, and the test would then pass
+    // for the wrong reason.
     await expect(
       launchProfileApps(sender, 'iracing', ['C:/Tools/SimHub.exe'])
-    ).resolves.toMatchObject({ launchedCount: 0, skippedCount: 1 })
+    ).resolves.toMatchObject({ success: true, launchedCount: 0, skippedCount: 1 })
   } finally {
     vi.useRealTimers()
   }
 
-  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys).sort()).toEqual([
+    'ac',
+    'iracing'
+  ])
 })
 
 // The inverse failure the claim can cause, found by an adversarial review pass

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3601,6 +3601,104 @@ test('a claim goes when the UAC prompt is denied after the grace window (#853)',
   }
 })
 
+// Codex on #853, the third route to the same invariant: a child that emitted
+// `spawn` was positively observed, so its claim is not pending. Left pending it
+// was unprunable, and an app that exited before the first successful scan left
+// a claim that outlived it, ready to attribute a later hand-started copy to
+// this profile and take the control from the ones that share it.
+test('a spawned companion that exits before the first scan takes its claim (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot, adoptedCompanionOwners } =
+    await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+        iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+    })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  expect(adoptedCompanionOwners.get('c:\\tools\\simhub.exe')?.seenRunning).toBe(true)
+
+  // It dies immediately, before any tick ever polls for it.
+  processRegistry.clear()
+  processNames.clear()
+  await collectRunningAppsSnapshot()
+  expect(adoptedCompanionOwners.size).toBe(0)
+
+  // A copy someone starts by hand later belongs to nobody, so both profiles
+  // that configure it keep their control.
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '9999')
+  processNames.add('simhub.exe')
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys).sort()).toEqual([
+    'ac',
+    'iracing'
+  ])
+})
+
+// The hazard #779 already paid for, reached one rung along by the withdrawal
+// added for #853. A host left alive by an earlier timed-out handoff keeps
+// waiting on its prompt and can settle DURING a later sequence. The recorder
+// ignores it on the run id; the withdrawal beside it must too, or a stale
+// denial deletes the claim the CURRENT run just made for the same exe.
+test('a stale denial from an abandoned run does not withdraw the current claim (#853)', async () => {
+  vi.useFakeTimers()
+  try {
+    markExistingPath('C:/Tools/Admin Tool.exe')
+    markExistingPath('C:/Tools/App2.exe')
+    spawnErrors.set('C:/Tools/Admin Tool.exe', makeAccessDeniedError())
+    elevatedLaunchHangs = true
+    // Keeps run 2's loop alive past its own grace timer, so the stale callback
+    // lands while run 2 is still in flight. With a zero delay the sequence is
+    // already over and the test proves nothing.
+    storeData.launchDelayMs = 5000
+
+    const { launchProfileApps, runningProcesses, adoptedCompanionOwners } =
+      await loadProcessModulesWithStore({
+        profiles: {
+          ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+        },
+        appPaths: { admin: 'C:/Tools/Admin Tool.exe', customapp2: 'C:/Tools/App2.exe' }
+      })
+    const { ELEVATED_HANDOFF_MAX_WAIT_MS } = await import('../../src/main/processes/spawn')
+
+    // Run 1: the prompt goes unanswered, the grace timer fires, the sequence
+    // ends with the PowerShell host still alive and still waiting.
+    const firstPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS + 5000)
+    await firstPromise
+    const firstRunCallback = heldElevatedCallback
+    expect(firstRunCallback).not.toBeNull()
+
+    // Clear the cooldown, and forget what run 1 started so run 2 does not skip
+    // everything as already running.
+    await vi.advanceTimersByTimeAsync(11000)
+    processNames.clear()
+    runningProcesses.clear()
+
+    const secondPromise = launchProfileApps(sender, 'ac', [
+      'C:/Tools/Admin Tool.exe',
+      'C:/Tools/App2.exe'
+    ])
+    await vi.advanceTimersByTimeAsync(ELEVATED_HANDOFF_MAX_WAIT_MS)
+    expect(adoptedCompanionOwners.has('c:\\tools\\admin tool.exe')).toBe(true)
+
+    // Run 1's abandoned prompt is finally DENIED, mid-run-2.
+    firstRunCallback?.(makeAccessDeniedError())
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(adoptedCompanionOwners.has('c:\\tools\\admin tool.exe')).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await secondPromise
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
 // A DELIBERATE overlap, and the one place this mechanism does not narrow.
 // CodeRabbit on #853 asked for the opposite: refuse the second claim, because
 // the first profile still holds the handle and two rows offering a close means

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3450,6 +3450,35 @@ test('a companion already running at launch is claimed by the launching profile 
   expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
+// The case that survived the first fix (#853): the app WAS launched by us, but
+// elevated, so it runs under a PowerShell host we hold no handle to and
+// `runningProcesses` never records it. It is the same app the launch warns it
+// "cannot close from here", and it was lighting a close control on every other
+// profile that configures it.
+test('an elevated companion still belongs to the profile that launched it (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot, runningProcesses } =
+    await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+        iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+    })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  // EACCES on the direct spawn is what sends a launch down the elevated
+  // handoff, which is where the handle is lost.
+  spawnErrors.set('C:/Tools/SimHub.exe', makeAccessDeniedError())
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+
+  expect(runningProcesses.size).toBe(0)
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+})
+
 // The other half of the same rule: nobody launched this one, so no profile has
 // a better claim than any other and all of them keep it. Narrowing here would
 // be a guess, which is what #851 exists to replace with a memory.

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -833,6 +833,7 @@ async function loadProcessModules() {
     cancelPendingElevatedHandoffs: stateModule.cancelPendingElevatedHandoffs,
     suppressedProcessNameMismatchWarnings: stateModule.suppressedProcessNameMismatchWarnings,
     runningProcesses: stateModule.runningProcesses,
+    adoptedCompanionOwners: stateModule.adoptedCompanionOwners,
     unclosedProcesses: stateModule.unclosedProcesses,
     getRunningApps: (await import('../../src/main/processes/running')).getRunningApps,
     collectRunningAppsSnapshot: (await import('../../src/main/processes/running'))
@@ -875,6 +876,7 @@ const sender = {
 
 beforeEach(async () => {
   const {
+    adoptedCompanionOwners,
     processNameMismatchWarnings,
     runningProcesses,
     suppressedProcessNameMismatchWarnings,
@@ -928,6 +930,7 @@ beforeEach(async () => {
   invalidateProcessNameCacheMock.mockClear()
   processNameMismatchWarnings.clear()
   runningProcesses.clear()
+  adoptedCompanionOwners.clear()
   suppressedProcessNameMismatchWarnings.clear()
   unclosedProcesses.clear()
   Object.keys(storeData).forEach((key) => delete storeData[key])
@@ -3450,6 +3453,49 @@ test('a companion already running at launch is claimed by the launching profile 
   expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
+// The one that made the whole mechanism inert, caught only by logging the live
+// decision on a real machine (#853): a claim is made when the launch decides the
+// app is this profile's, which is BEFORE the app is up. Companions start one at
+// a time, and an elevated one waits on a consent prompt. The scan ticks in
+// between, and pruning a claim on the first "not running" deleted it seconds
+// after it was made. The measured result was a claim map that was empty on
+// every single tick while the leak it exists to stop happened anyway.
+test('a claim survives the ticks before its app is up, and ends when it goes (#853)', async () => {
+  const { collectRunningAppsSnapshot, adoptedCompanionOwners } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+      iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+  const { normalizePathForComparison } = await import('../../src/main/utils')
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  adoptedCompanionOwners.set(normalizePathForComparison('C:/Tools/SimHub.exe'), {
+    path: 'C:/Tools/SimHub.exe',
+    gameKey: 'ac',
+    seenRunning: false
+  })
+
+  // The app has not started yet: it is behind a consent prompt, or simply later
+  // in a sequential launch. The poll ticks anyway, and this is where every
+  // claim used to be deleted seconds after it was made.
+  await collectRunningAppsSnapshot()
+  await collectRunningAppsSnapshot()
+  expect(adoptedCompanionOwners.size).toBe(1)
+
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+
+  // Seen once, so from here its exit is real and ends the claim rather than
+  // meaning "not yet".
+  processRegistry.delete(normalizeRegistryKey('C:/Tools/SimHub.exe'))
+  processNames.delete('simhub.exe')
+  await collectRunningAppsSnapshot()
+  expect(adoptedCompanionOwners.size).toBe(0)
+})
+
 // The case that survived the first fix (#853): the app WAS launched by us, but
 // elevated, so it runs under a PowerShell host we hold no handle to and
 // `runningProcesses` never records it. It is the same app the launch warns it
@@ -3472,6 +3518,50 @@ test('an elevated companion still belongs to the profile that launched it (#853)
 
   await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
 
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+
+  expect(runningProcesses.size).toBe(0)
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+})
+
+// The window the fix above still lost on a real machine (#853): the claim is
+// written before the launch loop starts, so between the write and the app
+// actually appearing there is a stretch where nothing is running at that path —
+// the whole time an unanswered UAC prompt sits on screen. A scan tick lands in
+// it (the poll is FAST during a launch, and every sibling's spawn publishes one
+// of its own), the liveness prune reads the path as not-running and deletes the
+// claim, and the elevated app has no handle to re-establish ownership from. It
+// then comes up unowned and every OTHER profile that merely configures it lights
+// a close control.
+test('an elevated companion keeps its claim while the consent prompt is open (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot, runningProcesses } =
+    await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+        iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+    })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  spawnErrors.set('C:/Tools/SimHub.exe', makeAccessDeniedError())
+
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+
+  // The consent prompt is still on screen: the direct spawn failed, so nothing
+  // is running at that path yet. (The spawn mock marks every attempted exe as
+  // running regardless of whether it errored, which is precisely why the test
+  // above never enters this window.)
+  processNames.delete('simhub.exe')
+  expect(runningProcesses.size).toBe(0)
+
+  // The tick that the launch itself fires, and that the 2s poll fires anyway.
+  // Nothing is closable yet — the point is what it does to the claim.
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
+
+  // The user approves, and the elevated app comes up under a host we hold no
+  // handle to.
   registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
   processNames.add('simhub.exe')
 

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3400,6 +3400,51 @@ test('the closable set is true for a running non-game companion', async () => {
   expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
+// Seen live on #853: launching one game put a close control on three untouched
+// rows, because every profile that merely CONFIGURES the same companion claimed
+// the one running instance. A companion we launched belongs to the profile we
+// launched it for, and those other clicks would have closed the running game's
+// own companion.
+test('a launched companion is not claimed by the profiles that only configure it (#853)', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+      iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+  runningProcesses.set('c:\\tools\\simhub.exe', {
+    process: { pid: 1234 } as never,
+    path: 'C:/Tools/SimHub.exe',
+    name: 'SimHub.exe',
+    gameKey: 'ac',
+    isGame: false
+  })
+  processNames.add('simhub.exe')
+
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+})
+
+// The other half of the same rule: nobody launched this one, so no profile has
+// a better claim than any other and all of them keep it. Narrowing here would
+// be a guess, which is what #851 exists to replace with a memory.
+test('a companion nobody launched stays closable from every profile that configures it (#853)', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+      iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+  processNames.add('simhub.exe')
+
+  expect(runningProcesses.size).toBe(0)
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys).sort()).toEqual([
+    'ac',
+    'iracing'
+  ])
+})
+
 test('the closable set ignores the game itself', async () => {
   const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModules()
   runningProcesses.set('c:\\games\\acs.exe', {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3394,7 +3394,10 @@ test('the closable set is true for a running non-game companion', async () => {
   })
   processNames.add('simhub.exe')
 
-  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBeGreaterThan(0)
+  // The set is per-profile and drives a per-row control, so a companion
+  // attributed to the wrong game key would still satisfy a size check while
+  // putting the button on the wrong row.
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
 test('the closable set ignores the game itself', async () => {
@@ -3426,7 +3429,7 @@ test('the closable set is true for a configured companion with no game launched 
   // Nothing SimLauncher-launched is tracked; the companion is reachable only via
   // the configured-companion-targets branch.
   expect(runningProcesses.size).toBe(0)
-  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBeGreaterThan(0)
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
 // Codex P2 on #536: the no-arg close scans all profiles. A game exe configured
@@ -5957,7 +5960,7 @@ test('the closable set is true when the candidate runs at its own path (#674)', 
   })
   processNames.add('simhub.exe')
 
-  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBeGreaterThan(0)
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
 test('killProfileApps falls back to /IM for non-full-path utility companions (#352)', async () => {

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3496,6 +3496,71 @@ test('a claim survives the ticks before its app is up, and ends when it goes (#8
   expect(adoptedCompanionOwners.size).toBe(0)
 })
 
+// Codex on #853. A pending claim never expires, by design, so "pending" must
+// only ever mean "we have not looked yet". A companion the launch found ALREADY
+// RUNNING was observed by the launch itself, and recording that as pending made
+// the claim unprunable if the app exited before the next successful scan: a
+// hand-started copy would then be attributed to a stale owner and the other
+// profiles would lose their control over it.
+test('a companion the launch already saw running is claimed as observed (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot, adoptedCompanionOwners } =
+    await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+        iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+    })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    skippedCount: 1
+  })
+  expect(adoptedCompanionOwners.get('c:\\tools\\simhub.exe')?.seenRunning).toBe(true)
+
+  // It exits before any tick ever confirms it. The claim must go with it.
+  processRegistry.delete(normalizeRegistryKey('C:/Tools/SimHub.exe'))
+  processNames.delete('simhub.exe')
+
+  await collectRunningAppsSnapshot()
+  expect(adoptedCompanionOwners.size).toBe(0)
+})
+
+// Codex on #853, the other half of the same record: the claim is asked about by
+// PATH, and the tick keys its answers by the path as configured. A path re-saved
+// in a different case or slash style would go unanswered, and an unanswered path
+// reads as running, so the claim would outlive its process forever.
+test('a claim survives the path being re-saved in another spelling (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot, adoptedCompanionOwners } =
+    await loadProcessModulesWithStore({
+      profiles: {
+        ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+      },
+      appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+    })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+  await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+
+  // Same file, spelled the other way, which is what a re-save can produce.
+  storeData.appPaths = { simhub: 'C:\\Tools\\SimHub.exe' }
+  markExistingPath('C:\\Tools\\SimHub.exe')
+  registerProcess('C:\\Tools\\SimHub.exe', 'simhub.exe', '1234')
+
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+
+  processRegistry.clear()
+  processNames.delete('simhub.exe')
+  await collectRunningAppsSnapshot()
+  expect(adoptedCompanionOwners.size).toBe(0)
+})
+
 // A DELIBERATE overlap, and the one place this mechanism does not narrow.
 // CodeRabbit on #853 asked for the opposite: refuse the second claim, because
 // the first profile still holds the handle and two rows offering a close means

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3425,6 +3425,31 @@ test('a launched companion is not claimed by the profiles that only configure it
   expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
 })
 
+// The case a real config produced (#853): the companion was ALREADY RUNNING
+// when the launch reached it, so nothing spawned it and there is no child
+// handle to own it by — and every other profile that merely configures it lit
+// up a close control for an app it had not touched. The launch claims it too.
+test('a companion already running at launch is claimed by the launching profile (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+      iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+  processNames.add('simhub.exe')
+
+  await expect(launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])).resolves.toMatchObject({
+    launchedCount: 0,
+    skippedCount: 1
+  })
+
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+})
+
 // The other half of the same rule: nobody launched this one, so no profile has
 // a better claim than any other and all of them keep it. Narrowing here would
 // be a guess, which is what #851 exists to replace with a memory.

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -822,7 +822,6 @@ async function loadProcessModules() {
     launchProfileApps: spawnModule.launchProfileApps,
     spawnDetachedApp: spawnModule.spawnDetachedApp,
     killLaunchedApps: killModule.killLaunchedApps,
-    hasClosableLaunchedApps: killModule.hasClosableLaunchedApps,
     killProfileApps: killModule.killProfileApps,
     finalizeKillAttempts: killModule.finalizeKillAttempts,
     pruneUnclosedProcesses: killModule.pruneUnclosedProcesses,
@@ -836,6 +835,8 @@ async function loadProcessModules() {
     runningProcesses: stateModule.runningProcesses,
     unclosedProcesses: stateModule.unclosedProcesses,
     getRunningApps: (await import('../../src/main/processes/running')).getRunningApps,
+    collectRunningAppsSnapshot: (await import('../../src/main/processes/running'))
+      .collectRunningAppsSnapshot,
     subscribeRunningApps: (await import('../../src/main/processes/running')).subscribeRunningApps,
     publishRunningApps: (await import('../../src/main/processes/running')).publishRunningApps
   }
@@ -3372,15 +3373,18 @@ test('killLaunchedApps keeps generic no-op message for unrelated game wrapper wa
   })
 })
 
-// hasClosableLaunchedApps has no production caller today (see its JSDoc) and
-// must mirror killLaunchedApps' own target selection.
-test('hasClosableLaunchedApps is false when nothing is running', async () => {
-  const { hasClosableLaunchedApps } = await loadProcessModules()
-  await expect(hasClosableLaunchedApps()).resolves.toBe(false)
+// The closable set drives the secondary Close Apps control (#673), so it must
+// mirror killLaunchedApps' own target selection: offering the action when a
+// click would close nothing is the defect, and so is hiding it when it would.
+// Asserted through the real tick, which is where the path resolution these
+// answers depend on is actually assembled.
+test('the closable set is false when nothing is running', async () => {
+  const { collectRunningAppsSnapshot } = await loadProcessModules()
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
 })
 
-test('hasClosableLaunchedApps is true for a running non-game companion', async () => {
-  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModules()
+test('the closable set is true for a running non-game companion', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModules()
   runningProcesses.set('c:\\tools\\simhub.exe', {
     process: { pid: 1234 } as never,
     path: 'C:/Tools/SimHub.exe',
@@ -3390,11 +3394,11 @@ test('hasClosableLaunchedApps is true for a running non-game companion', async (
   })
   processNames.add('simhub.exe')
 
-  await expect(hasClosableLaunchedApps()).resolves.toBe(true)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBeGreaterThan(0)
 })
 
-test('hasClosableLaunchedApps ignores the game itself', async () => {
-  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModules()
+test('the closable set ignores the game itself', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModules()
   runningProcesses.set('c:\\games\\acs.exe', {
     process: { pid: 1234 } as never,
     path: 'C:/Games/acs.exe',
@@ -3404,14 +3408,14 @@ test('hasClosableLaunchedApps ignores the game itself', async () => {
   })
   processNames.add('acs.exe')
 
-  await expect(hasClosableLaunchedApps()).resolves.toBe(false)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
 })
 
 // Codex P2 on #536: a configured companion can be running while its game is NOT
 // launched/adopted. killLaunchedApps still closes it (via companion targets), so
 // the tray must be enabled — even though getRunningApps would not surface it.
-test('hasClosableLaunchedApps is true for a configured companion with no game launched (#519)', async () => {
-  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModulesWithStore({
+test('the closable set is true for a configured companion with no game launched (#519)', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModulesWithStore({
     profiles: {
       ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
     },
@@ -3422,14 +3426,14 @@ test('hasClosableLaunchedApps is true for a configured companion with no game la
   // Nothing SimLauncher-launched is tracked; the companion is reachable only via
   // the configured-companion-targets branch.
   expect(runningProcesses.size).toBe(0)
-  await expect(hasClosableLaunchedApps()).resolves.toBe(true)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBeGreaterThan(0)
 })
 
 // Codex P2 on #536: the no-arg close scans all profiles. A game exe configured
 // as a companion under a DIFFERENT profile must never become a kill target — the
 // confirmation promises the game is untouched.
 test('the global close never targets a game exe configured as a companion elsewhere (#519)', async () => {
-  const { hasClosableLaunchedApps, killLaunchedApps, runningProcesses } =
+  const { collectRunningAppsSnapshot, killLaunchedApps, runningProcesses } =
     await loadProcessModulesWithStore({
       gamePaths: { ac: 'C:/Games/acs.exe' },
       // acs.exe (a game) is also configured as a tracked app, surfaced under a
@@ -3452,7 +3456,7 @@ test('the global close never targets a game exe configured as a companion elsewh
 
   // The only running process is the game → nothing closable, and a global close
   // must be a no-op rather than killing the game via the other profile's target.
-  await expect(hasClosableLaunchedApps()).resolves.toBe(false)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
   await expect(killLaunchedApps()).resolves.toMatchObject({
     success: true,
     closedCount: 0,
@@ -3464,7 +3468,7 @@ test('the global close never targets a game exe configured as a companion elsewh
 // companion whose basename collides with a DIFFERENT game's exe (different path)
 // must still be closable — otherwise the per-game close drops legitimate apps.
 test('a companion sharing a basename with another game is still closable (#519)', async () => {
-  const { hasClosableLaunchedApps } = await loadProcessModulesWithStore({
+  const { collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
     gamePaths: { ac: 'C:/Games/acs.exe', other: 'C:/OtherGame/app.exe' },
     // The selected profile's companion is named app.exe but lives elsewhere than
     // the "other" game's app.exe.
@@ -3479,7 +3483,7 @@ test('a companion sharing a basename with another game is still closable (#519)'
 
   // app.exe is a real companion for profile ac (its path is not a game path), so
   // the per-game close must reach it despite the basename collision.
-  await expect(hasClosableLaunchedApps('ac')).resolves.toBe(true)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.has('ac')).toBe(true)
 })
 
 // Codex P2 on #536 (Option B): a game exe launched under a NON-owning profile is
@@ -3487,7 +3491,7 @@ test('a companion sharing a basename with another game is still closable (#519)'
 // it via the runningProcesses branch despite the "game not affected" promise. The
 // configured-game-path guard must protect it regardless of the cached isGame flag.
 test('the global close never kills a game launched under another profile (#519)', async () => {
-  const { hasClosableLaunchedApps, killLaunchedApps, runningProcesses } =
+  const { collectRunningAppsSnapshot, killLaunchedApps, runningProcesses } =
     await loadProcessModulesWithStore({
       gamePaths: { ac: 'C:/Games/acs.exe' }
     })
@@ -3502,7 +3506,7 @@ test('the global close never kills a game launched under another profile (#519)'
   })
   processNames.add('acs.exe')
 
-  await expect(hasClosableLaunchedApps()).resolves.toBe(false)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
   await expect(killLaunchedApps()).resolves.toMatchObject({
     success: true,
     closedCount: 0,
@@ -4761,6 +4765,64 @@ test('publishRunningApps deduplicates emissions if snapshot is identical', async
   expect(webContents.send).not.toHaveBeenCalled()
 })
 
+// #673's state, end to end and from a cold start: no in-memory record of ever
+// having launched anything (exactly what a restart leaves behind), a configured
+// companion alive, and the game closed. The strip stays empty because
+// `getTrackedRunningApps` still gates on adoption, which is #794's call and not
+// this fix's; what changes is that the row is now told there is something to
+// close. Before this, `subscribeRunningApps` could only ever answer "nothing".
+test('the bootstrap snapshot reports closable companions with an empty strip (#673)', async () => {
+  const { subscribeRunningApps, runningProcesses } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    gamePaths: { ac: 'C:/Games/acs.exe' },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+  markExistingPath('C:/Games/acs.exe')
+  markExistingPath('C:/Tools/SimHub.exe')
+  // The companion is running; the game is NOT, so nothing adopts the key.
+  processNames.add('simhub.exe')
+
+  const snapshot = await subscribeRunningApps(asWebContents(createMockWebContents()))
+
+  expect(runningProcesses.size).toBe(0)
+  expect(snapshot.apps).toEqual([])
+  expect(snapshot.closableGameKeys).toEqual(['ac'])
+})
+
+// The proving test for the refresh architecture: the control has to clear on
+// its own when the companion exits, with no click and no relaunch. A per-click
+// answer would pass every other test in this file and still leave a button that
+// lies until the user interacts with it.
+test('the closable set clears on its own once the companion exits (#673)', async () => {
+  const webContents = createMockWebContents()
+  const { subscribeRunningApps, publishRunningApps } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+  markExistingPath('C:/Tools/SimHub.exe')
+  processNames.add('simhub.exe')
+
+  const snapshot = await subscribeRunningApps(asWebContents(webContents))
+  expect(snapshot.closableGameKeys).toEqual(['ac'])
+
+  webContents.send.mockClear()
+  processNames.delete('simhub.exe')
+  await publishRunningApps('scan')
+
+  // Both halves matter. The payload must SAY the set is empty, and it must have
+  // been sent at all: the app list was empty before and after, so the identical
+  // -snapshot gate is what would otherwise swallow this tick and freeze the
+  // control in its last state for the rest of the session.
+  expect(webContents.send).toHaveBeenCalledWith(
+    'running-apps-changed',
+    expect.objectContaining({ reason: 'scan', apps: [], closableGameKeys: [] })
+  )
+})
+
 test('concurrent launchProfileApps rejects with the active-launch message (#342)', async () => {
   const childHandlers = new Map<string, (...args: unknown[]) => void>()
   const child = {
@@ -5860,13 +5922,13 @@ test('a close with nothing surviving runs no enumeration at all (#674)', async (
   expect(enumerations).toHaveLength(0)
 })
 
-// hasClosableLaunchedApps answers "would Close Apps do anything?", so a
+// The closable set answers "would Close Apps do anything?", so a
 // same-named stranger must not make it say yes — that would offer the user an
 // action that closes nothing (#674, pre-wiring for #673). Deliberately MORE
 // precise than killLaunchedApps' own scheduling, which stays name-gated
 // because attempting a doomed path-scoped kill is harmless.
-test('hasClosableLaunchedApps is false when only a same-named stranger runs (#674)', async () => {
-  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModules()
+test('the closable set is false when only a same-named stranger runs (#674)', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModules()
   registerProcess('C:/Other/SimHub.exe', 'simhub.exe', '4321')
   runningProcesses.set('c:\\tools\\simhub.exe', {
     process: { pid: 1234 } as never,
@@ -5877,14 +5939,14 @@ test('hasClosableLaunchedApps is false when only a same-named stranger runs (#67
   })
   processNames.add('simhub.exe')
 
-  await expect(hasClosableLaunchedApps()).resolves.toBe(false)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBe(0)
 })
 
 // The other direction, and the one that keeps the action reachable (CodeRabbit
 // on #845): pinning only the `false` answer would let a change that always
 // returns `false` hide Close Apps entirely and still pass.
-test('hasClosableLaunchedApps is true when the candidate runs at its own path (#674)', async () => {
-  const { hasClosableLaunchedApps, runningProcesses } = await loadProcessModules()
+test('the closable set is true when the candidate runs at its own path (#674)', async () => {
+  const { collectRunningAppsSnapshot, runningProcesses } = await loadProcessModules()
   registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
   runningProcesses.set('c:\\tools\\simhub.exe', {
     process: { pid: 1234 } as never,
@@ -5895,7 +5957,7 @@ test('hasClosableLaunchedApps is true when the candidate runs at its own path (#
   })
   processNames.add('simhub.exe')
 
-  await expect(hasClosableLaunchedApps()).resolves.toBe(true)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.size).toBeGreaterThan(0)
 })
 
 test('killProfileApps falls back to /IM for non-full-path utility companions (#352)', async () => {
@@ -6816,7 +6878,7 @@ test('close apps does not kill a tracking-off profile companion (#591)', async (
 test('close apps is not offered for a tracking-off profile (#591)', async () => {
   processNames.add('garage61 telemetry agent.exe')
 
-  const { hasClosableLaunchedApps } = await loadProcessModulesWithStore({
+  const { collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
     profiles: {
       ac: {
         activeProfileId: 'quiet',
@@ -6825,7 +6887,7 @@ test('close apps is not offered for a tracking-off profile (#591)', async () => 
     }
   })
 
-  await expect(hasClosableLaunchedApps('ac')).resolves.toBe(false)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.has('ac')).toBe(false)
 })
 
 // The same profile with tracking left ON, so the two tests above cannot pass by
@@ -6833,7 +6895,7 @@ test('close apps is not offered for a tracking-off profile (#591)', async () => 
 test('close apps still targets the same companion when tracking is on (#591)', async () => {
   processNames.add('garage61 telemetry agent.exe')
 
-  const { killLaunchedApps, hasClosableLaunchedApps } = await loadProcessModulesWithStore({
+  const { killLaunchedApps, collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
     profiles: {
       ac: {
         activeProfileId: 'loud',
@@ -6842,7 +6904,7 @@ test('close apps still targets the same companion when tracking is on (#591)', a
     }
   })
 
-  await expect(hasClosableLaunchedApps('ac')).resolves.toBe(true)
+  expect((await collectRunningAppsSnapshot()).closableGameKeys.has('ac')).toBe(true)
   await killLaunchedApps()
 
   const killCalls = execFileCalls.filter((call) => call.command === 'taskkill')

--- a/tests/main/processes.test.ts
+++ b/tests/main/processes.test.ts
@@ -3496,6 +3496,42 @@ test('a claim survives the ticks before its app is up, and ends when it goes (#8
   expect(adoptedCompanionOwners.size).toBe(0)
 })
 
+// CodeRabbit on #853: a live handle outranks a claim. One profile launches a
+// shared companion, a second profile then finds it already running. Letting the
+// second one claim it would put the control on BOTH rows and let the second
+// close the first's companion, which is the exact bug this whole mechanism
+// exists to fix, reintroduced from the other direction.
+test('a second profile does not claim a companion the first one launched (#853)', async () => {
+  const { launchProfileApps, collectRunningAppsSnapshot } = await loadProcessModulesWithStore({
+    profiles: {
+      ac: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] },
+      iracing: { activeProfileId: 'default', profiles: [{ id: 'default', name: 'Default' }] }
+    },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' }
+  })
+
+  markExistingPath('C:/Tools/SimHub.exe')
+  vi.useFakeTimers()
+  try {
+    await launchProfileApps(sender, 'ac', ['C:/Tools/SimHub.exe'])
+    registerProcess('C:/Tools/SimHub.exe', 'simhub.exe', '1234')
+    processNames.add('simhub.exe')
+
+    // Past the post-launch cooldown, or the second launch is refused outright
+    // and the test would pass without ever exercising the claim.
+    await vi.advanceTimersByTimeAsync(11000)
+
+    // iRacing's launch finds it already up and skips it.
+    await expect(
+      launchProfileApps(sender, 'iracing', ['C:/Tools/SimHub.exe'])
+    ).resolves.toMatchObject({ launchedCount: 0, skippedCount: 1 })
+  } finally {
+    vi.useRealTimers()
+  }
+
+  expect(Array.from((await collectRunningAppsSnapshot()).closableGameKeys)).toEqual(['ac'])
+})
+
 // The inverse failure the claim can cause, found by an adversarial review pass
 // on #853: a claim is made for everything the launch INTENDS to handle, so an
 // app that then fails to start would still attach this profile to whatever is

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -66,6 +66,10 @@ async function loadRunningModule(opts?: {
 
   const killMock = {
     pruneUnclosedProcesses: pruneUnclosedProcessesMock,
+    // Its own behaviour is covered in processes.test.ts against the real store;
+    // here it only has to not be undefined, since every assertion in this file
+    // is about the app list or the poll cadence.
+    getClosableLaunchedAppGameKeys: vi.fn(() => new Set<string>()),
     killLaunchedApps: vi.fn(),
     killProfileApps: vi.fn()
   }

--- a/tests/renderer/gameListShellFetchSkip.test.tsx
+++ b/tests/renderer/gameListShellFetchSkip.test.tsx
@@ -111,6 +111,7 @@ async function renderGameList(
   runningAppsMock.mockReturnValue({
     runningApps,
     runningStatus: { iracing: runningApps.length > 0 },
+    closableGameKeys: new Set<string>(),
     refreshRunningState: vi.fn().mockResolvedValue(undefined)
   })
 

--- a/tests/renderer/gameRowClosableApps.test.tsx
+++ b/tests/renderer/gameRowClosableApps.test.tsx
@@ -141,15 +141,41 @@ test('a running profile keeps the primary Close Apps and adds nothing (#673)', a
   expect(buttonByLabel(LAUNCH_LABEL)).toBeNull()
 })
 
-// The slot the secondary control lives in is the relaunch slot. The two states
-// are mutually exclusive upstream (relaunch needs a running profile, which
-// makes the row a `canKill` row), but the slot renders one occupant regardless
-// so a future change upstream cannot produce two buttons in a 36px box.
-test('relaunch wins the shared slot if both are somehow true (#673)', async () => {
+// Codex on #853 disproved the assumption this file was built on: relaunch and
+// the secondary close are NOT mutually exclusive. `canRelaunch` reads the
+// aggregate running state, which the game's own exe satisfies alone, while the
+// strip behind `canKill` excludes that exe — so a game running alongside an
+// ambient companion (never ours to launch, so never in the strip) reaches both.
+// Hiding one behind the other there would put the close out of reach in exactly
+// the state #673 exists for, so both render.
+test('an ambient companion stays reachable while relaunch also applies (#853)', async () => {
   await renderActions({ canKill: false, canCloseLeftovers: true, canRelaunch: true })
 
   expect(buttonByLabel('Relaunch missing apps for Assetto Corsa')).not.toBeNull()
-  expect(buttonByLabel(SECONDARY_LABEL)).toBeNull()
+  expect(buttonByLabel(SECONDARY_LABEL)).not.toBeNull()
+  // Still exactly one close per row: the secondary must not have become a
+  // second primary on the way.
+  expect(buttonByLabel('Close companion apps for Assetto Corsa')).toBeNull()
+})
+
+// The overlap is the only state that widens the row. Every other row keeps one
+// reserved 36px slot, so the primary button stays on the same vertical line
+// down the list whether or not a row has anything in it.
+test('only the overlap adds a second icon slot (#853)', async () => {
+  // Direct children of the actions row only: the buttons carry the same sizing
+  // classes, and counting those would pass no matter how the slots are nested.
+  const slots = () => container.querySelectorAll('.gap-3.no-drag > div.h-9.w-9').length
+
+  await renderActions({ canKill: false, canCloseLeftovers: true })
+  expect(slots()).toBe(1)
+
+  await act(async () => {
+    root?.unmount()
+  })
+  container.remove()
+
+  await renderActions({ canKill: false, canCloseLeftovers: true, canRelaunch: true })
+  expect(slots()).toBe(2)
 })
 
 // It has to actually close: the control reaches the same handler the primary

--- a/tests/renderer/gameRowClosableApps.test.tsx
+++ b/tests/renderer/gameRowClosableApps.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * #673: after a SimLauncher restart (or a process-tracking toggle cycle, or a
+ * companion that autostarts with Windows) a profile's companions can be running
+ * while nothing is in the strip. The row used to offer NOTHING in that state,
+ * even though `killLaunchedApps` would have closed them: the only way back was
+ * to launch the game.
+ *
+ * What is pinned here is the shape of the fix, because the obvious version of
+ * it is a regression. `canKill` REPLACES the primary action rather than adding
+ * to it, so widening `canKill` would hand anyone with an autostarted SimHub a
+ * red Close Apps primary and no way to launch the game from that row, removing
+ * the one in-app recovery the bug leaves intact. The rule, decided on the issue
+ * 2026-08-04: Close Apps displaces Launch only when there is visible session
+ * state; ambient closable state gets a SECONDARY control.
+ */
+
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRowActions } from '../../src/renderer/src/components/game-list/GameRowActions'
+
+const activeProfileSet = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+const PROFILE_MENU_PROPS = {
+  profileSet: activeProfileSet,
+  activeProfile: activeProfileSet.profiles[0],
+  profileMenuOpen: false,
+  openProfileMenu: vi.fn(),
+  closeProfileMenu: vi.fn(),
+  profileMenuRef: { current: null },
+  menuRef: { current: null },
+  triggerRef: { current: null },
+  handleProfileMenuTriggerKeyDown: vi.fn(),
+  handleProfileMenuKeyDown: vi.fn(),
+  newProfileFormOpen: false,
+  newProfileName: '',
+  setNewProfileName: vi.fn(),
+  newProfileInputRef: { current: null },
+  gameName: 'Assetto Corsa',
+  onProfileSelect: vi.fn(),
+  onNewProfileSubmit: vi.fn()
+} as unknown as React.ComponentProps<typeof GameRowActions>['profileMenuProps']
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderActions(state: {
+  canKill: boolean
+  canCloseLeftovers: boolean
+  canRelaunch?: boolean
+  onKill?: () => void
+  onPrimary?: () => void
+}): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <GameRowActions
+        isActive={false}
+        isLaunching={false}
+        isLaunchBlocked={false}
+        canKill={state.canKill}
+        canCloseLeftovers={state.canCloseLeftovers}
+        canRelaunch={state.canRelaunch ?? false}
+        onPrimary={state.onPrimary ?? vi.fn()}
+        onKill={state.onKill ?? vi.fn()}
+        onRelaunchMissing={vi.fn()}
+        onToggleEditor={vi.fn()}
+        gameName="Assetto Corsa"
+        activeProfileName="Default"
+        editorId="editor-ac"
+        profileMenuProps={PROFILE_MENU_PROPS}
+      />
+    )
+  })
+}
+
+function buttonByLabel(label: string): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+}
+
+const SECONDARY_LABEL = 'Close companion apps for Assetto Corsa that are still running'
+const LAUNCH_LABEL = 'Launch Assetto Corsa: Default profile'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount()
+  })
+  root = null
+  container.remove()
+})
+
+// The whole point of the fix: the row now offers something, and it is NOT at
+// the cost of the primary button.
+test('ambient closable state adds a secondary close and leaves Launch primary (#673)', async () => {
+  await renderActions({ canKill: false, canCloseLeftovers: true })
+
+  expect(buttonByLabel(SECONDARY_LABEL)).not.toBeNull()
+  // The regression this shape exists to avoid. If this ever fails, the row has
+  // lost its only in-app recovery path for a profile whose game is closed.
+  expect(buttonByLabel(LAUNCH_LABEL)).not.toBeNull()
+  expect(buttonByLabel('Close companion apps for Assetto Corsa')).toBeNull()
+})
+
+// Nothing closable is the ordinary state of most rows most of the time, so the
+// control has to be absent rather than merely disabled: an always-present close
+// on every row with SimHub configured is exactly the ambient invitation the
+// secondary placement is meant to avoid.
+test('no closable apps means no secondary control at all (#673)', async () => {
+  await renderActions({ canKill: false, canCloseLeftovers: false })
+
+  expect(buttonByLabel(SECONDARY_LABEL)).toBeNull()
+  expect(buttonByLabel(LAUNCH_LABEL)).not.toBeNull()
+})
+
+// Visible session state is the case where displacement IS correct, and the two
+// controls must not both appear: one close per row, in one place.
+test('a running profile keeps the primary Close Apps and adds nothing (#673)', async () => {
+  await renderActions({ canKill: true, canCloseLeftovers: false })
+
+  expect(buttonByLabel('Close companion apps for Assetto Corsa')).not.toBeNull()
+  expect(buttonByLabel(SECONDARY_LABEL)).toBeNull()
+  expect(buttonByLabel(LAUNCH_LABEL)).toBeNull()
+})
+
+// The slot the secondary control lives in is the relaunch slot. The two states
+// are mutually exclusive upstream (relaunch needs a running profile, which
+// makes the row a `canKill` row), but the slot renders one occupant regardless
+// so a future change upstream cannot produce two buttons in a 36px box.
+test('relaunch wins the shared slot if both are somehow true (#673)', async () => {
+  await renderActions({ canKill: false, canCloseLeftovers: true, canRelaunch: true })
+
+  expect(buttonByLabel('Relaunch missing apps for Assetto Corsa')).not.toBeNull()
+  expect(buttonByLabel(SECONDARY_LABEL)).toBeNull()
+})
+
+// It has to actually close: the control reaches the same handler the primary
+// Close Apps does, not a new path that would need its own confirmation and
+// cancellation semantics.
+test('the secondary control fires the same kill handler as the primary (#673)', async () => {
+  const onKill = vi.fn()
+  const onPrimary = vi.fn()
+  await renderActions({ canKill: false, canCloseLeftovers: true, onKill, onPrimary })
+
+  await act(async () => {
+    buttonByLabel(SECONDARY_LABEL)?.click()
+  })
+
+  expect(onKill).toHaveBeenCalledTimes(1)
+  expect(onPrimary).not.toHaveBeenCalled()
+})

--- a/tests/renderer/useRunningApps.test.tsx
+++ b/tests/renderer/useRunningApps.test.tsx
@@ -46,9 +46,10 @@ const IRACING_APP = {
 
 function payload(
   apps: RunningAppsChangedPayload['apps'],
-  reason: RunningAppsChangedPayload['reason'] = 'scan'
+  reason: RunningAppsChangedPayload['reason'] = 'scan',
+  closableGameKeys: string[] = []
 ): RunningAppsChangedPayload {
-  return { apps, reason, updatedAt: 1 }
+  return { apps, reason, updatedAt: 1, closableGameKeys }
 }
 
 function Probe({
@@ -146,6 +147,47 @@ describe('useRunningApps push-subscription lifecycle', () => {
 
     expect(removeChangeListenerMock).toHaveBeenCalledTimes(1)
     expect(unsubscribeRunningAppsMock).toHaveBeenCalledTimes(1)
+  })
+
+  // The one-shot poll answers with apps only, and it is what runs immediately
+  // after every kill click and profile switch. Treating that silence as
+  // "nothing left to close" would hide the secondary Close Apps control the
+  // moment a partial kill failure makes it most needed (#673).
+  test('the one-shot refresh leaves the pushed closable set alone', async () => {
+    const harness = await mountProbe(GAMES)
+    try {
+      await act(async () => {
+        changeListener?.(payload([IRACING_APP], 'launch', ['iracing']))
+      })
+      expect(Array.from(harness.getResult().closableGameKeys)).toEqual(['iracing'])
+
+      getRunningAppsMock.mockResolvedValue([IRACING_APP])
+      await act(async () => {
+        await harness.getResult().refreshRunningState()
+      })
+
+      expect(Array.from(harness.getResult().closableGameKeys)).toEqual(['iracing'])
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  test('a push with an empty closable set still clears it', async () => {
+    const harness = await mountProbe(GAMES)
+    try {
+      await act(async () => {
+        changeListener?.(payload([IRACING_APP], 'launch', ['iracing']))
+      })
+      expect(harness.getResult().closableGameKeys.size).toBe(1)
+
+      await act(async () => {
+        changeListener?.(payload([IRACING_APP], 'kill', []))
+      })
+
+      expect(harness.getResult().closableGameKeys.size).toBe(0)
+    } finally {
+      harness.unmount()
+    }
   })
 
   test('with no configured games it never subscribes and reports empty state', async () => {


### PR DESCRIPTION
## Summary

- A profile's companions are surfaced only when its game is running or was launched this session, so a restart, a process-tracking toggle cycle, or a plain tray Quit leaves live companions with no strip icons and no Close Apps control. `killLaunchedApps` would still have closed them; nothing in the UI could reach it, and the only way back was to launch the game.
- The row now gets a **secondary** Close Apps control in that state, driven by a new per-tick answer to "would a click close anything", carried on the existing running-apps payload.
- Deliberately **not** a widening of `canKill`, and deliberately **not** a change to the strip. Both are explained below.

## Why the existing predicate could not drive this

`hasClosableLaunchedApps` already existed, was fully tested, and was dead production code. Its shape was the problem: it answered one game key per call and ran its own enumeration, and its own JSDoc said *"do not call it from a timer"*. The control has to appear and clear on its own as processes come and go, so a per-click answer would have been a button that lies until the user interacts with it, and a per-row poll would have been N PowerShell spawns per tick.

It is replaced by `getClosableLaunchedAppGameKeys`, which answers every key at once from the resolver the running-apps tick has already built. That costs **no extra spawn**: the tick's candidate set already spans every profile's trackable paths. Its own JSDoc authorised the deletion rather than leaving it to look load-bearing again, and its seven tests moved to the new surface rather than being dropped.

This also means no new IPC channel. The answer rides `RunningAppsChangedPayload`, which is what makes it refresh on its own.

## Why not simply widen `canKill`

`canKill` REPLACES the primary action rather than adding to it. Widening it would give anyone whose SimHub autostarts a red Close Apps primary on every row that configures it, with **no way to launch the game from that row**, removing the one in-app recovery the bug leaves intact. The rule decided on the issue on 2026-08-04 is followed instead: Close Apps displaces Launch only when there is visible session state; ambient closable state gets a secondary control. A test pins this specific regression.

## The change-gate had to widen too

`publishRunningApps` suppresses a scan whose snapshot is unchanged. The state this fix is about is exactly one where the app list is empty before and after, so a companion appearing or exiting moves the closable set while leaving `apps` byte-identical. Without adding the set to the snapshot the control would freeze in its last state for the rest of the session. Both halves are pinned by the same test, and reverting either one fails it.

## Scope left open, tracked as issues

- **#851** restores the STRIP, not just the button. #673's decision scoped it to the button and gave the strip to #794; the Codex-found second route recorded on 2026-08-18 then asked for the strip too. Those cannot both land in one PR, so the button ships here and the strip is tracked there with the ownership-persistence design and its reboot trap written out. Worth reading before closing #673 out entirely, since half of that later acceptance is met and half is not.
- **#852** the control does not say WHAT it will close, and a companion configured in several profiles is reachable from all of them. Inherent to per-profile closing rather than caused by this PR, but newly visible.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (819 passing, 7 new)
- [x] Mutation-checked both load-bearing changes: folding `canCloseLeftovers` into `primaryAction` fails the displacement test; dropping the closable set from the change-gate fails the clears-on-its-own test.
- [ ] Manual, batched into the 1.2.0 smoke run: launch a profile with a companion, close only the game, tray Quit, reopen. The row must show a secondary close next to Launch, with Launch still primary and the strip still empty. Clicking it closes the companion and the control disappears. Then kill the companion from Task Manager instead and confirm the control clears on its own within a couple of ticks.

Closes #673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a secondary close action for companion apps that remain running but aren’t visible in the active app list.
  - Game rows now indicate when additional companion apps can be closed.
  - Launch remains primary, while relaunching missing apps takes priority over closing leftovers.
  - Running-app updates now account for closable companion apps.

- **Bug Fixes**
  - Improved detection across profiles and path-based configurations.
  - Improved ownership tracking to prevent closing companions attributed to another launch.
  - Preserved accurate close availability during launches, failures, and process exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #673
<!-- auto-closes -->