### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simlauncher",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simlauncher",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@floating-ui/react": "^0.27.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlauncher",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "SimLauncher - Multi app launcher for simracing",
   "main": "out/main/index.js",
   "repository": {


### PR DESCRIPTION
## Summary

Bumps `1.1.0` to `1.2.0`. Version bump only, no behaviour change. CHANGELOG.md is a pointer to GitHub Releases by design, so the full notes go on the published release.

This lands **before** the smoke, not after, so the build being smoked identifies itself as 1.2.0. The About check and the `sbom.cdx.json` version check are both meaningless against a 1.1.0 artifact.

## What ships (53 commits since v1.1.0, 31 issues)

**New, all opt-in and all default OFF:**

- Companion apps close on their own when the sim exits, per profile (#204)
- Tray menu gets **Close Apps** back, across every profile (#519)
- Turning off *Track running indicator* now genuinely means fire and forget: apps start, nothing is recorded, nothing is closed (#591)
- Apps can be asked to close themselves before being force-killed, so a tool like SimHub can flush its layout (#659)

**The elevation and process-tracking wave.** This is where most of the release went:

- A same-named exe from another folder no longer speaks for a configured app: it faked already-running, then blamed elevation for an app it never started (#674)
- An ignored UAC prompt no longer parks the whole launch chain, or every other game launch, for two minutes (#675)
- Leaving a profile cancels the consent prompt its apps left behind, so approving it later cannot start a companion belonging to a profile you already left (#782)
- A cancelled handoff explains the dead prompt Windows leaves on screen instead of leaving it unexplained (#809)
- An all-profiles close stops attributing a shared companion to the wrong game (#772), and a companion can no longer clobber another entry by exe name (#677, #766)
- The row keeps a way to close leftover companions after a restart with the game closed (#673)
- A broken game path says `Game not found` instead of going silent (#794)
- A game exe that exits within 10s of launch shows an amber ring meaning "cannot tell", not a green dot asserting it is running (#737)

**Correctness and copy:**

- The launch summary no longer contradicts its own skip warning (#739)
- Settings stops being permanently dirty after a cleared or over-long custom app name (#711)
- Discard reverts the Windows login item instead of applying it on toggle (#676)
- Blocked buttons say why they are blocked rather than naming an action they cannot run (#830)
- A path pasted from Windows **Copy as path** is accepted instead of rejected for its quotes (#859)
- Em dashes removed from user-facing copy (#848)

**Structure and CI:**

- The config/profile domain model was three parallel copies, now one in `src/shared` (#692, the biggest Tauri-prep win so far)
- Launch cancellation centralized instead of a check at each await (#715), low-level Win32 kill helpers extracted (#773)
- `typecheck:tsc` was blind to `src/main` and `src/preload` (#752), and a flaky kill-failure test was silently failing CI on unrelated PRs (#751)
- A targeted audit pass over `src/main/processes` ran before this bump and filed no issues (#810)

**Dependencies:** #768, #770, #796, #802, #812.

## Not in this release, despite the milestone

- **#430** is closed as completed but did **not** ship. It was unified into #528 on 2026-08-05, and #528 sits in Future Releases. Do not list it in the release notes.
- **#843** is open in 1.3.0. Its containment shipped (PR #864); the precise fix did not.

## Do NOT publish yet

Merge, then run the pre-tag smoke on a local install per the 1.2.0 Smoke Run Sheet in internal-docs, then tag `v1.2.0`, then verify the signed draft installer and its auto-update artifacts, then publish.

## Test plan

- [x] `npm run format:check`
- [x] `npm run typecheck` (tsc, node, preload types)
- [x] `npm run test` (874 passed)
- [ ] The whole point of the bump: About reports 1.2.0 on the smoked build

Refs #204, #519, #591, #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->