### PR TITLE
chore(ci): fail the build when a known large file grows (#918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Fails when a file that is already large gets larger (#918). Raising a
+      # ceiling is fine and expected; doing it in the diff is the whole point.
+      - name: Code-line budget
+        run: npm run size:check
+
       - name: Type check
         run: npm run typecheck
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,7 @@ Electron desktop app for simracing enthusiasts — React + TypeScript + Tailwind
 
 ## Code-line budget
 
-`npm run size:check` runs in the required `build` job and fails when a file that is already large gets larger. Ceilings live in [`scripts/size-budget.json`](scripts/size-budget.json); any `src/` file crossing 300 lines of code needs an entry there, or an exclusion with a written reason.
-
-It counts **code** only, so blank and comment-only lines are free. Add the comment. `kill.ts` is 43% comment and that documentation is why its race conditions are maintainable; a budget that charged for it would push exactly the wrong way.
-
-**Raising a ceiling is allowed — edit the number in the same PR.** The gate does not forbid growth, it makes growth appear in a diff. The current numbers are not an endorsement: `GameRow.tsx` was cut to 403 lines by #340 in the 0.9.8 refactor milestone and is over 800 today, and `spawn.ts` went 509 → 728 → 1317 while two issues sat open about that growth. Nobody noticed for months. A refactor PR should lower its file's number; nothing forces it to, and that omission was a deliberate call recorded on #918.
+`npm run size:check` runs in the required `build` job and fails when a file that is already large gets larger. Ceilings live in [`scripts/size-budget.json`](scripts/size-budget.json); any `src/` file at or above 300 lines of code needs an entry there, or an exclusion with a written reason. It counts **code** only, so blank and comment-only lines are free: add the comment. **Raising a ceiling is allowed — edit the number in the same PR**, because the gate does not forbid growth, it makes growth show up in a diff. The current numbers are not an endorsement; `GameRow.tsx` was cut to 403 lines by #340 and is over 800 today. A refactor PR should lower its file's number, and nothing forces it to. See #918.
 
 ## Tooling facts that get guessed wrong
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@ Electron desktop app for simracing enthusiasts — React + TypeScript + Tailwind
 - Doc-comment public/exported items (TS JSDoc) where applicable. English only.
 - Applies to AI agents too.
 
+## Code-line budget
+
+`npm run size:check` runs in the required `build` job and fails when a file that is already large gets larger. Ceilings live in [`scripts/size-budget.json`](scripts/size-budget.json); any `src/` file crossing 300 lines of code needs an entry there, or an exclusion with a written reason.
+
+It counts **code** only, so blank and comment-only lines are free. Add the comment. `kill.ts` is 43% comment and that documentation is why its race conditions are maintainable; a budget that charged for it would push exactly the wrong way.
+
+**Raising a ceiling is allowed — edit the number in the same PR.** The gate does not forbid growth, it makes growth appear in a diff. The current numbers are not an endorsement: `GameRow.tsx` was cut to 403 lines by #340 in the 0.9.8 refactor milestone and is over 800 today, and `spawn.ts` went 509 → 728 → 1317 while two issues sat open about that growth. Nobody noticed for months. A refactor PR should lower its file's number; nothing forces it to, and that omission was a deliberate call recorded on #918.
+
 ## Tooling facts that get guessed wrong
 
 - The package manager is **npm**. There is no pnpm and no yarn; `package-lock.json` is the only lockfile. Never generate a `pnpm-lock.yaml`.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "preload:types:check": "node scripts/generate-preload-types.mjs --check",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "size:check": "node scripts/checkSizeBudget.mjs",
     "typecheck": "npm run typecheck:tsc && npm run typecheck:node && npm run preload:types:check",
     "typecheck:tsc": "tsc -p tsconfig.json --noEmit",
     "typecheck:node": "tsc -p tsconfig.node.json --noEmit",

--- a/scripts/checkSizeBudget.mjs
+++ b/scripts/checkSizeBudget.mjs
@@ -82,7 +82,20 @@ export function evaluateBudget({ files, config, codeLinesFor }) {
   }
 
   for (const file of [...present].sort()) {
-    if (Object.hasOwn(exclusions, file)) continue
+    // An exclusion must carry a written reason. Checking only for the key would
+    // let `"src/huge.ts": ""` silently buy an exemption, which is the one way
+    // this config can be weakened without it looking like anything happened.
+    if (Object.hasOwn(exclusions, file)) {
+      const reason = exclusions[file]
+      if (typeof reason === 'string' && reason.trim().length > 0) continue
+
+      violations.push(
+        `${file} is excluded with no reason (${JSON.stringify(reason)})\n` +
+          `  fix: give the exclusion a sentence saying why this file is not measured,\n` +
+          `       or remove it and give the file a budget`
+      )
+      continue
+    }
 
     const budget = budgets[file]
 

--- a/scripts/checkSizeBudget.mjs
+++ b/scripts/checkSizeBudget.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { countCodeLines } from './countCodeLines.mjs'
+
+// Fails the build when a file that is already large gets larger. See #918.
+//
+// This is NOT a size limit and the current ceilings are NOT an endorsement:
+// 569 code lines in GameRow.tsx is not fine, the ceiling only stops 570.
+// Lowering the numbers is the job of the refactor issues (#530, #775, #776,
+// #396), and a refactor PR is expected to drop its file's number by hand.
+//
+// Why it exists: consolidation has been done here before and did not hold.
+// GameRow.tsx was cut to 403 lines by #340 in the 0.9.8 "Refactor & Testing"
+// milestone and is back over 800; spawn.ts went 509 -> 728 -> 1317 while two
+// issues sat open about that exact growth. Nothing noticed for months. Every
+// one of those cases is caught by a plain upper bound on the first added line.
+//
+// Raising a ceiling is allowed and deliberately easy: edit the one number. The
+// point is not to forbid growth, it is to make growth appear in a diff where a
+// reviewer sees it, instead of surfacing four months later.
+//
+// A downward ratchet was designed and rejected as unproven need; the reasoning
+// and the trigger to revisit it are recorded on #918.
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+const budgetPath = path.join(scriptDir, 'size-budget.json')
+
+/** Repo-relative, forward-slashed, so Windows and Linux produce the same keys. */
+export function toPosix(relativePath) {
+  return relativePath.split(/[\\/]/).join('/')
+}
+
+/**
+ * Every violation in one pass, as readable strings.
+ *
+ * Pure on purpose: `files`, the config and `codeLinesFor` are all injected, so
+ * the rules can be tested without a repo, a git checkout or the filesystem.
+ */
+export function evaluateBudget({ files, config, codeLinesFor }) {
+  const threshold = config.thresholdCodeLines
+  const budgets = config.budgets ?? {}
+  const exclusions = config.exclusions ?? {}
+
+  if (!Number.isInteger(threshold) || threshold <= 0) {
+    return ['size-budget.json: thresholdCodeLines must be a positive integer']
+  }
+
+  const present = new Set(files.map(toPosix))
+  const violations = []
+
+  // Config rot first: a stale entry means the gate is measuring something that
+  // no longer exists, and silently dropping it is how a budget stops covering
+  // the file it was written for.
+  for (const file of Object.keys(budgets)) {
+    if (!present.has(file)) {
+      violations.push(
+        `stale budget entry: ${file}\n` +
+          `  no such tracked file under src/\n` +
+          `  fix: remove the entry, or correct the path if the file moved`
+      )
+    }
+    if (Object.hasOwn(exclusions, file)) {
+      violations.push(
+        `${file} is both budgeted and excluded\n` +
+          `  fix: keep one. An excluded file is not measured, so a budget on it is dead config`
+      )
+    }
+  }
+
+  for (const file of Object.keys(exclusions)) {
+    if (!present.has(file)) {
+      violations.push(
+        `stale exclusion: ${file}\n` +
+          `  no such tracked file under src/\n` +
+          `  fix: remove the entry, or correct the path if the file moved`
+      )
+    }
+  }
+
+  for (const file of [...present].sort()) {
+    if (Object.hasOwn(exclusions, file)) continue
+
+    const budget = budgets[file]
+
+    if (budget !== undefined && (!Number.isInteger(budget) || budget < 0)) {
+      violations.push(
+        `${file} has a non-integer budget (${JSON.stringify(budget)})\n` +
+          `  fix: set it to a whole number of code lines`
+      )
+      continue
+    }
+
+    const code = codeLinesFor(file)
+
+    if (budget === undefined) {
+      // A file only needs an entry once it crosses the threshold. Below it,
+      // files are unlisted and unconstrained.
+      if (code >= threshold) {
+        violations.push(
+          `${file} is new above the threshold: ${code} code lines (threshold ${threshold})\n` +
+            `  fix: add "${file}": ${code} to budgets in scripts/size-budget.json,\n` +
+            `       or add it to exclusions with a reason if it is generated or data`
+        )
+      }
+      continue
+    }
+
+    // Deliberately no lower bound. A tracked file that shrinks is fine and
+    // stays tracked, so it cannot quietly climb back toward the threshold.
+    if (code > budget) {
+      violations.push(
+        `${file} grew past its budget: ${code} code lines, budget ${budget} (+${code - budget})\n` +
+          `  fix: reduce the file, or raise the number in scripts/size-budget.json\n` +
+          `       in this PR so the growth is visible in review`
+      )
+    }
+  }
+
+  return violations
+}
+
+function listSourceFiles() {
+  const output = execFileSync('git', ['ls-files', '-z', 'src'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024
+  })
+
+  return output
+    .split('\0')
+    .filter(Boolean)
+    .map(toPosix)
+    .filter((file) => file.endsWith('.ts') || file.endsWith('.tsx'))
+    .sort()
+}
+
+function main() {
+  const config = JSON.parse(fs.readFileSync(budgetPath, 'utf8'))
+  const files = listSourceFiles()
+
+  const violations = evaluateBudget({
+    files,
+    config,
+    codeLinesFor: (file) => countCodeLines(path.join(repoRoot, file)).code
+  })
+
+  if (violations.length > 0) {
+    console.error(`\nCode-line budget: ${violations.length} problem(s).\n`)
+    for (const violation of violations) console.error(`  ${violation}\n`)
+    console.error(
+      `These budgets are a stop against growth, not a verdict on the current sizes.\n` +
+        `Raising one is a normal thing to do; doing it in the diff is the point. See #918.\n`
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `Code-line budget: ${Object.keys(config.budgets ?? {}).length} tracked file(s) within budget.`
+  )
+}
+
+// Importing this module for its rules must not run the check.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/scripts/countCodeLines.mjs
+++ b/scripts/countCodeLines.mjs
@@ -1,0 +1,133 @@
+import ts from 'typescript'
+import fs from 'node:fs'
+
+// Counts lines of real TS/TSX code, ignoring blanks and comment-only lines.
+//
+// Comments are found with the TypeScript PARSER, not a regex and not a bare
+// scanner. `ts.createScanner` looks like the obvious tool and is wrong here: it
+// has no parser context, so it reads a `/` as the start of a regex literal and
+// swallows whole regions. Measured on spawn.ts it reported 105 single-line
+// comments where the file has 401 — worse than the regex it would replace.
+//
+// Comments are excluded on purpose. kill.ts is 43% comment and spawn.ts 38%,
+// and that documentation is what keeps their race conditions maintainable.
+// Charging budget for it would push exactly the wrong way: a comment should
+// always be free to add, logic should not. See #918.
+
+/**
+ * Every distinct comment range in a source file, as parsed.
+ *
+ * Ranges are collected per node rather than by scanning, and deduplicated
+ * because a node's trailing comment is the next node's leading comment.
+ */
+function collectCommentRanges(text, sourceFile) {
+  const ranges = []
+  const seen = new Set()
+
+  const add = (found) => {
+    if (!found) return
+    for (const range of found) {
+      const key = `${range.pos}:${range.end}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      ranges.push(range)
+    }
+  }
+
+  const visit = (node) => {
+    add(ts.getLeadingCommentRanges(text, node.getFullStart()))
+    add(ts.getTrailingCommentRanges(text, node.getEnd()))
+
+    // `{/* why */}` parses as a JsxExpression with no expression inside. Its
+    // braces are real tokens, so without this the line reads as code and a JSX
+    // comment costs budget — the exact incentive this counter exists to avoid.
+    // Claim the whole node, braces included.
+    if (ts.isJsxExpression(node) && node.expression === undefined) {
+      add([
+        { pos: node.getStart(), end: node.getEnd(), kind: ts.SyntaxKind.MultiLineCommentTrivia }
+      ])
+    }
+
+    node.forEachChild(visit)
+  }
+
+  visit(sourceFile)
+  // The trailing block of a file hangs off the EOF token, which forEachChild
+  // does not reach, so a file ending in a comment would lose it.
+  add(ts.getLeadingCommentRanges(text, sourceFile.endOfFileToken.getFullStart()))
+
+  return ranges
+}
+
+/** Whether the line still holds non-whitespace once every comment on it is blanked out. */
+function hasCodeOutsideComments(lineText, lineStart, ranges) {
+  const lineEnd = lineStart + lineText.length
+  const chars = [...lineText]
+
+  for (const range of ranges) {
+    const from = Math.max(range.pos, lineStart)
+    const to = Math.min(range.end, lineEnd)
+    for (let pos = from; pos < to; pos++) {
+      chars[pos - lineStart] = ' '
+    }
+  }
+
+  return chars.join('').trim().length > 0
+}
+
+/**
+ * Line counts for one TS/TSX file.
+ *
+ * A line with code and a trailing comment counts as code, which is why this
+ * masks comment ranges out of the line rather than classifying whole lines.
+ *
+ * Throws on a file the parser cannot read. A wrong number that looks fine is
+ * the one outcome a budget gate must never produce.
+ */
+export function countCodeLines(filePath, sourceText) {
+  const text = sourceText ?? fs.readFileSync(filePath, 'utf8')
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    text,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  )
+
+  const syntactic = sourceFile.parseDiagnostics ?? []
+  if (syntactic.length > 0) {
+    const first = syntactic[0]
+    const message = ts.flattenDiagnosticMessageText(first.messageText, ' ')
+    throw new Error(`${filePath}: could not be parsed (${message})`)
+  }
+
+  const ranges = collectCommentRanges(text, sourceFile)
+
+  // Split on the three line endings rather than trusting one, then drop the
+  // empty tail a trailing newline produces so counts match `wc -l`.
+  const lines = text.split(/\r\n|\r|\n/)
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+
+  let code = 0
+  let comment = 0
+  let blank = 0
+
+  for (let index = 0; index < lines.length; index++) {
+    const lineText = lines[index]
+
+    if (!lineText.trim()) {
+      blank++
+      continue
+    }
+
+    const lineStart = sourceFile.getPositionOfLineAndCharacter(index, 0)
+    if (hasCodeOutsideComments(lineText, lineStart, ranges)) {
+      code++
+    } else {
+      comment++
+    }
+  }
+
+  return { total: lines.length, code, comment, blank }
+}

--- a/scripts/countCodeLines.mjs
+++ b/scripts/countCodeLines.mjs
@@ -48,13 +48,17 @@ function collectCommentRanges(text, sourceFile) {
       ])
     }
 
-    node.forEachChild(visit)
+    // getChildren, not forEachChild. forEachChild skips punctuation tokens, so
+    // a comment sitting on its own line before a closing `}` or `]` leads no
+    // node and trails nothing on its line, falls through, and gets counted as
+    // code. That is the common shape of a why-comment at the end of a body, so
+    // it would have charged budget for exactly the comments this repo asks for.
+    // Walking tokens too fixes every container at once rather than the three
+    // that happened to get reported.
+    for (const child of node.getChildren(sourceFile)) visit(child)
   }
 
   visit(sourceFile)
-  // The trailing block of a file hangs off the EOF token, which forEachChild
-  // does not reach, so a file ending in a comment would lose it.
-  add(ts.getLeadingCommentRanges(text, sourceFile.endOfFileToken.getFullStart()))
 
   return ranges
 }

--- a/scripts/size-budget.json
+++ b/scripts/size-budget.json
@@ -1,0 +1,24 @@
+{
+  "$comment": [
+    "Code-line ceilings for files that are already large. Checked by scripts/checkSizeBudget.mjs, wired into the CI build job. See #918.",
+    "These numbers are NOT an endorsement of the current sizes. 569 code lines in GameRow.tsx is not fine; the ceiling only stops 570. Lowering them is the job of the refactor issues (#530, #775, #776, #396), and a refactor PR should drop its file's number here.",
+    "Counting excludes blank and comment-only lines, so a comment is always free to add. kill.ts is 43% comment and spawn.ts 38%, and that documentation is what keeps their race conditions maintainable.",
+    "Raising a ceiling is allowed: edit the number, in the same PR. The point is that the growth shows up in a diff rather than surfacing months later, which is what happened to GameRow.tsx (403 after #340, over 800 today) and spawn.ts (509 -> 728 -> 1317)."
+  ],
+  "thresholdCodeLines": 300,
+  "budgets": {
+    "src/main/ipc/config.ts": 464,
+    "src/main/processes/kill.ts": 573,
+    "src/main/processes/running.ts": 424,
+    "src/main/processes/spawn.ts": 733,
+    "src/main/processes/win32KillUtils.ts": 384,
+    "src/main/store.ts": 700,
+    "src/renderer/src/App.tsx": 399,
+    "src/renderer/src/components/game-list/GameRow.tsx": 569,
+    "src/renderer/src/components/settings/SettingsContext.tsx": 482,
+    "src/renderer/src/hooks/useProfileEditor.tsx": 637
+  },
+  "exclusions": {
+    "src/renderer/src/components/icons/index.tsx": "Declarative SVG barrel: 372 code lines carrying 5 comment lines, almost all of it path data. Length here is volume, not complexity, and splitting it would buy nothing."
+  }
+}

--- a/tests/ci/sizeBudget.test.ts
+++ b/tests/ci/sizeBudget.test.ts
@@ -66,6 +66,23 @@ describe('countCodeLines', () => {
     expect(count(source, 'probe.tsx')).toBe(5)
   })
 
+  // Found by both review bots on #919, independently. `forEachChild` skips
+  // punctuation, so a comment on its own line before a closing token leads no
+  // node and trails nothing on its line. It was counted as code, which charged
+  // budget for the end-of-body why-comment this repo explicitly asks for.
+  it.each([
+    ['block body', 'function f() {\n  doThing()\n  // why we stop here\n}\n'],
+    ['object literal', 'const o = {\n  a: 1\n  // no b on purpose\n}\n'],
+    ['array literal', 'const a = [\n  1\n  // deliberately short\n]\n'],
+    ['if body', 'if (x) {\n  go()\n  // nothing else\n}\n']
+  ])('ignores a dangling comment before the closing token of a %s', (_name, source) => {
+    expect(count(source)).toBe(3)
+  })
+
+  it('ignores a comment on the last line of the file', () => {
+    expect(count('const a = 1\n// a trailing note\n')).toBe(1)
+  })
+
   it('does not treat comment markers inside a template string as comments', () => {
     expect(count('const url = `https://x/y`\nconst c = `/* not a comment */`\n')).toBe(2)
   })
@@ -113,6 +130,25 @@ describe('evaluateBudget', () => {
 
   it('skips an excluded file however large it is', () => {
     expect(run(['src/data.ts'], { 'src/data.ts': 5000 })).toEqual([])
+  })
+
+  // Raised by CodeRabbit on #919 as Major, and it was right: checking only for
+  // the key let an empty reason buy an exemption, which is the one way this
+  // config could be weakened while looking untouched.
+  it.each([
+    ['an empty string', ''],
+    ['whitespace', '   '],
+    ['null', null],
+    ['a non-string', 42]
+  ])('refuses to skip a file excluded with %s as its reason', (_name, reason) => {
+    const violations = run(
+      ['src/huge.ts'],
+      { 'src/huge.ts': 5000 },
+      {
+        exclusions: { 'src/huge.ts': reason as string }
+      }
+    )
+    expect(violations.some((v) => v.includes('excluded with no reason'))).toBe(true)
   })
 
   it('fails a budget entry whose file is gone', () => {

--- a/tests/ci/sizeBudget.test.ts
+++ b/tests/ci/sizeBudget.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+// @ts-expect-error - plain .mjs repo tooling, no type declarations by design
+import { countCodeLines } from '../../scripts/countCodeLines.mjs'
+// @ts-expect-error - plain .mjs repo tooling, no type declarations by design
+import { evaluateBudget, toPosix } from '../../scripts/checkSizeBudget.mjs'
+
+/**
+ * Guards the code-line budget gate (#918).
+ *
+ * The rules are imported from the real script rather than restated here, so a
+ * change to the gate cannot leave a green test describing behaviour that no
+ * longer exists. `evaluateBudget` is pure for exactly this reason: the cases
+ * below need no repo, no git and no filesystem.
+ */
+
+const count = (source: string, file = 'probe.ts'): number => countCodeLines(file, source).code
+
+const config = {
+  thresholdCodeLines: 300,
+  budgets: { 'src/a.ts': 100 },
+  exclusions: { 'src/data.ts': 'generated' }
+}
+
+// The base config names src/a.ts and src/data.ts, so both are present by
+// default. A case that is about staleness passes its own file list instead.
+const run = (
+  files: string[],
+  counts: Record<string, number>,
+  overrides: Partial<typeof config> & { onlyTheseFiles?: boolean } = {}
+): string[] => {
+  const { onlyTheseFiles, ...configOverrides } = overrides
+  const merged = { ...config, ...configOverrides }
+  const referenced = onlyTheseFiles
+    ? []
+    : [...Object.keys(merged.budgets ?? {}), ...Object.keys(merged.exclusions ?? {})]
+
+  return evaluateBudget({
+    files: [...new Set([...referenced, ...files])],
+    config: merged,
+    codeLinesFor: (file: string) => counts[file] ?? 0
+  })
+}
+
+describe('countCodeLines', () => {
+  it('ignores blank lines and whole-line comments', () => {
+    expect(count('const a = 1\n\n// a comment\nconst b = 2\n')).toBe(2)
+  })
+
+  it('counts a line holding code and a trailing comment as code', () => {
+    expect(count('const a = 1 // explains a\n')).toBe(1)
+  })
+
+  it('ignores every line of a block comment', () => {
+    expect(count('/**\n * one\n * two\n */\nconst a = 1\n')).toBe(1)
+  })
+
+  it('counts a line where code follows a block comment that ends on it', () => {
+    expect(count('/* lead */ const a = 1\n')).toBe(1)
+  })
+
+  it('ignores JSX comments, which a regex counter reads as code', () => {
+    const source = 'export const V = () => (\n  <div>\n    {/* why */}\n    <p />\n  </div>\n)\n'
+    // Six lines, one of them a JSX comment.
+    expect(count(source, 'probe.tsx')).toBe(5)
+  })
+
+  it('does not treat comment markers inside a template string as comments', () => {
+    expect(count('const url = `https://x/y`\nconst c = `/* not a comment */`\n')).toBe(2)
+  })
+
+  it('does not treat a regex literal as the start of a comment', () => {
+    // A bare ts.createScanner mis-lexes this and swallows the following lines.
+    expect(count('const re = /https?:\\/\\//\nconst a = 1\nconst b = 2\n')).toBe(3)
+  })
+
+  it('counts CRLF the same as LF', () => {
+    const lf = 'const a = 1\n// c\nconst b = 2\n'
+    expect(count(lf.replace(/\n/g, '\r\n'))).toBe(count(lf))
+  })
+
+  it('throws rather than returning a wrong number for an unparseable file', () => {
+    expect(() => count('const a = (((\n')).toThrow(/could not be parsed/)
+  })
+})
+
+describe('evaluateBudget', () => {
+  it('passes a tracked file sitting exactly on its budget', () => {
+    expect(run(['src/a.ts'], { 'src/a.ts': 100 })).toEqual([])
+  })
+
+  it('fails a tracked file one line over its budget', () => {
+    const [violation] = run(['src/a.ts'], { 'src/a.ts': 101 })
+    expect(violation).toContain('grew past its budget')
+    expect(violation).toContain('101 code lines, budget 100 (+1)')
+  })
+
+  it('passes a tracked file that shrank, and keeps tracking it', () => {
+    // No lower bound by design: the downward ratchet was rejected on #918.
+    expect(run(['src/a.ts'], { 'src/a.ts': 10 })).toEqual([])
+  })
+
+  it('fails a new file at the threshold with no entry', () => {
+    const [violation] = run(['src/new.ts'], { 'src/new.ts': 300 })
+    expect(violation).toContain('is new above the threshold')
+    expect(violation).toContain('"src/new.ts": 300')
+  })
+
+  it('allows a new file below the threshold to stay unlisted', () => {
+    expect(run(['src/new.ts'], { 'src/new.ts': 299 })).toEqual([])
+  })
+
+  it('skips an excluded file however large it is', () => {
+    expect(run(['src/data.ts'], { 'src/data.ts': 5000 })).toEqual([])
+  })
+
+  it('fails a budget entry whose file is gone', () => {
+    const violations = run([], {}, { onlyTheseFiles: true })
+    expect(violations.some((v) => v.includes('stale budget entry: src/a.ts'))).toBe(true)
+  })
+
+  it('fails an exclusion whose file is gone', () => {
+    const violations = run(['src/a.ts'], { 'src/a.ts': 100 }, { onlyTheseFiles: true })
+    expect(violations.some((v) => v.includes('stale exclusion: src/data.ts'))).toBe(true)
+  })
+
+  it('fails a path that is both budgeted and excluded', () => {
+    const violations = run(
+      ['src/a.ts'],
+      { 'src/a.ts': 100 },
+      {
+        exclusions: { 'src/a.ts': 'contradictory' }
+      }
+    )
+    expect(violations.some((v) => v.includes('both budgeted and excluded'))).toBe(true)
+  })
+
+  it('reports every problem in one pass rather than stopping at the first', () => {
+    const violations = run(
+      ['src/a.ts', 'src/new.ts'],
+      { 'src/a.ts': 400, 'src/new.ts': 350 },
+      { onlyTheseFiles: true }
+    )
+    // over budget, new-over-threshold, and the now-stale exclusion
+    expect(violations).toHaveLength(3)
+    expect(violations.some((v) => v.includes('grew past its budget'))).toBe(true)
+    expect(violations.some((v) => v.includes('is new above the threshold'))).toBe(true)
+    expect(violations.some((v) => v.includes('stale exclusion'))).toBe(true)
+  })
+
+  it('rejects a non-integer threshold instead of silently passing everything', () => {
+    expect(run(['src/a.ts'], { 'src/a.ts': 999 }, { thresholdCodeLines: 0 })[0]).toContain(
+      'thresholdCodeLines'
+    )
+  })
+
+  it('normalises Windows separators so both platforms agree', () => {
+    expect(toPosix('src\\main\\store.ts')).toBe('src/main/store.ts')
+    expect(run(['src\\a.ts'], { 'src/a.ts': 100 })).toEqual([])
+  })
+})
+
+describe('the committed budget', () => {
+  const budget = JSON.parse(
+    readFileSync(fileURLToPath(new URL('../../scripts/size-budget.json', import.meta.url)), 'utf8')
+  )
+
+  it('gives every exclusion a written reason', () => {
+    for (const [file, reason] of Object.entries(budget.exclusions)) {
+      expect(typeof reason, `${file} needs a reason`).toBe('string')
+      expect((reason as string).length, `${file} needs a real reason`).toBeGreaterThan(20)
+    }
+  })
+
+  it('uses forward slashes in every key, so the keys match on Windows', () => {
+    const keys = [...Object.keys(budget.budgets), ...Object.keys(budget.exclusions)]
+    expect(keys.filter((k) => k.includes('\\'))).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

`npm run size:check` runs in the existing `build` job and fails when a file that is already large gets larger. Ceilings live in `scripts/size-budget.json`.

**This is not a size limit and the committed numbers are not an endorsement.** 569 code lines in `GameRow.tsx` is not fine; the ceiling only stops 570. Lowering them belongs to [#530](https://github.com/Stashpeak/SimLauncher/issues/530), [#775](https://github.com/Stashpeak/SimLauncher/issues/775), [#776](https://github.com/Stashpeak/SimLauncher/issues/776) and [#396](https://github.com/Stashpeak/SimLauncher/issues/396).

### Why

Consolidation has been done here before, in a milestone named for it, and it did not hold:

| File | After the refactor that split it | Today |
|---|---|---:|
| `GameRow.tsx` | **403** ([#340](https://github.com/Stashpeak/SimLauncher/issues/340), v0.9.8 "Refactor & Testing") | 844 |
| `spawn.ts` | 509 at [#530](https://github.com/Stashpeak/SimLauncher/issues/530), 728 at [#776](https://github.com/Stashpeak/SimLauncher/issues/776), which was filed *about that growth* | 1317 |

Nobody noticed for months. All of it is caught by a plain upper bound on the first added line.

### Counts code, not lines

`kill.ts` is 43 % comment and `spawn.ts` 38 %, and that documentation is why their race conditions stay maintainable. A total-line budget would charge for writing it. **A comment is always free to add; logic is not.**

### The parser, and the trap in it

⚠️ Worth recording because the obvious implementation is wrong. `ts.createScanner` has no parser context, reads `/` as the start of a regex literal and swallows whole regions: on `spawn.ts` it reported **105** single-line comments where the file has **401**. That is worse than the regex it replaces. `ts.createSourceFile` with `getLeadingCommentRanges` is correct.

Parsing then surfaced a case neither approach handles for free: `{/* why */}` is a `JsxExpression` whose braces are **real tokens**, so it counted as code and adding a JSX comment would have cost budget. Claimed explicitly. This moved `GameRow.tsx` from 580 to 569 and `App.tsx` from 404 to 399.

### Rejected

A downward ratchet plus `size:update`, designed in full and dropped as unproven need: it catches none of the three observed failures, and it costs false CI failures on any PR that deletes a few lines from a tracked file. The trigger to revisit is recorded on [#918](https://github.com/Stashpeak/SimLauncher/issues/918).

## Smoke check

- [x] **Needs no manual check.** <!-- smoke:none --> Reason: no file under `src/` is touched, so the app and the shipped bundle are byte-for-byte unaffected. The change is repo tooling plus one npm script, one CI step and one `AGENTS.md` section.
- [ ] **Needs a manual check.** <!-- smoke:check --> What to do, and what a correct result looks like:

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run size:check`
- [x] `npm run test` (935 passed, 21 new)
- [x] `npm run build`
- [x] **Proven red, not just green.** Adding one line of code to `GameRow.tsx` exits 1 with `570 code lines, budget 569 (+1)`. Adding two comment lines to the same file stays green and exits 0.
- [x] Also exercised by hand: a new tracked file over 300 lines with no entry, a stale budget entry, a stale exclusion, and a path both budgeted and excluded. All fail, and all violations report together.

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] Tested manually — the red/green pair above

Closes #918


<!-- auto-closes -->
Closes #918
<!-- auto-closes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code-size budget checks to the build process.
  * Large source files are now monitored against configured code-line limits, with clear build feedback when limits are exceeded.

* **Documentation**
  * Added contributor guidance explaining code-size thresholds, exclusions, and budget updates.

* **Tests**
  * Added coverage for line counting, budget validation, configuration errors, and reported violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->