### PR TITLE
fix(deps): raise the fast-uri override above the new advisory range (#905)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4665,9 +4665,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "overrides": {
     "@electron/asar": "4.2.0",
     "js-yaml": "^4.3.1",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "esbuild": "^0.28.1",
     "form-data": "4.0.6",
     "tar": "7.5.22",


### PR DESCRIPTION
## Summary

- Raises the `fast-uri` override from `^3.1.5` to `^3.1.7`, above the advisory range `3.0.0 - 3.1.5`, and moves the lockfile entry to `3.1.7`
- Unblocks every open PR: `npm audit --omit=dev` runs inside the required `build` check, and four new high-severity advisories turned it red across the board this afternoon

The chain is `electron-store -> conf -> ajv -> fast-uri`, a production path, so `--omit=dev` does not hide it. Staying inside the 3.x line leaves `ajv` untouched; `fast-uri@4.1.4` exists but is a major that `ajv` does not ask for.

The lockfile diff is deliberately three lines. Letting the local npm rewrite it stripped 40-odd `libc` hints from unrelated native optional dependencies, which is churn this change has no business carrying, so the entry was edited in place and validated with `npm ci --dry-run`.

## Smoke check

- [x] **Needs no manual check.** <!-- smoke:none --> Reason: a transitive patch bump inside the config-validation chain. Nothing in our code calls `fast-uri`, no user-visible surface changes, and the only assertion that matters here is the `build` check going green again.
- [ ] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like:

## Test plan

- [x] `npm audit --omit=dev` reports `found 0 vulnerabilities`, was 1 high
- [x] `npm ci --dry-run` accepts the hand-edited lockfile
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`, 93 files and 902 tests
- [x] `build` check green on this PR

Closes #905
