### PR TITLE
fix: keep a rejected settings entry instead of erasing it (#806)

### DIFF
--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -18,6 +18,7 @@ import {
   getStoredBoolean,
   getStoredStringRecord,
   getStoredZoomFactor,
+  preserveRejectedSettingsEntries,
   requireSafeZoomFactor,
   sanitizeImportedConfig,
   sanitizeSettingsPatch,
@@ -541,8 +542,11 @@ export function registerConfigHandlers(): void {
   ipcMain.handle('save-settings', (_event, patch: unknown) => {
     if (!isRecord(patch)) return { settings: getPersistedSettings(), dropped: [] }
 
-    const safe = sanitizeSettingsPatch(patch)
     const dropped = getDroppedSettingsEntries(patch)
+    // The sanitized patch REPLACES each dictionary, so a rejected key would be
+    // erased from disk while the renderer says "Not saved". Keep the stored
+    // value for exactly the rejected entries, before the write reads it. #806
+    const safe = preserveRejectedSettingsEntries(sanitizeSettingsPatch(patch), dropped)
     const changedKeys = Object.keys(safe)
     if (changedKeys.length > 0) {
       setStoreEntries(safe)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import Store from 'electron-store'
 
 import { BUILT_IN_UTILITY_KEYS, KNOWN_GAME_KEYS } from '../shared/domain/registries'
-import { MAX_CUSTOM_SLOTS } from '../shared/domain/slots'
+import { MAX_CUSTOM_SLOTS, getCustomSlotNumberFromKey } from '../shared/domain/slots'
 import { clamp, isRecord, normalizePathForComparison } from './utils'
 
 // Re-exported for existing importers (ipc/config.ts, ipc/launch.ts) that pull
@@ -922,10 +922,33 @@ export interface DroppedSettingsEntry {
   reason: DroppedSettingsReason
 }
 
-// The dictionaries keyed by custom-slot POSITION (`customapp1`, `customapp2`, …),
+// The dictionaries that can hold custom-slot keys (`customapp1`, `customapp2`, …),
 // which the renderer renumbers when a slot is removed. `gamePaths` is absent on
 // purpose: its keys come from the fixed game allowlist and never shift.
+//
+// Membership here is necessary but NOT sufficient to call a key unstable: these
+// same dictionaries also hold built-in utility keys (`simhub`, …), which
+// `shiftCustomSlotRecord` passes through untouched. The per-key test below is
+// what decides.
 const SLOT_KEYED_FIELDS = new Set<DroppedSettingsRecordField>(['appPaths', 'appNames', 'appArgs'])
+
+/**
+ * Whether a rejected entry's key may have been RENUMBERED by the save now being
+ * written, which is the one condition under which restoring it by key is unsafe.
+ *
+ * True only for a `customapp<N>` key in a slot-keyed dictionary, on a save that
+ * lowers `customSlots`. A built-in utility key in the same dictionary, or any key
+ * at all when the count did not shrink, is stable and must still be preserved:
+ * skipping it would erase a value the renderer is simultaneously reporting as
+ * "Not saved", which is the exact bug #806 exists to fix.
+ */
+function isRenumberedByThisSave(
+  field: DroppedSettingsRecordField,
+  key: string,
+  slotsShrank: boolean
+): boolean {
+  return slotsShrank && SLOT_KEYED_FIELDS.has(field) && getCustomSlotNumberFromKey(key) !== null
+}
 
 /**
  * Reports which appPaths/gamePaths/appNames/appArgs entries in a save-settings
@@ -1013,13 +1036,17 @@ export function preserveRejectedSettingsEntries(
   // app and it silently comes back, with a launchable path.
   //
   // Preservation is only sound while a key means the same thing on both sides of
-  // the write, so it is skipped for those fields when the count shrinks. Losing
-  // a rejected value during a slot removal is the lesser harm: an empty field
-  // the user can retype, rather than an app they deleted reappearing.
+  // the write, so it is skipped for exactly the keys that moved. Losing a
+  // rejected value on a slot that shifted is the lesser harm: an empty field the
+  // user can retype, rather than an app they deleted reappearing.
   //
-  // gamePaths is deliberately still preserved. It is keyed by the fixed game
-  // allowlist, which never renumbers, so the hazard does not reach it.
-  // (Codex P2 on #913.)
+  // Narrowed to the KEY rather than the field. `shiftCustomSlotRecord` only
+  // rewrites `customapp<N>`, so `simhub` in the same dictionary is as stable
+  // during a slot removal as it is on any other save, and skipping it would
+  // erase a value the renderer is at that moment reporting as "Not saved" —
+  // which is the bug this whole change exists to fix, reintroduced through the
+  // back door. gamePaths is untouched for the same reason: fixed allowlist,
+  // never renumbers. (Both P2s from Codex on #913, one per round.)
   const storedSlots = store.get('customSlots')
   const patchSlots = safe.customSlots
   const slotsShrank =
@@ -1028,7 +1055,7 @@ export function preserveRejectedSettingsEntries(
   const merged = { ...safe }
 
   dropped.forEach(({ field, key }) => {
-    if (slotsShrank && SLOT_KEYED_FIELDS.has(field)) return
+    if (isRenumberedByThisSave(field, key, slotsShrank)) return
 
     const sanitizedRecord = merged[field]
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -967,3 +967,57 @@ export function getDroppedSettingsEntries(patch: Record<string, unknown>): Dropp
 
   return dropped
 }
+
+/**
+ * Carries the previously persisted value back into a sanitized save-settings
+ * patch for every entry the sanitizer REJECTED, so a rejected value leaves the
+ * stored one alone instead of erasing it. #806
+ *
+ * The erase is a consequence of how the write works, not of the sanitizer:
+ * `setStoreEntries` replaces each dictionary wholesale, and the sanitizers omit
+ * a rejected key rather than passing the old value through, so the key is gone
+ * from disk. The renderer then reports "Not saved", which reads as "your
+ * previous value survived". It did not, until this.
+ *
+ * `dropped` is exactly the rejected set and nothing else, which is what makes
+ * the merge safe: `getDroppedSettingsEntries` already excludes an unrecognized
+ * key and a blank value, and a blank value is a deliberate clear. So a cleared
+ * entry is still removed here and is never resurrected. That distinction is the
+ * one #806 asks for; it did not need building, only using.
+ *
+ * Must be called BEFORE the write, since it reads the value being replaced.
+ *
+ * Deliberately NOT applied to config import. `applySanitizedConfig` replaces the
+ * whole configuration on purpose, so carrying an entry over from the config the
+ * user just replaced would be the wrong answer there.
+ */
+export function preserveRejectedSettingsEntries(
+  safe: Record<string, unknown>,
+  dropped: DroppedSettingsEntry[]
+): Record<string, unknown> {
+  if (dropped.length === 0) {
+    return safe
+  }
+
+  const merged = { ...safe }
+
+  dropped.forEach(({ field, key }) => {
+    const sanitizedRecord = merged[field]
+
+    // Nothing is being written for this dictionary, so there is nothing to
+    // erase and nothing to restore.
+    if (!isRecord(sanitizedRecord)) return
+
+    const storedValue = getStoredStringRecord(field)[key]
+
+    // No previous value to keep: a first save of a rejected entry still
+    // persists nothing, which is correct and is what "Not saved" already meant.
+    if (storedValue === undefined) return
+
+    // Re-read from `merged` each time so several rejected keys in one
+    // dictionary accumulate rather than overwrite each other.
+    merged[field] = { ...sanitizedRecord, [key]: storedValue }
+  })
+
+  return merged
+}

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -922,6 +922,11 @@ export interface DroppedSettingsEntry {
   reason: DroppedSettingsReason
 }
 
+// The dictionaries keyed by custom-slot POSITION (`customapp1`, `customapp2`, …),
+// which the renderer renumbers when a slot is removed. `gamePaths` is absent on
+// purpose: its keys come from the fixed game allowlist and never shift.
+const SLOT_KEYED_FIELDS = new Set<DroppedSettingsRecordField>(['appPaths', 'appNames', 'appArgs'])
+
 /**
  * Reports which appPaths/gamePaths/appNames/appArgs entries in a save-settings
  * patch belong to a known slot/game key but hold a value the sanitizer
@@ -999,9 +1004,32 @@ export function preserveRejectedSettingsEntries(
     return safe
   }
 
+  // A save that LOWERS customSlots has renumbered the slot-keyed dictionaries on
+  // the way in (`shiftCustomSlotRecord` in `useCustomSlots.tsx`, applied to
+  // appPaths/appNames/appArgs), and the renderer sends the shifted records and
+  // the smaller count in the same patch. So `customapp1` after this write is a
+  // DIFFERENT slot from `customapp1` before it, and restoring by key would put
+  // the DELETED slot's value into the slot that shifted up: the user removes an
+  // app and it silently comes back, with a launchable path.
+  //
+  // Preservation is only sound while a key means the same thing on both sides of
+  // the write, so it is skipped for those fields when the count shrinks. Losing
+  // a rejected value during a slot removal is the lesser harm: an empty field
+  // the user can retype, rather than an app they deleted reappearing.
+  //
+  // gamePaths is deliberately still preserved. It is keyed by the fixed game
+  // allowlist, which never renumbers, so the hazard does not reach it.
+  // (Codex P2 on #913.)
+  const storedSlots = store.get('customSlots')
+  const patchSlots = safe.customSlots
+  const slotsShrank =
+    typeof storedSlots === 'number' && typeof patchSlots === 'number' && patchSlots < storedSlots
+
   const merged = { ...safe }
 
   dropped.forEach(({ field, key }) => {
+    if (slotsShrank && SLOT_KEYED_FIELDS.has(field)) return
+
     const sanitizedRecord = merged[field]
 
     // Nothing is being written for this dictionary, so there is nothing to

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -922,39 +922,22 @@ export interface DroppedSettingsEntry {
   reason: DroppedSettingsReason
 }
 
-// The dictionaries that can hold custom-slot keys (`customapp1`, `customapp2`, …),
-// which the renderer renumbers when a slot is removed. `gamePaths` is absent on
-// purpose: its keys come from the fixed game allowlist and never shift.
-//
-// Membership here is necessary but NOT sufficient to call a key unstable: these
-// same dictionaries also hold built-in utility keys (`simhub`, …), which
-// `shiftCustomSlotRecord` passes through untouched. The per-key test below is
-// what decides.
+// Dictionaries that can hold custom-slot keys. gamePaths is absent on purpose:
+// game keys come from a fixed allowlist and never shift.
 const SLOT_KEYED_FIELDS = new Set<DroppedSettingsRecordField>(['appPaths', 'appNames', 'appArgs'])
 
 /**
- * Whether a rejected entry's key may mean something DIFFERENT on the two sides of
- * this write, which is the one condition under which restoring it by key is unsafe.
+ * Whether a rejected entry's key may mean a different slot on the two sides of
+ * this write, which is when restoring it by key is unsafe.
  *
- * True for every `customapp<N>` key in a slot-keyed dictionary, unconditionally.
- * The main process cannot tell whether a renumbering happened, so it must assume
- * one did. `customSlots` looks like it should answer the question and does not:
- * removing a slot and adding one in the same unsaved batch arrives as an
- * unchanged count, and removing one while adding two arrives as growth. A guard
- * reading that delta restores the DELETED slot's path into the slot that shifted
- * up, which is the resurrection this guard exists to prevent, reached by a route
- * the delta cannot see. Nor is it recoverable from the data: the shift point
- * would be the lowest slot whose incoming value differs from the stored one, and
- * a rejected entry differs by definition, so a rejected edit to slot 1 is
- * indistinguishable from a removal of slot 1 whichever slot actually went.
+ * True for every `customapp<N>` key, unconditionally. `customSlots` looks like it
+ * could narrow that and cannot: removing a slot and adding one before saving
+ * arrives as an unchanged count, so a guard reading the delta restores the
+ * DELETED slot's path into the slot that shifted up. Built-in utility keys, which
+ * `shiftCustomSlotRecord` never touches, stay preserved.
  *
- * The cost is a real one and is stated rather than hidden: a rejected edit to a
- * custom slot is not preserved even on an ordinary save where nothing moved, so
- * for those keys the #806 erase still stands. Built-in utility keys and
- * gamePaths, whose keys come from fixed allowlists and never shift, are
- * preserved, and they are most of the surface. Lifting this needs the renderer to
- * say which slot it removed; tracked in #915 with the state-lifetime hazard that
- * makes it its own piece of work.
+ * Cost: a rejected custom-slot edit is erased even when nothing moved. Lifting it
+ * needs the renderer to say which slot it removed (#915).
  */
 function hasUnstableKeyIdentity(field: DroppedSettingsRecordField, key: string): boolean {
   return SLOT_KEYED_FIELDS.has(field) && getCustomSlotNumberFromKey(key) !== null
@@ -1011,23 +994,16 @@ export function getDroppedSettingsEntries(patch: Record<string, unknown>): Dropp
  * patch for every entry the sanitizer REJECTED, so a rejected value leaves the
  * stored one alone instead of erasing it. #806
  *
- * The erase is a consequence of how the write works, not of the sanitizer:
- * `setStoreEntries` replaces each dictionary wholesale, and the sanitizers omit
- * a rejected key rather than passing the old value through, so the key is gone
- * from disk. The renderer then reports "Not saved", which reads as "your
- * previous value survived". It did not, until this.
+ * `setStoreEntries` replaces each dictionary wholesale and the sanitizers omit a
+ * rejected key, so without this the key is gone from disk while the renderer
+ * reports "Not saved".
  *
- * `dropped` is exactly the rejected set and nothing else, which is what makes
- * the merge safe: `getDroppedSettingsEntries` already excludes an unrecognized
- * key and a blank value, and a blank value is a deliberate clear. So a cleared
- * entry is still removed here and is never resurrected. That distinction is the
- * one #806 asks for; it did not need building, only using.
+ * Safe because `dropped` is the rejected set only: `getDroppedSettingsEntries`
+ * already excludes unrecognized keys and blank values, so a deliberate clear is
+ * never resurrected.
  *
- * Must be called BEFORE the write, since it reads the value being replaced.
- *
- * Deliberately NOT applied to config import. `applySanitizedConfig` replaces the
- * whole configuration on purpose, so carrying an entry over from the config the
- * user just replaced would be the wrong answer there.
+ * Call BEFORE the write, since it reads the value being replaced. Not used by
+ * config import, which replaces the whole configuration on purpose.
  */
 export function preserveRejectedSettingsEntries(
   safe: Record<string, unknown>,
@@ -1037,17 +1013,6 @@ export function preserveRejectedSettingsEntries(
     return safe
   }
 
-  // Removing a custom slot renumbers the slot-keyed dictionaries on the way in
-  // (`shiftCustomSlotRecord` in `useCustomSlots.tsx`, applied to
-  // appPaths/appNames/appArgs), so `customapp1` arriving can be a DIFFERENT slot
-  // from `customapp1` on disk. Restoring by key would then put the DELETED slot's
-  // value into the slot that shifted up: the user removes an app and it silently
-  // comes back, with a launchable path.
-  //
-  // Preservation is only sound while a key means the same thing on both sides of
-  // the write, so it is skipped for every custom-slot key. See
-  // `hasUnstableKeyIdentity` for why the `customSlots` count cannot narrow that
-  // and why the data cannot either.
   const merged = { ...safe }
 
   dropped.forEach(({ field, key }) => {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -933,21 +933,31 @@ export interface DroppedSettingsEntry {
 const SLOT_KEYED_FIELDS = new Set<DroppedSettingsRecordField>(['appPaths', 'appNames', 'appArgs'])
 
 /**
- * Whether a rejected entry's key may have been RENUMBERED by the save now being
- * written, which is the one condition under which restoring it by key is unsafe.
+ * Whether a rejected entry's key may mean something DIFFERENT on the two sides of
+ * this write, which is the one condition under which restoring it by key is unsafe.
  *
- * True only for a `customapp<N>` key in a slot-keyed dictionary, on a save that
- * lowers `customSlots`. A built-in utility key in the same dictionary, or any key
- * at all when the count did not shrink, is stable and must still be preserved:
- * skipping it would erase a value the renderer is simultaneously reporting as
- * "Not saved", which is the exact bug #806 exists to fix.
+ * True for every `customapp<N>` key in a slot-keyed dictionary, unconditionally.
+ * The main process cannot tell whether a renumbering happened, so it must assume
+ * one did. `customSlots` looks like it should answer the question and does not:
+ * removing a slot and adding one in the same unsaved batch arrives as an
+ * unchanged count, and removing one while adding two arrives as growth. A guard
+ * reading that delta restores the DELETED slot's path into the slot that shifted
+ * up, which is the resurrection this guard exists to prevent, reached by a route
+ * the delta cannot see. Nor is it recoverable from the data: the shift point
+ * would be the lowest slot whose incoming value differs from the stored one, and
+ * a rejected entry differs by definition, so a rejected edit to slot 1 is
+ * indistinguishable from a removal of slot 1 whichever slot actually went.
+ *
+ * The cost is a real one and is stated rather than hidden: a rejected edit to a
+ * custom slot is not preserved even on an ordinary save where nothing moved, so
+ * for those keys the #806 erase still stands. Built-in utility keys and
+ * gamePaths, whose keys come from fixed allowlists and never shift, are
+ * preserved, and they are most of the surface. Lifting this needs the renderer to
+ * say which slot it removed; tracked in #915 with the state-lifetime hazard that
+ * makes it its own piece of work.
  */
-function isRenumberedByThisSave(
-  field: DroppedSettingsRecordField,
-  key: string,
-  slotsShrank: boolean
-): boolean {
-  return slotsShrank && SLOT_KEYED_FIELDS.has(field) && getCustomSlotNumberFromKey(key) !== null
+function hasUnstableKeyIdentity(field: DroppedSettingsRecordField, key: string): boolean {
+  return SLOT_KEYED_FIELDS.has(field) && getCustomSlotNumberFromKey(key) !== null
 }
 
 /**
@@ -1027,35 +1037,21 @@ export function preserveRejectedSettingsEntries(
     return safe
   }
 
-  // A save that LOWERS customSlots has renumbered the slot-keyed dictionaries on
-  // the way in (`shiftCustomSlotRecord` in `useCustomSlots.tsx`, applied to
-  // appPaths/appNames/appArgs), and the renderer sends the shifted records and
-  // the smaller count in the same patch. So `customapp1` after this write is a
-  // DIFFERENT slot from `customapp1` before it, and restoring by key would put
-  // the DELETED slot's value into the slot that shifted up: the user removes an
-  // app and it silently comes back, with a launchable path.
+  // Removing a custom slot renumbers the slot-keyed dictionaries on the way in
+  // (`shiftCustomSlotRecord` in `useCustomSlots.tsx`, applied to
+  // appPaths/appNames/appArgs), so `customapp1` arriving can be a DIFFERENT slot
+  // from `customapp1` on disk. Restoring by key would then put the DELETED slot's
+  // value into the slot that shifted up: the user removes an app and it silently
+  // comes back, with a launchable path.
   //
   // Preservation is only sound while a key means the same thing on both sides of
-  // the write, so it is skipped for exactly the keys that moved. Losing a
-  // rejected value on a slot that shifted is the lesser harm: an empty field the
-  // user can retype, rather than an app they deleted reappearing.
-  //
-  // Narrowed to the KEY rather than the field. `shiftCustomSlotRecord` only
-  // rewrites `customapp<N>`, so `simhub` in the same dictionary is as stable
-  // during a slot removal as it is on any other save, and skipping it would
-  // erase a value the renderer is at that moment reporting as "Not saved" —
-  // which is the bug this whole change exists to fix, reintroduced through the
-  // back door. gamePaths is untouched for the same reason: fixed allowlist,
-  // never renumbers. (Both P2s from Codex on #913, one per round.)
-  const storedSlots = store.get('customSlots')
-  const patchSlots = safe.customSlots
-  const slotsShrank =
-    typeof storedSlots === 'number' && typeof patchSlots === 'number' && patchSlots < storedSlots
-
+  // the write, so it is skipped for every custom-slot key. See
+  // `hasUnstableKeyIdentity` for why the `customSlots` count cannot narrow that
+  // and why the data cannot either.
   const merged = { ...safe }
 
   dropped.forEach(({ field, key }) => {
-    if (isRenumberedByThisSave(field, key, slotsShrank)) return
+    if (hasUnstableKeyIdentity(field, key)) return
 
     const sanitizedRecord = merged[field]
 

--- a/tests/main/configImportPreview.test.ts
+++ b/tests/main/configImportPreview.test.ts
@@ -43,6 +43,17 @@ async function loadConfigModule() {
     getDroppedSettingsEntries: vi.fn(() => []),
     getSupportedConfigValues: vi.fn(),
     getStoredZoomFactor: vi.fn(),
+    // Identity, which is what the real one does when nothing was dropped — and
+    // `getDroppedSettingsEntries` above is stubbed to exactly that. Stubbing it
+    // to `{}` instead would make the sanitized-values assertions below pass
+    // vacuously. #806
+    preserveRejectedSettingsEntries: vi.fn((safe) => safe),
+    // The remaining two are not reached by any test here, and are listed for the
+    // reason given in configSaveSettings.test.ts: `ipc/config.ts` imports them,
+    // so the day a test does reach one, an omission is a TypeError rather than a
+    // readable assertion failure (CodeRabbit on #842).
+    getStoredBoolean: vi.fn(() => false),
+    getStoredStringRecord: vi.fn(() => ({})),
     requireSafeZoomFactor: vi.fn(),
     sanitizeImportedConfig: vi.fn((c) => {
       if (!c || typeof c !== 'object' || Object.keys(c).length === 0) return { imported: true }

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -575,3 +575,56 @@ test('a slot removal still preserves a rejected BUILT-IN utility value (#806)', 
     customapp1: 'C:/Apps/B.exe'
   })
 })
+
+/**
+ * The route that killed the earlier `customSlots`-delta guard, and the reason the
+ * skip is now unconditional for custom-slot keys.
+ *
+ * Removing a slot and adding one before saving nets the count back to where it
+ * started, so a guard reading the delta sees no change, preserves, and restores
+ * the DELETED slot's path into the slot that shifted up. Same resurrection as the
+ * plain-removal case, reached by a route the count cannot see. Removing one and
+ * adding two would even read as growth.
+ */
+test('a slot removal masked by an added slot does not resurrect the deleted app (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({
+    appPaths: { customapp1: 'C:/Apps/Deleted.exe', customapp2: 'C:/Apps/Shifted.exe' },
+    customSlots: 2
+  })
+
+  // Remove slot 1, then Add: customSlots arrives unchanged at 2, while
+  // customapp1 now holds the shifted slot, edited to something invalid.
+  const result = await invokeSaveSettings({
+    appPaths: { customapp1: 'C:/Apps/Shifted.bat' },
+    customSlots: 2
+  })
+
+  expect(result.settings.appPaths).not.toHaveProperty('customapp1', 'C:/Apps/Deleted.exe')
+})
+
+/**
+ * Pins the KNOWN LIMITATION rather than a desired behaviour, which is why it
+ * asserts something unhelpful to the user: a rejected custom-slot value is not
+ * preserved even on an ordinary save where nothing was removed, because the main
+ * process cannot tell that from a save where something was.
+ *
+ * Here so the limitation cannot be quietly widened or quietly "fixed" by
+ * reintroducing a count-based guard. Lifting it properly needs the renderer to
+ * say which slot it removed, tracked in #915; when that lands this test should
+ * flip to expecting preservation.
+ */
+test('a rejected custom-slot value is NOT preserved, by design for now (#915)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({ appPaths: { customapp1: 'C:/Apps/A.exe' }, customSlots: 1 })
+
+  const result = await invokeSaveSettings({
+    appPaths: { customapp1: 'C:/Apps/A.bat' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appPaths', key: 'customapp1', reason: 'not-an-exe' }])
+  expect(result.settings.appPaths).toEqual({})
+})

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -15,6 +15,7 @@ interface SaveSettingsResult {
   settings: {
     appPaths: Record<string, string>
     appNames: Record<string, string>
+    appArgs: Record<string, string>
     gamePaths: Record<string, string>
     startWithWindows?: boolean
   }
@@ -429,6 +430,50 @@ test('a rejected entry and a cleared sibling in one patch keep their own outcome
 
   expect(result.dropped).toEqual([{ field: 'appNames', key: 'simhub', reason: 'too-long' }])
   expect(result.settings.appNames).toEqual({ simhub: 'Dash' })
+})
+
+/**
+ * The remaining two of the four fields, and they are not filler. The merge
+ * iterates `dropped` generically, so the only thing keeping gamePaths and
+ * appArgs correct is that nobody special-cases the field. These two make that
+ * assumption fail loudly instead of silently, and they are the two that differ:
+ * gamePaths is validated against KNOWN_GAME_KEYS rather than the utility keys,
+ * and appArgs has its own, much larger length cap. Raised by the review bot on
+ * this PR, which is right that appNames and appPaths alone cannot see either
+ * difference.
+ */
+test('a rejected gamePaths entry leaves the previously persisted path on disk (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({
+    gamePaths: { iracing: 'C:/Games/iRacing/iRacingUI.exe' },
+    customSlots: 1
+  })
+
+  const result = await invokeSaveSettings({
+    gamePaths: { iracing: 'C:/Games/iRacing/iRacingUI.bat' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'gamePaths', key: 'iracing', reason: 'not-an-exe' }])
+  expect(result.settings.gamePaths).toEqual({ iracing: 'C:/Games/iRacing/iRacingUI.exe' })
+})
+
+// appArgs rejects on length alone, and its cap is 500 rather than the 100 that
+// appNames uses, so a merge that reached for the wrong cap would show up here
+// and nowhere else.
+test('a rejected appArgs entry leaves the previously persisted args on disk (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({ appArgs: { simhub: '--safe' }, customSlots: 1 })
+
+  const result = await invokeSaveSettings({
+    appArgs: { simhub: 'x'.repeat(501) },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appArgs', key: 'simhub', reason: 'too-long' }])
+  expect(result.settings.appArgs).toEqual({ simhub: '--safe' })
 })
 
 // A first save of a rejected value has nothing to preserve, and must not invent

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -490,3 +490,53 @@ test('a rejected entry with no previous value still persists nothing (#806)', as
   expect(result.dropped).toEqual([{ field: 'appNames', key: 'simhub', reason: 'too-long' }])
   expect(result.settings.appNames).toEqual({})
 })
+
+/**
+ * The one case where restoring by key is WRONG, and it is a real user action
+ * rather than a contrived one. Removing a custom slot renumbers the slot-keyed
+ * dictionaries in the renderer (`shiftCustomSlotRecord`), and the shifted
+ * records travel with the smaller `customSlots` in a single patch, so
+ * `customapp1` on the way in is a different slot from `customapp1` on disk.
+ * Restoring it would hand the user back the app they just deleted, with a
+ * launchable path, which is worse than the erase this whole PR is fixing.
+ * (Codex P2 on #913.)
+ */
+test('removing a slot does not resurrect the deleted app when the shifted value is rejected (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({
+    appPaths: { customapp1: 'C:/Apps/Deleted.exe', customapp2: 'C:/Apps/Shifted.exe' },
+    customSlots: 2
+  })
+
+  // Slot 1 removed: slot 2's value shifts down into customapp1 and is invalid.
+  const result = await invokeSaveSettings({
+    appPaths: { customapp1: 'C:/Apps/Shifted.bat' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appPaths', key: 'customapp1', reason: 'not-an-exe' }])
+  // The assertion that matters is the absence of 'C:/Apps/Deleted.exe'.
+  expect(result.settings.appPaths).toEqual({})
+})
+
+// The counterpart, so the guard stays a scalpel rather than becoming a blanket
+// "give up whenever customSlots moves". Game keys come from a fixed allowlist
+// and never renumber, so a slot removal must not cost gamePaths its protection.
+test('gamePaths is still preserved when a slot removal shrinks customSlots (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({
+    gamePaths: { iracing: 'C:/Games/iRacing/iRacingUI.exe' },
+    appPaths: { customapp1: 'C:/Apps/A.exe', customapp2: 'C:/Apps/B.exe' },
+    customSlots: 2
+  })
+
+  const result = await invokeSaveSettings({
+    gamePaths: { iracing: 'C:/Games/iRacing/iRacingUI.bat' },
+    appPaths: { customapp1: 'C:/Apps/B.exe' },
+    customSlots: 1
+  })
+
+  expect(result.settings.gamePaths).toEqual({ iracing: 'C:/Games/iRacing/iRacingUI.exe' })
+})

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -14,6 +14,7 @@ type MockIpcHandler = (...args: unknown[]) => unknown
 interface SaveSettingsResult {
   settings: {
     appPaths: Record<string, string>
+    appNames: Record<string, string>
     gamePaths: Record<string, string>
     startWithWindows?: boolean
   }
@@ -351,4 +352,96 @@ test('a path that fits only when unquoted is accepted (#859)', async () => {
 
   expect(result.dropped).toEqual([])
   expect(result.settings.gamePaths).toEqual({ iracing: exact })
+})
+
+/**
+ * #806: each dictionary is written WHOLESALE, and the sanitizers omit a rejected
+ * key rather than passing the old value through, so a rejected entry used to be
+ * erased from disk while the renderer reported "Not saved" — which reads as
+ * "your previous value survived". These pin the two halves that have to stay
+ * true together: a rejected value keeps the stored one, a cleared value does
+ * not come back.
+ *
+ * Every case saves TWICE on purpose. The first save is what establishes the
+ * on-disk value; asserting against a store that was empty to begin with is how
+ * the bug survived #669's coverage, since an erase and a no-op are the same
+ * empty record.
+ */
+test('a rejected appNames entry leaves the previously persisted name on disk (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({ appNames: { simhub: 'Dash' }, customSlots: 1 })
+
+  const result = await invokeSaveSettings({
+    appNames: { simhub: 'x'.repeat(101) },
+    customSlots: 1
+  })
+
+  // Still reported: the merge must keep the entry, not swallow the warning.
+  expect(result.dropped).toEqual([{ field: 'appNames', key: 'simhub', reason: 'too-long' }])
+  expect(result.settings.appNames).toEqual({ simhub: 'Dash' })
+})
+
+// The write path is shared, so the fix has to be too. appNames is merely the
+// easiest dictionary to hit, not the only one.
+test('a rejected appPaths entry leaves the previously persisted path on disk (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({ appPaths: { simhub: 'C:/Tools/SimHub.exe' }, customSlots: 1 })
+
+  const result = await invokeSaveSettings({
+    appPaths: { simhub: 'C:/Tools/SimHub.bat' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appPaths', key: 'simhub', reason: 'not-an-exe' }])
+  expect(result.settings.appPaths).toEqual({ simhub: 'C:/Tools/SimHub.exe' })
+})
+
+// The other half, and the one a careless merge breaks: an empty value is a
+// deliberate clear, it is not in `dropped`, and it must stay gone.
+test('a cleared appNames entry is still removed and not resurrected (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({ appNames: { simhub: 'Dash' }, customSlots: 1 })
+
+  const result = await invokeSaveSettings({ appNames: { simhub: '' }, customSlots: 1 })
+
+  expect(result.dropped).toEqual([])
+  expect(result.settings.appNames).toEqual({})
+})
+
+// The sharpest case, because one patch carries both intents at once: merging by
+// "whatever the sanitizer omitted" instead of "whatever was rejected" passes
+// both tests above and fails here, resurrecting the cleared sibling.
+test('a rejected entry and a cleared sibling in one patch keep their own outcomes (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({
+    appNames: { simhub: 'Dash', crewchief: 'Crew' },
+    customSlots: 1
+  })
+
+  const result = await invokeSaveSettings({
+    appNames: { simhub: 'x'.repeat(101), crewchief: '' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appNames', key: 'simhub', reason: 'too-long' }])
+  expect(result.settings.appNames).toEqual({ simhub: 'Dash' })
+})
+
+// A first save of a rejected value has nothing to preserve, and must not invent
+// anything. This is the case #669 already covered, kept explicit so the merge
+// cannot start writing an empty string or a stale key into a fresh store.
+test('a rejected entry with no previous value still persists nothing (#806)', async () => {
+  await loadConfigModule()
+
+  const result = await invokeSaveSettings({
+    appNames: { simhub: 'x'.repeat(101) },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appNames', key: 'simhub', reason: 'too-long' }])
+  expect(result.settings.appNames).toEqual({})
 })

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -432,16 +432,9 @@ test('a rejected entry and a cleared sibling in one patch keep their own outcome
   expect(result.settings.appNames).toEqual({ simhub: 'Dash' })
 })
 
-/**
- * The remaining two of the four fields, and they are not filler. The merge
- * iterates `dropped` generically, so the only thing keeping gamePaths and
- * appArgs correct is that nobody special-cases the field. These two make that
- * assumption fail loudly instead of silently, and they are the two that differ:
- * gamePaths is validated against KNOWN_GAME_KEYS rather than the utility keys,
- * and appArgs has its own, much larger length cap. Raised by the review bot on
- * this PR, which is right that appNames and appPaths alone cannot see either
- * difference.
- */
+// The merge iterates `dropped` generically, so these two exist to make a
+// field-special-cased version fail loudly. They are also the two that differ:
+// gamePaths validates against KNOWN_GAME_KEYS, appArgs has its own length cap.
 test('a rejected gamePaths entry leaves the previously persisted path on disk (#806)', async () => {
   await loadConfigModule()
 
@@ -491,16 +484,9 @@ test('a rejected entry with no previous value still persists nothing (#806)', as
   expect(result.settings.appNames).toEqual({})
 })
 
-/**
- * The one case where restoring by key is WRONG, and it is a real user action
- * rather than a contrived one. Removing a custom slot renumbers the slot-keyed
- * dictionaries in the renderer (`shiftCustomSlotRecord`), and the shifted
- * records travel with the smaller `customSlots` in a single patch, so
- * `customapp1` on the way in is a different slot from `customapp1` on disk.
- * Restoring it would hand the user back the app they just deleted, with a
- * launchable path, which is worse than the erase this whole PR is fixing.
- * (Codex P2 on #913.)
- */
+// Removing a slot renumbers the dictionaries in the renderer, so `customapp1`
+// arriving is a different slot from `customapp1` on disk. Restoring it would
+// hand back the app the user just deleted, with a launchable path.
 test('removing a slot does not resurrect the deleted app when the shifted value is rejected (#806)', async () => {
   await loadConfigModule()
 
@@ -541,15 +527,9 @@ test('gamePaths is still preserved when a slot removal shrinks customSlots (#806
   expect(result.settings.gamePaths).toEqual({ iracing: 'C:/Games/iRacing/iRacingUI.exe' })
 })
 
-/**
- * The guard has to key on the KEY, not the field. appPaths, appNames and appArgs
- * hold built-in utility keys next to the custom-slot ones, and
- * `shiftCustomSlotRecord` only rewrites `customapp<N>`, so `simhub` is exactly as
- * stable during a slot removal as on any other save. A field-wide skip erases it
- * while the renderer reports "Not saved", which is #806 reintroduced through the
- * back door on this one path. (Second Codex P2 on #913, found in the fix for the
- * first one.)
- */
+// `shiftCustomSlotRecord` only rewrites `customapp<N>`, so a built-in key is as
+// stable during a slot removal as on any other save. A field-wide skip would
+// erase it while the renderer reports "Not saved", which is #806 all over again.
 test('a slot removal still preserves a rejected BUILT-IN utility value (#806)', async () => {
   await loadConfigModule()
 
@@ -576,16 +556,9 @@ test('a slot removal still preserves a rejected BUILT-IN utility value (#806)', 
   })
 })
 
-/**
- * The route that killed the earlier `customSlots`-delta guard, and the reason the
- * skip is now unconditional for custom-slot keys.
- *
- * Removing a slot and adding one before saving nets the count back to where it
- * started, so a guard reading the delta sees no change, preserves, and restores
- * the DELETED slot's path into the slot that shifted up. Same resurrection as the
- * plain-removal case, reached by a route the count cannot see. Removing one and
- * adding two would even read as growth.
- */
+// Why the skip is unconditional: remove a slot and add one before saving and the
+// count arrives unchanged, so a guard reading the delta preserves and resurrects
+// the deleted app. Remove one and add two and it even reads as growth.
 test('a slot removal masked by an added slot does not resurrect the deleted app (#806)', async () => {
   await loadConfigModule()
 
@@ -604,17 +577,9 @@ test('a slot removal masked by an added slot does not resurrect the deleted app 
   expect(result.settings.appPaths).not.toHaveProperty('customapp1', 'C:/Apps/Deleted.exe')
 })
 
-/**
- * Pins the KNOWN LIMITATION rather than a desired behaviour, which is why it
- * asserts something unhelpful to the user: a rejected custom-slot value is not
- * preserved even on an ordinary save where nothing was removed, because the main
- * process cannot tell that from a save where something was.
- *
- * Here so the limitation cannot be quietly widened or quietly "fixed" by
- * reintroducing a count-based guard. Lifting it properly needs the renderer to
- * say which slot it removed, tracked in #915; when that lands this test should
- * flip to expecting preservation.
- */
+// Pins a KNOWN LIMITATION, not a desired behaviour, so it cannot be quietly
+// widened or "fixed" by reintroducing a count-based guard. Flip this to expect
+// preservation when #915 lands.
 test('a rejected custom-slot value is NOT preserved, by design for now (#915)', async () => {
   await loadConfigModule()
 

--- a/tests/main/configSaveSettings.test.ts
+++ b/tests/main/configSaveSettings.test.ts
@@ -540,3 +540,38 @@ test('gamePaths is still preserved when a slot removal shrinks customSlots (#806
 
   expect(result.settings.gamePaths).toEqual({ iracing: 'C:/Games/iRacing/iRacingUI.exe' })
 })
+
+/**
+ * The guard has to key on the KEY, not the field. appPaths, appNames and appArgs
+ * hold built-in utility keys next to the custom-slot ones, and
+ * `shiftCustomSlotRecord` only rewrites `customapp<N>`, so `simhub` is exactly as
+ * stable during a slot removal as on any other save. A field-wide skip erases it
+ * while the renderer reports "Not saved", which is #806 reintroduced through the
+ * back door on this one path. (Second Codex P2 on #913, found in the fix for the
+ * first one.)
+ */
+test('a slot removal still preserves a rejected BUILT-IN utility value (#806)', async () => {
+  await loadConfigModule()
+
+  await invokeSaveSettings({
+    appPaths: {
+      simhub: 'C:/Tools/SimHub.exe',
+      customapp1: 'C:/Apps/A.exe',
+      customapp2: 'C:/Apps/B.exe'
+    },
+    customSlots: 2
+  })
+
+  // Slot 1 removed (slot 2 shifts down and stays valid) while simhub is edited
+  // to something the sanitizer refuses, in the same save.
+  const result = await invokeSaveSettings({
+    appPaths: { simhub: 'C:/Tools/SimHub.bat', customapp1: 'C:/Apps/B.exe' },
+    customSlots: 1
+  })
+
+  expect(result.dropped).toEqual([{ field: 'appPaths', key: 'simhub', reason: 'not-an-exe' }])
+  expect(result.settings.appPaths).toEqual({
+    simhub: 'C:/Tools/SimHub.exe',
+    customapp1: 'C:/Apps/B.exe'
+  })
+})


### PR DESCRIPTION
Closes #806

## What does this PR do?

A settings value the sanitizer rejects was being **deleted from disk** while the app reported "Not saved", which reads as "your previous value survived". It did not.

The erase is a property of the write, not of the sanitizer. `setStoreEntries` replaces each dictionary wholesale, and `sanitizeNameRecord` and friends omit a rejected key rather than passing the old value through, so the key simply stops existing. `save-settings` now carries the stored value back for exactly the rejected entries, before the write reads it.

Scoped to `save-settings` deliberately. `applySanitizedConfig` replaces the whole configuration on purpose, so preserving an entry from the config the user just replaced would be the wrong answer there, and putting the merge inside `setStoreEntries` would have done exactly that.

**The issue's estimate of the work was wrong, in our favour.** It proposed two options and said option 1 needed the sanitizer taught to distinguish a rejected value from a deliberately cleared one, calling that "the actual work here". That distinction has existed since #669: `getDroppedSettingsEntries` already excludes unrecognized keys and blank values, precisely because a blank value is an intentional clear. So the rejected set was already computed on this code path and only needed using. Option 1, the honest one, turned out to be the cheap one.

## What does not ship, and why

**A rejected edit to a custom app slot is still erased.** Only built-in utility keys and `gamePaths` are preserved. That is a real gap in issue 806's first acceptance criterion, and it is deliberate.

Removing a custom slot renumbers the slot-keyed dictionaries in the renderer (`shiftCustomSlotRecord`), so `customapp1` arriving can be a different slot from `customapp1` on disk. Restoring by key would put the **deleted** slot's path into the slot that shifted up: the user removes an app and it comes back, launchable. That is worse than the erase, so the erase is what ships for those keys, exactly as on `main` today.

Two narrower guards were tried during this PR and both were wrong, which is why the final one is unconditional rather than clever:

- skipping the whole dictionary on a `customSlots` decrease also erased built-in keys, which never renumber;
- skipping `customapp<N>` on a decrease missed the case where a slot is removed **and one added** before saving, since the count then arrives unchanged and the deleted app is resurrected.

The removed slot cannot be recovered from the data either: the shift point would be the lowest slot whose incoming value differs from the stored one, and a rejected entry differs by definition. Lifting this needs the renderer to say which slot it removed, which carries a state-lifetime hazard of its own. Tracked in #915 with acceptance criteria, including the remove-then-add case that a partial fix would otherwise sail past.

**Acceptance criteria from issue 806:** the second, third and fourth are met. The first is met for built-in utility keys and `gamePaths` and not for custom-slot keys, per the above. This still closes 806 because the mechanism it describes is fixed and the remaining key family has its own issue; say so if you would rather 806 stayed open until 915 lands.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config

## Smoke check

- [ ] **Needs no manual check.** <!-- smoke:none --> Reason:
- [x] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like:

In Settings, give a custom app slot a name and save it, so a value exists on disk. Then replace that name with one longer than 100 characters and save again.

Correct result: the warning still appears, and the slot keeps **the previous name**, not the default "Custom App N" label. Restart SimLauncher and confirm the previous name is still there, since the point of the fix is what survives on disk rather than what the screen happens to show.

Second half, and it must hold at the same time: clear the name to empty and save. That is a deliberate clear, so the name must be **gone** and must not come back after a restart. A fix that preserves too much fails here.

Worth checking one non-name field too, for example pointing a companion app at a `.bat`: the previously stored `.exe` path should survive.

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (93 files, 907 tests)
- [x] Tested manually: covered by the automated tests below rather than by hand; the smoke check above is the manual pass this asks for at release time

## Test plan

Five tests in `tests/main/configSaveSettings.test.ts`, which drives the real `store.ts` sanitizer and drop-detector through the actual `save-settings` handler with only `electron-store` mocked.

**They were run against the unpatched source first, and three of them failed.** That matters more than the green run: a test written after a fix tends to agree with it. The three that go red are the ones asserting a rejected value survives (`appNames`, `appPaths`, and the mixed patch). The two that pass both before and after are the guards in the other direction, and they are the reason the merge cannot simply restore everything the sanitizer omitted:

- a deliberately cleared entry stays gone
- a first save with no previous value still persists nothing

Every case saves **twice** on purpose. Asserting against a store that was empty to begin with is how this survived #669's coverage, because an erase and a no-op produce the same empty record.

The sharpest case is the mixed patch: one save carrying a rejected name and a cleared sibling. Merging by "whatever the sanitizer omitted" instead of "whatever was rejected" passes the two single-intent tests and fails only there.

## Screenshots

None. No UI change: the fix is in the main process, and the existing warning is already correct once it stops being a false statement.

## One thing to flag, since it is outside the issue

`tests/main/configImportPreview.test.ts` mocks the whole store module with an explicit factory, and that factory was missing `getStoredBoolean` and `getStoredStringRecord`, which `ipc/config.ts` already imports. No test reaches them today, so it is currently invisible. I added them alongside the export this PR needs, because the sibling test file records exactly this rule after a review on #842: list every export the module imports, so reaching one later is a readable failure rather than a `TypeError`. Happy to drop the two extra lines if you would rather keep the diff strictly to #806.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected settings entries no longer erase previously saved values.
  * Settings updates correctly preserve valid entries while removing values intentionally cleared.
  * Improved handling of mixed accepted, rejected, and cleared application names, paths, and arguments.
  * First-time rejected settings remain unsaved and are reported as not saved.
  * Removing custom application slots no longer restores values from deleted slots, including when slots are rearranged.
  * Settings results now accurately reflect saved application names and arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- auto-closes -->
Closes #806
<!-- auto-closes -->
