### PR TITLE
fix(config): accept a path pasted from Windows Copy as path (#859)

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -418,21 +418,56 @@ function getSafeThemeMode(value: unknown) {
   return typeof value === 'string' && THEME_MODES.has(value) ? value : undefined
 }
 
+/**
+ * The form of a pasted path we are willing to store: trimmed, and with ONE
+ * matched pair of surrounding double quotes removed (#859).
+ *
+ * Windows 11's own "Copy as path" wraps the clipboard value in quotes, which
+ * makes the most natural way to get a path out of Explorer the one way that
+ * used to fail: the closing quote defeated the `.exe` test, so the entry was
+ * dropped and reported as `not-an-exe` while the user was looking at a path
+ * that plainly ended in `.exe`.
+ *
+ * Only a MATCHED pair is removed, and only the outermost one. A quote is not a
+ * legal character in a Windows path, so a matched pair can only be a quoting
+ * artifact, while anything left over means the value is not a path at all and
+ * the caller rejects it below rather than silently storing half-stripped
+ * nonsense.
+ */
+function normalizeConfiguredExePath(value: string): string {
+  const trimmed = value.trim()
+
+  return trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+    ? trimmed.slice(1, -1).trim()
+    : trimmed
+}
+
 // Single source of truth for WHY an exe path is rejected, so the sanitizer's
 // accept/reject decision and the dropped-entry reason reported to the renderer
 // (#669) can never disagree. Returns null when the path is acceptable.
+//
+// Every check runs against the NORMALIZED form, because that is what would be
+// stored. Validating the raw string and persisting the stripped one (or the
+// reverse) is how a length cap gets bypassed by two characters.
 function getExePathRejectReason(value: unknown): DroppedSettingsReason | null {
   if (typeof value !== 'string') {
     return 'not-an-exe'
   }
 
-  const trimmedPath = value.trim()
+  const normalizedPath = normalizeConfiguredExePath(value)
 
-  if (trimmedPath.length === 0 || !/\.exe$/i.test(trimmedPath)) {
+  // A surviving quote means it was unmatched, or nested, or embedded. None of
+  // those is a path Windows can open, so this is a rejection rather than
+  // something to strip harder.
+  if (normalizedPath.includes('"')) {
     return 'not-an-exe'
   }
 
-  if (trimmedPath.length > MAX_IMPORT_PATH_LENGTH) {
+  if (normalizedPath.length === 0 || !/\.exe$/i.test(normalizedPath)) {
+    return 'not-an-exe'
+  }
+
+  if (normalizedPath.length > MAX_IMPORT_PATH_LENGTH) {
     return 'too-long'
   }
 
@@ -444,7 +479,7 @@ function isImportableExePath(value: unknown): value is string {
 }
 
 function getImportableExePath(value: unknown) {
-  return isImportableExePath(value) ? value.trim() : undefined
+  return isImportableExePath(value) ? normalizeConfiguredExePath(value) : undefined
 }
 
 function getUtilityKeySet(customSlots: number) {

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -270,3 +270,85 @@ test('a rejected profile save does not republish (#591)', async () => {
 
   expect(publishRunningApps).not.toHaveBeenCalled()
 })
+
+// #859: Windows 11's own "Copy as path" wraps the value in double quotes, so the
+// shortest route from an exe in Explorer to a configured app was also the one
+// route that failed. The closing quote defeated the `.exe` test, and the user
+// was told `not-an-exe` while looking at a path plainly ending in `.exe`.
+test('a path pasted from Windows "Copy as path" is accepted, unquoted (#859)', async () => {
+  await loadConfigModule()
+
+  const result = await invokeSaveSettings({
+    appPaths: { simhub: '"D:/Apps/SimHub/SimHub.exe"' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([])
+  // Stored WITHOUT the quotes. Accepting the value but persisting it verbatim
+  // would only move the failure to spawn time, further from its cause.
+  expect(result.settings.appPaths).toEqual({ simhub: 'D:/Apps/SimHub/SimHub.exe' })
+})
+
+test('the same holds for a game path (#859)', async () => {
+  await loadConfigModule()
+
+  const result = await invokeSaveSettings({
+    gamePaths: { iracing: '"A:/Games/iRacing/ui/iRacingUI.exe"' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([])
+  expect(result.settings.gamePaths).toEqual({ iracing: 'A:/Games/iRacing/ui/iRacingUI.exe' })
+})
+
+// Only a MATCHED outer pair is a quoting artifact. Anything else means the value
+// is not a path Windows could open, and half-stripping it would store something
+// that fails later and further from the cause.
+test.each([
+  ['leading quote only', '"D:/Apps/SimHub/SimHub.exe'],
+  ['trailing quote only', 'D:/Apps/SimHub/SimHub.exe"'],
+  ['single quotes', "'D:/Apps/SimHub/SimHub.exe'"],
+  ['embedded quote', 'D:/Apps/Sim"Hub/SimHub.exe']
+])('an unmatched or embedded quote is still rejected: %s (#859)', async (_label, badPath) => {
+  await loadConfigModule()
+
+  const result = await invokeSaveSettings({ appPaths: { simhub: badPath }, customSlots: 1 })
+
+  expect(result.dropped).toEqual([{ field: 'appPaths', key: 'simhub', reason: 'not-an-exe' }])
+  expect(result.settings.appPaths).toEqual({})
+})
+
+// The length cap has to run on the form that gets STORED. Validating the raw
+// string and persisting the stripped one is how a cap gets beaten by two
+// characters, and the reason must stay 'too-long' rather than drifting to
+// 'not-an-exe' now that a stray quote is a rejection too.
+test('the length cap is measured after the quotes come off (#859)', async () => {
+  await loadConfigModule()
+
+  const overlong = `C:/${'x'.repeat(301)}.exe`
+
+  const result = await invokeSaveSettings({
+    gamePaths: { iracing: `"${overlong}"` },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'gamePaths', key: 'iracing', reason: 'too-long' }])
+  expect(result.settings.gamePaths).toEqual({})
+})
+
+// The same bug from the other side: a path that fits only once the quotes are
+// off must not be rejected for their two characters.
+test('a path that fits only when unquoted is accepted (#859)', async () => {
+  await loadConfigModule()
+
+  const exact = `C:/${'x'.repeat(300 - 'C:/.exe'.length)}.exe`
+  expect(exact.length).toBe(300)
+
+  const result = await invokeSaveSettings({
+    gamePaths: { iracing: `"${exact}"` },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([])
+  expect(result.settings.gamePaths).toEqual({ iracing: exact })
+})


### PR DESCRIPTION
## Summary

- Windows 11's **Copy as path** wraps the clipboard value in double quotes. Pasting that into a game or app path field was rejected, because the closing quote defeated the extension test. The user was told `not-an-exe` while looking at a path that plainly ended in `.exe`, which is the shortest route from "exe in Explorer" to "configured app" and the one Windows itself offers.
- One matched pair of surrounding quotes now comes off before validation, inside the single helper that the accept/reject decision and the stored value already share, so those two cannot disagree (#669's invariant).
- Because every path field routes through that helper, this covers game paths, app paths, custom slots, profile tracked process paths and config import in one change.

## The two decisions worth reviewing

**An unmatched, nested or embedded quote is a rejection, not something to strip harder.** A quote is not a legal character in a Windows path, so a matched outer pair can only be a quoting artifact while anything left over means the value is not a path at all. Half-stripping it would persist something that fails at spawn time instead, further from its cause. `"C:/x.exe` (leading quote only) previously slipped through the extension test and would have been stored with the quote attached; it is now rejected.

**Both the length cap and the extension test run on the normalized form**, because that is what gets written. Validating the raw string and persisting the stripped one is how a cap gets beaten by two characters. The suite pins this from both sides: an over-length path still reports `too-long` rather than drifting to `not-an-exe`, and a path that fits only once unquoted is accepted.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (clean, no warnings)
- [x] `npm run typecheck` (tsc, node, preload types)
- [x] `npm run build`
- [x] `npm run test` (866 passed, up from 858)
- [x] Mutation-checked: making the strip a no-op turns four of the new tests red, so they are pinning the fix rather than the fixture
- [ ] Manual: right-click an exe in Explorer, **Copy as path**, paste into Settings, Games and Save. It saves, and reopening Settings shows the path without quotes.

Closes #859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of executable paths copied from Windows.
  * Matching surrounding double quotes are removed before validation and storage.
  * Invalid unmatched, embedded, or single quotes are rejected.
  * Path length and extension checks now apply to the cleaned path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->