### PR TITLE
fix(ui): refuse a profile switch while a launch is in flight (#843)

### DIFF
--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -162,7 +162,18 @@ export function GameRow({
   // Committing synchronously puts the update in the same task as the click that
   // started the launch, ahead of any continuation that resumes after it.
   const isLaunchBlockedRef = useRef(isLaunchBlocked)
+  // How many times the lock has been HANDED BACK. This is the identity a plain
+  // "did I start it" boolean could not provide (Codex twice on #864): the lock
+  // can be released and taken again by someone else while a switch is suspended,
+  // and both times that happened the boolean went on claiming a lock that was no
+  // longer the one it started. Counting releases lets a suspended continuation
+  // ask the only question that matters, which is whether the lock it is looking
+  // at is still the one it took, rather than merely whether it ever took one.
+  const lockReleaseCountRef = useRef(0)
   useLayoutEffect(() => {
+    if (isLaunchBlockedRef.current && !isLaunchBlocked) {
+      lockReleaseCountRef.current += 1
+    }
     isLaunchBlockedRef.current = isLaunchBlocked
   }, [isLaunchBlocked])
 
@@ -326,7 +337,15 @@ export function GameRow({
       // never save the profile. It is also the case that needs the check least:
       // running `switchProfileApps` means main's guard already ran, and it
       // refuses a competing launch for as long as our controller is registered.
+      //
+      // Paired with the release count, because ownership has to expire. It ends
+      // the moment the lock goes back, whether that is immediately (a switch
+      // that started nothing gets a zero cooldown) or ten seconds later (the
+      // cooldown running out while the refresh below is still pending). In both
+      // cases the next lock belongs to someone else, and both were shipped as
+      // bugs before this counter existed.
       let ownsTheLaunchLock = false
+      let lockReleaseCountWhenTaken = 0
 
       if (isRunning) {
         const diff = await getProfileSwitchDiff(game.key, currentProfile.id, nextProfile.id)
@@ -348,6 +367,7 @@ export function GameRow({
 
           onLaunchStart(game.key)
           ownsTheLaunchLock = true
+          lockReleaseCountWhenTaken = lockReleaseCountRef.current
           const result = await switchProfileApps(game.key, currentProfile.id, nextProfile.id)
           // The kill phase runs before the switch can cancel or fail, so a
           // stranded consent prompt has to be reported on every one of the
@@ -381,22 +401,7 @@ export function GameRow({
             onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
             return
           }
-          const switchCooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
-          onLaunchEnd(game.key, switchCooldownMs)
-          // Ownership ends the moment the lock is actually released, which is
-          // NOT the moment the switch stops running (Codex P2 on #864). A
-          // switch that started nothing gets a zero cooldown, so the lock is
-          // free again while `onRunningStateRefresh` below is still awaited,
-          // and the Launch button is live. A launch begun in there owns a
-          // BRAND NEW lock, and continuing to claim it as ours would skip the
-          // guard and abort it with the save.
-          //
-          // With a non-zero cooldown the opposite holds and the flag must
-          // stay: the lock is still ours, and no competing launch can start
-          // because the button is blocked for its duration.
-          if (switchCooldownMs === 0) {
-            ownsTheLaunchLock = false
-          }
+          onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
 
           const switchWarnings: string[] = []
           if (result.killFailures && result.killFailures.length > 0) {
@@ -439,7 +444,10 @@ export function GameRow({
       // on a failed switch. The alternative is killing a launch the user just
       // started, which is #843 itself and gives them a game that never starts
       // with nothing on screen to explain it.
-      if (!ownsTheLaunchLock && isLaunchBlockedRef.current) {
+      const stillHoldsItsOwnLock =
+        ownsTheLaunchLock && lockReleaseCountRef.current === lockReleaseCountWhenTaken
+
+      if (!stillHoldsItsOwnLock && isLaunchBlockedRef.current) {
         notify('Launch is settling. Try again shortly.', 'warn')
         return
       }

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react'
 import {
   createProfileId,
   getActiveGameProfile,
@@ -145,8 +153,16 @@ export function GameRow({
   // gate below is checked before an IPC round-trip and acted on after it, and a
   // captured prop cannot see a launch that started in between: the re-render
   // does not reach an async closure that already read it.
+  //
+  // LAYOUT effect, not a passive one, and that is load-bearing (CodeRabbit on
+  // #864). A passive effect is scheduled and can run after paint, while the
+  // continuation this mirror exists for resumes on a microtask as soon as its
+  // IPC settles. The passive version could therefore lose the race and hand the
+  // continuation the answer from before the launch, which is the whole bug.
+  // Committing synchronously puts the update in the same task as the click that
+  // started the launch, ahead of any continuation that resumes after it.
   const isLaunchBlockedRef = useRef(isLaunchBlocked)
-  useEffect(() => {
+  useLayoutEffect(() => {
     isLaunchBlockedRef.current = isLaunchBlocked
   }, [isLaunchBlocked])
 

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -274,26 +274,20 @@ export function GameRow({
     // abort only reaches controllers still in the registry, every one is
     // unregistered in a `finally` when its sequence returns, and every launch
     // initiator sets this flag synchronously before dispatching its IPC.
+    //
+    // This is the entry gate and it reads the PROP, which is correct here
+    // because nothing has suspended yet. It is not the last word: everything
+    // after this point is separated from the save by at least one await, so the
+    // authoritative check is the one immediately before `saveProfileSet`, which
+    // reads the ref. Refusing early is still worth it, because it spares an IPC
+    // round-trip and, on a running row, avoids raising a switch confirmation
+    // for something that is going to be refused anyway.
     if (isLaunchBlocked) {
       notify('Launch is settling. Try again shortly.', 'warn')
       return
     }
 
     const latestProfileSet = await getProfileRuntimeConfig()
-
-    // Asked again, and from the ref rather than the prop, because the check
-    // above is now separated from the save by an IPC round-trip. Starting this
-    // row's game during that round-trip leaves the closure holding the answer
-    // it read before the launch existed, and the save it then performs is the
-    // very abort this guard exists to prevent (Codex on #864).
-    //
-    // This is the cheap one, taken before any side effect so the common case
-    // costs nothing further. It is NOT sufficient on its own: see the second
-    // check immediately before the save, which is the authoritative one.
-    if (isLaunchBlockedRef.current) {
-      notify('Launch is settling. Try again shortly.', 'warn')
-      return
-    }
 
     const currentProfile = getActiveGameProfile(latestProfileSet)
     const nextProfile = latestProfileSet.profiles.find((profile) => profile.id === nextProfileId)
@@ -309,6 +303,14 @@ export function GameRow({
 
     try {
       let switchWarning: string | undefined
+      // Whether the lock the check below sees is OUR OWN (Codex P1 on #864).
+      // A confirmed running switch calls `onLaunchStart` itself and then holds
+      // the lock through the post-launch cooldown, so a check that rejects any
+      // active lock would reject this switch's own, leave the apps moved and
+      // never save the profile. It is also the case that needs the check least:
+      // running `switchProfileApps` means main's guard already ran, and it
+      // refuses a competing launch for as long as our controller is registered.
+      let ownsTheLaunchLock = false
 
       if (isRunning) {
         const diff = await getProfileSwitchDiff(game.key, currentProfile.id, nextProfile.id)
@@ -329,6 +331,7 @@ export function GameRow({
           }
 
           onLaunchStart(game.key)
+          ownsTheLaunchLock = true
           const result = await switchProfileApps(game.key, currentProfile.id, nextProfile.id)
           // The kill phase runs before the switch can cancel or fail, so a
           // stranded consent prompt has to be reported on every one of the
@@ -405,7 +408,7 @@ export function GameRow({
       // on a failed switch. The alternative is killing a launch the user just
       // started, which is #843 itself and gives them a game that never starts
       // with nothing on screen to explain it.
-      if (isLaunchBlockedRef.current) {
+      if (!ownsTheLaunchLock && isLaunchBlockedRef.current) {
         notify('Launch is settling. Try again shortly.', 'warn')
         return
       }

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -287,12 +287,9 @@ export function GameRow({
     // it read before the launch existed, and the save it then performs is the
     // very abort this guard exists to prevent (Codex on #864).
     //
-    // Placed HERE, before anything with a side effect, rather than immediately
-    // before the save: on the running path `switchProfileApps` has already
-    // stopped and started apps by then, and bailing at that point would leave a
-    // half-switch behind. That path does not need it anyway, since main refuses
-    // the switch itself while a launch is active and this function returns on
-    // its failure. Nothing has happened yet at this line, so returning is clean.
+    // This is the cheap one, taken before any side effect so the common case
+    // costs nothing further. It is NOT sufficient on its own: see the second
+    // check immediately before the save, which is the authoritative one.
     if (isLaunchBlockedRef.current) {
       notify('Launch is settling. Try again shortly.', 'warn')
       return
@@ -389,6 +386,28 @@ export function GameRow({
         }
 
         await onRunningStateRefresh()
+      }
+
+      // The authoritative check, in the same block as the action it guards.
+      //
+      // The earlier one is not enough, and the reason is the empty-diff case
+      // (Codex on #864): on a running row `getProfileSwitchDiff` and
+      // `onRunningStateRefresh` are both awaited above, and when the diff is
+      // empty `switchProfileApps` is skipped entirely, so main's own launch
+      // guard never runs. A launch starting during either await would otherwise
+      // arrive here unopposed and be aborted by the save.
+      //
+      // Bailing here can leave a switch half applied, when `switchProfileApps`
+      // succeeded and a launch began during the refresh that follows it. That
+      // is the better of the two outcomes and is chosen deliberately: an
+      // unsaved profile whose apps have moved is visible, recoverable by
+      // retrying the switch, and the same shape this function already produces
+      // on a failed switch. The alternative is killing a launch the user just
+      // started, which is #843 itself and gives them a game that never starts
+      // with nothing on screen to explain it.
+      if (isLaunchBlockedRef.current) {
+        notify('Launch is settling. Try again shortly.', 'warn')
+        return
       }
 
       // The save is what cancels a pending UAC handoff the outgoing profile

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -249,7 +249,23 @@ export function GameRow({
       return
     }
 
-    if (isRunning && isLaunchBlocked) {
+    // Not gated on `isRunning`, and that is the fix rather than an oversight
+    // (#843). A row whose game is not running skips the diff branch below and
+    // falls through to a bare `saveProfileSet`, and that save is what calls
+    // `abortActiveLaunches(gameKey)` in main. Since `activeLaunchControllers`
+    // holds one controller per GAME, the abort takes down the entire in-flight
+    // sequence rather than the leaving entry, and the game never starts.
+    //
+    // Main already refuses this: `switch-profile-apps` bails on
+    // `isAnyLaunchActive() || hasOtherActiveLaunchControllers()`. Only the
+    // empty-diff fall-through was more permissive than the path beside it, so
+    // this makes the two agree rather than inventing a rule.
+    //
+    // `isLaunchBlocked` covers the whole dangerous span by construction: the
+    // abort only reaches controllers still in the registry, every one is
+    // unregistered in a `finally` when its sequence returns, and every launch
+    // initiator sets this flag synchronously before dispatching its IPC.
+    if (isLaunchBlocked) {
       notify('Launch is settling. Try again shortly.', 'warn')
       return
     }

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -141,6 +141,15 @@ export function GameRow({
     isActiveRef.current = isActive
   }, [isActive])
 
+  // Same mirror, same reason, for the launch lock (Codex on #864). The switch
+  // gate below is checked before an IPC round-trip and acted on after it, and a
+  // captured prop cannot see a launch that started in between: the re-render
+  // does not reach an async closure that already read it.
+  const isLaunchBlockedRef = useRef(isLaunchBlocked)
+  useEffect(() => {
+    isLaunchBlockedRef.current = isLaunchBlocked
+  }, [isLaunchBlocked])
+
   // Removes a still-pending "+" profile and restores the previously-active one.
   // Clears the ref up front so the two callers (the close effect and the
   // post-save guard) can't double-run, and reads the store fresh so it reflects
@@ -271,6 +280,24 @@ export function GameRow({
     }
 
     const latestProfileSet = await getProfileRuntimeConfig()
+
+    // Asked again, and from the ref rather than the prop, because the check
+    // above is now separated from the save by an IPC round-trip. Starting this
+    // row's game during that round-trip leaves the closure holding the answer
+    // it read before the launch existed, and the save it then performs is the
+    // very abort this guard exists to prevent (Codex on #864).
+    //
+    // Placed HERE, before anything with a side effect, rather than immediately
+    // before the save: on the running path `switchProfileApps` has already
+    // stopped and started apps by then, and bailing at that point would leave a
+    // half-switch behind. That path does not need it anyway, since main refuses
+    // the switch itself while a launch is active and this function returns on
+    // its failure. Nothing has happened yet at this line, so returning is clean.
+    if (isLaunchBlockedRef.current) {
+      notify('Launch is settling. Try again shortly.', 'warn')
+      return
+    }
+
     const currentProfile = getActiveGameProfile(latestProfileSet)
     const nextProfile = latestProfileSet.profiles.find((profile) => profile.id === nextProfileId)
 

--- a/src/renderer/src/components/game-list/GameRow.tsx
+++ b/src/renderer/src/components/game-list/GameRow.tsx
@@ -381,7 +381,22 @@ export function GameRow({
             onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
             return
           }
-          onLaunchEnd(game.key, result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS)
+          const switchCooldownMs = result.launchedCount === 0 ? 0 : POST_LAUNCH_BLOCK_MS
+          onLaunchEnd(game.key, switchCooldownMs)
+          // Ownership ends the moment the lock is actually released, which is
+          // NOT the moment the switch stops running (Codex P2 on #864). A
+          // switch that started nothing gets a zero cooldown, so the lock is
+          // free again while `onRunningStateRefresh` below is still awaited,
+          // and the Launch button is live. A launch begun in there owns a
+          // BRAND NEW lock, and continuing to claim it as ours would skip the
+          // guard and abort it with the save.
+          //
+          // With a non-zero cooldown the opposite holds and the flag must
+          // stay: the lock is still ours, and no competing launch can start
+          // because the button is blocked for its duration.
+          if (switchCooldownMs === 0) {
+            ownsTheLaunchLock = false
+          }
 
           const switchWarnings: string[] = []
           if (result.killFailures && result.killFailures.length > 0) {

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -34,6 +34,9 @@ const launchProfileMock = vi.fn()
 const saveProfileSetMock = vi.fn().mockResolvedValue(undefined)
 const getProfileSwitchDiffMock = vi.fn()
 const switchProfileAppsMock = vi.fn()
+// Controllable too: a switch that started nothing releases its lock BEFORE
+// this runs, so this is the window in which a competing launch can appear.
+const onRunningStateRefreshMock = vi.fn()
 
 vi.mock('../../src/renderer/src/lib/electron', () => ({
   launchProfile: (...args: unknown[]) => launchProfileMock(...args),
@@ -156,7 +159,7 @@ function Harness({ isRunning = false }: { isRunning?: boolean }) {
         isLaunchBlocked={launching}
         onLaunchStart={onLaunchStart}
         onLaunchEnd={onLaunchEnd}
-        onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+        onRunningStateRefresh={onRunningStateRefreshMock}
         onToggleEditor={vi.fn()}
         onCloseEditor={vi.fn()}
         cacheInitialized={true}
@@ -197,6 +200,7 @@ beforeEach(() => {
   saveProfileSetMock.mockResolvedValue(undefined)
   getProfileRuntimeConfigMock.mockResolvedValue(PROFILE_SET)
   switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 1 })
+  onRunningStateRefreshMock.mockResolvedValue(undefined)
 })
 
 afterEach(async () => {
@@ -351,6 +355,61 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
 
     expect(switchProfileAppsMock).toHaveBeenCalledTimes(1)
     expect(saveProfileSetMock).toHaveBeenCalledTimes(1)
+  })
+
+  // Ownership has to end when the LOCK is released, not when the switch stops
+  // running. A switch that started nothing gets a zero cooldown, so the lock is
+  // free again while `onRunningStateRefresh` is still awaited and the Launch
+  // button is live. A launch begun in there owns a brand new lock, and treating
+  // it as the switch's own would skip the guard and abort it (Codex P2 on
+  // #864). The previous ownership test could not see this: it returned
+  // `launchedCount: 1`, which keeps the original lock held.
+  test('a switch that started nothing stops claiming the lock it released (#864)', async () => {
+    getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 1, toStartCount: 0 })
+    // Success, but nothing started: this is what releases the lock early.
+    switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 0 })
+
+    let settleRefresh: (() => void) | undefined
+    onRunningStateRefreshMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          settleRefresh = () => resolve()
+        })
+    )
+    let settleLaunch: ((result: unknown) => void) | undefined
+    launchProfileMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleLaunch = resolve
+        })
+    )
+
+    await mountRow(true)
+    await clickProfile('Race')
+
+    const confirm = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Switch Profile')
+    )
+    await act(async () => {
+      confirm!.click()
+    })
+
+    // Parked on the refresh, with the switch's own lock already handed back.
+    expect(switchProfileAppsMock).toHaveBeenCalledTimes(1)
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    // A competing launch takes a NEW lock in that window.
+    await clickLaunch()
+
+    await act(async () => {
+      settleRefresh?.()
+    })
+
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      settleLaunch?.({ success: true, launchedCount: 1 })
+    })
   })
 
   // The half that stops "refuse everything" from passing. Without it, deleting

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -68,12 +68,16 @@ const PROFILE_SET = {
   ]
 }
 
+// Controllable, because the interesting window is the one this IPC round-trip
+// opens: the gate is read before it and the save happens after it.
+const getProfileRuntimeConfigMock = vi.fn()
+
 vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
   useGameProfile: () => ({
     profileSet: PROFILE_SET,
     profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
     loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
-    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: (...args: unknown[]) => getProfileRuntimeConfigMock(...args),
     saveProfileSet: saveProfileSetMock
   })
 }))
@@ -180,6 +184,7 @@ async function clickProfile(name: string): Promise<void> {
 beforeEach(() => {
   vi.clearAllMocks()
   saveProfileSetMock.mockResolvedValue(undefined)
+  getProfileRuntimeConfigMock.mockResolvedValue(PROFILE_SET)
 })
 
 afterEach(async () => {
@@ -211,6 +216,48 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
     expect(notifyMock).toHaveBeenCalledWith('Launch is settling. Try again shortly.', 'warn')
 
     // Leave nothing hanging for the next test.
+    await act(async () => {
+      settleLaunch?.({ success: true, launchedCount: 1 })
+    })
+  })
+
+  // The gate is read before an IPC round-trip and acted on after it, so a
+  // launch that starts in between leaves the closure holding an answer from
+  // before it existed. This is the same check-then-suspend shape that produced
+  // five separate findings on #714 and was the reason #715 moved the launch
+  // path's own check into the same synchronous block as the start.
+  test('a launch that starts during the profile read still stops the save (#864)', async () => {
+    let settleProfileRead: ((value: unknown) => void) | undefined
+    getProfileRuntimeConfigMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleProfileRead = resolve
+        })
+    )
+    let settleLaunch: ((result: unknown) => void) | undefined
+    launchProfileMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleLaunch = resolve
+        })
+    )
+
+    await mountRow()
+
+    // The switch starts while nothing is launching, so it passes the first gate
+    // and parks on the profile read.
+    await clickProfile('Race')
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    // Only NOW does a launch begin, which the parked closure cannot see.
+    await clickLaunch()
+
+    await act(async () => {
+      settleProfileRead?.(PROFILE_SET)
+    })
+
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
     await act(async () => {
       settleLaunch?.({ success: true, launchedCount: 1 })
     })

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -31,13 +31,14 @@ const notifyMock = vi.fn()
 const launchProfileMock = vi.fn()
 const saveProfileSetMock = vi.fn().mockResolvedValue(undefined)
 const getProfileSwitchDiffMock = vi.fn()
+const switchProfileAppsMock = vi.fn()
 
 vi.mock('../../src/renderer/src/lib/electron', () => ({
   launchProfile: (...args: unknown[]) => launchProfileMock(...args),
   killLaunchedApps: vi.fn(),
   relaunchMissingProfile: vi.fn(),
   getProfileSwitchDiff: (...args: unknown[]) => getProfileSwitchDiffMock(...args),
-  switchProfileApps: vi.fn()
+  switchProfileApps: (...args: unknown[]) => switchProfileAppsMock(...args)
 }))
 
 vi.mock('../../src/renderer/src/lib/store', () => ({
@@ -117,16 +118,23 @@ let container: HTMLDivElement
 let root: Root | null = null
 
 /**
- * Stands in for GameList's `useLaunchBlock`, and only for the part this test is
- * about: `isLaunchBlocked` goes true synchronously when a launch starts and
- * false when it ends. The real hook also holds it through a cooldown, which
- * only widens the closed window and has its own coverage in
- * `useLaunchBlock.test.tsx`.
+ * Stands in for GameList's `useLaunchBlock`: the lock goes true synchronously
+ * when a launch starts, and a non-zero cooldown HOLDS it after the launch ends.
+ *
+ * That cooldown is not a detail. An earlier version of this harness cleared the
+ * lock the moment a launch ended, which quietly made a whole class of case
+ * untestable: a confirmed running switch takes the lock itself and then holds it
+ * through the cooldown, so the row's own guard can be looking at its own lock.
+ * With the cooldown modelled away the tests agreed with the code and both were
+ * wrong (Codex P1 on #864).
  */
 function Harness({ isRunning = false }: { isRunning?: boolean }) {
   const [launching, setLaunching] = useState(false)
   const onLaunchStart = useCallback(() => setLaunching(true), [])
-  const onLaunchEnd = useCallback(() => setLaunching(false), [])
+  const onLaunchEnd = useCallback((_key: string, cooldownMs?: number) => {
+    if (cooldownMs && cooldownMs > 0) return
+    setLaunching(false)
+  }, [])
 
   return (
     <AppDirtyProvider>
@@ -186,6 +194,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   saveProfileSetMock.mockResolvedValue(undefined)
   getProfileRuntimeConfigMock.mockResolvedValue(PROFILE_SET)
+  switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 1 })
 })
 
 afterEach(async () => {
@@ -215,6 +224,13 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
 
     expect(saveProfileSetMock).not.toHaveBeenCalled()
     expect(notifyMock).toHaveBeenCalledWith('Launch is settling. Try again shortly.', 'warn')
+
+    // Refused at the FIRST gate, before the profile read. The later gate would
+    // catch this one too, so without this line the early bail is unpinned and
+    // could be deleted with the suite still green. It earns its place by
+    // sparing an IPC round-trip and, on a running row, by not raising a switch
+    // confirmation dialog for a switch that is going to be refused anyway.
+    expect(getProfileRuntimeConfigMock).not.toHaveBeenCalled()
 
     // Leave nothing hanging for the next test.
     await act(async () => {
@@ -306,10 +322,46 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
     })
   })
 
+  // The guard must not fire on the lock this switch took itself. A confirmed
+  // running switch calls `onLaunchStart`, then holds the lock through the
+  // post-launch cooldown, so rejecting any active lock would move the apps and
+  // never save the profile: a half-switch on the ordinary path rather than the
+  // rare one (Codex P1 on #864). This case also needs the guard least, since
+  // running `switchProfileApps` means main's own guard already ran.
+  test('a confirmed running switch still saves, despite holding its own lock (#864)', async () => {
+    getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 1, toStartCount: 1 })
+    switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 1 })
+
+    await mountRow(true)
+
+    await clickProfile('Race')
+
+    // Staged, not performed: the running switch asks first.
+    expect(switchProfileAppsMock).not.toHaveBeenCalled()
+
+    const confirm = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Switch Profile')
+    )
+    expect(confirm).toBeDefined()
+    await act(async () => {
+      confirm!.click()
+    })
+
+    expect(switchProfileAppsMock).toHaveBeenCalledTimes(1)
+    expect(saveProfileSetMock).toHaveBeenCalledTimes(1)
+  })
+
   // The half that stops "refuse everything" from passing. Without it, deleting
   // the switch entirely would go green.
-  test('the same switch goes through once the launch has settled', async () => {
-    launchProfileMock.mockResolvedValue({ success: true, launchedCount: 1 })
+  //
+  // Uses a launch that STARTED nothing, because that is the real path on which
+  // the lock clears immediately: GameRow passes `launchedCount === 0 ? 0 :
+  // POST_LAUNCH_BLOCK_MS`, so only this shape releases without waiting out the
+  // cooldown. Asserting liveness after a launch that did start something would
+  // require waiting the block out, which is `useLaunchBlock`'s own contract and
+  // is covered there.
+  test('the same switch goes through once the lock has cleared', async () => {
+    launchProfileMock.mockResolvedValue({ success: true, launchedCount: 0 })
 
     await mountRow()
     await clickLaunch()

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * #843: a profile switch during an in-flight launch could kill the launch.
+ *
+ * `save-profile` calls `abortActiveLaunches(gameKey)` when the switch leaves a
+ * utility behind, and `activeLaunchControllers` holds one controller per GAME,
+ * so that abort takes down the whole sequence rather than the leaving entry.
+ * The game never starts.
+ *
+ * The main process already refuses this: `switch-profile-apps` bails on
+ * `isAnyLaunchActive() || hasOtherActiveLaunchControllers()`. The renderer got
+ * around it, because a row whose game is not running skips the diff branch
+ * entirely and falls through to a bare `saveProfileSet`, which is the abort's
+ * only transport. So the two paths disagreed, and this closes that.
+ *
+ * What is asserted is the WINDOW, not the gate's boolean. The dangerous span is
+ * exactly [launch IPC dispatched -> launch IPC resolved]: `abortActiveLaunches`
+ * only reaches controllers still in the registry, and every one of them is
+ * unregistered in a `finally` when its sequence returns. So the launch promise
+ * is left deliberately unsettled and the question asked is whether the save can
+ * be emitted at all while it hangs.
+ *
+ * The liveness half matters just as much: an implementation that refused every
+ * switch forever would pass the first assertion and be worse than the bug.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, useCallback, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+const notifyMock = vi.fn()
+const launchProfileMock = vi.fn()
+const saveProfileSetMock = vi.fn().mockResolvedValue(undefined)
+const getProfileSwitchDiffMock = vi.fn()
+
+vi.mock('../../src/renderer/src/lib/electron', () => ({
+  launchProfile: (...args: unknown[]) => launchProfileMock(...args),
+  killLaunchedApps: vi.fn(),
+  relaunchMissingProfile: vi.fn(),
+  getProfileSwitchDiff: (...args: unknown[]) => getProfileSwitchDiffMock(...args),
+  switchProfileApps: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/lib/store', () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getProfiles: vi.fn(),
+  saveProfile: vi.fn(),
+  saveProfiles: vi.fn(),
+  getMigrationFlags: vi.fn(),
+  setMigrationFlags: vi.fn(),
+  onStoreConfigChanged: vi.fn(),
+  exportConfig: vi.fn(),
+  previewImportConfig: vi.fn(),
+  applyImportConfig: vi.fn(),
+  cancelImportConfig: vi.fn()
+}))
+
+vi.mock('../../src/renderer/src/components/Notify', () => ({
+  useNotify: () => ({ notify: notifyMock, announce: vi.fn() }),
+  NotifyProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+const PROFILE_SET = {
+  activeProfileId: 'default',
+  profiles: [
+    { id: 'default', name: 'Default' },
+    { id: 'race', name: 'Race' }
+  ]
+}
+
+vi.mock('../../src/renderer/src/hooks/useGameProfile', () => ({
+  useGameProfile: () => ({
+    profileSet: PROFILE_SET,
+    profileState: { killControlsEnabled: true, relaunchControlsEnabled: true },
+    loadProfileSet: vi.fn().mockResolvedValue(PROFILE_SET),
+    getProfileRuntimeConfig: vi.fn().mockResolvedValue(PROFILE_SET),
+    saveProfileSet: saveProfileSetMock
+  })
+}))
+
+// Open, so the menu items are in the DOM for the switch to be driven through.
+vi.mock('../../src/renderer/src/hooks/useProfileMenu', () => ({
+  useProfileMenu: () => ({
+    profileMenuOpen: true,
+    setProfileMenuOpen: vi.fn(),
+    openProfileMenu: vi.fn(),
+    closeProfileMenu: vi.fn(),
+    newProfileFormOpen: false,
+    setNewProfileName: vi.fn(),
+    setNewProfileFormOpen: vi.fn(),
+    newProfileName: '',
+    profileMenuRef: { current: null },
+    menuRef: { current: null },
+    triggerRef: { current: null },
+    handleProfileMenuTriggerKeyDown: vi.fn(),
+    handleProfileMenuKeyDown: vi.fn(),
+    newProfileInputRef: { current: null }
+  })
+}))
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+import { GameRow } from '../../src/renderer/src/components/game-list/GameRow'
+import { AppDirtyProvider } from '../../src/renderer/src/contexts/AppDirtyContext'
+import type { Game } from '../../src/renderer/src/lib/config'
+
+const GAME: Game = { key: 'ac', name: 'Assetto Corsa', icon: 'assets/ac.png' }
+const LAUNCH_LABEL = 'Launch Assetto Corsa: Default profile'
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+/**
+ * Stands in for GameList's `useLaunchBlock`, and only for the part this test is
+ * about: `isLaunchBlocked` goes true synchronously when a launch starts and
+ * false when it ends. The real hook also holds it through a cooldown, which
+ * only widens the closed window and has its own coverage in
+ * `useLaunchBlock.test.tsx`.
+ */
+function Harness() {
+  const [launching, setLaunching] = useState(false)
+  const onLaunchStart = useCallback(() => setLaunching(true), [])
+  const onLaunchEnd = useCallback(() => setLaunching(false), [])
+
+  return (
+    <AppDirtyProvider>
+      <GameRow
+        game={GAME}
+        isActive={false}
+        // The whole point: the game is NOT running, which is the case that used
+        // to skip the diff branch and fall through to a bare save.
+        isRunning={false}
+        isGameRunning={false}
+        runningAppIcons={[]}
+        hasClosableApps={false}
+        gamePathMissing={false}
+        isDimmed={false}
+        isLaunching={launching}
+        isLaunchBlocked={launching}
+        onLaunchStart={onLaunchStart}
+        onLaunchEnd={onLaunchEnd}
+        onRunningStateRefresh={vi.fn().mockResolvedValue(undefined)}
+        onToggleEditor={vi.fn()}
+        onCloseEditor={vi.fn()}
+        cacheInitialized={true}
+      />
+    </AppDirtyProvider>
+  )
+}
+
+async function mountRow(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<Harness />)
+  })
+}
+
+async function clickLaunch(): Promise<void> {
+  const button = container.querySelector<HTMLButtonElement>(`button[aria-label="${LAUNCH_LABEL}"]`)
+  expect(button).not.toBeNull()
+  await act(async () => {
+    button!.click()
+  })
+}
+
+async function clickProfile(name: string): Promise<void> {
+  const option = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]')
+  ).find((button) => button.textContent?.includes(name))
+  expect(option).toBeDefined()
+  await act(async () => {
+    option!.click()
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  saveProfileSetMock.mockResolvedValue(undefined)
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount()
+  })
+  root = null
+  container.remove()
+})
+
+describe('a profile switch cannot reach the store while a launch is in flight (#843)', () => {
+  test('the bare save is never emitted while the launch promise is unsettled', async () => {
+    // Never resolved for the duration of the assertion: this is the exact span
+    // in which the main-process abort can still reach the sequence.
+    let settleLaunch: ((result: unknown) => void) | undefined
+    launchProfileMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleLaunch = resolve
+        })
+    )
+
+    await mountRow()
+    await clickLaunch()
+
+    await clickProfile('Race')
+
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+    expect(notifyMock).toHaveBeenCalledWith('Launch is settling. Try again shortly.', 'warn')
+
+    // Leave nothing hanging for the next test.
+    await act(async () => {
+      settleLaunch?.({ success: true, launchedCount: 1 })
+    })
+  })
+
+  // The half that stops "refuse everything" from passing. Without it, deleting
+  // the switch entirely would go green.
+  test('the same switch goes through once the launch has settled', async () => {
+    launchProfileMock.mockResolvedValue({ success: true, launchedCount: 1 })
+
+    await mountRow()
+    await clickLaunch()
+
+    await clickProfile('Race')
+
+    expect(saveProfileSetMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -123,7 +123,7 @@ let root: Root | null = null
  * only widens the closed window and has its own coverage in
  * `useLaunchBlock.test.tsx`.
  */
-function Harness() {
+function Harness({ isRunning = false }: { isRunning?: boolean }) {
   const [launching, setLaunching] = useState(false)
   const onLaunchStart = useCallback(() => setLaunching(true), [])
   const onLaunchEnd = useCallback(() => setLaunching(false), [])
@@ -133,9 +133,10 @@ function Harness() {
       <GameRow
         game={GAME}
         isActive={false}
-        // The whole point: the game is NOT running, which is the case that used
-        // to skip the diff branch and fall through to a bare save.
-        isRunning={false}
+        // Not running is the case that used to skip the diff branch and fall
+        // through to a bare save. Running is the case that reaches the save
+        // through a DIFFERENT set of awaits when the diff turns out empty.
+        isRunning={isRunning}
         isGameRunning={false}
         runningAppIcons={[]}
         hasClosableApps={false}
@@ -154,12 +155,12 @@ function Harness() {
   )
 }
 
-async function mountRow(): Promise<void> {
+async function mountRow(isRunning = false): Promise<void> {
   container = document.createElement('div')
   document.body.appendChild(container)
   await act(async () => {
     root = createRoot(container)
-    root.render(<Harness />)
+    root.render(<Harness isRunning={isRunning} />)
   })
 }
 
@@ -254,6 +255,48 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
 
     await act(async () => {
       settleProfileRead?.(PROFILE_SET)
+    })
+
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      settleLaunch?.({ success: true, launchedCount: 1 })
+    })
+  })
+
+  // The earlier re-check is not the last suspension on a RUNNING row. When the
+  // app diff comes back empty, `switchProfileApps` is skipped entirely, so
+  // main's own launch guard never runs, and `getProfileSwitchDiff` plus
+  // `onRunningStateRefresh` are both still awaited before the save. A launch
+  // starting in there arrives at the save unopposed (Codex on #864).
+  test('an empty diff on a running row does not carry the save past a new launch (#864)', async () => {
+    let settleDiff: ((value: unknown) => void) | undefined
+    getProfileSwitchDiffMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleDiff = resolve
+        })
+    )
+    let settleLaunch: ((result: unknown) => void) | undefined
+    launchProfileMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleLaunch = resolve
+        })
+    )
+
+    await mountRow(true)
+
+    // Parks on the diff read, having passed the first gate.
+    await clickProfile('Race')
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    await clickLaunch()
+
+    // Empty on both sides, which is what skips switchProfileApps and with it
+    // main's refusal.
+    await act(async () => {
+      settleDiff?.({ toStopCount: 0, toStartCount: 0 })
     })
 
     expect(saveProfileSetMock).not.toHaveBeenCalled()

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -121,6 +121,9 @@ const LAUNCH_LABEL = 'Launch Assetto Corsa: Default profile'
 
 let container: HTMLDivElement
 let root: Root | null = null
+// Set by the harness whenever a non-zero cooldown starts; calling it is the
+// test's stand-in for the cooldown timer firing.
+let expireCooldown: (() => void) | undefined
 
 /**
  * Stands in for GameList's `useLaunchBlock`: the lock goes true synchronously
@@ -137,7 +140,12 @@ function Harness({ isRunning = false }: { isRunning?: boolean }) {
   const [launching, setLaunching] = useState(false)
   const onLaunchStart = useCallback(() => setLaunching(true), [])
   const onLaunchEnd = useCallback((_key: string, cooldownMs?: number) => {
-    if (cooldownMs && cooldownMs > 0) return
+    if (cooldownMs && cooldownMs > 0) {
+      // Held, and released later, exactly as `useLaunchBlock` does. Modelling
+      // the cooldown as "held forever" is what hid the expiry case.
+      expireCooldown = () => setLaunching(false)
+      return
+    }
     setLaunching(false)
   }, [])
 
@@ -201,6 +209,7 @@ beforeEach(() => {
   getProfileRuntimeConfigMock.mockResolvedValue(PROFILE_SET)
   switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 1 })
   onRunningStateRefreshMock.mockResolvedValue(undefined)
+  expireCooldown = undefined
 })
 
 afterEach(async () => {
@@ -412,6 +421,63 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
     })
   })
 
+  // The other half of the same mistake. With a NON-zero cooldown the lock is
+  // genuinely still the switch's, right up until the cooldown runs out. If that
+  // happens while `onRunningStateRefresh` is still pending, the next launch
+  // takes a fresh lock and a boolean set once goes on claiming it (Codex P2 on
+  // #864, second time). Ownership has to expire with the lock, not with the
+  // switch.
+  test('ownership expires with the cooldown, not with the switch (#864)', async () => {
+    getProfileSwitchDiffMock.mockResolvedValue({ toStopCount: 1, toStartCount: 1 })
+    // Started something, so the switch holds the lock through a real cooldown.
+    switchProfileAppsMock.mockResolvedValue({ success: true, launchedCount: 1 })
+
+    let settleRefresh: (() => void) | undefined
+    onRunningStateRefreshMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          settleRefresh = () => resolve()
+        })
+    )
+    let settleLaunch: ((result: unknown) => void) | undefined
+    launchProfileMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleLaunch = resolve
+        })
+    )
+
+    await mountRow(true)
+    await clickProfile('Race')
+
+    const confirm = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Switch Profile')
+    )
+    await act(async () => {
+      confirm!.click()
+    })
+
+    expect(switchProfileAppsMock).toHaveBeenCalledTimes(1)
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    // The cooldown runs out while the refresh is still pending, and somebody
+    // takes the freed lock.
+    await act(async () => {
+      expireCooldown?.()
+    })
+    await clickLaunch()
+
+    await act(async () => {
+      settleRefresh?.()
+    })
+
+    expect(saveProfileSetMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      settleLaunch?.({ success: true, launchedCount: 1 })
+    })
+  })
+
   // The half that stops "refuse everything" from passing. Without it, deleting
   // the switch entirely would go green.
   //
@@ -454,10 +520,17 @@ test('the launch-lock mirror is committed synchronously (#864)', () => {
     join(process.cwd(), 'src/renderer/src/components/game-list/GameRow.tsx'),
     'utf8'
   )
-  const mirror = source.match(
-    /(useEffect|useLayoutEffect)\(\(\) => \{\s*isLaunchBlockedRef\.current = isLaunchBlocked/
-  )
+  // Located by walking back from the assignment to whichever effect encloses
+  // it, rather than by matching the effect's exact body. The body has already
+  // grown once (it counts lock releases now), and a shape-matching regex that
+  // silently stops matching is a test that quietly stops testing.
+  const assignment = source.indexOf('isLaunchBlockedRef.current = isLaunchBlocked')
+  expect(assignment).toBeGreaterThan(-1)
 
-  expect(mirror).not.toBeNull()
-  expect(mirror?.[1]).toBe('useLayoutEffect')
+  const enclosingEffect = source
+    .slice(0, assignment)
+    .match(/(useEffect|useLayoutEffect)\(\(\) => \{(?![\s\S]*?\}, \[[\s\S]*?\}, \[)/g)
+
+  expect(enclosingEffect).not.toBeNull()
+  expect(enclosingEffect?.[enclosingEffect.length - 1]).toContain('useLayoutEffect')
 })

--- a/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
+++ b/tests/renderer/gameRowSwitchDuringLaunch.test.tsx
@@ -26,6 +26,8 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import { act, useCallback, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 const notifyMock = vi.fn()
 const launchProfileMock = vi.fn()
@@ -370,4 +372,33 @@ describe('a profile switch cannot reach the store while a launch is in flight (#
 
     expect(saveProfileSetMock).toHaveBeenCalledTimes(1)
   })
+})
+
+/**
+ * A structural assertion, deliberately, because the behaviour it protects
+ * cannot be reached from a test in this environment.
+ *
+ * The hazard is a scheduling race: a passive effect is scheduled and may run
+ * after paint, while the switch continuation resumes on a microtask the moment
+ * its IPC settles. Lose that race and the continuation reads the lock from
+ * before the launch existed, which is the bug this whole file is about
+ * (CodeRabbit on #864).
+ *
+ * `act` flushes effects, so every behavioural test above commits the mirror
+ * before any continuation can resume. That is exactly why they all stayed green
+ * with the passive version, and why writing another one here would assert
+ * nothing. Pinning the shape is the honest option: it is the same approach
+ * `tests/main/guardedStart.test.ts` takes for its own timing invariant.
+ */
+test('the launch-lock mirror is committed synchronously (#864)', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/renderer/src/components/game-list/GameRow.tsx'),
+    'utf8'
+  )
+  const mirror = source.match(
+    /(useEffect|useLayoutEffect)\(\(\) => \{\s*isLaunchBlockedRef\.current = isLaunchBlocked/
+  )
+
+  expect(mirror).not.toBeNull()
+  expect(mirror?.[1]).toBe('useLayoutEffect')
 })


### PR DESCRIPTION
## Summary

- #843 is a regression this release introduced: `abortActiveLaunches` first appears in `ipc/config.ts` in `5367a4e`, which is PR #842. A profile switch during an in-flight launch could take down the whole sequence, and **the game never started**.
- This is the **containment**, one line in the renderer and zero lines in the process layer that 1.2.0 just rewrote and that #810 has now audited and frozen. The precise fix, per-entry abort scope, stays in #843 for 1.3.0.
- The gate at `GameRow.tsx` drops `isRunning &&`. A row whose game is not running skipped the diff branch and fell through to a bare `saveProfileSet`, and that save is the abort's only transport.

## Why this is agreement, not a new rule

Main already refuses this: `switch-profile-apps` bails on `isAnyLaunchActive() || hasOtherActiveLaunchControllers()`. Only the empty-diff fall-through was more permissive than the path beside it. The refusal is not silent either, it reuses the existing "Launch is settling. Try again shortly." toast.

## Why the launch cooldown does not enter into it

This was the part worth checking rather than assuming, because `POST_LAUNCH_BLOCK_MS` and the elevated grace window do not start at the same moment. They do not need to:

- `abortActiveLaunches` only reaches controllers still in `activeLaunchControllers`, and every one is unregistered in a `finally` when its sequence returns (`spawn.ts:641`, `ipc/launch.ts:151`). **After the launch IPC resolves the abort is a no-op**, so the dangerous span is exactly [IPC dispatched, IPC resolved].
- A pre-grace handoff cannot outlive its sequence: the grace timer registers the handoff *before* it resolves, and the loop awaits each entry. So a pending pre-grace handoff implies the IPC is still unresolved.
- Every launch initiator sets the flag synchronously *before* dispatching its IPC (`GameRow` launch, switch and relaunch, plus the editor launch). `isLaunchBlocked` is therefore true for a strict superset of the dangerous span.

## What this does NOT close

Both belong to fix A and are noted on the issue rather than left as prose here:

- a renderer reload mid-launch resets the flag while main is still mid-sequence
- deleting the active profile from the editor changes `activeProfileId` without passing this gate

Each needs a reload or a profile deletion inside the same few seconds as an in-flight launch and a pre-grace prompt.

## Visible change

During any in-flight launch the profile dropdown now refuses on **every** row, where before it refused only on rows whose game was running. Launches are seconds long and the toast explains it.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (clean, no warnings)
- [x] `npm run typecheck` (tsc, node, preload types)
- [x] `npm run build`
- [x] `npm run test` (868 passed, up from 866)
- [x] **Run red first against the unfixed gate**: with `isRunning && isLaunchBlocked` and a non-running row, the mid-flight save went through, which is the bug firing inside the harness. The test asserts the WINDOW rather than the gate's boolean: the launch promise is left deliberately unsettled and the question is whether the save can be emitted at all while it hangs.
- [x] Liveness half asserted too, so an implementation that refused every switch forever cannot go green
- [ ] Manual: start a launch on a row whose game is not running, and while it is still spinning try to switch that row's profile. It refuses with the settling toast. Once the launch settles, the same switch goes through.

Refs #843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented profile switching while a game launch is still settling.
  * Blocked profile saves when a competing launch starts during the switch process.
  * Preserved valid profile switching for already-running games and after launch activity completes.

* **Tests**
  * Added regression coverage for profile switching during launches, including blocked, allowed, and cooldown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->