### PR TITLE
fix(ui): explain the empty row instead of leaving it blank (#794)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -16,13 +16,14 @@ import {
   getDroppedSettingsEntries,
   getSupportedConfigValues,
   getStoredBoolean,
+  getStoredStringRecord,
   getStoredZoomFactor,
   requireSafeZoomFactor,
   sanitizeImportedConfig,
   sanitizeSettingsPatch,
   store
 } from '../store'
-import { isRecord } from '../utils'
+import { isRecord, isValidExePath } from '../utils'
 import {
   abortActiveLaunches,
   cancelPendingElevatedHandoffs,
@@ -509,6 +510,32 @@ export function registerConfigHandlers(): void {
 
   ipcMain.handle('get-settings', () => {
     return getPersistedSettings()
+  })
+
+  /**
+   * Game keys whose configured executable no longer resolves on disk (#794).
+   *
+   * Deliberately a one-shot query rather than a field on the running-apps
+   * payload. The filesystem cost is not the reason — the scan already calls
+   * `isValidExePath` on every configured game path each tick, in
+   * `getProfileTrackablePaths` and again over `gamePaths` — the CADENCE is.
+   * Anything the renderer draws has to join `normalizeRunningAppsSnapshot`, so
+   * a path that flaps (a share reconnecting, a drive spinning up, an antivirus
+   * holding the file) would publish and re-render the row every 2 seconds. This
+   * is config state answered on a settled cadence, on a channel that carries
+   * process state.
+   *
+   * A blank or unset path answers "not missing". Those rows are not rendered at
+   * all (GameList keeps only games with a truthy `gamePaths` entry), and saying
+   * a game is missing because it was never configured is wrong in the one
+   * direction that sends the user looking for a file that was never there.
+   */
+  ipcMain.handle('get-missing-game-paths', () => {
+    const gamePaths = getStoredStringRecord('gamePaths')
+
+    return Object.entries(gamePaths)
+      .filter(([, gamePath]) => gamePath.trim().length > 0 && !isValidExePath(gamePath))
+      .map(([gameKey]) => gameKey)
   })
 
   ipcMain.handle('save-settings', (_event, patch: unknown) => {

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -301,6 +301,8 @@ export interface ElectronAPI {
   checkForUpdates: () => Promise<unknown>
   getUpdateInfo: () => Promise<UpdateAvailability | null>
   getSettings: () => Promise<Settings>
+  /** Game keys whose configured executable no longer resolves on disk (#794). */
+  getMissingGamePaths: () => Promise<string[]>
   saveSettings: (patch: Partial<WritableSettings>) => Promise<SaveSettingsResult>
   getProfiles: () => Promise<Record<string, unknown>>
   saveProfile: (gameKey: string, profileSet: unknown) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -124,6 +124,7 @@ const electronAPI: ElectronAPI = {
 
   // typed store channels
   getSettings: () => ipcRenderer.invoke('get-settings'),
+  getMissingGamePaths: () => ipcRenderer.invoke('get-missing-game-paths'),
   saveSettings: (patch: unknown) => ipcRenderer.invoke('save-settings', patch),
   getProfiles: () => ipcRenderer.invoke('get-profiles'),
   saveProfile: (gameKey: string, profileSet: unknown) =>

--- a/src/renderer/src/components/GameList.tsx
+++ b/src/renderer/src/components/GameList.tsx
@@ -4,6 +4,7 @@ import { getSettings, onStoreConfigChanged } from '../lib/store'
 import { getFileIcon } from '../lib/electron'
 import { useLaunchBlock } from '../hooks/useLaunchBlock'
 import { useRunningApps } from '../hooks/useRunningApps'
+import { useMissingGamePaths } from '../hooks/useMissingGamePaths'
 import { findGameExeRunningApp, isGameExeRunning } from '../lib/runningGame'
 import { getPathComparisonKey } from '../../../shared/path'
 import { useNotify } from './Notify'
@@ -56,6 +57,7 @@ export function GameList({
   const { announce } = useNotify()
   const { runningApps, runningStatus, closableGameKeys, refreshRunningState } =
     useRunningApps(configuredGames)
+  const { missingGamePathKeys, refreshMissingGamePaths } = useMissingGamePaths()
   // Announce "X is now running" once a launch cooldown settles — but only if the
   // game EXECUTABLE itself is detected running by then. The cooldown also runs on
   // partial failures (a companion app started while the game exe failed), and
@@ -74,6 +76,17 @@ export function GameList({
       if (name) announce(`${name} is now running`)
     }
   })
+  // A launch attempt is the one moment the user is already being told a path is
+  // broken, via the skipped-entries toast, so the badge has to agree with that
+  // toast right then rather than at the next window focus. It also catches the
+  // repair: a launch that finally works clears a badge left from before (#794).
+  const handleLaunchEndAndRecheckPaths = useCallback(
+    (gameKey: string, cooldownMs?: number, options?: { primaryLaunch?: boolean }) => {
+      handleLaunchEnd(gameKey, cooldownMs, options)
+      void refreshMissingGamePaths()
+    },
+    [handleLaunchEnd, refreshMissingGamePaths]
+  )
   const { gameIcons } = useGamesSettings()
   const { appPaths: utilityAppPaths, utilityIcons } = useAppsSettings()
 
@@ -317,11 +330,12 @@ export function GameList({
               gameStatusTracked={gameRunningApp?.tracked}
               runningAppIcons={runningAppIcons}
               hasClosableApps={closableGameKeys.has(game.key)}
+              gamePathMissing={missingGamePathKeys.has(game.key)}
               isDimmed={hasActiveTitle && !runningStatus[game.key]}
               isLaunching={launchingGameKey === game.key}
               isLaunchBlocked={launchingGameKey !== null}
               onLaunchStart={handleLaunchStart}
-              onLaunchEnd={handleLaunchEnd}
+              onLaunchEnd={handleLaunchEndAndRecheckPaths}
               onRunningStateRefresh={refreshRunningState}
               onToggleEditor={() =>
                 setActiveEditorKey((current) => (current === game.key ? null : game.key))

--- a/src/renderer/src/components/game-list/GamePathMissingBadge.tsx
+++ b/src/renderer/src/components/game-list/GamePathMissingBadge.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+import { Tooltip } from '../Tooltip'
+
+/**
+ * The only place the user is told their game moved or was uninstalled, on a row
+ * that would otherwise look merely idle (#794).
+ *
+ * The detail is duplicated into an `sr-only` span rather than living only in
+ * the tooltip. A tooltip opens on hover and on focus, but a badge is not a
+ * control and must not take tab focus, so keyboard and screen-reader users
+ * would never reach the one sentence that says how to fix it. The visible badge
+ * stays short because it sits inline with the game title.
+ *
+ * Whether the path is malformed or simply gone is deliberately not
+ * distinguished, matching the launch-time warning: both point at the same fix
+ * (#639).
+ */
+const DETAIL =
+  "SimLauncher cannot find this game's files. Update the path in the Games section of Settings."
+
+export function GamePathMissingBadge(): ReactNode {
+  return (
+    <Tooltip label={DETAIL}>
+      <span className="shrink-0 rounded-full border border-(--warning-border) bg-(--warning-surface) px-2 py-0.5 text-xs font-medium text-(--warning-text)">
+        Game not found
+        <span className="sr-only">. {DETAIL}</span>
+      </span>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -20,6 +20,7 @@ import { formatSkippedLaunchEntries } from '../../lib/skippedLaunchEntries'
 import { useGameProfile } from '../../hooks/useGameProfile'
 import { useProfileMenu } from '../../hooks/useProfileMenu'
 import { GameIcon } from './GameIcon'
+import { GamePathMissingBadge } from './GamePathMissingBadge'
 import { RunningAppsStrip, type RunningAppIcon } from './RunningAppsStrip'
 import { GameRowActions } from './GameRowActions'
 import { ConfirmDialog } from '../ConfirmDialog'
@@ -40,6 +41,7 @@ export function GameRow({
   gameStatusTracked,
   runningAppIcons,
   hasClosableApps,
+  gamePathMissing,
   gameIconUrl,
   isDimmed,
   isLaunching,
@@ -75,6 +77,12 @@ export function GameRow({
   // than session state: after a restart, after the process-tracking toggle is
   // cycled, or whenever a companion autostarts with Windows.
   hasClosableApps: boolean
+  // This game's configured executable no longer resolves on disk (#794). Config
+  // state, not process state, which is why it is a badge next to the title and
+  // never the status dot: the dot's vocabulary is entirely about processes
+  // (green = running, amber ring = cannot tell, #737), so any dot on an idle row
+  // would read as "something is running".
+  gamePathMissing: boolean
   gameIconUrl?: string
   isDimmed: boolean
   isLaunching: boolean
@@ -621,6 +629,7 @@ export function GameRow({
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
               <h2 className="game-title font-normal text-(--text-primary)">{game.name}</h2>
+              {gamePathMissing && <GamePathMissingBadge />}
             </div>
             <RunningAppsStrip
               runningAppIcons={runningAppIcons}

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -617,7 +617,18 @@ export function GameRow({
       <div
         className={`accent-subtle-hover glass-surface flex h-[72px] w-full items-center justify-between rounded-[20px] px-6 ${profileMenuOpen ? 'isolation-auto! z-20' : 'z-0'}`}
       >
-        <div className="flex items-center gap-5">
+        {/* The `min-w-0` chain down to the title is what lets a long name give
+            way instead of pushing the row wider than it is. A flex item refuses
+            to shrink below its content by default, and this row is fixed height
+            with the action group on the other side of a `justify-between`, so
+            without it an overflowing title walks into Launch and Close Apps.
+            That is worst at the 175% zoom preset, where an 800px window is only
+            about 457 CSS pixels wide, and worst of all on a broken-path row:
+            the badge is `shrink-0` by design, so the name is what has to yield,
+            and the controls it would otherwise displace are the recovery path
+            (Codex on PR #858). Truncated text stays whole in the accessibility
+            tree, and the row's own `aria-label` carries the full name anyway. */}
+        <div className="flex min-w-0 items-center gap-5">
           <GameIcon
             game={game}
             isRunning={isGameRunning}
@@ -626,9 +637,9 @@ export function GameRow({
             dismissPath={gameStatusDismissPath}
             tracked={gameStatusTracked}
           />
-          <div className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <h2 className="game-title font-normal text-(--text-primary)">{game.name}</h2>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <h2 className="game-title truncate font-normal text-(--text-primary)">{game.name}</h2>
               {gamePathMissing && <GamePathMissingBadge />}
             </div>
             <RunningAppsStrip

--- a/src/renderer/src/hooks/useMissingGamePaths.ts
+++ b/src/renderer/src/hooks/useMissingGamePaths.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { getMissingGamePaths, onStoreConfigChanged } from '../lib/store'
 
 // Derived from the store binding rather than imported, matching GameList, so
@@ -59,9 +59,21 @@ export function useMissingGamePaths(): UseMissingGamePathsResult {
     })
   }, [])
 
+  // Every trigger below shares one refresh, so they share one generation
+  // counter. Focus and a launch attempt overlap in the ordinary flow (launching
+  // takes focus away, coming back brings it straight back), and without this an
+  // in-flight older read landing last would reinstate the answer the newer read
+  // had just corrected. The state it would corrupt is exactly the one this hook
+  // exists to keep honest: a badge describing a path that is already fixed.
+  const latestRequestRef = useRef(0)
+  const mountedRef = useRef(true)
+
   const refreshMissingGamePaths = useCallback(async () => {
+    const requestId = ++latestRequestRef.current
     try {
-      applyKeys(await getMissingGamePaths())
+      const keys = await getMissingGamePaths()
+      if (!mountedRef.current || requestId !== latestRequestRef.current) return
+      applyKeys(keys)
     } catch (err) {
       // Leave the last answer standing. Clearing here would retract a true
       // warning because one IPC round-trip failed.
@@ -70,43 +82,38 @@ export function useMissingGamePaths(): UseMissingGamePathsResult {
   }, [applyKeys])
 
   useEffect(() => {
-    const alive = { current: true }
+    // Set on entry, not just cleared on exit: an effect can re-run after a
+    // cleanup (StrictMode, a remount), and a ref left false would silently
+    // discard every answer from then on.
+    mountedRef.current = true
 
-    const refresh = async () => {
-      try {
-        const keys = await getMissingGamePaths()
-        if (!alive.current) return
-        applyKeys(keys)
-      } catch (err) {
-        console.error('Failed to read missing game paths', err)
-      }
-    }
+    const refresh = () => void refreshMissingGamePaths()
 
-    void refresh()
+    refresh()
 
     // Same gate as GameList's own settings reload: only 'import-config' (full
     // store replace) and 'save-settings' can carry gamePaths. Profile writes
     // and migration flags cannot, so they earn no round-trip.
     const unsubscribe = onStoreConfigChanged((payload: StoreConfigChangePayload) => {
       if (payload.reason !== 'import-config' && payload.reason !== 'save-settings') return
-      void refresh()
+      refresh()
     })
 
-    const handleFocus = () => void refresh()
+    const handleFocus = () => refresh()
     const handleVisibility = () => {
-      if (document.visibilityState === 'visible') void refresh()
+      if (document.visibilityState === 'visible') refresh()
     }
 
     window.addEventListener('focus', handleFocus)
     document.addEventListener('visibilitychange', handleVisibility)
 
     return () => {
-      alive.current = false
+      mountedRef.current = false
       unsubscribe()
       window.removeEventListener('focus', handleFocus)
       document.removeEventListener('visibilitychange', handleVisibility)
     }
-  }, [applyKeys])
+  }, [refreshMissingGamePaths])
 
   return { missingGamePathKeys, refreshMissingGamePaths }
 }

--- a/src/renderer/src/hooks/useMissingGamePaths.ts
+++ b/src/renderer/src/hooks/useMissingGamePaths.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getMissingGamePaths, onStoreConfigChanged } from '../lib/store'
+
+// Derived from the store binding rather than imported, matching GameList, so
+// the reason gate below stays in sync with StoreConfigChangeReason.
+type StoreConfigChangePayload = Parameters<typeof onStoreConfigChanged>[0] extends (
+  payload: infer Payload
+) => void
+  ? Payload
+  : never
+
+const EMPTY_MISSING_GAME_PATH_KEYS: ReadonlySet<string> = new Set<string>()
+
+export interface UseMissingGamePathsResult {
+  /** Game keys whose configured executable no longer resolves on disk (#794). */
+  missingGamePathKeys: Set<string>
+  refreshMissingGamePaths: () => Promise<void>
+}
+
+/**
+ * Which configured games have lost their executable, on a cadence that is
+ * settled rather than continuous (#794).
+ *
+ * The answer is config-shaped but the thing that changes it is the FILESYSTEM:
+ * a game moved by a Steam library change, uninstalled, or reinstalled to the
+ * same path. So the config-change channel alone is not enough, in both
+ * directions, and the second one is the dangerous half:
+ *
+ * - a game that disappears mid-session would show no explanation until the next
+ *   restart, which is the silent dead row this issue is about
+ * - a game the user REPAIRS (Steam rewrites the same path with no SimLauncher
+ *   config write at all) would keep the badge forever. A warning that is wrong
+ *   is worse than one that is missing, because the user goes looking for a
+ *   problem that no longer exists.
+ *
+ * Window focus closes both, because leaving to fix a path and coming back is
+ * the shape of every real repair. `visibilitychange` is here too rather than as
+ * a duplicate: a window restored from the tray can become visible without
+ * taking focus.
+ *
+ * Deliberately NOT refreshed from the running-apps push. That fires every 2
+ * seconds and would reintroduce exactly the flicker this cadence avoids.
+ */
+export function useMissingGamePaths(): UseMissingGamePathsResult {
+  const [missingGamePathKeys, setMissingGamePathKeys] = useState<Set<string>>(
+    EMPTY_MISSING_GAME_PATH_KEYS as Set<string>
+  )
+
+  const applyKeys = useCallback((keys: string[]) => {
+    // Referential stability: the common answer is "nothing is missing" on every
+    // refresh, and a fresh Set each time would re-render every row for no
+    // change.
+    setMissingGamePathKeys((current) => {
+      const next = new Set(keys)
+      if (next.size === current.size && keys.every((key) => current.has(key))) {
+        return current
+      }
+      return next
+    })
+  }, [])
+
+  const refreshMissingGamePaths = useCallback(async () => {
+    try {
+      applyKeys(await getMissingGamePaths())
+    } catch (err) {
+      // Leave the last answer standing. Clearing here would retract a true
+      // warning because one IPC round-trip failed.
+      console.error('Failed to read missing game paths', err)
+    }
+  }, [applyKeys])
+
+  useEffect(() => {
+    const alive = { current: true }
+
+    const refresh = async () => {
+      try {
+        const keys = await getMissingGamePaths()
+        if (!alive.current) return
+        applyKeys(keys)
+      } catch (err) {
+        console.error('Failed to read missing game paths', err)
+      }
+    }
+
+    void refresh()
+
+    // Same gate as GameList's own settings reload: only 'import-config' (full
+    // store replace) and 'save-settings' can carry gamePaths. Profile writes
+    // and migration flags cannot, so they earn no round-trip.
+    const unsubscribe = onStoreConfigChanged((payload: StoreConfigChangePayload) => {
+      if (payload.reason !== 'import-config' && payload.reason !== 'save-settings') return
+      void refresh()
+    })
+
+    const handleFocus = () => void refresh()
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') void refresh()
+    }
+
+    window.addEventListener('focus', handleFocus)
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    return () => {
+      alive.current = false
+      unsubscribe()
+      window.removeEventListener('focus', handleFocus)
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [applyKeys])
+
+  return { missingGamePathKeys, refreshMissingGamePaths }
+}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -1,4 +1,5 @@
 export const getSettings = () => window.electronAPI.getSettings()
+export const getMissingGamePaths = () => window.electronAPI.getMissingGamePaths()
 export const saveSettings = window.electronAPI.saveSettings
 export const getProfiles = () => window.electronAPI.getProfiles()
 export const saveProfile = window.electronAPI.saveProfile

--- a/tests/main/missingGamePaths.test.ts
+++ b/tests/main/missingGamePaths.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+/**
+ * The resolver behind the "Game not found" badge (#794).
+ *
+ * Runs the REAL `isValidExePath` against a mocked filesystem rather than
+ * stubbing the predicate, because two of the three answers here are about what
+ * that predicate does with edge inputs (a blank entry, a path with no file
+ * behind it) and a stub would just be asserting the fixture.
+ */
+
+type MockIpcHandler = (...args: unknown[]) => unknown
+
+// Whatever the fixture calls missing. `isValidExePath` runs `path.resolve`
+// before `existsSync`, so entries are compared with slashes and case folded.
+const missingPaths = new Set<string>()
+const normalize = (value: string) => value.toLowerCase().replace(/\//g, '\\')
+
+async function invokeGetMissingGamePaths(): Promise<string[]> {
+  const { __ipcHandlers } = await import('electron')
+  return (await (__ipcHandlers as Record<string, MockIpcHandler>)['get-missing-game-paths'](
+    {}
+  )) as string[]
+}
+
+async function loadConfigModule(gamePaths: Record<string, unknown>) {
+  const { clearIpcHandlers } = await import('electron')
+  ;(clearIpcHandlers as () => void)()
+
+  vi.doMock('fs', () => ({
+    default: {
+      existsSync: (filePath: unknown) =>
+        typeof filePath === 'string' &&
+        /\.exe$/i.test(filePath) &&
+        !missingPaths.has(normalize(filePath)),
+      // Present but unused: the handler under test never reaches the config-file
+      // paths, and a missing member would fail as a TypeError rather than an
+      // assertion the day one of them does.
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      statSync: vi.fn(),
+      existsSyncRaw: vi.fn()
+    }
+  }))
+
+  vi.doMock('electron-store', () => ({
+    default: class MockStore {
+      store: Record<string, unknown> = { gamePaths }
+
+      get(key: string) {
+        return this.store[key]
+      }
+
+      set(key: string, value: unknown) {
+        this.store[key] = value
+      }
+
+      clear() {
+        this.store = {}
+      }
+    }
+  }))
+  vi.doMock('../../src/main/migrator', () => ({ migrateProfilesToNamedSets: vi.fn() }))
+  vi.doMock('../../src/main/profiles', () => ({
+    isStoredProfileSet: () => false,
+    getProfileSwitchLeavingKeys: vi.fn(() => []),
+    getProfileLaunchEntryId: (entry: { key: string; path: string }) =>
+      `${entry.key} ${entry.path.toLowerCase()}`
+  }))
+  vi.doMock('../../src/main/processes', () => ({
+    publishRunningApps: vi.fn(async () => {}),
+    abortActiveLaunches: vi.fn(),
+    cancelPendingElevatedHandoffs: vi.fn(),
+    drainStrandedConsentPrompts: vi.fn(() => 0)
+  }))
+  vi.doMock('../../src/main/tray', () => ({ applyTrayVisibility: vi.fn() }))
+  vi.doMock('../../src/main/window', () => ({
+    applyRuntimeConfigSettings: vi.fn(),
+    getMainWindow: vi.fn(),
+    sendToRenderer: vi.fn()
+  }))
+
+  const mod = await import('../../src/main/ipc/config')
+  mod.registerConfigHandlers()
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  missingPaths.clear()
+})
+
+test('a configured game whose exe is gone is reported missing (#794)', async () => {
+  missingPaths.add(normalize('C:/Games/iRacing/ui/iRacingUI.exe'))
+  await loadConfigModule({
+    iracing: 'C:/Games/iRacing/ui/iRacingUI.exe',
+    beamng: 'C:/Games/BeamNG/BeamNG.drive.exe'
+  })
+
+  expect(await invokeGetMissingGamePaths()).toEqual(['iracing'])
+})
+
+test('every game resolving reports nothing missing (#794)', async () => {
+  await loadConfigModule({
+    iracing: 'C:/Games/iRacing/ui/iRacingUI.exe',
+    beamng: 'C:/Games/BeamNG/BeamNG.drive.exe'
+  })
+
+  expect(await invokeGetMissingGamePaths()).toEqual([])
+})
+
+// A game the user never configured must not be called missing. Its row is not
+// rendered at all, and the badge would send someone hunting for a file that was
+// never there. Blank and whitespace are the same non-answer as absent: the
+// Settings input clears to an empty string rather than deleting the key.
+test('a blank or whitespace game path is not missing, it is unset (#794)', async () => {
+  await loadConfigModule({ iracing: '', beamng: '   ', acc: undefined })
+
+  expect(await invokeGetMissingGamePaths()).toEqual([])
+})
+
+// The badge must not answer on data it cannot read. A non-string entry is a
+// corrupt or hand-edited config, and `getStoredStringRecord` drops it before the
+// resolver sees it, so the row stays quiet rather than warning about a value
+// nobody can interpret.
+test('a non-string game path entry is dropped rather than reported (#794)', async () => {
+  await loadConfigModule({ iracing: 42, beamng: null })
+
+  expect(await invokeGetMissingGamePaths()).toEqual([])
+})

--- a/tests/main/running.test.ts
+++ b/tests/main/running.test.ts
@@ -13,12 +13,26 @@ async function loadRunningModule(opts?: {
   gamePaths?: Record<string, string>
   appPaths?: Record<string, string>
   trackablePaths?: string[]
+  // Paths that must answer "gone" to existsSync while everything else answers
+  // "there" — a game whose exe moved, was uninstalled, or sits on a share that
+  // dropped (#794). Compared case-insensitively, like every other path in this
+  // codebase.
+  missingPaths?: string[]
 }) {
   // utils.isValidExePath checks fs.existsSync; pretend every .exe exists so
   // adoption (which validates the configured game path) works host-independently.
+  // Slashes as well as case: `isValidExePath` runs `path.resolve` BEFORE
+  // `existsSync`, so what reaches this mock is backslashed regardless of how the
+  // fixture wrote it. Comparing raw strings made the missing set silently never
+  // match, which is a green test asserting nothing.
+  const normalizeForFixture = (value: string) => value.toLowerCase().replace(/\//g, '\\')
+  const missing = new Set((opts?.missingPaths ?? []).map(normalizeForFixture))
   vi.doMock('fs', () => ({
     default: {
-      existsSync: (filePath: unknown) => typeof filePath === 'string' && /\.exe$/i.test(filePath)
+      existsSync: (filePath: unknown) =>
+        typeof filePath === 'string' &&
+        /\.exe$/i.test(filePath) &&
+        !missing.has(normalizeForFixture(filePath))
     }
   }))
 
@@ -519,4 +533,69 @@ test('a throwing reconcile does not fail the caller (#591)', async () => {
   } finally {
     consoleError.mockRestore()
   }
+})
+
+// #794 acceptance, and it pins a DECISION rather than a fix: when the game's
+// configured exe no longer resolves, its companions stay unsurfaced. Adoption
+// runs `isValidExePath` on the game path (`running.ts` in
+// `getExternallyAdoptableGameKeys`), so a broken path keeps the key out of
+// `adoptedOrLaunchedGameKeys` and `getTrackedRunningApps` skips the whole
+// profile at its first gate.
+//
+// Surfacing them instead was considered and rejected on the issue: the
+// membership test would be intent-blind (a companion that autostarts with
+// Windows would light up every profile configuring it), and it would hold the
+// FAST poll open indefinitely, reversing #672. The row explains itself with a
+// badge instead. #851 is what gives these companions back, through remembered
+// ownership rather than inference, so this test exists to make sure that lands
+// deliberately rather than as a side effect.
+//
+// Reachable without any config edit: a game on a share or an external drive
+// that drops fails `existsSync` while its process is still very much alive.
+//
+// Mutation-checked, and the answer was not the obvious one: deleting the
+// `isValidExePath` guard in the ADOPTION loop leaves this green, because the
+// guard in the loop that builds `gameExeOwners` has already kept the key out of
+// the map, so `owners?.size === 1` is false anyway. Both have to go for this to
+// turn red. Worth knowing before anyone "simplifies" one of them away and reads
+// the still-green suite as permission.
+test('a game path that no longer resolves leaves its companions unsurfaced (#794)', async () => {
+  const { runningModule } = await loadRunningModule({
+    profiles: { iracing: {} },
+    gamePaths: { iracing: 'C:/Games/iRacingUI.exe' },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    trackablePaths: ['C:/Tools/SimHub.exe'],
+    missingPaths: ['C:/Games/iRacingUI.exe']
+  })
+  // The game AND the companion are both running. Only the config path is broken.
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'simhub.exe']),
+    succeeded: true
+  })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(apps).toEqual([])
+})
+
+// The control for the test above, and it is the whole reason that one means
+// anything: same fixture, same running processes, only the path resolves. If
+// this ever stops surfacing SimHub, the test above is passing because adoption
+// broke for some unrelated reason rather than because of the path check.
+test('the same fixture with a resolvable game path does surface them (#794)', async () => {
+  const { runningModule } = await loadRunningModule({
+    profiles: { iracing: {} },
+    gamePaths: { iracing: 'C:/Games/iRacingUI.exe' },
+    appPaths: { simhub: 'C:/Tools/SimHub.exe' },
+    trackablePaths: ['C:/Tools/SimHub.exe'],
+    missingPaths: []
+  })
+  readRunningProcessNamesMock.mockResolvedValue({
+    processNames: new Set(['iracingui.exe', 'simhub.exe']),
+    succeeded: true
+  })
+
+  const apps = await runningModule.getRunningApps()
+
+  expect(apps.map((app) => app.path)).toContain('C:/Tools/SimHub.exe')
 })

--- a/tests/renderer/gameListShellFetchSkip.test.tsx
+++ b/tests/renderer/gameListShellFetchSkip.test.tsx
@@ -18,6 +18,10 @@ const getSettingsMock = vi.fn()
 
 vi.mock('../../src/renderer/src/lib/store', () => ({
   getSettings: (...args: unknown[]) => getSettingsMock(...args),
+  // Reached through useMissingGamePaths on mount (#794). Omitting it left the
+  // hook calling `undefined()`, which its own catch swallowed into a console
+  // error — the test still passed, on a component that was half-broken.
+  getMissingGamePaths: vi.fn().mockResolvedValue([]),
   onStoreConfigChanged: () => () => {}
 }))
 

--- a/tests/renderer/gameRowGamePathMissing.test.tsx
+++ b/tests/renderer/gameRowGamePathMissing.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * The "Game not found" badge (#794).
+ *
+ * The row is the only place a broken game path can be reported once the game is
+ * not running, because the launch-time warning needs a launch to happen first.
+ * What is pinned here is that the badge EXPLAINS without DISPLACING: it must not
+ * take over the primary action, since Launch is the other half of the recovery
+ * path and the row would read as healthy without it.
+ *
+ * Placement is deliberate too. The status dot is not used, because its
+ * vocabulary is entirely about processes (green = running, amber ring = cannot
+ * tell, #737) and a dot on an idle row reads as "something is running" whatever
+ * its colour.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  dismissAppIcon: vi.fn(),
+  launchProfile: vi.fn(),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: vi.fn(),
+  switchProfileApps: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: vi.fn(), announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [{ id: 'default', name: 'Default' }]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: false,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    setNewProfileName: vi.fn(),
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'beamng', name: 'BeamNG.drive', icon: 'assets/beamng.png' }
+const LAUNCH_LABEL = 'Launch BeamNG.drive: Default profile'
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+async function renderRow(gamePathMissing: boolean): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(
+      <AppDirtyProvider>
+        <GameRow
+          game={GAME}
+          isActive={false}
+          isRunning={false}
+          isGameRunning={false}
+          runningAppIcons={[]}
+          hasClosableApps={false}
+          gamePathMissing={gamePathMissing}
+          isDimmed={false}
+          isLaunching={false}
+          isLaunchBlocked={false}
+          onLaunchStart={vi.fn()}
+          onLaunchEnd={vi.fn()}
+          onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+          onToggleEditor={vi.fn()}
+          onCloseEditor={vi.fn()}
+          cacheInitialized={true}
+        />
+      </AppDirtyProvider>
+    )
+  })
+}
+
+function rowText(): string {
+  return container.textContent || ''
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount()
+  })
+  root = null
+  container.remove()
+})
+
+describe('GameRow broken-game-path badge (#794)', () => {
+  test('a game whose path no longer resolves says so on the row', async () => {
+    await renderRow(true)
+
+    expect(rowText()).toContain('Game not found')
+  })
+
+  // The ordinary state of every row. An always-present badge would be noise on
+  // a healthy list.
+  test('a game whose path resolves shows no badge', async () => {
+    await renderRow(false)
+
+    expect(rowText()).not.toContain('Game not found')
+  })
+
+  // The regression this shape exists to avoid. Launch is the other channel that
+  // reports a broken path (it names the skipped entry in its toast), so a badge
+  // that displaced it would remove the more actionable of the two.
+  test('the badge explains without displacing the primary action', async () => {
+    await renderRow(true)
+
+    expect(container.querySelector(`button[aria-label="${LAUNCH_LABEL}"]`)).not.toBeNull()
+  })
+
+  // The badge is not a control, so it must not take tab focus, which means the
+  // tooltip alone cannot carry the fix: nothing would ever open it for a
+  // keyboard or screen-reader user. The instruction has to be in the
+  // accessibility tree unconditionally, and it has to name where to go.
+  test('the fix is readable without hovering, and names the screen', async () => {
+    await renderRow(true)
+
+    expect(rowText()).toContain('Games section of Settings')
+
+    // And not focusable: a badge in the tab order would add a stop that does
+    // nothing on Enter. This is the reason the sentence above cannot live in
+    // the tooltip alone.
+    const badge = Array.from(container.querySelectorAll('span')).find((element) =>
+      element.textContent?.startsWith('Game not found')
+    )
+    expect(badge).toBeDefined()
+    expect(badge?.hasAttribute('tabindex')).toBe(false)
+  })
+})

--- a/tests/renderer/onboarding.test.tsx
+++ b/tests/renderer/onboarding.test.tsx
@@ -25,6 +25,9 @@ vi.mock('../../src/renderer/src/lib/store', () => ({
   getOnboardingSeen: vi.fn(async () => h.onboardingSeen),
   setOnboardingSeen: h.persistOnboardingSeen,
   getSettings: vi.fn(async () => ({ gamePaths: h.gamePaths, zoomFactor: 1 })),
+  // Reached through useMissingGamePaths on mount (#794); nothing here is about
+  // a broken path, so it answers "all resolve".
+  getMissingGamePaths: vi.fn(async () => []),
   saveSettings: h.saveSettings,
   onStoreConfigChanged: vi.fn(() => () => {})
 }))

--- a/tests/renderer/useMissingGamePaths.test.tsx
+++ b/tests/renderer/useMissingGamePaths.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { act } from 'react'
+import { act, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 
 import {
@@ -33,8 +33,14 @@ vi.mock('../../src/renderer/src/lib/store', () => ({
   }
 }))
 
+// Captured from an effect, not from render. Render has to stay pure, because
+// React is free to replay or discard it, so a prop callback invoked there can
+// fire for work that never commits (React Doctor, CodeRabbit on PR #858).
 function Probe({ onCapture }: { onCapture: (result: UseMissingGamePathsResult) => void }) {
-  onCapture(useMissingGamePaths())
+  const result = useMissingGamePaths()
+  useEffect(() => {
+    onCapture(result)
+  })
   return null
 }
 
@@ -158,6 +164,43 @@ describe('useMissingGamePaths cadence (#794)', () => {
       expect(Array.from(harness.getResult().missingGamePathKeys)).toEqual(['iracing'])
     } finally {
       consoleError.mockRestore()
+      harness.unmount()
+    }
+  })
+
+  // Focus and a launch attempt overlap in the ordinary flow: launching takes
+  // focus away and coming back brings it straight back. If the older read lands
+  // last it reinstates the answer the newer one just corrected, which is the
+  // badge describing a path that has already been fixed.
+  test('an older read resolving last does not overwrite the newer answer', async () => {
+    const harness = await mountProbe()
+    try {
+      let resolveFirst: ((keys: string[]) => void) | undefined
+      getMissingGamePathsMock.mockImplementationOnce(
+        () =>
+          new Promise<string[]>((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      getMissingGamePathsMock.mockResolvedValueOnce([])
+
+      // Both in flight; the second is the newer question.
+      const first = harness.getResult().refreshMissingGamePaths()
+      const second = harness.getResult().refreshMissingGamePaths()
+
+      await act(async () => {
+        await second
+      })
+      expect(harness.getResult().missingGamePathKeys.size).toBe(0)
+
+      // The older one lands afterwards, carrying the pre-repair answer.
+      await act(async () => {
+        resolveFirst?.(['iracing'])
+        await first
+      })
+
+      expect(harness.getResult().missingGamePathKeys.size).toBe(0)
+    } finally {
       harness.unmount()
     }
   })

--- a/tests/renderer/useMissingGamePaths.test.tsx
+++ b/tests/renderer/useMissingGamePaths.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * The cadence of the "Game not found" badge (#794).
+ *
+ * The badge answers a config-shaped question, but what changes the answer is the
+ * FILESYSTEM: a game moved by a library change, uninstalled, or reinstalled to
+ * the same path. So the store-config channel alone is not enough in either
+ * direction, and the second direction is the dangerous one: a badge that keeps
+ * claiming a game is missing after the user has put it back sends them hunting
+ * for a problem that no longer exists.
+ *
+ * These tests pin both halves of that: which events DO re-ask, and that the 2s
+ * running-apps push is not one of them.
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import {
+  useMissingGamePaths,
+  type UseMissingGamePathsResult
+} from '../../src/renderer/src/hooks/useMissingGamePaths'
+
+const getMissingGamePathsMock = vi.fn()
+let configListener: ((payload: { reason: string; keys: string[] }) => void) | null = null
+const unsubscribeConfigMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getMissingGamePaths: (...args: unknown[]) => getMissingGamePathsMock(...args),
+  onStoreConfigChanged: (listener: (payload: { reason: string; keys: string[] }) => void) => {
+    configListener = listener
+    return unsubscribeConfigMock
+  }
+}))
+
+function Probe({ onCapture }: { onCapture: (result: UseMissingGamePathsResult) => void }) {
+  onCapture(useMissingGamePaths())
+  return null
+}
+
+async function mountProbe() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let captured: UseMissingGamePathsResult | null = null
+  let root: Root | null = null
+
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Probe onCapture={(result) => (captured = result)} />)
+  })
+
+  return {
+    unmount: () => {
+      act(() => {
+        root?.unmount()
+      })
+      container.remove()
+    },
+    getResult: () => {
+      if (!captured) throw new Error('Probe did not capture state')
+      return captured
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  configListener = null
+  getMissingGamePathsMock.mockResolvedValue([])
+})
+
+describe('useMissingGamePaths cadence (#794)', () => {
+  test('asks once on mount and reports the answer', async () => {
+    getMissingGamePathsMock.mockResolvedValue(['iracing'])
+    const harness = await mountProbe()
+    try {
+      expect(getMissingGamePathsMock).toHaveBeenCalledTimes(1)
+      expect(Array.from(harness.getResult().missingGamePathKeys)).toEqual(['iracing'])
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // Same gate GameList uses for its own settings reload: only these two reasons
+  // can carry gamePaths, so the others must not buy a round-trip.
+  test.each([
+    ['save-settings', true],
+    ['import-config', true],
+    ['save-profile', false],
+    ['save-profiles', false],
+    ['set-migration-flags', false]
+  ])('a %s config change re-asks: %s', async (reason, shouldAsk) => {
+    const harness = await mountProbe()
+    try {
+      getMissingGamePathsMock.mockClear()
+
+      await act(async () => {
+        configListener?.({ reason: reason as string, keys: ['gamePaths'] })
+      })
+
+      expect(getMissingGamePathsMock).toHaveBeenCalledTimes(shouldAsk ? 1 : 0)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // The direction that matters most. Nothing in the config changes when a game
+  // is reinstalled to the same path, so without this the badge would be a
+  // permanent lie.
+  test('window focus re-asks, which is how a repaired path clears', async () => {
+    getMissingGamePathsMock.mockResolvedValue(['iracing'])
+    const harness = await mountProbe()
+    try {
+      expect(harness.getResult().missingGamePathKeys.size).toBe(1)
+
+      getMissingGamePathsMock.mockResolvedValue([])
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'))
+      })
+
+      expect(harness.getResult().missingGamePathKeys.size).toBe(0)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // A window restored from the tray can become visible without taking focus,
+  // which is the ordinary way this app comes back.
+  test('becoming visible re-asks even without focus', async () => {
+    const harness = await mountProbe()
+    try {
+      getMissingGamePathsMock.mockClear()
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+
+      expect(getMissingGamePathsMock).toHaveBeenCalledTimes(1)
+    } finally {
+      harness.unmount()
+    }
+  })
+
+  // A failed round-trip must not retract a true warning. Clearing on error would
+  // make the badge blink off on any transient IPC hiccup.
+  test('a failed read leaves the previous answer standing', async () => {
+    getMissingGamePathsMock.mockResolvedValue(['iracing'])
+    const harness = await mountProbe()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      expect(harness.getResult().missingGamePathKeys.size).toBe(1)
+
+      getMissingGamePathsMock.mockRejectedValue(new Error('ipc broken'))
+      await act(async () => {
+        await harness.getResult().refreshMissingGamePaths()
+      })
+
+      expect(Array.from(harness.getResult().missingGamePathKeys)).toEqual(['iracing'])
+    } finally {
+      consoleError.mockRestore()
+      harness.unmount()
+    }
+  })
+
+  test('unmount stops listening on every channel it subscribed to', async () => {
+    const harness = await mountProbe()
+
+    harness.unmount()
+    getMissingGamePathsMock.mockClear()
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(unsubscribeConfigMock).toHaveBeenCalledTimes(1)
+    expect(getMissingGamePathsMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- A profile whose **game** path no longer resolves used to go silent: no running dots, no explanation, and the only place the broken path was ever reported was a launch attempt. The row now carries a `Game not found` badge next to the title.
- The badge **explains without displacing**. Launch stays primary, because it is the other half of the recovery path and its toast names the broken entry. The status dot is untouched: its vocabulary is entirely about processes (green = running, amber ring = cannot tell, #639/#737), so a dot on an idle row would read as "something is running" whatever its colour.
- Companions of a broken-path profile **stay unsurfaced**, per the decision of 2026-08-05 on the issue. The gate that does that is now pinned by a test, with a control case, so #851 cannot regress it by accident.

## Why a separate IPC query rather than a field on the running-apps payload

The filesystem cost is the same either way. The scan already runs `isValidExePath` over every configured game path each tick, in `getProfileTrackablePaths` and again over `gamePaths`. What differs is the cadence: anything the renderer draws joins `normalizeRunningAppsSnapshot`, so a path that flaps (a share reconnecting, a drive spinning up, an antivirus holding the file) would publish and re-render the row every 2 seconds. Path validity is config state; that channel carries process state.

## The cadence is the part worth reviewing

Config changes alone are not enough, because what breaks a game path is the **filesystem**, not the config. A game moved by a library change never touches our store, and neither does one reinstalled to the same path. The second direction is the dangerous one: a badge that keeps claiming a game is missing after the user has put it back sends them hunting for a problem that no longer exists.

So the hook re-asks on mount, on `store-config-changed` (only the two reasons that can carry `gamePaths`), on window focus, on becoming visible, and after a launch attempt. Focus and visibility are what close both directions, because leaving to fix a path and coming back is the shape of every real repair.

## Ordering note

**This should merge before #851.** Once #851 surfaces companions on a broken-path row, `canKill` flips the primary button to Close Apps and Launch disappears, and Launch is currently the only place a broken path is reported. Without this badge already in place, that row would read entirely healthy while the game is missing.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (clean, no warnings)
- [x] `npm run typecheck` (tsc, node, preload types)
- [x] `npm run build`
- [x] `npm run test` (857 passed, up from 837)
- [x] Mutation-checked both new guards: removing the blank-path guard turns the "blank is unset, not missing" test red; the broken-path acceptance test needs **both** `isValidExePath` guards in `getExternallyAdoptableGameKeys` removed before it turns red, and that surprise is recorded in the test comment
- [ ] Manual: point a game at a path that does not exist in Settings, Games. The row shows `Game not found` and still offers Launch. Fix the path outside SimLauncher (or restore the file) and alt-tab back to the window: the badge clears without a restart.

Closes #794


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Game not found” warning when a configured game executable is missing.
  * Missing-path status refreshes after launches, configuration changes, window focus, and returning to the app.
  * Launch actions remain available so users can correct or retry missing game paths.
  * Running companion processes are hidden when their associated game executable cannot be found.

* **Bug Fixes**
  * Improved handling of invalid, blank, or unresolved game executable paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->