### PR TITLE
chore(ci): require a smoke-check declaration on user-visible PRs (#892)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,9 @@ Closes #
 Tick exactly ONE box below and write the text after it.
 
 You are only asked this when the PR touches something a user can reach. A PR
-that changes only tests, docs, CI or tsconfig is not asked, and you can leave
-this section untouched — CI works that out from the diff, so there is nothing
-to declare and nothing to skip.
+that changes only tests, docs, CI, Markdown, editor dotfiles or tsconfig is not
+asked, and you can leave this section untouched: CI works that out from the
+diff, so there is nothing to declare and nothing to skip.
 
 This is the input to the next release's smoke run sheet. The delta section of
 `internal-docs/SimLauncher/QA/<version> Smoke Test.md` is built by reading these

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,34 @@ Closes #
 - [ ] Refactor / cleanup
 - [ ] Docs / config
 
+## Smoke check
+
+<!--
+Tick exactly ONE box below and write the text after it.
+
+You are only asked this when the PR touches something a user can reach. A PR
+that changes only tests, docs, CI or tsconfig is not asked, and you can leave
+this section untouched — CI works that out from the diff, so there is nothing
+to declare and nothing to skip.
+
+This is the input to the next release's smoke run sheet. The delta section of
+`internal-docs/SimLauncher/QA/<version> Smoke Test.md` is built by reading these
+blocks out of every PR merged since the last tag, so an in-scope PR without one
+is a coverage hole that nothing can see: the smoke document still looks complete.
+
+That is not hypothetical. #677 and #766 both shipped in 1.2.0 with no smoke check
+anywhere, because their PRs carried no note, and the gap sat in the same area
+where a real defect (#878) was later found by accident rather than by a check.
+
+"Needs no manual check" is a perfectly good answer for an internal refactor.
+Saying so explicitly is the point: it is the difference between "covered" and
+"nobody looked". It is also adjudicated against the diff at release time, so a
+wrong "needs none" gets named in the run-sheet closeout rather than never.
+-->
+
+- [ ] **Needs no manual check.** <!-- smoke:none --> Reason:
+- [ ] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like:
+
 ## Checklist
 
 - [ ] `npm run build` passes

--- a/.github/workflows/pr-smoke-note.yml
+++ b/.github/workflows/pr-smoke-note.yml
@@ -35,6 +35,13 @@ on:
       - reopened
       - synchronize
 
+# Body edits arrive in bursts, and sync-pr-closes.yml rewrites the body from a
+# push while this may be running. Without a group, an older run can report after
+# a newer one and leave a stale conclusion standing on the PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 
@@ -159,7 +166,10 @@ jobs:
               found.push({ ...opt, ticked, answer })
             }
 
-            if (found.length !== OPTIONS.length) {
+            // At least one marker, not both: deleting the option you did not
+            // pick is a normal way to tidy a PR body, and it must not read as a
+            // missing declaration.
+            if (found.length === 0) {
               return fail(
                 'The "Smoke check" section is missing from this PR body.',
                 '',
@@ -174,8 +184,13 @@ jobs:
               return fail(
                 'Tick one box in the "Smoke check" section.',
                 '',
-                '  - Needs no manual check  — nothing here changes what a user sees',
-                '  - Needs a manual check   — anything a user can see or feel',
+                // List only the options actually present, so a body that kept
+                // one option is not told to tick something it does not contain.
+                ...found.map((o) =>
+                  o.marker === 'smoke:none'
+                    ? '  - Needs no manual check  — nothing here changes what a user sees'
+                    : '  - Needs a manual check   — anything a user can see or feel'
+                ),
                 '',
                 "Both answers are fine. Recording which one is the requirement:",
                 "the next release's smoke checklist is built from these notes."

--- a/.github/workflows/pr-smoke-note.yml
+++ b/.github/workflows/pr-smoke-note.yml
@@ -1,0 +1,209 @@
+name: PR smoke note
+
+# A PR that can change what a user sees must declare whether it needs a manual
+# smoke check, so the next release's smoke coverage is driven by what shipped
+# rather than by whoever remembered to write a note.
+#
+# Why this exists: the delta section of the per-release smoke document is built
+# by reading manual-check notes out of merged PRs. In the 1.2.0 milestone, #677
+# and #766 shipped with no check anywhere in either QA document because their
+# PRs carried no note, and nothing flagged the absence — the smoke document
+# looked complete. Both were user-visible, and both sat in the area where a real
+# defect (#878) was later found by accident instead of by a check.
+#
+# ⚠️ This gate produces CONTENT, not coverage. The authority on whether a
+# release was actually covered is the `simlauncher-smoke` skill's phase A1: every
+# closed issue in the milestone, grepped against both QA documents, bucketed as
+# covered / waived / gap. Where the two disagree, A1 wins. Two sources of truth
+# for the run sheet is itself a way for this to rot, so the blocks below feed the
+# run sheet, they do not certify it.
+#
+# The gate is deliberately shallow. It checks that a decision was RECORDED, not
+# that the decision was good; only a human reading the diff can judge that, and
+# the run-sheet closeout is where a wrong "needs none" gets named.
+#
+# `pull_request_target` (matching pr-title.yml) so the gate also fires when the
+# body is edited after opening, which is when most people fill this in. Nothing
+# from the PR is ever checked out or executed here — this job reads the event
+# payload and the changed-file list, and treats both strictly as data — which is
+# what keeps that trigger safe.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  smoke-note:
+    runs-on: ubuntu-latest
+    # Bot PRs are exempt: Dependabot writes its own body from a template we do
+    # not control, and a red check that cannot be satisfied only teaches us to
+    # ignore red checks.
+    #
+    # ⚠️ That exemption has one real hole, and it is handled in the smoke skill
+    # rather than here: dependabot.yml isolates the electron stack into its own
+    # grouped PR precisely because a major bump needs a real-launch smoke and a
+    # signed-build check (#634). So the electron dependency PR is the one bot PR
+    # that always needs a check, and `simlauncher-smoke` phase A1 carries a
+    # standing entry for it when building the run sheet.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
+    steps:
+      - name: Require a smoke-check declaration
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request
+
+            // --- 1. Is this PR even in scope? -----------------------------
+            //
+            // The default is COMPUTED from the diff rather than typed by the
+            // author. This is the part that keeps the box from becoming a
+            // ritual: on the 1.2.0 milestone, 11 of the 13 issues without a
+            // check legitimately needed none, so a gate that fires on every PR
+            // would train the "no check needed" reflex on the majority of PRs
+            // where ticking it is correct — and that trained reflex is exactly
+            // what would fire on the one PR where it is wrong.
+            //
+            // A PR that touches ONLY these paths cannot change what a user sees
+            // at runtime, so it is not asked. Anything else is.
+            const EXEMPT = [
+              /^tests\//,
+              /^docs\//,
+              /^\.github\//,
+              /\.md$/,
+              /^tsconfig(\.\w+)?\.json$/,
+              /^\.(gitignore|gitattributes|editorconfig|prettierrc.*|npmrc)$/,
+              /^\.vscode\//
+            ]
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            })
+
+            const inScope = files
+              .map((f) => f.filename)
+              .filter((name) => !EXEMPT.some((re) => re.test(name)))
+
+            // A release PR is a version bump and a lockfile. Its smoke is the
+            // entire run that precedes the tag, not a per-PR note.
+            const isRelease = /^chore\(release\):/.test(pr.title || '')
+
+            if (isRelease) {
+              core.info('Release PR — the smoke run itself is the check. Skipping.')
+              return
+            }
+
+            if (files.length > 0 && inScope.length === 0) {
+              core.info(
+                `Out of scope: ${files.length} file(s), none outside tests/docs/CI. No declaration needed.`
+              )
+              return
+            }
+
+            // --- 2. In scope: a decision has to be on the record ------------
+            //
+            // Key on the HTML markers, never on the prose around them, so the
+            // template wording can be rewritten without breaking this gate.
+            // Same convention as the <!-- auto-closes --> block that
+            // sync-pr-closes.yml maintains in this same body.
+            const OPTIONS = [
+              { marker: 'smoke:none', label: 'Needs no manual check' },
+              { marker: 'smoke:check', label: 'Needs a manual check' }
+            ]
+
+            const scope = `Touches ${inScope.length} file(s) outside tests/docs/CI, e.g. ${inScope
+              .slice(0, 3)
+              .join(', ')}.`
+
+            const fail = (...lines) => core.setFailed([...lines, '', scope].join('\n'))
+
+            const lines = (pr.body || '').split(/\r?\n/)
+            const found = []
+
+            for (const opt of OPTIONS) {
+              const index = lines.findIndex(
+                (line) => line.includes(opt.marker) && /^\s*[-*]\s*\[[ xX]\]/.test(line)
+              )
+              if (index === -1) continue
+
+              const ticked = /^\s*[-*]\s*\[[xX]\]/.test(lines[index])
+
+              // The author's text may sit after the marker on the same line, or
+              // continue on the lines below it until the next checkbox or the
+              // next heading. Both shapes are accepted, because a real check
+              // description does not fit on one line.
+              let text = lines[index].split(opt.marker)[1] || ''
+              text = text.replace(/-->/, '')
+              for (let i = index + 1; i < lines.length; i++) {
+                if (/^\s*[-*]\s*\[[ xX]\]/.test(lines[i]) || /^\s*#{1,6}\s/.test(lines[i])) break
+                text += '\n' + lines[i]
+              }
+
+              // Strip the template's own prompt words and any HTML comments, so
+              // an untouched template does not read as a filled-in answer.
+              const answer = text
+                .replace(/<!--[\s\S]*?-->/g, '')
+                .replace(/^\s*(Reason|What to do, and what a correct result looks like)\s*:/i, '')
+                .trim()
+
+              found.push({ ...opt, ticked, answer })
+            }
+
+            if (found.length !== OPTIONS.length) {
+              return fail(
+                'The "Smoke check" section is missing from this PR body.',
+                '',
+                'Paste it back from .github/pull_request_template.md, tick exactly one',
+                'box, and write the text after it.'
+              )
+            }
+
+            const ticked = found.filter((o) => o.ticked)
+
+            if (ticked.length === 0) {
+              return fail(
+                'Tick one box in the "Smoke check" section.',
+                '',
+                '  - Needs no manual check  — nothing here changes what a user sees',
+                '  - Needs a manual check   — anything a user can see or feel',
+                '',
+                "Both answers are fine. Recording which one is the requirement:",
+                "the next release's smoke checklist is built from these notes."
+              )
+            }
+
+            if (ticked.length > 1) {
+              return fail(
+                'Tick exactly one box in the "Smoke check" section, not both.',
+                '',
+                'A change that is partly invisible and partly not needs a check,',
+                'so tick "Needs a manual check" and describe only the visible half.'
+              )
+            }
+
+            const [choice] = ticked
+
+            if (!choice.answer) {
+              return fail(
+                `"${choice.label}" is ticked but says nothing.`,
+                '',
+                choice.marker === 'smoke:none'
+                  ? 'Write the reason after it, e.g. "internal refactor, no behaviour reaches the UI".'
+                  : 'Write what to do and what a correct result looks like, precisely enough' +
+                    '\nthat someone else can judge pass or fail without asking you.',
+                '',
+                'A check that says "verify it works" cannot be run by anyone but its author.'
+              )
+            }
+
+            core.info(`${choice.label}: ${choice.answer.replace(/\s+/g, ' ').slice(0, 200)}`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Electron desktop app for simracing enthusiasts — React + TypeScript + Tailwind
 - Commit messages MUST reference an issue (`#N`); a `docs:` subject line is exempt
 - Hook at [`.githooks/commit-msg`](.githooks/commit-msg) enforces only that reference, not the commit format
 - Conventional Commits are enforced on the PR title by [`.github/workflows/pr-title.yml`](.github/workflows/pr-title.yml)
-- A PR touching anything outside `tests/`, `docs/`, `.github/` and tsconfig must tick one box in the **Smoke check** section of [`.github/pull_request_template.md`](.github/pull_request_template.md), enforced by [`.github/workflows/pr-smoke-note.yml`](.github/workflows/pr-smoke-note.yml). `Needs no manual check` is a normal answer, but **it is adjudicated against the diff at release time and a wrong one is named in the smoke closeout**, so write the honest reason rather than the one that goes green
+- A PR touching anything outside `tests/`, `docs/`, `.github/`, Markdown files, editor and tooling dotfiles, and tsconfig must tick one box in the **Smoke check** section of [`.github/pull_request_template.md`](.github/pull_request_template.md), enforced by [`.github/workflows/pr-smoke-note.yml`](.github/workflows/pr-smoke-note.yml). `Needs no manual check` is a normal answer, but **it is adjudicated against the diff at release time and a wrong one is named in the smoke closeout**, so write the honest reason rather than the one that goes green
 
 ## Architecture Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Electron desktop app for simracing enthusiasts — React + TypeScript + Tailwind
 - Commit messages MUST reference an issue (`#N`); a `docs:` subject line is exempt
 - Hook at [`.githooks/commit-msg`](.githooks/commit-msg) enforces only that reference, not the commit format
 - Conventional Commits are enforced on the PR title by [`.github/workflows/pr-title.yml`](.github/workflows/pr-title.yml)
+- A PR touching anything outside `tests/`, `docs/`, `.github/` and tsconfig must tick one box in the **Smoke check** section of [`.github/pull_request_template.md`](.github/pull_request_template.md), enforced by [`.github/workflows/pr-smoke-note.yml`](.github/workflows/pr-smoke-note.yml). `Needs no manual check` is a normal answer, but **it is adjudicated against the diff at release time and a wrong one is named in the smoke closeout**, so write the honest reason rather than the one that goes green
 
 ## Architecture Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Three-process Electron app:
 
 **Tailwind:** v4 via `@tailwindcss/vite` — no `tailwind.config.js`. Custom tokens go in `@theme {}` blocks in `App.css`.
 
-**Tests:** Vitest with two named projects — `renderer` (jsdom, `tests/renderer/**`) and `main` (node, `tests/main/**`). Tests in `tests/main/` can't use browser APIs; tests in `tests/renderer/` can't import Electron modules.
+**Tests:** Vitest with three named projects — `renderer` (jsdom, `tests/renderer/**`), `main` (node, `tests/main/**`) and `ci` (node, `tests/ci/**`). Tests in `tests/main/` can't use browser APIs; tests in `tests/renderer/` can't import Electron modules. `tests/ci/` is for repo tooling rather than the app: it exercises files under `.github/`, so it belongs to neither of the other two.
 
 **electron-store in tests:** requires `projectName: 'SimLauncher'` in the constructor (already set in `store.ts`). Without it, electron-store throws in a non-Electron test environment.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Three-process Electron app:
 
 **electron-store in tests:** requires `projectName: 'SimLauncher'` in the constructor (already set in `store.ts`). Without it, electron-store throws in a non-Electron test environment.
 
-**Commit messages** must reference an issue (`#N`), which the `.githooks/commit-msg` hook enforces; a `docs:` subject line is exempt. Conventional Commits are enforced on the **PR title** by `.github/workflows/pr-title.yml`, not on individual commits. A PR touching anything outside `tests/`, `docs/`, `.github/` and tsconfig must also tick one box in the **Smoke check** section of the PR template, enforced by `.github/workflows/pr-smoke-note.yml`; that block is what the next release's manual smoke checklist is built from. `Needs no manual check` is a normal answer, but it is adjudicated against the diff at release time and a wrong one is named in the smoke closeout, so write the honest reason rather than the one that goes green.
+**Commit messages** must reference an issue (`#N`), which the `.githooks/commit-msg` hook enforces; a `docs:` subject line is exempt. Conventional Commits are enforced on the **PR title** by `.github/workflows/pr-title.yml`, not on individual commits. A PR touching anything outside `tests/`, `docs/`, `.github/`, Markdown files, editor and tooling dotfiles, and tsconfig must also tick one box in the **Smoke check** section of the PR template, enforced by `.github/workflows/pr-smoke-note.yml`; that block is what the next release's manual smoke checklist is built from. `Needs no manual check` is a normal answer, but it is adjudicated against the diff at release time and a wrong one is named in the smoke closeout, so write the honest reason rather than the one that goes green.
 
 ## Code documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Three-process Electron app:
 
 **electron-store in tests:** requires `projectName: 'SimLauncher'` in the constructor (already set in `store.ts`). Without it, electron-store throws in a non-Electron test environment.
 
-**Commit messages** must reference an issue (`#N`), which the `.githooks/commit-msg` hook enforces; a `docs:` subject line is exempt. Conventional Commits are enforced on the **PR title** by `.github/workflows/pr-title.yml`, not on individual commits.
+**Commit messages** must reference an issue (`#N`), which the `.githooks/commit-msg` hook enforces; a `docs:` subject line is exempt. Conventional Commits are enforced on the **PR title** by `.github/workflows/pr-title.yml`, not on individual commits. A PR touching anything outside `tests/`, `docs/`, `.github/` and tsconfig must also tick one box in the **Smoke check** section of the PR template, enforced by `.github/workflows/pr-smoke-note.yml`; that block is what the next release's manual smoke checklist is built from. `Needs no manual check` is a normal answer, but it is adjudicated against the diff at release time and a wrong one is named in the smoke closeout, so write the honest reason rather than the one that goes green.
 
 ## Code documentation
 

--- a/tests/ci/prSmokeNote.test.ts
+++ b/tests/ci/prSmokeNote.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Guards the parsing and scoping logic inside `.github/workflows/pr-smoke-note.yml`.
+ *
+ * The script is extracted from the YAML at test time rather than copied here, so
+ * these cases cannot drift from what CI actually runs: editing the workflow and
+ * forgetting the test is the failure mode this is built to prevent, and a copied
+ * script would silently pass while the real one broke.
+ */
+
+const repoFile = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8')
+
+const WORKFLOW = repoFile('.github/workflows/pr-smoke-note.yml')
+const TEMPLATE = repoFile('.github/pull_request_template.md')
+
+const SCRIPT = (() => {
+  const marker = '          script: |\n'
+  const start = WORKFLOW.indexOf(marker)
+  if (start === -1) {
+    throw new Error(
+      'Could not find the `script: |` block in pr-smoke-note.yml. If the workflow was ' +
+        'restructured, update this extractor rather than deleting the test.'
+    )
+  }
+  return WORKFLOW.slice(start + marker.length)
+    .split(/\r?\n/)
+    .map((line) => (line.startsWith('            ') ? line.slice(12) : line))
+    .join('\n')
+})()
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+  ...args: string[]
+) => (...args: unknown[]) => Promise<void>
+
+interface RunInput {
+  body: string
+  files?: string[]
+  title?: string
+}
+
+/** Runs the real workflow script and returns the failure message, or null on pass. */
+async function run({
+  body,
+  files = ['src/main/index.ts'],
+  title = 'fix: something (#1)'
+}: RunInput): Promise<string | null> {
+  let failure: string | null = null
+  const core = {
+    setFailed: (message: string) => {
+      failure = message
+    },
+    info: () => {}
+  }
+  const github = {
+    paginate: async () => files.map((filename) => ({ filename })),
+    rest: { pulls: { listFiles: 'listFiles' } }
+  }
+  const context = {
+    repo: { owner: 'Stashpeak', repo: 'SimLauncher' },
+    payload: { pull_request: { body, number: 1, title } }
+  }
+  await new AsyncFunction('core', 'context', 'github', SCRIPT)(core, context, github)
+  return failure
+}
+
+const tick = (body: string, marker: string): string =>
+  body
+    .split(/\r?\n/)
+    .map((line) => (line.includes(marker) ? line.replace(/\[ \]/, '[x]') : line))
+    .join('\n')
+
+const answer = (body: string, marker: string, text: string): string =>
+  body
+    .split(/\r?\n/)
+    .map((line) => (line.includes(marker) ? `${line.replace(/\s*$/, '')} ${text}` : line))
+    .join('\n')
+
+const filled = (marker: string, text: string): string =>
+  answer(tick(TEMPLATE, marker), marker, text)
+
+const dropOption = (body: string, marker: string): string =>
+  body
+    .split(/\r?\n/)
+    .filter((line) => !line.includes(marker))
+    .join('\n')
+
+const AUTO_CLOSES = '\n\n<!-- auto-closes -->\nCloses #123\n<!-- auto-closes -->'
+const SRC = ['src/renderer/src/components/GameList.tsx', 'tests/renderer/GameList.test.tsx']
+
+describe('pr-smoke-note gate', () => {
+  describe('in scope, a declaration is required', () => {
+    it.each([
+      ['the template is untouched', { body: TEMPLATE, files: SRC }],
+      ['the section was deleted', { body: '## Summary\n\nrenamed a var\n', files: SRC }],
+      ['the body is empty', { body: '', files: SRC }],
+      [
+        'both boxes are ticked',
+        {
+          body: answer(tick(tick(TEMPLATE, 'smoke:none'), 'smoke:check'), 'smoke:none', 'x'),
+          files: SRC
+        }
+      ],
+      ['"needs none" is ticked with no reason', { body: tick(TEMPLATE, 'smoke:none'), files: SRC }],
+      [
+        '"needs a check" is ticked with no text',
+        { body: tick(TEMPLATE, 'smoke:check'), files: SRC }
+      ]
+    ])('fails when %s', async (_name, input) => {
+      expect(await run(input)).not.toBeNull()
+    })
+
+    it.each([
+      ['packaging', ['electron-builder.yml']],
+      ['a dependency bump', ['package.json']],
+      ['build scripts', ['scripts/generate.mjs']],
+      ['one src file among exempt ones', ['tests/a.test.ts', 'README.md', 'src/main/kill.ts']]
+    ])('treats %s as in scope', async (_name, files) => {
+      expect(await run({ body: TEMPLATE, files })).not.toBeNull()
+    })
+  })
+
+  describe('in scope, a filled declaration passes', () => {
+    it.each([
+      [
+        '"needs none" with a reason',
+        filled('smoke:none', 'internal refactor, nothing reaches the UI')
+      ],
+      [
+        '"needs a check" with instructions',
+        filled('smoke:check', 'Launch a profile; the strip shows companions only.')
+      ],
+      [
+        'the answer written on the following line',
+        tick(TEMPLATE, 'smoke:check').replace(
+          /(<!-- smoke:check -->.*)$/m,
+          '$1\n      Change the accent, restart, it must persist.'
+        )
+      ],
+      ['a CRLF body', filled('smoke:none', 'refactor').replace(/\n/g, '\r\n')],
+      ['asterisk bullets', filled('smoke:none', 'refactor').replace(/^- \[/gm, '* [')],
+      ['an uppercase [X]', filled('smoke:none', 'refactor').replace('[x]', '[X]')]
+    ])('passes with %s', async (_name, body) => {
+      expect(await run({ body, files: SRC })).toBeNull()
+    })
+
+    it('survives the auto-closes block that sync-pr-closes.yml appends', async () => {
+      expect(
+        await run({ body: filled('smoke:none', 'CI only') + AUTO_CLOSES, files: SRC })
+      ).toBeNull()
+    })
+
+    it('accepts a body where the unchosen option was deleted', async () => {
+      const body = dropOption(filled('smoke:check', 'Launch a profile and close it.'), 'smoke:none')
+      expect(body).not.toContain('smoke:none')
+      expect(await run({ body, files: SRC })).toBeNull()
+    })
+
+    it('still fails when the only remaining option is unticked', async () => {
+      const body = dropOption(TEMPLATE, 'smoke:none')
+      expect(await run({ body, files: SRC })).not.toBeNull()
+    })
+  })
+
+  describe('out of scope, nothing is asked', () => {
+    it.each([
+      ['tests only', ['tests/main/kill.test.ts']],
+      ['docs only', ['README.md', 'CHANGELOG.md']],
+      ['CI only', ['.github/workflows/ci.yml']],
+      ['tsconfig only', ['tsconfig.json']],
+      ['editor and tooling dotfiles', ['.gitignore', '.prettierrc.json', '.vscode/settings.json']],
+      ['a mix of exempt paths', ['tests/main/a.test.ts', 'docs/x.md', '.github/dependabot.yml']]
+    ])('passes an untouched template for %s', async (_name, files) => {
+      expect(await run({ body: TEMPLATE, files })).toBeNull()
+    })
+  })
+
+  describe('release PRs', () => {
+    it('are exempt, because their check is the smoke run that precedes the tag', async () => {
+      const result = await run({
+        body: TEMPLATE,
+        files: ['package.json', 'package-lock.json'],
+        title: 'chore(release): v1.2.1'
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('the template itself', () => {
+    it('carries both markers as unticked checkboxes', () => {
+      for (const marker of ['smoke:none', 'smoke:check']) {
+        const line = TEMPLATE.split(/\r?\n/).find((l) => l.includes(marker))
+        expect(line, `template is missing ${marker}`).toBeDefined()
+        expect(line).toMatch(/^\s*[-*]\s*\[ \]/)
+      }
+    })
+
+    it('keeps the sections the template had before the smoke block was added', () => {
+      for (const heading of ['## What does this PR do?', '## Checklist', '## Screenshots']) {
+        expect(TEMPLATE).toContain(heading)
+      }
+      expect(TEMPLATE.startsWith('Closes #')).toBe(true)
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ const rendererTests = [
   'tests/renderer/**/*.test.tsx'
 ]
 const mainProcessTests = ['tests/electronApiSurface.test.ts', 'tests/main/**/*.test.ts']
+// Repo-tooling tests: they exercise files under .github/, not the app, so they
+// get their own project rather than pretending to be main-process tests.
+const ciTests = ['tests/ci/**/*.test.ts']
 
 export default defineConfig({
   test: {
@@ -26,6 +29,9 @@ export default defineConfig({
           },
           pool: 'vmThreads'
         }
+      },
+      {
+        test: { name: 'ci', environment: 'node', include: ciTests, pool: 'vmThreads' }
       }
     ]
   }


### PR DESCRIPTION
Closes #892

## What does this PR do?

Makes a PR that can change what a user reaches declare whether it needs a manual smoke check, so the next release's smoke coverage is driven by what shipped instead of by whoever remembered to write a note.

`#677` and `#766` shipped in 1.2.0 with zero smoke checks anywhere in either QA document, and nothing flagged the absence: a smoke document with a hole in it looks complete. Both were user-visible, and both sat in the area where `#878` was later found by unscripted poking rather than by a check.

**The scope rule is the part that matters.** The requirement is computed from the diff, not asked of everyone. A PR touching only `tests/`, `docs/`, `.github/`, `*.md` or tsconfig is never asked. On 1.2.0, 11 of the 13 uncovered issues legitimately needed no check, so a gate firing on every PR would train the "no check needed" reflex on the majority of PRs where ticking it is correct, and that trained reflex is exactly what would fire on the one PR where it is wrong.

This produces **content, not coverage**. The authority on whether a release was covered stays the `simlauncher-smoke` skill's phase A1 grep of the milestone's closed issues; where the two disagree, A1 wins.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / config

## Smoke check

- [x] **Needs no manual check.** <!-- smoke:none --> Reason: this PR touches only `.github/` and two markdown files, so it is out of scope by its own rule and the gate skips it. Nothing in the app changes.
- [ ] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like:

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] Tested manually

## Test plan

The gate's script is extracted **straight out of the YAML at test time** rather than copied, so the tests cannot drift from what CI runs. 23 fixtures, and the red cases were confirmed red before the green ones were trusted:

**Must fail (10):** untouched template · section deleted · empty body · both boxes ticked · `smoke:none` ticked with no reason · `smoke:check` ticked with no text · a packaging change · a dependency bump · a `scripts/` change · one `src/` file among otherwise exempt ones.

**Must pass (13):** each option filled · answer written on the line below the checkbox · CRLF body · `*` bullets · `[X]` · a body with `sync-pr-closes.yml`'s `<!-- auto-closes -->` block appended · tests-only · docs-only · CI-only · tsconfig-only · combinations of those · `chore(release):` untouched.

- [x] All 23 behave as intended
- [x] `npm run format:check`
- [x] Workflow YAML parses; triggers, permissions and the job condition verified against `pr-title.yml`'s shape

⚠️ **Known residual, corrected after opening this PR.** I first wrote that this PR's own run would at least exercise the *skip* path. It does not: `pull_request_target` executes the workflow definition from the **base branch**, so a workflow a PR introduces never runs on that PR. Confirmed on this branch, where only `PR title` ran as `pull_request_target` and `PR smoke note` is absent from the run list entirely.

So the live behaviour of this workflow is **unverified on GitHub** until it is on `main`. What is verified is the script's logic, against the 23 fixtures above, driven out of the YAML itself. What is not verified is the one runtime call the harness stubs: `github.paginate(github.rest.pulls.listFiles, ...)`. That is the documented `actions/github-script` pattern and `@v9` is already used by `sync-pr-closes.yml` in this repo, but it has not executed.

**Therefore, right after merge:** open a throwaway PR touching one file under `src/` with the section left untouched, confirm the check goes red with the intended message, then fill the box and confirm it goes green, then close it. That is the first real proof and it should not be skipped.

## Screenshots

<!-- No UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pull request Smoke check section with options to indicate whether manual verification is needed.
  * Added automated validation to ensure applicable pull requests provide exactly one valid Smoke check response.

* **Documentation**
  * Updated contributor guidance to explain the Smoke check requirement, scope, and release verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->