### PR TITLE
docs(scripts): correct the #728 source-loss figure in the survival check (#903)

### DIFF
--- a/scripts/survived.py
+++ b/scripts/survived.py
@@ -91,8 +91,8 @@ TEST_PATH = re.compile(r"(^|/)(tests?|__tests__|__mocks__)/|\.(test|spec)\.[jt]s
 # decide the aggregate on their own. Measured at 3a4ada1: PR #703 read 5% live
 # because package-lock.json contributed 222 of its 227 lines, and PR #728
 # escalated on 11 deleted CONTRIBUTING.md lines while its real source loss was
-# 4. Both are routine cleanup, and both are exactly the false alarm this tool
-# exists to avoid.
+# 5, four in config.ts and one in AppsSection.tsx. Both are routine cleanup,
+# and both are exactly the false alarm this tool exists to avoid.
 #
 # A blocklist, deliberately. An allowlist of known code extensions would fail
 # SILENT on an unlisted one, reporting "ok" for a fix that was deleted, which


### PR DESCRIPTION
## What does this PR do?

Corrects one figure in an explanatory comment in `scripts/survived.py`. It said PR #728's real source loss was 4 lines. It was 5: four in `src/renderer/src/lib/config.ts` and one in `AppsSection.tsx`.

Measured rather than recalled:

```
$ python scripts/survived.py 3a4ada1 728
PR #728   8e9fb3f  ok             src 8/13 live (62%)
      [gen ] CONTRIBUTING.md                                0/11 live, 11 LOST
      [SRC ] src/renderer/src/components/settings/AppsSection.tsx 7/8 live, 1 LOST
      [SRC ] src/renderer/src/lib/config.ts                 0/4 live, 4 LOST
      [test] tests/renderer/appsSectionUtilityIcon.test.tsx 55/56 live, 1 LOST
```

The argument the comment makes is unaffected: 11 deleted `CONTRIBUTING.md` lines still dwarf the real loss, which is why documents are excluded from the verdict. Only the number was wrong.

Worth a PR for one number because that comment exists specifically to justify a design decision, and a wrong figure in it gets quoted later. It was found by auditing everything written on 2026-09-02, after four of the six issues filed that day turned out to carry figures written from memory rather than measured. This one had reached merged code.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / config

## Smoke check

- [x] **Needs no manual check.** <!-- smoke:none --> Reason: a comment in a maintainer script that is not shipped, not imported by the app, and not run in CI. No executable line changes; `git show --numstat` is 2 insertions and 2 deletions, all inside a `#` block.
- [ ] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like:

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (93 files, 902 tests)
- [x] Tested manually: `python scripts/survived.py --selftest` exits 0 with all four cases passing, and `python scripts/survived.py 3a4ada1 728` reproduces the output quoted above

## Screenshots

None. The change is a comment in a script with no UI.

## Issue reference

`Refs #903`, deliberately, not `Closes`.

#903 is already closed as completed by #904, so a closing keyword here would be inaccurate about what this PR does. GitHub registers a closing keyword context-blind anywhere in a body, and it has already misfired once on this account: in `Stashpeak/stashpeak-app`, PR 238 auto-closed issue 232 on 2026-06-27. That body wrote a deliberate `Refs` line for issue 232, then explained one sentence later that a *future* docs PR was the one that would close it. GitHub read the explanation as the instruction. So the keyword is only written when it is meant.

> **Correction, after merge.** This paragraph originally said the misfire happened *in this repo*. It did not: it was `Stashpeak/stashpeak-app`, and that attribution was recalled rather than checked. In `Stashpeak/SimLauncher`, issue 232 was closed 2026-04-29 by PR 233 and 238 is not a pull request at all. Established with `gh pr view 238 --repo Stashpeak/stashpeak-app --json mergedAt,closingIssuesReferences` (merged 2026-06-27T11:31:05Z, closing refs `[232, 236]`). The mechanism the paragraph describes is unchanged and verified against that body; only the repo was wrong.

Refs #903

