### PR TITLE
chore(scripts): check whether the code that closed an issue is still in the tag (#903)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,7 @@ vite.config.ts.timestamp-*
 .jules/
 .Jules/
 pnpm-lock.yaml
+
+# scripts/survived.py is the only Python here, and importing it leaves a
+# __pycache__ beside it that would otherwise show up as an untracked dir.
+__pycache__/

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -180,14 +180,14 @@ def survives(ref, path, lines):
     blob = git("show", "%s:%s" % (ref, path), allow_fail=True)
     pool = {}
     if blob:
-        for i, l in enumerate(blob.split("\n"), 1):
-            s = l.strip()
+        for i, existing in enumerate(blob.split("\n"), 1):
+            s = existing.strip()
             if s:
                 pool.setdefault(s, []).append(str(i))
 
     kept = 0
-    for l in lines:
-        occurrences = pool.get(l)
+    for line in lines:
+        occurrences = pool.get(line)
         if occurrences:
             occurrences.pop()
             kept += 1
@@ -214,17 +214,21 @@ def report(ref, pr):
     # conclusive. They stay in the report, out of the verdict.
     src_live = src_tot = 0
     notes = []
+    examined = []
     escalate = False
     for path, lines in sorted(files.items()):
         kept, lost = survives(ref, path, lines)
         n = len(lines)
         kind = classify(path)
+        row = "      [%s] %-46s %d/%d live" % (kind, path, kept, n)
+        if lost:
+            row += ", %d LOST" % lost
+        examined.append(row)
         if kind == "SRC ":
             src_live += kept
             src_tot += n
         if lost:
-            notes.append("      [%s] %-46s %d/%d live, %d LOST"
-                         % (kind, path, kept, n, lost))
+            notes.append(row)
             # A STRICT majority gone, not a total wipe, and not exactly half:
             # `>=` escalated a 5-of-10 partial loss, which is not a majority.
             #
@@ -238,11 +242,16 @@ def report(ref, pr):
     # No source lines means this tool has no opinion, and it has to SAY so.
     # Printing "ok ... 0/0 live (100%)" is the same failure as a self-test that
     # passes without running: it certifies precisely what it never looked at.
+    #
+    # This branch lists EVERY file it looked at, losses or not, which the normal
+    # report deliberately does not. When the tool declines to judge, the reader
+    # has to be able to check that it was right to decline, and "tests/generated
+    # only" is a claim about files it does not otherwise name.
     if not src_tot:
         print("PR #%-4s  %s  no source lines to judge (tests/generated only)"
               % (pr, sha[:7]))
-        for note in notes:
-            print(note)
+        for row in examined:
+            print(row)
         return
 
     # The same small-sample floor the per-file rule already carries. Without it

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -85,6 +85,32 @@ TRIVIAL = re.compile(
 
 TEST_PATH = re.compile(r"(^|/)(tests?|__tests__|__mocks__)/|\.(test|spec)\.[jt]sx?$")
 
+# Generated files and prose are reported but never judged. A lockfile is
+# rewritten wholesale by npm and a document is rewritten by hand, so neither
+# says anything about whether the FIX survived, and both are big enough to
+# decide the aggregate on their own. Measured at 3a4ada1: PR #703 read 5% live
+# because package-lock.json contributed 222 of its 227 lines, and PR #728
+# escalated on 11 deleted CONTRIBUTING.md lines while its real source loss was
+# 4. Both are routine cleanup, and both are exactly the false alarm this tool
+# exists to avoid.
+#
+# A blocklist, deliberately. An allowlist of known code extensions would fail
+# SILENT on an unlisted one, reporting "ok" for a fix that was deleted, which
+# is the failure this tool was written to catch. A blocklist fails the other
+# way: an unknown generated file makes noise that a human dismisses in a glance.
+GENERATED = re.compile(
+    r"(^|/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$|\.(md|lock|snap)$"
+)
+
+
+def classify(path):
+    """`SRC ` counts toward the verdict. `test` and `gen ` are reported only."""
+    if TEST_PATH.search(path):
+        return "test"
+    if GENERATED.search(path):
+        return "gen "
+    return "SRC "
+
 
 def is_substantive(body):
     stripped = body.strip()
@@ -184,14 +210,13 @@ def report(ref, pr):
     for path, lines in sorted(files.items()):
         kept, lost = survives(ref, path, lines)
         n = len(lines)
-        test = bool(TEST_PATH.search(path))
-        if not test:
+        kind = classify(path)
+        if kind == "SRC ":
             src_live += kept
             src_tot += n
         if lost:
-            tag = "test" if test else "SRC "
             notes.append("      [%s] %-46s %d/%d live, %d LOST"
-                         % (tag, path, kept, n, lost))
+                         % (kind, path, kept, n, lost))
             # A STRICT majority gone, not a total wipe, and not exactly half:
             # `>=` escalated a 5-of-10 partial loss, which is not a majority.
             #
@@ -199,28 +224,49 @@ def report(ref, pr):
             # single incidental match was enough to disarm it on the real #519
             # loss. The selftest caught that, which is the whole argument for
             # having one: the fix that introduced it was itself a correct fix.
-            if not test and lost >= 5 and lost * 2 > n:
+            if kind == "SRC " and lost >= 5 and lost * 2 > n:
                 escalate = True
 
-    pct = 100.0 * src_live / src_tot if src_tot else 100.0
-    if src_tot and pct < 50:
+    # No source lines means this tool has no opinion, and it has to SAY so.
+    # Printing "ok ... 0/0 live (100%)" is the same failure as a self-test that
+    # passes without running: it certifies precisely what it never looked at.
+    if not src_tot:
+        print("PR #%-4s  %s  no source lines to judge (tests/generated only)"
+              % (pr, sha[:7]))
+        for note in notes:
+            print(note)
+        return
+
+    # The same small-sample floor the per-file rule already carries. Without it
+    # a 5-line source footprint escalates on 3 lines: PR #703 is a dependency
+    # bump whose only source lines are 3 in package.json, which the NEXT bump
+    # rewrites by definition. A fix that small is caught by the per-file rule
+    # or not at all, so the aggregate has nothing to add below this size.
+    pct = 100.0 * src_live / src_tot
+    if src_tot >= 10 and pct < 50:
         escalate = True
     verdict = "!! ADJUDICATE" if escalate else "ok           "
     print("PR #%-4s  %s  %s  src %d/%d live (%.0f%%)"
           % (pr, sha[:7], verdict, src_live, src_tot, pct))
-    for n in notes:
-        print(n)
+    for note in notes:
+        print(note)
 
 
+# Every ref below is immutable. These started on `origin/main`, which drifts:
+# a later legitimate refactor touching lines these PRs added would fail the
+# suite with nothing wrong in this script, and the answer changed with how
+# recently the clone had fetched, so two people could run it and disagree.
+# A tag where one exists, a full commit id where none does: #893 landed one
+# commit after v1.2.0 was cut, so it has no tag to hang on.
 SELFTEST = [
     # (ref, pr, must_escalate, why)
     ("v1.1.0", "536", True,
      "the #519 loss as it stood: closeApps.ts deleted by #557, not yet re-landed"),
-    ("origin/main", "536", False,
+    ("v1.2.0", "536", False,
      "same PR after #819 re-landed it"),
-    ("origin/main", "893", False,
+    ("3a4ada1cf91c22f9f5897096299225843103ca34", "893", False,
      "healthy control, nothing removed"),
-    ("origin/main", "819", False,
+    ("v1.2.0", "819", False,
      "false-positive control: reported 0/9 on kill.ts while all nine were JSDoc"),
 ]
 

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -104,16 +104,46 @@ def added_lines(sha):
     return {f: v for f, v in by_file.items() if v}
 
 
-def survives(ref, path, lines):
+def find_elsewhere(ref, line, exclude_path, claimed):
+    """One unclaimed whole-line occurrence of `line` outside `exclude_path`, or None.
+
+    Exactness and consume-once both matter here, and neither is free.
+    `git grep -F --quiet` answers "does this appear anywhere", which is a
+    substring test that also never runs out: a genuinely deleted line reads as
+    moved because it is contained in some longer line, and two deleted copies
+    both point at one survivor. Reporting a deletion as a move is the failure
+    that hides the #519 class, so the match is compared stripped and whole, and
+    each target occurrence is claimed by at most one source line.
+
+    `-e` is not decoration: a substantive line beginning with `-`, which is
+    every CSS custom property in this repo, is otherwise parsed as an option
+    and the resulting failure would be swallowed into a false loss.
+    """
+    out = git("grep", "-n", "-F", "-e", line, ref, allow_fail=True)
+    if not out:
+        return None
+    for hit in out.split("\n"):
+        # <ref>:<path>:<lineno>:<text>
+        parts = hit.split(":", 3)
+        if len(parts) < 4:
+            continue
+        _, path, lineno, text = parts
+        if path == exclude_path or text.strip() != line:
+            continue
+        key = (path, lineno)
+        if key in claimed:
+            continue
+        claimed.add(key)
+        return key
+    return None
+
+
+def survives(ref, path, lines, claimed):
     """(kept, moved, lost) for these lines at ref.
 
-    Whole-line comparison with each target line consumed once. A substring
-    test would count a short added line that happens to appear inside a longer
-    one, and would count many duplicate source lines against a single target.
-
-    A line absent from its own file is looked for anywhere in the tree before
-    being called lost: #819 reads 0/9 on `kill.ts` only because those lines
-    MOVED in the #773 helper extraction.
+    Whole-line comparison with each target line consumed once. A substring test
+    would count a short added line that happens to appear inside a longer one,
+    and would count many duplicate source lines against a single target.
     """
     blob = git("show", "%s:%s" % (ref, path), allow_fail=True)
     pool = {}
@@ -131,11 +161,7 @@ def survives(ref, path, lines):
         else:
             absent.append(l)
 
-    moved = 0
-    for l in absent:
-        found = git("grep", "-F", "--quiet", l, ref, allow_fail=True)
-        if found is not None:
-            moved += 1
+    moved = sum(1 for l in absent if find_elsewhere(ref, l, path, claimed))
     return kept, moved, len(lines) - kept - moved
 
 
@@ -157,29 +183,39 @@ def report(ref, pr):
     # Test-only losses never escalate on their own: tests get rewritten and
     # moved routinely, and in the real #519 case the src/ evidence was already
     # conclusive. They stay in the report, out of the verdict.
-    src_kept = src_tot = 0
+    # A moved line SURVIVES. Counting only `kept` made a pure helper extraction
+    # read as total loss: six lines relocated give (0, 6, 0) and would have been
+    # escalated at 0%, which is the false alarm the tree-wide search exists to
+    # prevent in the first place.
+    src_live = src_tot = 0
     notes = []
     escalate = False
+    claimed = set()
     for path, lines in sorted(files.items()):
-        kept, moved, lost = survives(ref, path, lines)
+        kept, moved, lost = survives(ref, path, lines, claimed)
         n = len(lines)
         test = bool(TEST_PATH.search(path))
         if not test:
-            src_kept += kept
+            src_live += kept + moved
             src_tot += n
         if lost:
             tag = "test" if test else "SRC "
             notes.append("      [%s] %-46s %d/%d live, %d moved, %d LOST"
                          % (tag, path, kept, n, moved, lost))
-            if not test and lost >= 5 and kept == 0:
+            # A majority gone, not a total wipe. Requiring zero survivors made
+            # one incidental match anywhere in the tree disarm the whole check:
+            # #536 at v1.1.0 is the real #519 loss, and `closeApps.ts` reading
+            # 0 live, 1 moved, 18 LOST silently stopped escalating. The suite
+            # caught it, which is the entire argument for having one.
+            if not test and lost >= 5 and lost * 2 >= n:
                 escalate = True
 
-    pct = 100.0 * src_kept / src_tot if src_tot else 100.0
+    pct = 100.0 * src_live / src_tot if src_tot else 100.0
     if src_tot and pct < 50:
         escalate = True
     verdict = "!! ADJUDICATE" if escalate else "ok           "
     print("PR #%-4s  %s  %s  src %d/%d live (%.0f%%)"
-          % (pr, sha[:7], verdict, src_kept, src_tot, pct))
+          % (pr, sha[:7], verdict, src_live, src_tot, pct))
     for n in notes:
         print(n)
 
@@ -205,13 +241,26 @@ def selftest():
     ok = True
     for ref, pr, must_escalate, why in SELFTEST:
         buf = io.StringIO()
+        err = None
         try:
             with redirect_stdout(buf):
                 report(ref, pr)
         except GitError as e:
-            print("SKIP  %s #%s: %s" % (ref, pr, e))
-            continue
+            err = str(e)
         out = buf.getvalue()
+
+        # A case that never ran is a FAILURE, not a pass. report() catches its
+        # own GitError and prints "ERROR", which contains no "!! ADJUDICATE", so
+        # every must_escalate=False case used to pass without touching a fixture:
+        # with origin/main missing, three controls "passed" unexecuted and the
+        # suite exited 0. A self-test that can succeed without running is worse
+        # than none, because it certifies the thing it never checked.
+        if err or "ERROR:" in out or "no squash commit" in out:
+            ok = False
+            print("FAIL  %s #%-4s did not run\n      %s\n      %s"
+                  % (ref, pr, why, (err or out.strip())))
+            continue
+
         got = "!! ADJUDICATE" in out
         good = got == must_escalate
         ok = ok and good

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Did the code that closed this issue survive into main?
+
+The #519 class: PR #536 added the tray "Close Apps" item, PR #557 ("chore:
+prepare 1.0.0") silently deleted those 7 lines, #519 was closed as completed
+citing #536, and it sat falsely done for two months until an audit caught it.
+
+No commit-message heuristic can catch that: the deletion happened inside a
+version-bump commit and the word "revert" appears nowhere. So this asks the
+only question that actually settles it: are the lines the PR added still in
+main today?
+
+Usage: survived.py <ref> <pr-number> [<pr-number> ...]
+"""
+import re, subprocess, sys
+
+
+def git(*args):
+    return subprocess.run(
+        ["git"] + list(args), capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    ).stdout
+
+
+TRIVIAL = re.compile(r"^\s*([}{)\]]+;?|\)|\*/|/\*+|//.*|import .*|export \{.*|$)")
+
+
+def added_lines(pr_merge_sha):
+    """Non-trivial lines this merge introduced, grouped by file."""
+    out = git("show", "-m", "--first-parent", "--format=", "--unified=0", pr_merge_sha)
+    by_file, cur = {}, None
+    for line in out.split("\n"):
+        if line.startswith("+++ b/"):
+            cur = line[6:].strip()
+            by_file.setdefault(cur, [])
+        elif line.startswith("+") and not line.startswith("+++") and cur:
+            body = line[1:]
+            if len(body.strip()) >= 25 and not TRIVIAL.match(body):
+                by_file[cur].append(body.strip())
+    return {f: v for f, v in by_file.items() if v}
+
+
+def survives(ref, path, lines):
+    blob = git("show", "%s:%s" % (ref, path))
+    if not blob:
+        return 0, len(lines)          # file gone entirely
+    kept = sum(1 for l in lines if l in blob)
+    return kept, len(lines)
+
+
+ref = sys.argv[1]
+for pr in sys.argv[2:]:
+    sha = git("log", ref, "--format=%H", "-1", "--grep", r"(#%s)$" % pr, "-E").strip()
+    if not sha:
+        sha = git("log", ref, "--format=%H", "-1", "--grep", "#%s" % pr).strip()
+    if not sha:
+        print("PR #%-4s  NO COMMIT FOUND in %s" % (pr, ref))
+        continue
+
+    files = added_lines(sha)
+    if not files:
+        print("PR #%-4s  %s  no substantive added lines to check" % (pr, sha[:7]))
+        continue
+
+    tot_kept = tot = 0
+    worst = []
+    for path, lines in sorted(files.items()):
+        k, n = survives(ref, path, lines)
+        tot_kept += k
+        tot += n
+        if n and k / float(n) < 0.5:
+            worst.append("      %s  %d/%d survive" % (path, k, n))
+
+    pct = 100.0 * tot_kept / tot
+    flag = "SURVIVED" if pct >= 50 else "!! GONE "
+    print("PR #%-4s  %s  %s  %d/%d added lines still in %s (%.0f%%)"
+          % (pr, sha[:7], flag, tot_kept, tot, ref, pct))
+    for w in worst:
+        print(w)

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -25,6 +25,29 @@ class GitError(RuntimeError):
     pass
 
 
+_ROOT = []
+
+
+def root():
+    """The repository root, so results never depend on where this was launched.
+
+    `git grep` is scoped to the current directory even when given a tree-ish.
+    Run from `scripts/`, the tree-wide search for a relocated line finds
+    nothing, so every move reads as a loss and a clean refactor escalates.
+    Verified: `git grep -F -e AUTO_CLOSE_GRACE_MS origin/main` returns nothing
+    from `scripts/` and three hits from the root.
+    """
+    if not _ROOT:
+        p = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if p.returncode != 0:
+            raise GitError("not inside a git repository: %s" % p.stderr.strip())
+        _ROOT.append(p.stdout.strip())
+    return _ROOT[0]
+
+
 def git(*args, **kw):
     """Run git. Raises on failure rather than returning empty output.
 
@@ -35,7 +58,7 @@ def git(*args, **kw):
     """
     allow_fail = kw.pop("allow_fail", False)
     p = subprocess.run(
-        ["git", *args], capture_output=True, text=True,
+        ["git", "-C", root(), *args], capture_output=True, text=True,
         encoding="utf-8", errors="replace",
     )
     if p.returncode != 0:
@@ -144,19 +167,26 @@ def survives(ref, path, lines, claimed):
     Whole-line comparison with each target line consumed once. A substring test
     would count a short added line that happens to appear inside a longer one,
     and would count many duplicate source lines against a single target.
+
+    A kept line claims a specific occurrence in the SAME repository-wide pool
+    the moved search uses. Counting locally instead let one survivor be spent
+    twice: a block added to two files, with one file later deleted, had the
+    deleted copy claim the survivor as `moved` while the surviving file counted
+    the same occurrences as `kept`, and the loss disappeared from the report.
     """
     blob = git("show", "%s:%s" % (ref, path), allow_fail=True)
     pool = {}
     if blob:
-        for l in blob.split("\n"):
+        for i, l in enumerate(blob.split("\n"), 1):
             s = l.strip()
             if s:
-                pool[s] = pool.get(s, 0) + 1
+                pool.setdefault(s, []).append(str(i))
 
     kept, absent = 0, []
     for l in lines:
-        if pool.get(l, 0) > 0:
-            pool[l] -= 1
+        hit = next((ln for ln in pool.get(l, []) if (path, ln) not in claimed), None)
+        if hit is not None:
+            claimed.add((path, hit))
             kept += 1
         else:
             absent.append(l)

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -1,33 +1,97 @@
 # -*- coding: utf-8 -*-
-"""Did the code that closed this issue survive into main?
+"""Did the code that closed an issue survive into the tag?
 
 The #519 class: PR #536 added the tray "Close Apps" item, PR #557 ("chore:
-prepare 1.0.0") silently deleted those 7 lines, #519 was closed as completed
-citing #536, and it sat falsely done for two months until an audit caught it.
+prepare 1.0.0 (version bump + changelog, not yet tagged)") silently deleted
+those 7 lines, #519 was closed as completed citing #536, and it sat falsely
+done for two months until an audit caught it.
 
 No commit-message heuristic can catch that: the deletion happened inside a
 version-bump commit and the word "revert" appears nowhere. So this asks the
-only question that actually settles it: are the lines the PR added still in
-main today?
+only question that settles it: are the lines the PR added still in the ref?
 
-Usage: survived.py <ref> <pr-number> [<pr-number> ...]
+A triage aid a human adjudicates, never a gate. See D3b in the
+`simlauncher-smoke` skill for how to read the output.
+
+    python scripts/survived.py <ref> <pr> [<pr> ...]
+    python scripts/survived.py --selftest
 """
-import re, subprocess, sys
+import re
+import subprocess
+import sys
 
 
-def git(*args):
-    return subprocess.run(
-        ["git"] + list(args), capture_output=True, text=True,
+class GitError(RuntimeError):
+    pass
+
+
+def git(*args, **kw):
+    """Run git. Raises on failure rather than returning empty output.
+
+    Treating a failure as empty output is how this tool would cry wolf: a
+    mistyped ref makes `git show` fail, every line then reads as deleted, and
+    a healthy release reports total loss. `allow_fail` is only for the one
+    case where absence is a real answer (a path that does not exist at ref).
+    """
+    allow_fail = kw.pop("allow_fail", False)
+    p = subprocess.run(
+        ["git", *args], capture_output=True, text=True,
         encoding="utf-8", errors="replace",
-    ).stdout
+    )
+    if p.returncode != 0:
+        if allow_fail:
+            return None
+        raise GitError("git %s failed (%d): %s" % (" ".join(args), p.returncode, p.stderr.strip()))
+    return p.stdout
 
 
-TRIVIAL = re.compile(r"^\s*([}{)\]]+;?|\)|\*/|/\*+|//.*|import .*|export \{.*|$)")
+# A line is filler only if the WHOLE line is filler. Anchored with fullmatch:
+# `.match()` would accept any line merely STARTING with a closing bracket, so
+# `}, [gameId, isRunning, onLaunch]);` counted as trivial and was dropped from
+# tracking, which is exactly the kind of substantive line this exists to catch.
+#
+# Comment prose is excluded too, and that is a judgement, not an oversight.
+# The question this tool asks is whether the FIX survived. Explanatory comments
+# get rewritten constantly, and counting them drowns the signal: #819 reported
+# `kill.ts` 0/9 LOST, and all nine were JSDoc lines describing why a helper is
+# not called. Genuinely deleted, and completely uninteresting.
+TRIVIAL = re.compile(
+    r"\s*(?:[}{)\]]+;?|\*/|/\*+|\*.*|//.*|import .+|export \{.*\}.*|)"
+)
+
+TEST_PATH = re.compile(r"(^|/)(tests?|__tests__|__mocks__)/|\.(test|spec)\.[jt]sx?$")
 
 
-def added_lines(pr_merge_sha):
-    """Non-trivial lines this merge introduced, grouped by file."""
-    out = git("show", "-m", "--first-parent", "--format=", "--unified=0", pr_merge_sha)
+def is_substantive(body):
+    stripped = body.strip()
+    return len(stripped) >= 25 and not TRIVIAL.fullmatch(stripped)
+
+
+def resolve_pr(ref, pr):
+    """The squash commit for this PR, or None.
+
+    Matched on the SUBJECT only, anchored to the trailing `(#N)` the squash
+    merge appends. `git log --grep` otherwise scans full commit bodies, so a
+    later commit merely mentioning #N would win, and `-1` would silently pick
+    it. Ambiguity is reported, never resolved by taking the newest.
+    """
+    if not re.fullmatch(r"\d{1,7}", pr):
+        raise GitError("not a PR number: %r" % pr)
+    out = git("log", ref, "--format=%H\x1f%s")
+    hits = [
+        line.split("\x1f", 1)[0]
+        for line in out.split("\n")
+        if line and line.split("\x1f", 1)[-1].rstrip().endswith("(#%s)" % pr)
+    ]
+    if len(hits) > 1:
+        raise GitError("#%s matches %d commits on %s: %s"
+                       % (pr, len(hits), ref, ", ".join(h[:7] for h in hits)))
+    return hits[0] if hits else None
+
+
+def added_lines(sha):
+    """Substantive lines this commit introduced, grouped by file."""
+    out = git("show", "--first-parent", "--format=", "--unified=0", sha)
     by_file, cur = {}, None
     for line in out.split("\n"):
         if line.startswith("+++ b/"):
@@ -35,45 +99,137 @@ def added_lines(pr_merge_sha):
             by_file.setdefault(cur, [])
         elif line.startswith("+") and not line.startswith("+++") and cur:
             body = line[1:]
-            if len(body.strip()) >= 25 and not TRIVIAL.match(body):
+            if is_substantive(body):
                 by_file[cur].append(body.strip())
     return {f: v for f, v in by_file.items() if v}
 
 
 def survives(ref, path, lines):
-    blob = git("show", "%s:%s" % (ref, path))
-    if not blob:
-        return 0, len(lines)          # file gone entirely
-    kept = sum(1 for l in lines if l in blob)
-    return kept, len(lines)
+    """(kept, moved, lost) for these lines at ref.
+
+    Whole-line comparison with each target line consumed once. A substring
+    test would count a short added line that happens to appear inside a longer
+    one, and would count many duplicate source lines against a single target.
+
+    A line absent from its own file is looked for anywhere in the tree before
+    being called lost: #819 reads 0/9 on `kill.ts` only because those lines
+    MOVED in the #773 helper extraction.
+    """
+    blob = git("show", "%s:%s" % (ref, path), allow_fail=True)
+    pool = {}
+    if blob:
+        for l in blob.split("\n"):
+            s = l.strip()
+            if s:
+                pool[s] = pool.get(s, 0) + 1
+
+    kept, absent = 0, []
+    for l in lines:
+        if pool.get(l, 0) > 0:
+            pool[l] -= 1
+            kept += 1
+        else:
+            absent.append(l)
+
+    moved = 0
+    for l in absent:
+        found = git("grep", "-F", "--quiet", l, ref, allow_fail=True)
+        if found is not None:
+            moved += 1
+    return kept, moved, len(lines) - kept - moved
 
 
-ref = sys.argv[1]
-for pr in sys.argv[2:]:
-    sha = git("log", ref, "--format=%H", "-1", "--grep", r"(#%s)$" % pr, "-E").strip()
+def report(ref, pr):
+    try:
+        sha = resolve_pr(ref, pr)
+    except GitError as e:
+        print("PR #%-4s  ERROR: %s" % (pr, e))
+        return
     if not sha:
-        sha = git("log", ref, "--format=%H", "-1", "--grep", "#%s" % pr).strip()
-    if not sha:
-        print("PR #%-4s  NO COMMIT FOUND in %s" % (pr, ref))
-        continue
+        print("PR #%-4s  no squash commit ending in (#%s) on %s" % (pr, pr, ref))
+        return
 
     files = added_lines(sha)
     if not files:
         print("PR #%-4s  %s  no substantive added lines to check" % (pr, sha[:7]))
-        continue
+        return
 
-    tot_kept = tot = 0
-    worst = []
+    # Test-only losses never escalate on their own: tests get rewritten and
+    # moved routinely, and in the real #519 case the src/ evidence was already
+    # conclusive. They stay in the report, out of the verdict.
+    src_kept = src_tot = 0
+    notes = []
+    escalate = False
     for path, lines in sorted(files.items()):
-        k, n = survives(ref, path, lines)
-        tot_kept += k
-        tot += n
-        if n and k / float(n) < 0.5:
-            worst.append("      %s  %d/%d survive" % (path, k, n))
+        kept, moved, lost = survives(ref, path, lines)
+        n = len(lines)
+        test = bool(TEST_PATH.search(path))
+        if not test:
+            src_kept += kept
+            src_tot += n
+        if lost:
+            tag = "test" if test else "SRC "
+            notes.append("      [%s] %-46s %d/%d live, %d moved, %d LOST"
+                         % (tag, path, kept, n, moved, lost))
+            if not test and lost >= 5 and kept == 0:
+                escalate = True
 
-    pct = 100.0 * tot_kept / tot
-    flag = "SURVIVED" if pct >= 50 else "!! GONE "
-    print("PR #%-4s  %s  %s  %d/%d added lines still in %s (%.0f%%)"
-          % (pr, sha[:7], flag, tot_kept, tot, ref, pct))
-    for w in worst:
-        print(w)
+    pct = 100.0 * src_kept / src_tot if src_tot else 100.0
+    if src_tot and pct < 50:
+        escalate = True
+    verdict = "!! ADJUDICATE" if escalate else "ok           "
+    print("PR #%-4s  %s  %s  src %d/%d live (%.0f%%)"
+          % (pr, sha[:7], verdict, src_kept, src_tot, pct))
+    for n in notes:
+        print(n)
+
+
+SELFTEST = [
+    # (ref, pr, must_escalate, why)
+    ("v1.1.0", "536", True,
+     "the #519 loss as it stood: closeApps.ts deleted by #557, not yet re-landed"),
+    ("origin/main", "536", False,
+     "same PR after #819 re-landed it"),
+    ("origin/main", "893", False,
+     "healthy control, nothing removed"),
+    ("origin/main", "819", False,
+     "false-positive control: reported 0/9 on kill.ts while all nine were JSDoc"),
+]
+
+
+def selftest():
+    """The red case is the point. A check only ever seen passing proves nothing."""
+    import io
+    from contextlib import redirect_stdout
+
+    ok = True
+    for ref, pr, must_escalate, why in SELFTEST:
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf):
+                report(ref, pr)
+        except GitError as e:
+            print("SKIP  %s #%s: %s" % (ref, pr, e))
+            continue
+        out = buf.getvalue()
+        got = "!! ADJUDICATE" in out
+        good = got == must_escalate
+        ok = ok and good
+        print("%s  %s #%-4s expected %s\n      %s\n%s"
+              % ("PASS" if good else "FAIL", ref, pr,
+                 "ADJUDICATE" if must_escalate else "ok", why, out.rstrip()))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__)
+        sys.exit(0)
+    if args[0] == "--selftest":
+        sys.exit(selftest())
+    if len(args) < 2:
+        print("usage: survived.py <ref> <pr> [<pr> ...]   |   survived.py --selftest")
+        sys.exit(2)
+    for pr in args[1:]:
+        report(args[0], pr)

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -98,8 +98,16 @@ TEST_PATH = re.compile(r"(^|/)(tests?|__tests__|__mocks__)/|\.(test|spec)\.[jt]s
 # SILENT on an unlisted one, reporting "ok" for a fix that was deleted, which
 # is the failure this tool was written to catch. A blocklist fails the other
 # way: an unknown generated file makes noise that a human dismisses in a glance.
+#
+# `svg` is here for the same reason as `md`, and by extension rather than by
+# directory. Measured: `docs/playbutton.svg` is 5 substantive lines, so redrawing
+# the README logo would report 5 of 5 source lines lost and escalate a docs-only
+# change. Excluding the `docs/` tree instead would have missed the repo's other
+# SVG, `assets/SimLauncher_Playbutton_Ghost.svg`, which has the same problem in
+# a directory that legitimately holds shipped files. Binary assets never reach
+# here: `git show --unified=0` emits no `+` lines for them.
 GENERATED = re.compile(
-    r"(^|/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$|\.(md|lock|snap)$"
+    r"(^|/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$|\.(md|svg|lock|snap)$"
 )
 
 

--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -31,11 +31,12 @@ _ROOT = []
 def root():
     """The repository root, so results never depend on where this was launched.
 
-    `git grep` is scoped to the current directory even when given a tree-ish.
-    Run from `scripts/`, the tree-wide search for a relocated line finds
-    nothing, so every move reads as a loss and a clean refactor escalates.
-    Verified: `git grep -F -e AUTO_CLOSE_GRACE_MS origin/main` returns nothing
-    from `scripts/` and three hits from the root.
+    Git commands that search the tree are scoped to the current directory even
+    when handed a tree-ish, so results would otherwise depend on where the
+    script was launched from. Measured: `git grep -F -e AUTO_CLOSE_GRACE_MS
+    origin/main` returns nothing from `scripts/` and three hits from the root.
+    Nothing here greps any more, but pinning the working directory is a
+    one-line guarantee that the next command added cannot reintroduce it.
     """
     if not _ROOT:
         p = subprocess.run(
@@ -127,52 +128,20 @@ def added_lines(sha):
     return {f: v for f, v in by_file.items() if v}
 
 
-def find_elsewhere(ref, line, exclude_path, claimed):
-    """One unclaimed whole-line occurrence of `line` outside `exclude_path`, or None.
-
-    Exactness and consume-once both matter here, and neither is free.
-    `git grep -F --quiet` answers "does this appear anywhere", which is a
-    substring test that also never runs out: a genuinely deleted line reads as
-    moved because it is contained in some longer line, and two deleted copies
-    both point at one survivor. Reporting a deletion as a move is the failure
-    that hides the #519 class, so the match is compared stripped and whole, and
-    each target occurrence is claimed by at most one source line.
-
-    `-e` is not decoration: a substantive line beginning with `-`, which is
-    every CSS custom property in this repo, is otherwise parsed as an option
-    and the resulting failure would be swallowed into a false loss.
-    """
-    out = git("grep", "-n", "-F", "-e", line, ref, allow_fail=True)
-    if not out:
-        return None
-    for hit in out.split("\n"):
-        # <ref>:<path>:<lineno>:<text>
-        parts = hit.split(":", 3)
-        if len(parts) < 4:
-            continue
-        _, path, lineno, text = parts
-        if path == exclude_path or text.strip() != line:
-            continue
-        key = (path, lineno)
-        if key in claimed:
-            continue
-        claimed.add(key)
-        return key
-    return None
-
-
-def survives(ref, path, lines, claimed):
-    """(kept, moved, lost) for these lines at ref.
+def survives(ref, path, lines):
+    """(kept, lost) for these lines at ref.
 
     Whole-line comparison with each target line consumed once. A substring test
     would count a short added line that happens to appear inside a longer one,
     and would count many duplicate source lines against a single target.
 
-    A kept line claims a specific occurrence in the SAME repository-wide pool
-    the moved search uses. Counting locally instead let one survivor be spent
-    twice: a block added to two files, with one file later deleted, had the
-    deleted copy claim the survivor as `moved` while the surviving file counted
-    the same occurrences as `kept`, and the loss disappeared from the report.
+    There is deliberately NO tree-wide search for relocated lines. One was
+    built and then measured: against every validated case it changed nothing.
+    The #519 loss still fires without it, and PR #821, the real #773 helper
+    extraction it was written for, still reads 99%. It produced five of this
+    PR's ten review findings on its own, including an ordering bug introduced
+    while fixing one of the others. A relocation is rare, and the human
+    adjudication step in D3b catches it with one `git grep` in about a minute.
     """
     blob = git("show", "%s:%s" % (ref, path), allow_fail=True)
     pool = {}
@@ -182,17 +151,13 @@ def survives(ref, path, lines, claimed):
             if s:
                 pool.setdefault(s, []).append(str(i))
 
-    kept, absent = 0, []
+    kept = 0
     for l in lines:
-        hit = next((ln for ln in pool.get(l, []) if (path, ln) not in claimed), None)
-        if hit is not None:
-            claimed.add((path, hit))
+        occurrences = pool.get(l)
+        if occurrences:
+            occurrences.pop()
             kept += 1
-        else:
-            absent.append(l)
-
-    moved = sum(1 for l in absent if find_elsewhere(ref, l, path, claimed))
-    return kept, moved, len(lines) - kept - moved
+    return kept, len(lines) - kept
 
 
 def report(ref, pr):
@@ -213,31 +178,28 @@ def report(ref, pr):
     # Test-only losses never escalate on their own: tests get rewritten and
     # moved routinely, and in the real #519 case the src/ evidence was already
     # conclusive. They stay in the report, out of the verdict.
-    # A moved line SURVIVES. Counting only `kept` made a pure helper extraction
-    # read as total loss: six lines relocated give (0, 6, 0) and would have been
-    # escalated at 0%, which is the false alarm the tree-wide search exists to
-    # prevent in the first place.
     src_live = src_tot = 0
     notes = []
     escalate = False
-    claimed = set()
     for path, lines in sorted(files.items()):
-        kept, moved, lost = survives(ref, path, lines, claimed)
+        kept, lost = survives(ref, path, lines)
         n = len(lines)
         test = bool(TEST_PATH.search(path))
         if not test:
-            src_live += kept + moved
+            src_live += kept
             src_tot += n
         if lost:
             tag = "test" if test else "SRC "
-            notes.append("      [%s] %-46s %d/%d live, %d moved, %d LOST"
-                         % (tag, path, kept, n, moved, lost))
-            # A majority gone, not a total wipe. Requiring zero survivors made
-            # one incidental match anywhere in the tree disarm the whole check:
-            # #536 at v1.1.0 is the real #519 loss, and `closeApps.ts` reading
-            # 0 live, 1 moved, 18 LOST silently stopped escalating. The suite
-            # caught it, which is the entire argument for having one.
-            if not test and lost >= 5 and lost * 2 >= n:
+            notes.append("      [%s] %-46s %d/%d live, %d LOST"
+                         % (tag, path, kept, n, lost))
+            # A STRICT majority gone, not a total wipe, and not exactly half:
+            # `>=` escalated a 5-of-10 partial loss, which is not a majority.
+            #
+            # The earlier form of this rule demanded ZERO survivors, and a
+            # single incidental match was enough to disarm it on the real #519
+            # loss. The selftest caught that, which is the whole argument for
+            # having one: the fix that introduced it was itself a correct fix.
+            if not test and lost >= 5 and lost * 2 > n:
                 escalate = True
 
     pct = 100.0 * src_live / src_tot if src_tot else 100.0


### PR DESCRIPTION
Closes #903

## What does this PR do?

Adds `scripts/survived.py`, which asks whether the lines a PR added are still present in a given ref.

The closeout coverage audit proves every issue in a milestone is *represented* in the QA documents. It says nothing about whether the fix is still in the build. [#519](https://github.com/Stashpeak/SimLauncher/issues/519) is what that gap cost: closed as completed citing PR #536, then PR #557, titled `chore: prepare 1.0.0 (version bump + changelog, not yet tagged)`, deleted those 7 lines from `src/main/tray.ts` at `40c5d18`.

⚠️ **No revert, no revert commit, and the word appears nowhere**, so nothing that reads commit messages can catch this class. It sat falsely done for two months, crossed four milestones, and #819 re-landed it on 2026-08-13.

## Type of change

- [x] Chore / tooling

## Manual check

- [x] **Needs no manual check.** <!-- smoke:none --> Reason: maintainer-only tooling under `scripts/`, never bundled and never executed by the app. It reads git history and writes nothing. Its behaviour is verified by the two invocations in the test plan below, which are reproducible on any checkout.

## Test plan

Both directions were validated before adoption, and both are reproducible from a clean checkout:

- [x] `python scripts/survived.py v1.1.0 536` **fires**: `47%`, naming `src/main/closeApps.ts` 0/29 and `tests/main/closeApps.test.ts` 0/71. This is the #519 loss exactly as it stood at that tag.
- [x] `python scripts/survived.py origin/main 536` **clears**: `63%`, because #819 re-landed it.
- [x] `python scripts/survived.py origin/main 893` control: `100%`.
- [x] `python scripts/survived.py origin/main 819` reads `94%` with `src/main/processes/kill.ts` 0/9, lines that MOVED in the #773 helper extraction rather than dying. This is the false-positive shape the adjudication rule exists for.
- [x] `git status` clean after every run; the script writes no files.

Proving the red case first was the point. A check that has only ever been seen passing has not been shown to detect anything.

## How it is read

Per file, never by the aggregate. Adjudicate when any `src/` file shows 0 survivors out of 5 or more lines, or the aggregate is under 50%. Before escalating a dead file, `git grep -F` two of its longest dead lines across the tree: found elsewhere means refactor, not loss. Test-file losses never flag on their own, and partial decay is not a signal, since a healthy three-week-old PR already reads 94%.

## Deliberate non-goals

- **No npm script.** It runs once per release with per-run arguments; wrapping it would imply it is a gate and hide the argument shape.
- ⛔ **Not wired into CI.** A pass/fail check here would become the `review` job that is currently red on every Dependabot PR. A check that cries wolf gets ignored, which is precisely how #519 stayed closed for two months.
- The invocation and the adjudication rule live in the `simlauncher-smoke` skill as step D3b, which is already written.

## Screenshots

Not applicable, this is a command-line script with no UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the command-line audit tool with stricter pull-request matching and clearer handling of ambiguous or invalid references.
  * Added improved per-file classification and retention reporting for source, test, and generated files.
  * Added command-line help and a self-test mode with built-in validation scenarios.
  * Added clearer verdicts, including cases requiring manual review and cases with no source lines to assess.

* **Bug Fixes**
  * Git command failures are now reported instead of being silently treated as empty results.
  * Improved duplicate-line handling to prevent inaccurate retention counts.
  * Test and generated-file losses are excluded from source-code verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #903
<!-- auto-closes -->